### PR TITLE
[FIX] module 'sale_line_description'

### DIFF
--- a/sale_line_description/__openerp__.py
+++ b/sale_line_description/__openerp__.py
@@ -21,12 +21,13 @@
 #
 {
     'name': "Sale line description",
-    'version': '0.1',
+    'version': '1.0',
     'category': 'Sales Management',
     'description': """
-This module allows to use only the product description on the sale order lines.
-To do so, the user has to belong to group_use_product_description_per_so_line.
-This is possible by selecting the related option in the following menu:
+This module allows to use only the product sale description on the sale order
+lines. To do so, the user has to belong to
+group_use_product_description_per_so_line. This is possible by selecting the
+related option in the following menu:
 
 Settings --> Configuration --> Sale --> Sale Features
     """,

--- a/sale_line_description/sale.py
+++ b/sale_line_description/sale.py
@@ -46,7 +46,7 @@ class sale_order_line(orm.Model):
                 cr, uid, 'sale_line_description',
                 'group_use_product_description_per_so_line'
             )
-            if ref and len(ref) > 1 and ref[1] and if not flag:
+            if ref and len(ref) > 1 and ref[1] and not flag:
                 group_id = ref[1]
                 if group_id in user_groups:
                     product_obj = self.pool.get('product.product')

--- a/sale_line_description/sale.py
+++ b/sale_line_description/sale.py
@@ -57,5 +57,5 @@ class sale_order_line(orm.Model):
                         and product.description
                         and 'value' in res
                     ):
-                        res['value']['name'] = product.description
+                        res['value']['name'] = product.description_sale
         return res

--- a/sale_line_description/sale.py
+++ b/sale_line_description/sale.py
@@ -46,7 +46,7 @@ class sale_order_line(orm.Model):
                 cr, uid, 'sale_line_description',
                 'group_use_product_description_per_so_line'
             )
-            if ref and len(ref) > 1 and ref[1]:
+            if ref and len(ref) > 1 and ref[1] and if not flag:
                 group_id = ref[1]
                 if group_id in user_groups:
                     product_obj = self.pool.get('product.product')


### PR DESCRIPTION
This PR contains the following changes about the module **sale_line_description**:
- replaced **description** by **description_sale** because the latter is that used in the sale order;
- got the change of the line sale description flag-aware
