### PR TITLE
[IMP] the exception should be also visible in the quotation

### DIFF
--- a/sale_exceptions/sale_view.xml
+++ b/sale_exceptions/sale_view.xml
@@ -89,6 +89,17 @@
             </field>
         </record>
 
+        <record id="view_quotation_tree" model="ir.ui.view">
+            <field name="name">sale_exceptions.view_quotation_tree</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_quotation_tree"/>
+            <field name="arch" type="xml">
+                <field name="state" position="after">
+                    <field name="main_exception_id"/>
+                </field>
+            </field>
+        </record>
+
         <record id="view_sales_order_filter" model="ir.ui.view">
             <field name="name">sale_exceptions.view_sales_order_filter</field>
             <field name="model">sale.order</field>


### PR DESCRIPTION
The main exception field was missing in the tree view. Now it's fixed ;)
