### PR TITLE
remove sourcing check on procurement validation

### DIFF
--- a/sale_quotation_sourcing/model/procurement.py
+++ b/sale_quotation_sourcing/model/procurement.py
@@ -19,8 +19,6 @@
 #
 from openerp import models, api, _
 
-from openerp import exceptions
-
 
 class ProcurementOrder(models.Model):
     _inherit = 'procurement.order'
@@ -44,21 +42,6 @@ class ProcurementOrder(models.Model):
 
             if sale_line and sale_line.manually_sourced:
                 po_line = sale_line.sourced_by
-
-                if po_line.order_id.location_id != procurement.location_id:
-                    raise exceptions.Warning(_(
-                        'The manually sourced Purchase Order has Destination '
-                        'location {}, while the Procurement was generated '
-                        'with destination {}. To solve the problem, please '
-                        'source a Sale Order Line with a Purchase Order '
-                        'consistent with the active Route. For example, if '
-                        'the active route is Drop Shipping, the chosen PO '
-                        'should have destination location Customers.'.format(
-                            po_line.order_id.location_id.name,
-                            procurement.location_id.name
-                        )
-                    ))
-
                 res[procurement.id] = po_line.id
                 procurement.purchase_line_id = po_line
                 procurement.message_post(body=_('Manually sourced'))


### PR DESCRIPTION
Supersedes #106.

This had two problems, and an attempt to fix did not work:
1. For MTO orders, this error in produced in background in the scheduler,
   and the error is not shown to the user. An exception blocks the
   scheduler completely in that case, and also breaks all subsequent
   runs.
2. With transit locations, the check fails because it compared "Customer"
   and "Transit". This situation is actually OK.

In an attempt to fix 1, I tried to raise the exception only when in
foreground and log an exception to the procurement otherwise. This
works, but in the MTO case the user does not see the problem and the
order is validated (so it is too late to change it).

In an attempt to fix 2, I changed the check to use the "final
destination" of the first move that generated the procurement. That
fixed the transit case, but broke the MTO case, where a BUY procurement
in Stock is chained to a MTO procurement in Customers.

There are already other consistency checks: the route of the sale order
line is changed automatically when a PO is chosen, and a sale exception
does a consistency check as well.

TL;DR: I am removing this check.
