### PR TITLE
split build because of incompatible tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ python:
 env:
   - VERSION="8.0" ODOO_REPO="odoo/odoo" EXCLUDE="sale_quotation_sourcing,sale_sourced_by_line"
   - VERSION="8.0" ODOO_REPO="OCA/OCB" EXCLUDE="sale_quotation_sourcing,sale_sourced_by_line"
-  - VERSION="8.0" ODOO_REPO="odoo/odoo" INCLUDE="sale_quotation_sourcing,sale_sourced_by_line"
-  - VERSION="8.0" ODOO_REPO="OCA/OCB" INCLUDE="sale_quotation_sourcing,sale_sourced_by_line"
+  - VERSION="8.0" ODOO_REPO="odoo/odoo" INCLUDE="sale_sourced_by_line"
+  - VERSION="8.0" ODOO_REPO="OCA/OCB" INCLUDE="sale_sourced_by_line"
+  - VERSION="8.0" ODOO_REPO="odoo/odoo" INCLUDE="sale_quotation_sourcing"
+  - VERSION="8.0" ODOO_REPO="OCA/OCB" INCLUDE="sale_quotation_sourcing"
 
 virtualenv:
   system_site_packages: true


### PR DESCRIPTION
The modules are not incompatible in production. They are when running
tests. That is of course unfortunate and should be investigated further
(i.e. a module has no access to methods added in other modules, while
constraints created in XML data are, so the constraints crash).
