### PR TITLE
New module sale_order_authorized_users

### DIFF
--- a/sale_order_authorized_users/__init__.py
+++ b/sale_order_authorized_users/__init__.py
@@ -1,0 +1,2 @@
+from . import sale
+

--- a/sale_order_authorized_users/__init__.py
+++ b/sale_order_authorized_users/__init__.py
@@ -1,2 +1,1 @@
 from . import sale
-

--- a/sale_order_authorized_users/__openerp__.py
+++ b/sale_order_authorized_users/__openerp__.py
@@ -29,9 +29,9 @@
 Sale Order Authorized Users
 ======================================
 
-Let Admin (or any user in the base.group_erp_manager) choose, for each sale order,
-which users will be able to access and see it. Any other user won't be able
-to see it.
+Let Admin (or any user in the base.group_erp_manager) choose,
+for each sale order,w hich users will be able to access and see it.
+Any other user won't be able to see it.
 If no users are set, the sale order has normal permissions.
 The field to set allowed users will be visibile only to admin, which makes it
 possible to make the users unaware of this feature.

--- a/sale_order_authorized_users/__openerp__.py
+++ b/sale_order_authorized_users/__openerp__.py
@@ -30,13 +30,13 @@ Sale Order Authorized Users
 ======================================
 
 Let Admin (or any user in the base.group_erp_manager) choose,
-for each sale order,w hich users will be able to access and see it.
+for each sale order, which users will be able to access and see it.
 Any other user won't be able to see it.
 If no users are set, the sale order has normal permissions.
 The field to set allowed users will be visibile only to admin, which makes it
 possible to make the users unaware of this feature.
 """,
-    'author': 'Leonardo Donelli @ Creativi Quadrati',
+    'author': 'Creativi Quadrati',
     'depends': ['sale'],
     'data': [
         'sale_view.xml',

--- a/sale_order_authorized_users/__openerp__.py
+++ b/sale_order_authorized_users/__openerp__.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# Author: Leonardo Donelli @ Creativi Quadrati
+# Copyright (C) 2014 Leonardo Donelli
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+{
+    'name': 'Sale Order Authorized Users',
+    'version': '1.0',
+    'category': 'Sale',
+    'summary': 'Sale orders, Security, Permissions, Users',
+    'description': """
+Sale Order Authorized Users
+======================================
+
+Let Admin (or any user in the base.group_erp_manager) choose, for each sale order,
+which users will be able to access and see it. Any other user won't be able
+to see it.
+If no users are set, the sale order has normal permissions.
+The field to set allowed users will be visibile only to admin, which makes it
+possible to make the users unaware of this feature.
+""",
+    'author': 'Leonardo Donelli @ Creativi Quadrati',
+    'depends': ['sale'],
+    'data': [
+        'sale_view.xml',
+        'security/hide_sale_orders_security.xml',
+    ],
+    'installable': True,
+    'auto_install': False,
+}

--- a/sale_order_authorized_users/__openerp__.py
+++ b/sale_order_authorized_users/__openerp__.py
@@ -42,8 +42,8 @@ that it's not his, even if he's selected as allowed.
 On the other hand, by setting some users as allowed, all other
 users, even if they are "See all leads", won't be able to see the order.
 
-*When you add allowed users to a sale order you should include yourself, or you
-won't be able to access it anymore!*
+*When you add allowed users to a sale order, unless you're connected as admin,
+you must include yourself, or you won't be able make the change!*
 
 If no users are set (the default), all users are considered as allowed,
 so the sale order follows the "normal" access rules with no additional

--- a/sale_order_authorized_users/__openerp__.py
+++ b/sale_order_authorized_users/__openerp__.py
@@ -37,10 +37,14 @@ The field to set allowed users will be visibile only to admin, which makes it
 possible to make the users unaware of this feature.
 """,
     'author': 'Creativi Quadrati',
+    'website': 'http://www.creativiquadrati.it',
     'depends': ['sale'],
     'data': [
         'sale_view.xml',
         'security/hide_sale_orders_security.xml',
+    ],
+    'test': [
+        'test/sale_order.yml',
     ],
     'installable': True,
     'auto_install': False,

--- a/sale_order_authorized_users/__openerp__.py
+++ b/sale_order_authorized_users/__openerp__.py
@@ -36,8 +36,8 @@ selected users.
 Details
 -------
 This acts as an **additional restriction**, access rules are still considered:
-for example, an user in the "Own leads only" group won't be able to see an order
-that it's not his, even if he's selected as allowed.
+for example, an user in the "Own leads only" group won't be able to see
+an order that it's not his, even if he's selected as allowed.
 
 On the other hand, by setting some users as allowed, all other
 users, even if they are "See all leads", won't be able to see the order.

--- a/sale_order_authorized_users/__openerp__.py
+++ b/sale_order_authorized_users/__openerp__.py
@@ -27,14 +27,27 @@
     'summary': 'Sale orders, Security, Permissions, Users',
     'description': """
 Sale Order Authorized Users
-======================================
+===========================
+This module allows you to implement "secret" sale orders.
+Users in the 'Sale / Secret orders' group will see a new field on sale orders,
+"Allowed Users", that can be used to restrict access to that sale order to
+selected users.
 
-Let Admin (or any user in the base.group_erp_manager) choose,
-for each sale order, which users will be able to access and see it.
-Any other user won't be able to see it.
-If no users are set, the sale order has normal permissions.
-The field to set allowed users will be visibile only to admin, which makes it
-possible to make the users unaware of this feature.
+Details
+-------
+This acts as an **additional restriction**, access rules are still considered:
+for example, an user in the "Own leads only" group won't be able to see an order
+that it's not his, even if he's selected as allowed.
+
+On the other hand, by setting some users as allowed, all other
+users, even if they are "See all leads", won't be able to see the order.
+
+*When you add allowed users to a sale order you should include yourself, or you
+won't be able to access it anymore!*
+
+If no users are set (the default), all users are considered as allowed,
+so the sale order follows the "normal" access rules with no additional
+restrictions.
 """,
     'author': 'Creativi Quadrati',
     'website': 'http://www.creativiquadrati.it',

--- a/sale_order_authorized_users/sale.py
+++ b/sale_order_authorized_users/sale.py
@@ -27,7 +27,7 @@ class sale_order(orm.Model):
         'allowed_users_ids': fields.many2many(
             'res.users',
             string='Allowed Users',
-            groups='base.group_erp_manager',
+            groups='base.group_sale_secret_orders',
             help=('Users that can see this order. If left empty, normal rules'
                   ' apply. If you want to make it invisible to everyone, add'
                   ' only yourself as allowed.'),

--- a/sale_order_authorized_users/sale.py
+++ b/sale_order_authorized_users/sale.py
@@ -26,10 +26,7 @@ class sale_order(orm.Model):
     _columns = {
         'allowed_users_ids': fields.many2many(
             'res.users',
-            'sale_order_res_users_rel',
-            'sale_order_id',
-            'user_id',
-            'Allowed Users',
+            string='Allowed Users',
             groups='base.group_erp_manager',
         ),
     }

--- a/sale_order_authorized_users/sale.py
+++ b/sale_order_authorized_users/sale.py
@@ -28,5 +28,8 @@ class sale_order(orm.Model):
             'res.users',
             string='Allowed Users',
             groups='base.group_erp_manager',
+            help=('Users that can see this order. If left empty, normal rules'
+                  ' apply. If you want to make it invisible to everyone, add'
+                  ' only yourself as allowed.'),
         ),
     }

--- a/sale_order_authorized_users/sale.py
+++ b/sale_order_authorized_users/sale.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Leonardo Donelli @ Creativi Quadrati
+#    Copyright 2014 Leonardo Donelli
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import orm, fields
+
+class sale_order(orm.Model):
+    _inherit = 'sale.order'
+
+    _columns = {
+        'allowed_users_ids': fields.many2many(
+            'res.users',
+            'sale_order_res_users_rel',
+            'sale_order_id',
+            'user_id',
+            'Allowed Users',
+            groups='base.group_erp_manager',
+        ),
+    }

--- a/sale_order_authorized_users/sale.py
+++ b/sale_order_authorized_users/sale.py
@@ -19,6 +19,7 @@
 ##############################################################################
 from openerp.osv import orm, fields
 
+
 class sale_order(orm.Model):
     _inherit = 'sale.order'
 

--- a/sale_order_authorized_users/sale_view.xml
+++ b/sale_order_authorized_users/sale_view.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0"?>
 <openerp>
-    <data>
+  <data>
 
-        <!-- Partners inherited form -->
-        <record id="view_order_form_allowed_users" model="ir.ui.view">
-            <field name="name">sale.order.form.allowed.users</field>
-            <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.view_order_form"/>
-            <field name="arch" type="xml">
-                <field name="client_order_ref" position="after">
-                    <field name="allowed_users_ids" widget="many2many_tags"/>
-                </field>
-            </field>
-        </record>
+    <!-- Partners inherited form -->
+    <record id="view_order_form_allowed_users" model="ir.ui.view">
+      <field name="name">sale.order.form.allowed.users</field>
+      <field name="model">sale.order</field>
+      <field name="inherit_id" ref="sale.view_order_form"/>
+      <field name="arch" type="xml">
+        <field name="client_order_ref" position="after">
+          <field name="allowed_users_ids" widget="many2many_tags"/>
+        </field>
+      </field>
+    </record>
 
-   </data>
+  </data>
 </openerp>

--- a/sale_order_authorized_users/sale_view.xml
+++ b/sale_order_authorized_users/sale_view.xml
@@ -2,7 +2,6 @@
 <openerp>
   <data>
 
-    <!-- Partners inherited form -->
     <record id="view_order_form_allowed_users" model="ir.ui.view">
       <field name="name">sale.order.form.allowed.users</field>
       <field name="model">sale.order</field>

--- a/sale_order_authorized_users/sale_view.xml
+++ b/sale_order_authorized_users/sale_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+        <!-- Partners inherited form -->
+        <record id="view_order_form_allowed_users" model="ir.ui.view">
+            <field name="name">sale.order.form.allowed.users</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form"/>
+            <field name="arch" type="xml">
+                <field name="client_order_ref" position="after">
+                    <field name="allowed_users_ids" widget="many2many_tags"/>
+                </field>
+            </field>
+        </record>
+
+   </data>
+</openerp>

--- a/sale_order_authorized_users/security/hide_sale_orders_security.xml
+++ b/sale_order_authorized_users/security/hide_sale_orders_security.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+	<data noupdate="0">
+
+		<record model="ir.rule" id="rule_hidden_orders">
+			<field name="name">Hidden orders</field>
+			<field name="model_id" ref="model_sale_order" />
+			<field name="global" eval="True" />
+			<field name="domain_force">['|',('allowed_users_ids','in',user.id),('allowed_users_ids','=',False)]</field>
+		</record>
+
+	</data>
+</openerp>

--- a/sale_order_authorized_users/security/hide_sale_orders_security.xml
+++ b/sale_order_authorized_users/security/hide_sale_orders_security.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-	<data noupdate="0">
+  <data noupdate="0">
 
-		<record model="ir.rule" id="rule_hidden_orders">
-			<field name="name">Hidden orders</field>
-			<field name="model_id" ref="model_sale_order" />
-			<field name="global" eval="True" />
-			<field name="domain_force">['|',('allowed_users_ids','in',user.id),('allowed_users_ids','=',False)]</field>
-		</record>
+    <record model="ir.rule" id="rule_hidden_orders">
+      <field name="name">Hidden orders</field>
+      <field name="model_id" ref="model_sale_order" />
+      <field name="global" eval="True" />
+      <field name="domain_force">['|',('allowed_users_ids','in',user.id),('allowed_users_ids','=',False)]</field>
+    </record>
 
-	</data>
+  </data>
 </openerp>

--- a/sale_order_authorized_users/security/hide_sale_orders_security.xml
+++ b/sale_order_authorized_users/security/hide_sale_orders_security.xml
@@ -5,6 +5,7 @@
     <record id="base.group_sale_secret_orders" model="res.groups">
         <field name="name">Secret orders</field>
         <field name="category_id" ref="base.module_category_sales_management"/>
+        <field name="implied_ids" eval="[(4, ref('base.group_sale_manager'))]"/>
         <field name="comment">the user will be able to hide sale orders to all users except the one explicitely allowed.</field>
     </record>
 

--- a/sale_order_authorized_users/security/hide_sale_orders_security.xml
+++ b/sale_order_authorized_users/security/hide_sale_orders_security.xml
@@ -2,6 +2,12 @@
 <openerp>
   <data noupdate="0">
 
+    <record id="base.group_sale_secret_orders" model="res.groups">
+        <field name="name">Secret orders</field>
+        <field name="category_id" ref="base.module_category_sales_management"/>
+        <field name="comment">the user will be able to hide sale orders to all users except the one explicitely allowed.</field>
+    </record>
+
     <record model="ir.rule" id="rule_hidden_orders">
       <field name="name">Hidden orders</field>
       <field name="model_id" ref="model_sale_order" />

--- a/sale_order_authorized_users/security/hide_sale_orders_security.xml
+++ b/sale_order_authorized_users/security/hide_sale_orders_security.xml
@@ -3,10 +3,10 @@
   <data noupdate="0">
 
     <record id="base.group_sale_secret_orders" model="res.groups">
-        <field name="name">Secret orders</field>
-        <field name="category_id" ref="base.module_category_sales_management"/>
-        <field name="implied_ids" eval="[(4, ref('base.group_sale_manager'))]"/>
-        <field name="comment">the user will be able to hide sale orders to all users except the one explicitely allowed.</field>
+      <field name="name">Secret orders</field>
+      <field name="category_id" ref="base.module_category_sales_management"/>
+      <field name="implied_ids" eval="[(4, ref('base.group_sale_manager'))]"/>
+      <field name="comment">the user will be able to hide sale orders to all users except the one explicitely allowed.</field>
     </record>
 
     <record model="ir.rule" id="rule_hidden_orders">

--- a/sale_order_authorized_users/security/hide_sale_orders_security.xml
+++ b/sale_order_authorized_users/security/hide_sale_orders_security.xml
@@ -9,5 +9,12 @@
       <field name="domain_force">['|',('allowed_users_ids','in',user.id),('allowed_users_ids','=',False)]</field>
     </record>
 
+    <record model="ir.rule" id="rule_hidden_order_lines">
+      <field name="name">Hidden order lines</field>
+      <field name="model_id" ref="sale.model_sale_order_line" />
+      <field name="global" eval="True" />
+      <field name="domain_force">['|',('order_id.allowed_users_ids','in',user.id),('order_id.allowed_users_ids','=',False)]</field>
+    </record>
+
   </data>
 </openerp>

--- a/sale_order_authorized_users/test/sale_order.yml
+++ b/sale_order_authorized_users/test/sale_order.yml
@@ -37,15 +37,28 @@
     allowed_users_ids:
      - res_users_illuminati
 -
+  And yet another one with no authorized users, standard rules should apply.
+-
+  !record {model: sale.order, id: sale_order_standard}:
+    partner_id: base.res_partner_2
+    order_line:
+      - name: "Standard sale order line"
+-
   Switch to Normal Employee
 -
   !context
     uid: 'res_users_normal_employee'
 -
-  I try to get the order I can see, I should be able to read it.
+  I try to get the order I'm authorized to, I should be able to read it.
 - 
   !python {model: sale.order} : |
     order = self.browse(cr, uid, ref('sale_order_normal'))
+    partner = order.partner_id
+-
+  Order without authorized_users, I should see it because I'm in see all leads
+-
+  !python {model: sale.order} : |
+    order = self.browse(cr, uid, ref('sale_order_standard'))
     partner = order.partner_id
 -
   Now I try to get the secret order, I shouldn't be able to read it.

--- a/sale_order_authorized_users/test/sale_order.yml
+++ b/sale_order_authorized_users/test/sale_order.yml
@@ -1,0 +1,68 @@
+-
+  I create two users, a normal one, and an Illuminati
+-
+  !record {model: res.users, id: res_users_normal_employee}:
+    company_id: base.main_company
+    name: Normal Employee
+    login: normal
+    password: normal
+    email: stockmanager@yourcompany.com
+    groups_id:
+      - base.group_sale_salesman_all_leads
+-
+  !record {model: res.users, id: res_users_illuminati}:
+    company_id: base.main_company
+    name: Member of Illuminati
+    login: illuminati
+    password: illuminati
+    email: illuminati1@illuminati.illuminati
+    groups_id:
+      - base.group_sale_salesman_all_leads
+-
+  I create a sale order accessible by normal
+-
+  !record {model: sale.order, id: sale_order_normal}:
+    partner_id: base.res_partner_2
+    order_line:
+      - name: "Product nobody cares about"
+    allowed_users_ids:
+      - res_users_normal_employee
+-
+  And another one not accessible by him
+-
+  !record {model: sale.order, id: sale_order_secret}:
+    partner_id: base.res_partner_2
+    order_line:
+      - name: "Super secret product"
+    allowed_users_ids:
+     - res_users_illuminati
+-
+  Switch to Normal Employee
+-
+  !context
+    uid: 'res_users_normal_employee'
+-
+  I try to get the order I can see, I should be able to read it.
+- 
+  !python {model: sale.order} : |
+    order = self.browse(cr, uid, ref('sale_order_normal'))
+    partner = order.partner_id
+-
+  Now I try to get the secret order, I shouldn't be able to read it.
+-
+  !python {model: sale.order} : |
+    from openerp.osv.orm import except_orm
+    order = self.browse(cr, uid, ref('sale_order_secret'))
+    try:
+      partner = order.partner_id
+      assert 1 == 0, "I should not be able to see the secret order!"
+    except except_orm:
+      pass
+-
+  Now I try to get the secret order lines, I shouldn't see any.
+-
+ !python {model: sale.order.line} : |
+   from openerp.osv.orm import except_orm
+   line_ids = self.search(cr, uid, [('order_id', '=', ref('sale_order_secret'))])
+   lines = self.browse(cr, uid, line_ids)
+   assert len(lines) == 0, "I see the secret order lines!"


### PR DESCRIPTION
Let Admin (or any user in the `base.group_erp_manager` group) choose, for each sale order,
which users will be able to access and see it. Any other user won't be able to see it.
If no users are set, the sale order has normal permissions.
The field to set allowed users will be visibile only to admin, which makes it
possible to make the users unaware of this feature.

Things that could be improved:
- Tests?
- create security rule also for `sale_order_line` if it's not automatic.

It's not 100% secure at the moment, but probably good enough for "normal" users.
