### PR TITLE
fix future exception for dropshipping

### DIFF
--- a/sale_exception_nostock/__openerp__.py
+++ b/sale_exception_nostock/__openerp__.py
@@ -19,7 +19,7 @@
 #
 #
 {'name': 'Sale stock exception',
- 'version': '1.0',
+ 'version': '1.1',
  'author': 'Camptocamp',
  'maintainer': 'Camptocamp',
  'category': 'sale',

--- a/sale_exception_nostock/model/sale.py
+++ b/sale_exception_nostock/model/sale.py
@@ -219,7 +219,7 @@ class SaleOrderLine(models.Model):
 
         if location.usage != 'internal':
             # for example, in the case of drop shipping, we skip the check
-            return True
+            return False
 
         ctx = {
             'compute_child': True,

--- a/sale_exception_nostock/tests/__init__.py
+++ b/sale_exception_nostock/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_dropshipping_skip_check

--- a/sale_exception_nostock/tests/test_dropshipping_skip_check.py
+++ b/sale_exception_nostock/tests/test_dropshipping_skip_check.py
@@ -1,0 +1,25 @@
+#    Author: Leonardo Pistone
+#    Copyright 2014 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from openerp.tests.common import TransactionCase
+
+
+class TestDropshippingSkipCheck(TransactionCase):
+    def test_dropshipping_sale_can_always_be_delivered(self):
+        source_loc = self.env['stock.location'].new({'usage': 'supplier'})
+        order_line = self.env['sale.order.line'].new()
+        order_line._get_line_location = lambda: source_loc
+
+        self.assertIs(True, order_line.can_command_at_delivery_date())

--- a/sale_exception_nostock/tests/test_dropshipping_skip_check.py
+++ b/sale_exception_nostock/tests/test_dropshipping_skip_check.py
@@ -23,3 +23,10 @@ class TestDropshippingSkipCheck(TransactionCase):
         order_line._get_line_location = lambda: source_loc
 
         self.assertIs(True, order_line.can_command_at_delivery_date())
+
+    def test_dropshipping_sale_does_not_affect_future_orders(self):
+        source_loc = self.env['stock.location'].new({'usage': 'supplier'})
+        order_line = self.env['sale.order.line'].new()
+        order_line._get_line_location = lambda: source_loc
+
+        self.assertIs(False, order_line.future_orders_are_affected())

--- a/sale_exception_nostock/tests/test_dropshipping_skip_check.py
+++ b/sale_exception_nostock/tests/test_dropshipping_skip_check.py
@@ -17,15 +17,20 @@ from openerp.tests.common import TransactionCase
 
 
 class TestDropshippingSkipCheck(TransactionCase):
-    def test_dropshipping_sale_can_always_be_delivered(self):
-        self.assertIs(True, self.order_line.can_command_at_delivery_date())
-
-    def test_dropshipping_sale_does_not_affect_future_orders(self):
-        self.assertIs(False, self.order_line.future_orders_are_affected())
-
     def setUp(self):
+        """Set up an dropshipping sale order line.
+
+        To do that, mock the computed source location to be a supplier.
+
+        """
         super(TestDropshippingSkipCheck, self).setUp()
 
         source_loc = self.env['stock.location'].new({'usage': 'supplier'})
         self.order_line = self.env['sale.order.line'].new()
         self.order_line._get_line_location = lambda: source_loc
+
+    def test_dropshipping_sale_can_always_be_delivered(self):
+        self.assertIs(True, self.order_line.can_command_at_delivery_date())
+
+    def test_dropshipping_sale_does_not_affect_future_orders(self):
+        self.assertIs(False, self.order_line.future_orders_are_affected())

--- a/sale_exception_nostock/tests/test_dropshipping_skip_check.py
+++ b/sale_exception_nostock/tests/test_dropshipping_skip_check.py
@@ -18,15 +18,14 @@ from openerp.tests.common import TransactionCase
 
 class TestDropshippingSkipCheck(TransactionCase):
     def test_dropshipping_sale_can_always_be_delivered(self):
-        source_loc = self.env['stock.location'].new({'usage': 'supplier'})
-        order_line = self.env['sale.order.line'].new()
-        order_line._get_line_location = lambda: source_loc
-
-        self.assertIs(True, order_line.can_command_at_delivery_date())
+        self.assertIs(True, self.order_line.can_command_at_delivery_date())
 
     def test_dropshipping_sale_does_not_affect_future_orders(self):
-        source_loc = self.env['stock.location'].new({'usage': 'supplier'})
-        order_line = self.env['sale.order.line'].new()
-        order_line._get_line_location = lambda: source_loc
+        self.assertIs(False, self.order_line.future_orders_are_affected())
 
-        self.assertIs(False, order_line.future_orders_are_affected())
+    def setUp(self):
+        super(TestDropshippingSkipCheck, self).setUp()
+
+        source_loc = self.env['stock.location'].new({'usage': 'supplier'})
+        self.order_line = self.env['sale.order.line'].new()
+        self.order_line._get_line_location = lambda: source_loc


### PR DESCRIPTION
In a previous commit by yours truly, I disabled the stock-based checks
in dropshipping situations, as was suggested in #47.

The idea was correct, but the method future_orders_are_affected needs to
return False to skip the check (it means that future orders are _not_
affected, and we are cool).
