### PR TITLE
fix mutable object as method arg default value

### DIFF
--- a/sale_condition_text/sale_order.py
+++ b/sale_condition_text/sale_order.py
@@ -27,7 +27,7 @@ class SaleOrder(osv.osv):
 
     def action_invoice_create(
         self, cursor, user, order_id, grouped=False,
-        states=['confirmed', 'done', 'exception'], date_inv=False, context=None
+        states=None, date_inv=False, context=None
     ):
         # function is design to return only one id
         invoice_obj = self.pool.get('account.invoice')


### PR DESCRIPTION
use `states=None` in `sale_order.action_invoice_create()` which is interpreted in
the parent class implementation as meaning `['confirmed', 'done', 'exception']`
