### PR TITLE
8.0 : Add module sale_partner_order_policy

### DIFF
--- a/sale_partner_order_policy/__init__.py
+++ b/sale_partner_order_policy/__init__.py
@@ -1,0 +1,24 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Sale Partner Order Policy for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import partner
+from . import sale

--- a/sale_partner_order_policy/__openerp__.py
+++ b/sale_partner_order_policy/__openerp__.py
@@ -1,0 +1,48 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Sale Partner Order Policy module for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com).
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Sale Partner Order Policy',
+    'version': '1.0',
+    'category': 'Sales Management',
+    'license': 'AGPL-3',
+    'summary': "Adds customer create invoice method on partner form",
+    'description': """
+This module adds a new field on the partner form in the *Accouting* tab:
+*Customer Create Invoice*. The value of this field will be used when you
+create a new Sale Order with this partner as customer.
+
+Beware that this module depends not only on *sale*, but also on *stock*.
+As there is only one create invoice method when the *stock* module is not
+installed, you should not install this module if the *stock* module is not
+installed.
+
+This module has been written by Alexis de Lattre
+<alexis.delattre@akretion.com>
+    """,
+    'author': 'Akretion',
+    'website': 'http://www.akretion.com',
+    'depends': ['sale_stock'],
+    'data': ['partner_view.xml'],
+    'demo': ['partner_demo.xml'],
+    'installable': True,
+}

--- a/sale_partner_order_policy/i18n/fr.po
+++ b/sale_partner_order_policy/i18n/fr.po
@@ -1,0 +1,52 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_partner_order_policy
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-19 09:23+0000\n"
+"PO-Revision-Date: 2014-11-19 09:23+0000\n"
+"Last-Translator: Alexis de Lattre <alexis.delattre@akretion.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_partner_order_policy
+#: selection:res.partner,customer_order_policy:0
+msgid "Before Delivery"
+msgstr "Avant Livraison"
+
+#. module: sale_partner_order_policy
+#: field:res.partner,customer_order_policy:0
+msgid "Customer Create Invoice"
+msgstr "Méthode de facturation client"
+
+#. module: sale_partner_order_policy
+#: selection:res.partner,customer_order_policy:0
+msgid "On Delivery Order"
+msgstr "Sur le bon de livraison"
+
+#. module: sale_partner_order_policy
+#: selection:res.partner,customer_order_policy:0
+msgid "On Demand"
+msgstr "À la demande"
+
+#. module: sale_partner_order_policy
+#: model:ir.model,name:sale_partner_order_policy.model_res_partner
+msgid "Partner"
+msgstr "Partenaire"
+
+#. module: sale_partner_order_policy
+#: model:ir.model,name:sale_partner_order_policy.model_sale_order
+msgid "Sales Order"
+msgstr "Commande de ventes"
+
+#. module: sale_partner_order_policy
+#: help:res.partner,customer_order_policy:0
+msgid "Select the default create invoice method for the sale orders of this customer"
+msgstr "Selectionnez la méthode de création de facture qui sera utilisée par défaut pour les bons de commande de ce client"
+

--- a/sale_partner_order_policy/i18n/sale_partner_order_policy.pot
+++ b/sale_partner_order_policy/i18n/sale_partner_order_policy.pot
@@ -1,0 +1,52 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_partner_order_policy
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-11-19 09:22+0000\n"
+"PO-Revision-Date: 2014-11-19 09:22+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_partner_order_policy
+#: selection:res.partner,customer_order_policy:0
+msgid "Before Delivery"
+msgstr ""
+
+#. module: sale_partner_order_policy
+#: field:res.partner,customer_order_policy:0
+msgid "Customer Create Invoice"
+msgstr ""
+
+#. module: sale_partner_order_policy
+#: selection:res.partner,customer_order_policy:0
+msgid "On Delivery Order"
+msgstr ""
+
+#. module: sale_partner_order_policy
+#: selection:res.partner,customer_order_policy:0
+msgid "On Demand"
+msgstr ""
+
+#. module: sale_partner_order_policy
+#: model:ir.model,name:sale_partner_order_policy.model_res_partner
+msgid "Partner"
+msgstr ""
+
+#. module: sale_partner_order_policy
+#: model:ir.model,name:sale_partner_order_policy.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: sale_partner_order_policy
+#: help:res.partner,customer_order_policy:0
+msgid "Select the default create invoice method for the sale orders of this customer"
+msgstr ""
+

--- a/sale_partner_order_policy/partner.py
+++ b/sale_partner_order_policy/partner.py
@@ -1,0 +1,42 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Sale Partner Order Policy for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields, api
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    customer_order_policy = fields.Selection([
+        ('manual', 'On Demand'),
+        ('picking', 'On Delivery Order'),
+        ('prepaid', 'Before Delivery')
+        ],
+        string='Customer Create Invoice', company_dependent=True,
+        help='Select the default create invoice method for the sale orders '
+        'of this customer')
+
+    @api.model
+    def _commercial_fields(self):
+        res = super(ResPartner, self)._commercial_fields()
+        res += ['customer_order_policy']
+        return res

--- a/sale_partner_order_policy/partner_demo.xml
+++ b/sale_partner_order_policy/partner_demo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright (C) 2014 Akretion (http://www.akretion.com/)
+    @author Alexis de Lattre <alexis.delattre@akretion.com>
+    The licence is in the file __openerp__.py
+-->
+
+<openerp>
+<data noupdate="1">
+
+
+<record id="base.res_partner_2" model="res.partner"> <!-- Agrolait -->
+    <field name="customer_order_policy">picking</field>
+</record>
+
+<record id="base.res_partner_5" model="res.partner"> <!-- EPIC -->
+    <field name="customer_order_policy">prepaid</field>
+</record>
+
+<record id="base.res_partner_8" model="res.partner"> <!-- Mediapole -->
+    <field name="customer_order_policy">picking</field>
+</record>
+
+<record id="base.res_partner_12" model="res.partner"> <!-- C2C -->
+    <field name="customer_order_policy">manual</field>
+</record>
+
+<record id="base.res_partner_23" model="res.partner"> <!-- Vauxoo -->
+    <field name="customer_order_policy">manual</field>
+</record>
+
+
+</data>
+</openerp>

--- a/sale_partner_order_policy/partner_view.xml
+++ b/sale_partner_order_policy/partner_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright (C) 2014 Akretion (http://www.akretion.com/)
+    @author Alexis de Lattre <alexis.delattre@akretion.com>
+    The licence is in the file __openerp__.py
+-->
+
+<openerp>
+<data>
+
+
+<record id="view_partner_property_form" model="ir.ui.view">
+    <field name="name">sale_partner_order_policy.partner_form</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="account.view_partner_property_form"/>
+    <field name="arch" type="xml">
+        <field name="property_payment_term" position="after">
+            <field name="customer_order_policy"/>
+        </field>
+    </field>
+</record>
+
+
+</data>
+</openerp>

--- a/sale_partner_order_policy/sale.py
+++ b/sale_partner_order_policy/sale.py
@@ -1,0 +1,37 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Sale Partner Order Policy for Odoo
+#    Copyright (C) 2014 Akretion (http://www.akretion.com)
+#    @author Alexis de Lattre <alexis.delattre@akretion.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, api
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.multi
+    def onchange_partner_id(self, partner_id):
+        res = super(SaleOrder, self).onchange_partner_id(partner_id)
+        if partner_id:
+            partner = self.env['res.partner'].browse(partner_id)
+            if partner.customer_order_policy:
+                res['value']['order_policy'] = \
+                    partner.customer_order_policy
+        return res


### PR DESCRIPTION
This module is the "twin" of the module purchase_partner_invoice_method that was merged yesterday in OCA/purchase-workflow. I promised that if the module purchase_partner_invoice_method was merged in OCA/purchase-workflow, then I would develop the equivalent module for sale. Here it is !
