### PR TITLE
Merge PO with sale_dropshipping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ virtualenv:
 
 before_install:
   - git clone https://github.com/OCA/product-attribute $HOME/product-attribute -b 7.0
-
+  - git clone https://github.com/OCA/purchase-workflow $HOME/purchase-workflow -b 7.0
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ virtualenv:
   system_site_packages: true
 
 before_install:
-  - git clone https://github.com/OCA/product-attribute $HOME/product-attribute -b 7.0
-  - git clone https://github.com/OCA/purchase-workflow $HOME/purchase-workflow -b 7.0
+  - git clone https://github.com/OCA/product-attribute $HOME/product-attribute -b ${VERSION}
+  - git clone https://github.com/OCA/purchase-workflow $HOME/purchase-workflow -b ${VERSION}
 
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ virtualenv:
 
 before_install:
   - git clone https://github.com/OCA/product-attribute $HOME/product-attribute -b 7.0
-  - git clone https://github.com/OCA/purchase-workflow $HOME/purchase-workflow -b 7.0
+
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ virtualenv:
 
 before_install:
   - git clone https://github.com/OCA/product-attribute $HOME/product-attribute -b 7.0
+  - git clone https://github.com/OCA/purchase-workflow $HOME/purchase-workflow -b 7.0
 
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools

--- a/sale_dropshipping/__openerp__.py
+++ b/sale_dropshipping/__openerp__.py
@@ -25,6 +25,7 @@
  "website": "http://www.openerp.com",
  "category": "Generic Modules/Purchase",
  "depends": ["purchase",
+             "purchase_group_hooks",
              "sale_stock"],
  "description": """
 Makes it better to deal with purchases with known sale schemes, specially the

--- a/sale_dropshipping/purchase.py
+++ b/sale_dropshipping/purchase.py
@@ -127,5 +127,5 @@ class purchase_order(orm.Model):
     def _initial_merged_order_data(self, order):
         """Populate the destination address in the merged order."""
         res = super(purchase_order, self)._initial_merged_order_data(order)
-        res['dest_address_id'] = order.dest_address_id
+        res['dest_address_id'] = order.dest_address_id and order.dest_address_id.id or False
         return res

--- a/sale_dropshipping/purchase.py
+++ b/sale_dropshipping/purchase.py
@@ -127,5 +127,5 @@ class purchase_order(orm.Model):
     def _initial_merged_order_data(self, order):
         """Populate the destination address in the merged order."""
         res = super(purchase_order, self)._initial_merged_order_data(order)
-        res['dest_address_id'] = order.dest_address_id and order.dest_address_id.id or False
+        res['dest_address_id'] = order.dest_address_id.id
         return res

--- a/sale_dropshipping/purchase.py
+++ b/sale_dropshipping/purchase.py
@@ -118,3 +118,8 @@ class purchase_order(orm.Model):
                          'sale_id': purchase.sale_id and purchase.sale_id.id},
                         context=context)
         return res
+
+    def _key_fields_for_grouping(self):
+        """Do not merge orders that have different destination addresses."""
+        field_list = super(purchase_order, self)._key_fields_for_grouping()
+        return field_list + ['dest_address_id']

--- a/sale_dropshipping/purchase.py
+++ b/sale_dropshipping/purchase.py
@@ -123,3 +123,9 @@ class purchase_order(orm.Model):
         """Do not merge orders that have different destination addresses."""
         field_list = super(purchase_order, self)._key_fields_for_grouping()
         return field_list + ['dest_address_id']
+
+    def _initial_merged_order_data(self, order):
+        """Populate the destination address in the merged order."""
+        res = super(purchase_order, self)._initial_merged_order_data(order)
+        res['dest_address_id'] = order.dest_address_id
+        return res

--- a/sale_dropshipping/purchase.py
+++ b/sale_dropshipping/purchase.py
@@ -122,7 +122,7 @@ class purchase_order(orm.Model):
     def _key_fields_for_grouping(self):
         """Do not merge orders that have different destination addresses."""
         field_list = super(purchase_order, self)._key_fields_for_grouping()
-        return field_list + ['dest_address_id']
+        return field_list + ('dest_address_id', )
 
     def _initial_merged_order_data(self, order):
         """Populate the destination address in the merged order."""

--- a/sale_dropshipping/tests/__init__.py
+++ b/sale_dropshipping/tests/__init__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Leonardo Pistone
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import test_merge_po
+
+checks = [
+    test_merge_po,
+]

--- a/sale_dropshipping/tests/test_merge_po.py
+++ b/sale_dropshipping/tests/test_merge_po.py
@@ -1,0 +1,35 @@
+from mock import Mock
+
+from openerp.tests.common import BaseCase
+from openerp.osv.orm import browse_record
+
+
+class TestGroupOrders(BaseCase):
+
+    def setUp(self):
+        super(TestGroupOrders, self).setUp()
+        self.order1 = Mock()
+        self.order2 = Mock()
+        # I have to use the registry to get an instance of a model. I cannot
+        # use the class constructor because that is modified to return nothing.
+        self.po = self.registry('purchase.order')
+
+    def test_two_orders_different_destination_addresses(self):
+        """Orders with the same partner, location, pricelist, but different
+        destination addresses should not be merged.
+
+        We do not care about the order lines here.
+        """
+        self.order1.partner_id = self.order2.partner_id = Mock(
+            spec=browse_record, id=1)
+        self.order1.location_id = self.order2.location_id = Mock(
+            spec=browse_record, id=2)
+        self.order1.pricelist_id = self.order2.pricelist_id = Mock(
+            spec=browse_record, id=3)
+        self.order1.order_line = self.order2.order_line = []
+
+        self.order1.dest_address_id = Mock(spec=browse_record, id=5)
+        self.order2.dest_address_id = Mock(spec=browse_record, id=6)
+
+        grouped = self.po._group_orders([self.order1, self.order2])
+        self.assertEqual(grouped, {}, u'These orders should not be merged')


### PR DESCRIPTION
Updates on sale_dropshipping to :

do not merge orders with different destination addresses
populate the destination address when merging two purchase orders
Original Launchpad MP : https://code.launchpad.net/~camptocamp/sale-wkfl/7.0-dropshipping-merge-po-lep/+merge/216756

PR rewrited from https://github.com/OCA/sale-workflow/pull/25
