### PR TITLE
sale_quotation_sourcing fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,14 @@ python:
 
 env:
   - VERSION="8.0" LINT_CHECK="1"
-  - VERSION="8.0" ODOO_REPO="odoo/odoo" EXCLUDE="sale_quotation_sourcing,sale_sourced_by_line" LINT_CHECK="0"
-  - VERSION="8.0" ODOO_REPO="OCA/OCB" EXCLUDE="sale_quotation_sourcing,sale_sourced_by_line" LINT_CHECK="0"
+  - VERSION="8.0" ODOO_REPO="odoo/odoo" EXCLUDE="sale_quotation_sourcing,sale_sourced_by_line,sale_quotation_sourcing_stock_route_transit" LINT_CHECK="0"
+  - VERSION="8.0" ODOO_REPO="OCA/OCB" EXCLUDE="sale_quotation_sourcing,sale_sourced_by_line,sale_quotation_sourcing_stock_route_transit" LINT_CHECK="0"
   - VERSION="8.0" ODOO_REPO="odoo/odoo" INCLUDE="sale_sourced_by_line" LINT_CHECK="0"
   - VERSION="8.0" ODOO_REPO="OCA/OCB" INCLUDE="sale_sourced_by_line" LINT_CHECK="0"
   - VERSION="8.0" ODOO_REPO="odoo/odoo" INCLUDE="sale_quotation_sourcing" LINT_CHECK="0"
   - VERSION="8.0" ODOO_REPO="OCA/OCB" INCLUDE="sale_quotation_sourcing" LINT_CHECK="0"
+  - VERSION="8.0" ODOO_REPO="odoo/odoo" INCLUDE="sale_quotation_sourcing_stock_route_transit" LINT_CHECK="0"
+  - VERSION="8.0" ODOO_REPO="OCA/OCB" INCLUDE="sale_quotation_sourcing_stock_route_transit" LINT_CHECK="0"
 
 virtualenv:
   system_site_packages: true

--- a/sale_quotation_sourcing/README.rst
+++ b/sale_quotation_sourcing/README.rst
@@ -1,0 +1,65 @@
+Sale Quotation Sourcing
+=======================
+
+Description
+===========
+
+This module implements manual sourcing of sale order lines from purchase
+order lines.
+
+Instead of having the confirmation of a SO generate procurements which in
+turn may generate a PO, we invert the process: in order to generate a quote
+for a customer, we ask quotes to different suppliers.
+
+Once the sale quotation is accepted by the customer and the user confirms
+it, a wizard is presented to choose which PO to use to source the SO lines.
+
+The process should mimic closely the way that Odoo handles a MTO, buy
+order. The only difference is that the PO is chosen manually and not
+automatically generated. The end result should be the same.
+
+To show that, two test cases are provided that show the standard process
+and the manually sourced one.
+
+The drop shipping case is handled as well, with a warning to check if the
+destination locations of the procurement and the sourced PO are consistent.
+In addition to that, when the user sources a sale line with a purchase
+line, the system tries to choose automatically an appropriate route (MTO or
+drophipping).
+
+This on_change method is the only place where the module stock_dropshipping
+is used, otherwise it contains little more than preconfigured Routes,
+Rules, and Picking Types. All other code and the tests do not use it.  That
+dependency can be easily removed later if it is needed to manually
+configure dropshipping and MTO routes.
+
+Note: the package nose is required to run the tests. It is not noted in the
+external dependencies since it is not required in production.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+* Yannick Vaucher <yannick.vaucher@camptocamp.com>
+* Leonardo Pistone <leonardo.pistone@camptocamp.com>
+* Joël Grand-Guillaume <joel.grandguillaume@camptocamp.com>
+* Nicolas Bessi <nicolas.bessi@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/sale_quotation_sourcing/__openerp__.py
+++ b/sale_quotation_sourcing/__openerp__.py
@@ -21,40 +21,6 @@
     'name': "Sale Quotation Sourcing",
 
     'summary': "manual sourcing of sale quotations",
-    'description': """
-    This module implements manual sourcing of sale order lines from purchase
-    order lines.
-
-    Instead of having the confirmation of a SO generate procurements which in
-    turn may generate a PO, we invert the process: in order to generate a quote
-    for a customer, we ask quotes to different suppliers.
-
-    Once the sale quotation is accepted by the customer and the user confirms
-    it, a wizard is presented to choose which PO to use to source the SO lines.
-
-    The process should mimic closely the way that Odoo handles a MTO, buy
-    order. The only difference is that the PO is chosen manually and not
-    automatically generated. The end result should be the same.
-
-    To show that, two test cases are provided that show the standard process
-    and the manually sourced one.
-
-    The drop shipping case is handled as well, with a warning to check if the
-    destination locations of the procurement and the sourced PO are consistent.
-    In addition to that, when the user sources a sale line with a purchase
-    line, the system tries to choose automatically an appropriate route (MTO or
-    drophipping).
-
-    This on_change method is the only place where the module stock_dropshipping
-    is used, otherwise it contains little more than preconfigured Routes,
-    Rules, and Picking Types. All other code and the tests do not use it.  That
-    dependency can be easily removed later if it is needed to manually
-    configure dropshipping and MTO routes.
-
-    Note: the package nose is required to run the tests. It is not noted in the
-    external dependencies since it is not required in production.
-
-    """,
 
     'author': "Camptocamp",
     'website': "http://www.camptocamp.com",

--- a/sale_quotation_sourcing/model/procurement.py
+++ b/sale_quotation_sourcing/model/procurement.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 #    Author: Alexandre Fayolle, Leonardo Pistone
-#    Copyright 2014 Camptocamp SA
+#    Copyright 2014-2015 Camptocamp SA
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -35,12 +35,13 @@ class ProcurementOrder(models.Model):
         res = {}
         to_propagate = self.browse()
         for procurement in self:
-
-            sale_line = (
-                procurement.sale_line_id or
-                procurement.move_dest_id.procurement_id.sale_line_id or
-                False
-            )
+            curr_proc = procurement
+            sale_line = False
+            while curr_proc:
+                if curr_proc.sale_line_id:
+                    sale_line = curr_proc.sale_line_id
+                    break
+                curr_proc = curr_proc.move_dest_id.procurement_id
 
             if sale_line and sale_line.manually_sourced:
                 po_line = sale_line.sourced_by

--- a/sale_quotation_sourcing_stock_route_transit/README.rst
+++ b/sale_quotation_sourcing_stock_route_transit/README.rst
@@ -1,0 +1,33 @@
+Sale Quotation Sourcing with Stock Route Transit
+=================================================
+
+Description
+===========
+
+This module makes sure `sale_quotation_sourcing` and `stock_route_transit` (from
+https://github.com/OCA/stock-logistics-workflow) work fine together: it updates the onchange
+methods selecting the route of the sale order line to handle the transit
+locations.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/sale_quotation_sourcing_stock_route_transit/__init__.py
+++ b/sale_quotation_sourcing_stock_route_transit/__init__.py
@@ -1,0 +1,1 @@
+from . import model

--- a/sale_quotation_sourcing_stock_route_transit/__openerp__.py
+++ b/sale_quotation_sourcing_stock_route_transit/__openerp__.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+#    Author: Alexandre Fayolle, Leonardo Pistone
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+{
+    'name': "Sale Quotation Sourcing with Stock Route Transit",
+
+    'summary': "Link module for sale_quotation_sourcing + stock_route_transit",
+    'description': """This module makes sure sale_quotation_sourcing and stock_route_transit
+    (from OCA/stock-logistics-workflow) work fine together: it updates the
+    onchange methods selecting the route of the sale order line to handle the
+    transit locations.
+    """,
+
+    'author': "Camptocamp",
+    'website': "http://www.camptocamp.com",
+
+    'category': 'Sales',
+    'version': '0.1',
+
+    'depends': ['sale_quotation_sourcing',
+                'stock_route_transit',
+                ],
+    'test': [
+    ],
+    'auto_install': True,
+}

--- a/sale_quotation_sourcing_stock_route_transit/__openerp__.py
+++ b/sale_quotation_sourcing_stock_route_transit/__openerp__.py
@@ -19,14 +19,7 @@
 #
 {
     'name': "Sale Quotation Sourcing with Stock Route Transit",
-
     'summary': "Link module for sale_quotation_sourcing + stock_route_transit",
-    'description': """This module makes sure sale_quotation_sourcing and stock_route_transit
-    (from OCA/stock-logistics-workflow) work fine together: it updates the
-    onchange methods selecting the route of the sale order line to handle the
-    transit locations.
-    """,
-
     'author': "Camptocamp",
     'website': "http://www.camptocamp.com",
 

--- a/sale_quotation_sourcing_stock_route_transit/model/__init__.py
+++ b/sale_quotation_sourcing_stock_route_transit/model/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order_line

--- a/sale_quotation_sourcing_stock_route_transit/model/sale_order_line.py
+++ b/sale_quotation_sourcing_stock_route_transit/model/sale_order_line.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+#
+#    Author: Alexandre Fayolle, Leonardo Pistone
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+from openerp import models, api
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    @api.model
+    def _get_po_location_usage(self, purchase_order_line):
+        """override the usage finding in case the PO delivers to a transit
+        stock.location.
+        """
+        _super = super(SaleOrderLine, self)
+        usage = _super._get_po_location_usage(purchase_order_line)
+        if usage == 'transit':
+            # heuristic: if there is a stock.warehouse with this location set
+            # as input transit location, then we consider this as 'internal';
+            # else if there is a stock warehouse with this location set as
+            # output transit location, then we consider this as 'customer'
+            StockWarehouse = self.env['stock.warehouse']
+            location = purchase_order_line.order_id.location_id
+            domain_input = [('wh_transit_in_loc_id', '=', location.id)]
+            domain_output = [('wh_transit_out_loc_id', '=', location.id)]
+            if StockWarehouse.search(domain_input, limit=1):
+                usage = 'internal'
+            elif StockWarehouse.search(domain_output, limit=1):
+                usage = 'customer'
+        return usage

--- a/sale_quotation_sourcing_stock_route_transit/model/sale_order_line.py
+++ b/sale_quotation_sourcing_stock_route_transit/model/sale_order_line.py
@@ -25,16 +25,17 @@ class SaleOrderLine(models.Model):
 
     @api.model
     def _get_po_location_usage(self, purchase_order_line):
-        """override the usage finding in case the PO delivers to a transit
-        stock.location.
+        """in case the PO delivers to a transit stock.location, implement a correct
+        usage computation.
+
+        If there is a stock.warehouse with this location set as input transit
+        location, then we consider this as 'internal'; else if there is a stock
+        warehouse with this location set as output transit location, then we
+        consider this as 'customer'.
         """
         _super = super(SaleOrderLine, self)
         usage = _super._get_po_location_usage(purchase_order_line)
         if usage == 'transit':
-            # heuristic: if there is a stock.warehouse with this location set
-            # as input transit location, then we consider this as 'internal';
-            # else if there is a stock warehouse with this location set as
-            # output transit location, then we consider this as 'customer'
             StockWarehouse = self.env['stock.warehouse']
             location = purchase_order_line.order_id.location_id
             domain_input = [('wh_transit_in_loc_id', '=', location.id)]

--- a/sale_quotation_sourcing_stock_route_transit/tests/__init__.py
+++ b/sale_quotation_sourcing_stock_route_transit/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sourced_by

--- a/sale_quotation_sourcing_stock_route_transit/tests/test_sourced_by.py
+++ b/sale_quotation_sourcing_stock_route_transit/tests/test_sourced_by.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Nicolas Bessi, Alexandre Fayolle
+#    Copyright 2014-2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+import openerp.tests.common as test_common
+
+
+class TestSourcedBy(test_common.TransactionCase):
+
+    def setUp(self):
+        super(TestSourcedBy, self).setUp()
+        self.warehouse = self.env.ref('stock.warehouse0')
+        self.warehouse.write({'reception_steps': 'transit_three_steps',
+                              'delivery_steps': 'pick_pack_ship_transit'})
+
+    def test_get_po_usage_transit_in(self):
+        so_line_model = self.env['sale.order.line']
+        po = self.env.ref('purchase.purchase_order_2')
+        po_line = po.order_line[0]
+        po.write({'location_id': self.warehouse.wh_transit_in_loc_id.id})
+        usage = so_line_model._get_po_location_usage(po_line)
+        self.assertEqual(usage, 'internal')
+
+    def test_get_po_usage_transit_out(self):
+        so_line_model = self.env['sale.order.line']
+        po = self.env.ref('purchase.purchase_order_2')
+        po_line = po.order_line[0]
+        po.write({'location_id': self.warehouse.wh_transit_out_loc_id.id})
+        usage = so_line_model._get_po_location_usage(po_line)
+        self.assertEqual(usage, 'customer')


### PR DESCRIPTION
Two issues:
- when a WH config with lots of chained locations is used, the procurement
  chain must be unrolled with a proper loop, and not with a hard coded 1 step
  lookahead.
- when stock_route_transit from OCA/stock-logistics-workflow is installed, the usage of the PO locations can be altered, and the code setting the route of the SO line must be updated
