### PR TITLE
[7.0] sale_dropshipping: improve display on the sale view

### DIFF
--- a/sale_dropshipping/sale.py
+++ b/sale_dropshipping/sale.py
@@ -76,7 +76,7 @@ class sale_order_line(orm.Model):
 
         vals = {}
         if product_id:
-            if sale_flow == 'direct_delivery':
+            if sale_flow in ('direct_delivery', 'direct_invoice_and_delivery'):
                 vals['type'] = 'make_to_order'
             else:
                 product = self.pool['product.product'].browse(cr, uid,

--- a/sale_dropshipping/sale_view.xml
+++ b/sale_dropshipping/sale_view.xml
@@ -22,8 +22,10 @@
                 <field name="sale_flow" on_change="onchange_sale_flow(sale_flow, product_id, context)"/>
             </xpath>
             <xpath expr="/form/sheet//field[@name='order_line']/form//label[@for='name']" position="before">
-                <group attrs="{'invisible': [('type', '=', 'make_to_stock')]}" colspan="2" cols="2">
+                <group>
                     <field name="sale_flow" on_change="onchange_sale_flow(sale_flow, product_id, context)"/>
+                </group>
+                <group attrs="{'invisible': [('sale_flow', '=', 'normal')]}" colspan="2" cols="2">
                     <field name="purchase_order_line_id"/>
                     <field name="purchase_order_id" readonly="1"/>
                     <field name="purchase_order_state" readonly="1"/>


### PR DESCRIPTION
- The fields are hidden when they should not:
  It should be displayed even if the type if make_to_stock because the
  sale_flow 'direct_invoice' is a make_to_stock flow.
- 'Direct invoice' is a make_to_order delivery: This mode allows to use
  dropshipping for the delivery, but invoiced by us and not by the supplier. The
  onchange must change it to make_to_order to generate a supplier order.
