### PR TITLE
[FIX] forbid to confirm a PO if SO, sourced by it, is not confirmed

### DIFF
--- a/sale_quotation_sourcing_stock_route_transit/README.rst
+++ b/sale_quotation_sourcing_stock_route_transit/README.rst
@@ -16,6 +16,7 @@ Contributors
 ------------
 
 * Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+* Yannick Vaucher <yannick.vaucher@camptocamp.com>
 
 Maintainer
 ----------

--- a/sale_quotation_sourcing_stock_route_transit/i18n/sale_quotation_sourcing_stock_route_transit.pot
+++ b/sale_quotation_sourcing_stock_route_transit/i18n/sale_quotation_sourcing_stock_route_transit.pot
@@ -1,0 +1,33 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_quotation_sourcing_stock_route_transit
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-03-09 10:11+0000\n"
+"PO-Revision-Date: 2015-03-09 10:11+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_quotation_sourcing_stock_route_transit
+#: model:ir.model,name:sale_quotation_sourcing_stock_route_transit.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: sale_quotation_sourcing_stock_route_transit
+#: model:ir.model,name:sale_quotation_sourcing_stock_route_transit.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""
+
+#. module: sale_quotation_sourcing_stock_route_transit
+#: code:addons/sale_quotation_sourcing_stock_route_transit/model/purchase.py:46
+#, python-format
+msgid "You cannot confirm the purchase order before confirming the sales order(s) which use it as source. Currently the following sales order(s) still needs confirmation:\n%s"
+msgstr ""
+

--- a/sale_quotation_sourcing_stock_route_transit/model/__init__.py
+++ b/sale_quotation_sourcing_stock_route_transit/model/__init__.py
@@ -1,1 +1,2 @@
 from . import sale_order_line
+from . import purchase

--- a/sale_quotation_sourcing_stock_route_transit/model/purchase.py
+++ b/sale_quotation_sourcing_stock_route_transit/model/purchase.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+#    Author: Yannick Vaucher
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+from openerp import models, api, exceptions, _
+
+
+class Purchase(models.Model):
+    _inherit = 'purchase.order'
+
+    @api.multi
+    def _unconfirmed_sourced_sales(self):
+        Sale = self.env['sale.order']
+        po_lines = self.mapped('order_line')
+
+        # accepted state is added to be compatible with
+        # OCA/vertical-ngo/logistic_order
+        unconfirmed_sales = Sale.search(
+            [('order_line.sourced_by', 'in', po_lines.ids),
+             ('state', 'in', ('draft', 'sent', 'accepted'))])
+        return unconfirmed_sales
+
+    @api.multi
+    def wkf_confirm_order(self):
+        """ Forbid confirmation of purchase order when there
+        are unconfirmed sale orders sourced by its purchase lines
+        """
+        unconfirmed_sourced_sales = self._unconfirmed_sourced_sales()
+        if unconfirmed_sourced_sales:
+            raise exceptions.Warning(
+                _("You cannot confirm the purchase order before confirming the"
+                  " sales order(s) which use it as source. Currently the"
+                  " following sales order(s) still needs confirmation:\n%s")
+                % "\n".join(unconfirmed_sourced_sales.mapped('name')))
+        return super(Purchase, self).wkf_confirm_order()


### PR DESCRIPTION
This ensure we won't create twice a move going from incoming transit location to stock
