### PR TITLE
Prevent unnecessary writes on sales orders

### DIFF
--- a/sale_exceptions/sale.py
+++ b/sale_exceptions/sale.py
@@ -168,15 +168,16 @@ class sale_order(orm.Model):
         for order in self.browse(cr, uid, ids, context=context):
             if order.ignore_exceptions:
                 continue
+            current_exception_ids = set(exc.id for exc in order.exception_ids)
             exception_ids = self._detect_exceptions(cr, uid,
                                                     order,
                                                     order_exceptions,
                                                     line_exceptions,
                                                     context=context)
-
-            self.write(cr, uid, [order.id],
-                       {'exceptions_ids': [(6, 0, exception_ids)]},
-                       context=context)
+            if set(exception_ids) != current_exception_ids:
+                self.write(cr, uid, [order.id],
+                           {'exceptions_ids': [(6, 0, exception_ids)]},
+                           context=context)
         return exception_ids
 
     def _exception_rule_eval_context(

--- a/sale_exceptions/sale.py
+++ b/sale_exceptions/sale.py
@@ -168,7 +168,7 @@ class sale_order(orm.Model):
         for order in self.browse(cr, uid, ids, context=context):
             if order.ignore_exceptions:
                 continue
-            current_exception_ids = set(exc.id for exc in order.exception_ids)
+            current_exception_ids = set(exc.id for exc in order.exceptions_ids)
             exception_ids = self._detect_exceptions(cr, uid,
                                                     order,
                                                     order_exceptions,


### PR DESCRIPTION
When the exceptions are the same, do not write them again,
this prevent to write on sales orders when it is not necessary.
