### PR TITLE
[FIX] sale_delivery_term tests

### DIFF
--- a/sale_delivery_term/sale_demo.xml
+++ b/sale_delivery_term/sale_demo.xml
@@ -2,10 +2,22 @@
 <openerp>
     <data noupdate="1">
 
+        <!-- sale.delivery.term -->
         <record id="sale_delivery_term_1" model="sale.delivery.term">
             <field name="name">15 - 30</field>
-            <field name="line_ids" eval="[(0, 0,  {'quantity_perc': 0.5, 'delay': 15}),(0, 0,  {'quantity_perc': 0.5, 'delay': 30})]"/>
+            <field name="line_ids" eval="[]"/>
         </record>
         
+        <!-- sale.delivery.term.line -->
+        <record id="sale_delivery_term_line_1" model="sale.delivery.term.line">
+            <field name="quantity_perc">0.5</field>
+            <field name="delay">15</field>
+            <field name="term_id" ref="sale_delivery_term_1"></field>
+        </record>
+        <record id="sale_delivery_term_line_2" model="sale.delivery.term.line">
+            <field name="quantity_perc">0.5</field>
+            <field name="delay">30</field>
+            <field name="term_id" ref="sale_delivery_term_1"></field>
+        </record>
     </data>
 </openerp>

--- a/sale_delivery_term/sale_demo.xml
+++ b/sale_delivery_term/sale_demo.xml
@@ -5,7 +5,6 @@
         <!-- sale.delivery.term -->
         <record id="sale_delivery_term_1" model="sale.delivery.term">
             <field name="name">15 - 30</field>
-            <field name="line_ids" eval="[]"/>
         </record>
         
         <!-- sale.delivery.term.line -->


### PR DESCRIPTION
```
File "/home/travis/build/OCA/sale-workflow/sale_delivery_term/sale.py", line 241, in generate_detailed_lines
len(group_ids)))
except_orm: (u'Error', u'Delivery term lines are 4. Order line groups are 2. Please create more groups')
```

found at https://travis-ci.org/OCA/sale-workflow/jobs/32663504
because `[(0, 0, {'quantity_perc': 0.5, 'delay': 15}),(0, 0, {'quantity_perc': 0.5, 'delay': 30})]` run more than 1 time created more than 2 term lines
