### PR TITLE
[7.0] [ADD] sale order amount shipped

### DIFF
--- a/sale_order_amount_shipped/__init__.py
+++ b/sale_order_amount_shipped/__init__.py
@@ -1,0 +1,25 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import (
+    sale_order,
+)

--- a/sale_order_amount_shipped/__openerp__.py
+++ b/sale_order_amount_shipped/__openerp__.py
@@ -36,7 +36,7 @@ Sale Order Amount Shipped
 This module adds a field "amount_shipped" on sale orders and displays
 it in the tree view. The field is calculated as
    to ship = (total - sum(total_amount for each invoice_id))
-based on 'draft', 'proformat', 'open' and 'done' invoices.
+based on 'draft', 'proformat', 'open' and 'paid' invoices.
 
 Contributors
 ------------

--- a/sale_order_amount_shipped/__openerp__.py
+++ b/sale_order_amount_shipped/__openerp__.py
@@ -1,0 +1,58 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Sale Order Amount Shipped',
+    'version': '0.1',
+    'author': 'Savoir-faire Linux',
+    'maintainer': 'Savoir-faire Linux',
+    'website': 'http://www.savoirfairelinux.com',
+    'license': 'AGPL-3',
+    'category': 'Sale',
+    'summary': 'Show amount left to ship in sale order tree',
+    'description': """
+Sale Order Amount Shipped
+=========================
+
+This module adds a field "amount_shipped" on sale orders and displays
+it in the tree view. The field is calculated as
+   to ship = (total - sum(total_amount for each invoice_id))
+based on 'draft', 'proformat', 'open' and 'done' invoices.
+
+Contributors
+------------
+* El Hadji Dem (elhadji.dem@savoirfairelinux.com)
+""",
+    'depends': [
+        'sale_order_amount_to_invoice',
+    ],
+    'external_dependencies': {
+        'python': [],
+    },
+    'data': [
+        'sale_order_view.xml',
+    ],
+    'demo': [],
+    'test': [],
+    'installable': True,
+    'auto_install': False,
+}

--- a/sale_order_amount_shipped/sale_order.py
+++ b/sale_order_amount_shipped/sale_order.py
@@ -33,7 +33,7 @@ class SaleOrder(orm.Model):
             invoiced_amount = sum(
                 invoice.amount_total
                 for invoice in sale.invoice_ids
-                if invoice.state in ('draft', 'proformat', 'open', 'done')
+                if invoice.state in ('draft', 'proformat', 'open', 'paid')
             )
             res[sale.id] = max(0.0, sale.amount_total - invoiced_amount)
         return res

--- a/sale_order_amount_shipped/sale_order.py
+++ b/sale_order_amount_shipped/sale_order.py
@@ -1,0 +1,71 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import fields, orm
+
+
+class SaleOrder(orm.Model):
+    _name = 'sale.order'
+    _inherit = 'sale.order'
+
+    def _amount_shipped(self, cursor, user, ids, name, arg, context=None):
+        res = {}
+        for sale in self.browse(cursor, user, ids, context=context):
+            invoiced_amount = sum(
+                invoice.amount_total
+                for invoice in sale.invoice_ids
+                if invoice.state in ('draft', 'proformat', 'open', 'done')
+            )
+            res[sale.id] = max(0.0, sale.amount_total - invoiced_amount)
+        return res
+
+    def _amount_shipped_search(self, cr, uid, obj, name, args, context=None):
+        """Amount shipped filter"""
+
+        if context is None:
+            context = {}
+
+        amount_shipped = None
+
+        for arg in args:
+            if arg[0] == 'amount_shipped':
+                amount_shipped = arg[2]
+                break
+
+        if amount_shipped is not None:
+            super_search = super(SaleOrder, self).search
+            all_ids = super_search(cr, uid, [],
+                                   context=context)
+            search_ids = []
+
+            for sale in self.browse(cr, uid, all_ids, context=context):
+                if sale.amount_shipped != 0.00:
+                    search_ids.append(sale.id)
+            return [('id', 'in', search_ids)]
+
+        return []
+
+    _columns = {
+        'amount_shipped': fields.function(
+            _amount_shipped, fnct_search=_amount_shipped_search,
+            string='Amount Shipped', type='float'),
+    }

--- a/sale_order_amount_shipped/sale_order_view.xml
+++ b/sale_order_amount_shipped/sale_order_view.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record id="view_amount_shipped_order_tree" model="ir.ui.view">
+      <field name="name">sale.order.amount.shipped.tree</field>
+      <field name="model">sale.order</field>
+      <field name="inherit_id" ref="sale_order_amount_to_invoice.view_order_tree" />
+      <field name="arch" type="xml">
+        <field name="amount_to_invoice" position="after">
+          <field name="amount_shipped" />
+        </field>
+      </field>
+    </record>
+
+
+
+    <!--Add filter for amount_shipped-->
+    <record id="view_sales_order_filter_amount_shipped" model="ir.ui.view">
+      <field name="name">view.sales.order.filter.amount.shipped</field>
+      <field name="inherit_id" ref="sale_order_amount_to_invoice.view_sales_order_filter_amount_to_invoice" />
+      <field name="model">sale.order</field>
+      <field name="arch" type="xml">
+        <data>
+          <filter string="Amount to invoice &gt; 0" position="after">
+            <filter icon="terp-dolar_ok!"
+                    string="Amount shipped &gt; 0"
+                    domain="[('amount_shipped','>', 0)]"/>
+          </filter>
+        </data>
+      </field>
+    </record>
+
+  </data>
+</openerp>


### PR DESCRIPTION
This module adds a field "amount_shipped" on sale orders and displays
it in the tree view. The field is calculated as
 to ship = (total - sum(total_amount for each invoice_id))
based on 'draft', 'proformat', 'open' and 'paid' invoices.
