### PR TITLE
[FIX]Automatically change type when changing sale flow to drop shipping ...

### DIFF
--- a/sale_dropshipping/sale.py
+++ b/sale_dropshipping/sale.py
@@ -68,7 +68,8 @@ class sale_order_line(orm.Model):
             if sale_flow == 'direct_delivery':
                 vals['type'] = 'make_to_order'
             else:
-                vals['type'] = self.pool.get('product.product').browse(cr,uid,product_id).procure_method
+                product = self.pool['product.product'].browse(cr, uid, product_id, context=context)
+                vals['type'] = product.procure_method
         return {'value': vals}
 
 

--- a/sale_dropshipping/sale.py
+++ b/sale_dropshipping/sale.py
@@ -60,6 +60,18 @@ class sale_order_line(orm.Model):
             result[order_line.id] = po_line_ids and po_line_ids[0] or False
         return result
 
+    def onchange_sale_flow(self, cr, uid, ids, sale_flow, product_id, context=None):
+        """ Change type to make_to_order when sale_flow is direct_delivery """
+
+        vals = {}
+        if product_id:
+            if sale_flow == 'direct_delivery':
+                vals['type'] = 'make_to_order'
+            else:
+                vals['type'] = self.pool.get('product.product').browse(cr,uid,product_id).procure_method
+        return {'value': vals}
+
+
     _columns = {
         'sale_flow': fields.selection([('normal', 'Normal'),
                                        ('direct_delivery', 'Drop Shipping'),

--- a/sale_dropshipping/sale_view.xml
+++ b/sale_dropshipping/sale_view.xml
@@ -19,11 +19,11 @@
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
             <xpath expr="/form/sheet//field[@name='order_line']/tree/field[@name='name']" position="before">
-                <field name="sale_flow" />
+                <field name="sale_flow" on_change="onchange_sale_flow(sale_flow, product_id, context)"/>
             </xpath>
             <xpath expr="/form/sheet//field[@name='order_line']/form//label[@for='name']" position="before">
                 <group attrs="{'invisible': [('type', '=', 'make_to_stock')]}" colspan="2" cols="2">
-                    <field name="sale_flow"/>
+                    <field name="sale_flow" on_change="onchange_sale_flow(sale_flow, product_id, context)"/>
                     <field name="purchase_order_line_id"/>
                     <field name="purchase_order_id" readonly="1"/>
                     <field name="purchase_order_state" readonly="1"/>


### PR DESCRIPTION
Hi,

When we change sale flow to Drop shipping on SOL it doesn't change type(Procurement method) to make to order which breaks drop shipping flow.

Steps to reproduce bug:
1. Open/Create any product type product and set Procurement Method:Make to Stock
2. Set supplier and do not mark drop shipping
3. Create SO(Sale order)
4. Add product from step one.
5. Change sale flow to drop shipping
6. Confirm Sale order
7. Run Procurement Scheduler

This commit fixes the bug
