### PR TITLE
[FIX] sale_dropshipping: set right dest_address_id

### DIFF
--- a/sale_dropshipping/purchase.py
+++ b/sale_dropshipping/purchase.py
@@ -63,9 +63,8 @@ class purchase_order(orm.Model):
             if sale_flow in ('direct_delivery', 'direct_invoice_and_delivery'):
                 partner = partner_obj.browse(cr, uid, partner_id,
                                              context=context)
-                address = partner.address_get(['delivery'])['delivery']
                 vals = {'location_id': partner.property_stock_customer.id,
-                        'dest_address_id': address}
+                        'dest_address_id': sale.partner_shipping_id.id}
                 if sale_flow == 'direct_delivery':
                     vals['invoice_method'] = 'order'
                 else:


### PR DESCRIPTION
to populate dest_address_id on PO,
select partner_shipping_id on sale instead of partner's delivery contact.
in this way, shipping address will be correct in the two cases :
- standard case
- case when group_sale_delivery_address option is activated
