### PR TITLE
fix error when >1 draft SO are checked

### DIFF
--- a/sale_exceptions/sale.py
+++ b/sale_exceptions/sale.py
@@ -122,8 +122,9 @@ class SaleOrder(models.Model):
         }
         return action
 
-    @api.one
+    @api.multi
     def action_button_confirm(self):
+        self.ensure_one()
         if self.detect_exceptions():
             return self._popup_exceptions()
         else:
@@ -192,9 +193,10 @@ class SaleOrder(models.Model):
                   'rule:\n %s \n(%s)') % (rule.name, e))
         return space.get('failed', False)
 
-    @api.one
+    @api.multi
     def _detect_exceptions(self, order_exceptions,
                            line_exceptions):
+        self.ensure_one()
         exception_ids = []
         for rule in order_exceptions:
             if self._rule_eval(rule, 'order', self):

--- a/sale_exceptions/sale.py
+++ b/sale_exceptions/sale.py
@@ -210,7 +210,6 @@ class SaleOrder(models.Model):
                     exception_ids.append(rule.id)
         return exception_ids
 
-
     @api.one
     def copy(self, default=None):
         if default is None:


### PR DESCRIPTION
when the wizard would run, then the @api.multi method `detect_exceptions` would
fail because it returns an attribute but it is called on a recordset of size >1

Code refactoring to:
- move the side effect of writing to so.exception_ids one method up
- document the side effect in the docstring
- fix the computation of the return value for the `detect_exceptions` method
