### PR TITLE
[7.0] [ADD] sale show addresses

### DIFF
--- a/sale_show_addresses/__init__.py
+++ b/sale_show_addresses/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import sale_order

--- a/sale_show_addresses/__openerp__.py
+++ b/sale_show_addresses/__openerp__.py
@@ -1,0 +1,54 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Sale Show Addresses',
+    'version': '0.1',
+    'author': 'Savoir-faire Linux',
+    'maintainer': 'Savoir-faire Linux',
+    'website': 'http://www.savoirfairelinux.com',
+    'license': 'AGPL-3',
+    'category': 'Sale',
+    'summary': 'Displays complete addresses on sale orders',
+    'description': """
+This module displays the complete addresses on the sales order before saving,
+so you don't have to open the partner form or save the sales order to check
+if you pick the right partner or address.
+
+Contributors
+------------
+* Vincent Vinet (vincent.vinet@savoirfairelinux.com)
+    """,
+    'depends': [
+        'sale',
+    ],
+    'external_dependencies': {
+        'python': [],
+    },
+    'data': [
+        'sale_view.xml',
+    ],
+    'demo': [],
+    'test': [],
+    'installable': True,
+    'auto_install': False,
+}

--- a/sale_show_addresses/sale_order.py
+++ b/sale_show_addresses/sale_order.py
@@ -1,0 +1,117 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import json
+from lxml import etree
+
+from openerp.tools.safe_eval import safe_eval
+from openerp.osv import orm, fields
+
+
+class SaleOrder(orm.Model):
+    _inherit = 'sale.order'
+
+    def _get_addresses(self, cr, uid, ids, field_names, arg, context=None):
+        partner_obj = self.pool['res.partner']
+        res = {}
+        for so in self.browse(cr, uid, ids, context=context):
+            res[so.id] = val = {
+                'ui_partner_address': '',
+                'ui_invoice_address': '',
+                'ui_deliver_address': '',
+            }
+
+            if so.partner_id:
+                val['ui_partner_address'] = partner_obj._display_address(
+                    cr, uid, so.partner_id, context=context)
+            if so.partner_invoice_id:
+                val['ui_invoice_address'] = partner_obj._display_address(
+                    cr, uid, so.partner_invoice_id, context=context)
+            if so.partner_shipping_id:
+                val['ui_deliver_address'] = partner_obj._display_address(
+                    cr, uid, so.partner_shipping_id, context=context)
+
+        return res
+
+    _columns = {
+        'ui_partner_address': fields.function(_get_addresses, method=True,
+                                              type='text', store=False,
+                                              multi='partner addresses'),
+        'ui_invoice_address': fields.function(_get_addresses, method=True,
+                                              type='text', store=False,
+                                              multi='partner addresses'),
+        'ui_deliver_address': fields.function(_get_addresses, method=True,
+                                              type='text', store=False,
+                                              multi='partner addresses'),
+    }
+
+    def fields_view_get(self, cr, uid, view_id=None, view_type='form',
+                        context=None, toolbar=False, submenu=False):
+        res = super(SaleOrder, self).fields_view_get(
+            cr, uid, view_id=view_id, view_type=view_type, context=context,
+            toolbar=toolbar, submenu=submenu)
+
+        if view_type == 'form':
+            arch = etree.fromstring(res['arch'])
+            for (ui, base, add_onchange) in [
+                    ('ui_partner_address', 'partner_id', False),
+                    ('ui_invoice_address', 'partner_invoice_id', True),
+                    ('ui_deliver_address', 'partner_shipping_id', True),
+            ]:
+                field = arch.xpath("//field[@name='{0}']".format(base))
+                if field and field[0].attrib['context']:
+                    field = field[0]
+                    context = safe_eval(field.attrib['context'])
+                    context.pop('show_address', None)
+                    field.attrib['context'] = json.dumps(context)
+                    field.attrib['on_change'] = (
+                        "onchange_partner_address('{0}', {1}, context)".format(
+                            ui, base))
+
+            res['arch'] = etree.tostring(arch)
+
+        return res
+
+    def onchange_partner_address(self, cr, uid, ids, ui_field, partner_id,
+                                 context=None):
+        res = {}
+        if partner_id:
+            partner_obj = self.pool['res.partner']
+            partner = partner_obj.browse(cr, uid, partner_id)
+            addr = partner_obj._display_address(cr, uid, partner,
+                                                context=context)
+            res['value'] = {ui_field: addr}
+        else:
+            res['value'] = {ui_field: ''}
+
+        return res
+
+    def onchange_partner_id(self, cr, uid, ids, part, context=None):
+        res = super(SaleOrder, self).onchange_partner_id(cr, uid, ids, part,
+                                                         context=context)
+
+        res.setdefault('value', {}).update(
+            self.onchange_partner_address(cr, uid, ids, 'ui_partner_address',
+                                          part, context=context)['value']
+        )
+
+        return res

--- a/sale_show_addresses/sale_order.py
+++ b/sale_show_addresses/sale_order.py
@@ -88,9 +88,10 @@ class SaleOrder(orm.Model):
                     context = safe_eval(field.attrib['context'])
                     context.pop('show_address', None)
                     field.attrib['context'] = json.dumps(context)
-                    field.attrib['on_change'] = (
-                        "onchange_partner_address('{0}', {1}, context)".format(
-                            ui, base))
+                    if add_onchange:
+                        field.attrib['on_change'] = (
+                            "onchange_partner_address('{0}', {1}, context)"
+                            .format(ui, base))
 
             res['arch'] = etree.tostring(arch)
 

--- a/sale_show_addresses/sale_order.py
+++ b/sale_show_addresses/sale_order.py
@@ -31,6 +31,7 @@ class SaleOrder(orm.Model):
     _inherit = 'sale.order'
 
     def _get_addresses(self, cr, uid, ids, field_names, arg, context=None):
+        """ Get formatted addresses for partner fields """
         partner_obj = self.pool['res.partner']
         res = {}
         for so in self.browse(cr, uid, ids, context=context):
@@ -66,6 +67,10 @@ class SaleOrder(orm.Model):
 
     def fields_view_get(self, cr, uid, view_id=None, view_type='form',
                         context=None, toolbar=False, submenu=False):
+        """ Overriden to:
+            - Remove 'show_address' from partner field contexts
+            - Add on_change on on partner_field contexts where applicable
+        """
         res = super(SaleOrder, self).fields_view_get(
             cr, uid, view_id=view_id, view_type=view_type, context=context,
             toolbar=toolbar, submenu=submenu)
@@ -93,6 +98,9 @@ class SaleOrder(orm.Model):
 
     def onchange_partner_address(self, cr, uid, ids, ui_field, partner_id,
                                  context=None):
+        """
+        on_change partner, write the address in the corresponding ui field
+        """
         res = {}
         if partner_id:
             partner_obj = self.pool['res.partner']
@@ -106,6 +114,9 @@ class SaleOrder(orm.Model):
         return res
 
     def onchange_partner_id(self, cr, uid, ids, part, context=None):
+        """
+        override onchange_partner_id, call super() and update ui field
+        """
         res = super(SaleOrder, self).onchange_partner_id(cr, uid, ids, part,
                                                          context=context)
 

--- a/sale_show_addresses/sale_view.xml
+++ b/sale_show_addresses/sale_view.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<openerp>
+  <data>
+    <record id="view_order_form" model="ir.ui.view">
+      <field name="name">Sale Order Form +addresses</field>
+      <field name="model">sale.order</field>
+      <field name="inherit_id" ref="sale.view_order_form" />
+      <field name="arch" type="xml">
+        <xpath expr="//field[@name='partner_id']" position="after">
+          <separator colspan="1" />
+          <field name="ui_partner_address" nolabel="1" />
+          <newline />
+        </xpath>
+
+        <xpath expr="//field[@name='partner_invoice_id']" position="after">
+          <separator colspan="1" />
+          <field name="ui_invoice_address" nolabel="1" />
+          <newline />
+        </xpath>
+
+        <xpath expr="//field[@name='partner_shipping_id']" position="after">
+          <separator colspan="1" />
+          <field name="ui_deliver_address" nolabel="1" />
+          <newline />
+        </xpath>
+      </field>
+    </record>
+  </data>
+</openerp>
+


### PR DESCRIPTION
This module changes the Sale Order UI so that the partner fields (partner, invoice, shipping) show
the address details in a separate field. This allows viewing the address details immediately when editing a new record.
