### PR TITLE
Add sale_payment_term_interest

### DIFF
--- a/sale_payment_term_interest/README.rst
+++ b/sale_payment_term_interest/README.rst
@@ -1,0 +1,54 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License
+
+Sales Payment Term Interests
+============================
+
+This module allows to compute interest fees based on payment terms and
+to add a line in the sales orders with the computed amount.
+
+Installation
+============
+
+To install this module, you need to:
+
+ * Install the `sale_payment_term_interest` module is the only things to do.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+ * Go to *Invoicing > Configuration > Payment Terms*
+ * On the lines of the payment terms, you can configure an interest
+   rate. It is based on the number of days.
+
+Usage
+=====
+
+To use this module, you need to:
+
+ * When a sales order has a payment term with interest fees, a line will
+   automatically be added when it is saved. A button next to the
+   payment terms allows to update it directly.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/sale_payment_term_interest/__init__.py
+++ b/sale_payment_term_interest/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Authors: Guewen Baconnier
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from . import model

--- a/sale_payment_term_interest/__openerp__.py
+++ b/sale_payment_term_interest/__openerp__.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Authors: Guewen Baconnier
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+{'name': 'Sales Payment Term Interests',
+ 'version': '1.0',
+ 'author': 'Camptocamp,Odoo Community Association (OCA)',
+ 'license': 'AGPL-3',
+ 'category': 'Accounting & Finance',
+ 'depends': ['sale'],
+ 'website': 'http://www.camptocamp.com',
+ 'data': ['data/product_data.xml',
+          'view/sale_order_view.xml',
+          'view/account_payment_term_view.xml',
+          ],
+ 'test': [],
+ 'installable': True,
+ 'auto_install': False,
+ }

--- a/sale_payment_term_interest/data/product_data.xml
+++ b/sale_payment_term_interest/data/product_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data noupdate="1">
+    <record id="product_product_sale_order_interest" model="product.product">
+      <field name="default_code">INTEREST</field>
+      <field name="list_price">0.0</field>
+      <field name="standard_price">0.0</field>
+      <field name="type">service</field>
+      <field name="name">Payment terms interests</field>
+    </record>
+  </data>
+</openerp>
+

--- a/sale_payment_term_interest/i18n/fr.po
+++ b/sale_payment_term_interest/i18n/fr.po
@@ -1,0 +1,70 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_payment_term_interest
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-03-16 13:56+0000\n"
+"PO-Revision-Date: 2015-03-16 13:56+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_payment_term_interest
+#: view:sale.order:sale_payment_term_interest.view_order_form
+msgid "(update interests)"
+msgstr "(mise à jour des intérêts)"
+
+#. module: sale_payment_term_interest
+#: field:account.payment.term.line,interest_rate:0
+msgid "Interest Rate"
+msgstr "Taux d'intérêt"
+
+#. module: sale_payment_term_interest
+#: code:addons/sale_payment_term_interest/model/sale_order.py:105
+#, python-format
+msgid "Interest amount differs. Click on \"(update interests)\" next to the payment terms."
+msgstr "Le taux d'intérêt diffère. Cliquez sur \"(mise à jour des intérêts)\" à côté des conditions de règlement."
+
+#. module: sale_payment_term_interest
+#: model:ir.model,name:sale_payment_term_interest.model_account_payment_term
+msgid "Payment Term"
+msgstr "Condition de règlement"
+
+#. module: sale_payment_term_interest
+#: model:ir.model,name:sale_payment_term_interest.model_account_payment_term_line
+msgid "Payment Term Line"
+msgstr "Détail des conditions de règlement"
+
+#. module: sale_payment_term_interest
+#: model:product.template,name:sale_payment_term_interest.product_product_sale_order_interest_product_template
+msgid "Payment terms interests"
+msgstr "Intérêt des conditions de règlement"
+
+#. module: sale_payment_term_interest
+#: view:sale.order:sale_payment_term_interest.view_order_form
+msgid "Recompute interests on payment terms"
+msgstr "Recalculer les intérêts sur conditions de règlement"
+
+#. module: sale_payment_term_interest
+#: model:ir.model,name:sale_payment_term_interest.model_sale_order
+msgid "Sales Order"
+msgstr "Bon de commande"
+
+#. module: sale_payment_term_interest
+#: model:ir.model,name:sale_payment_term_interest.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Ligne de bon de commande"
+
+#. module: sale_payment_term_interest
+#: help:account.payment.term.line,interest_rate:0
+msgid "The rate per day applied on a sales order. Value between 0 and 100.\n"
+"The interest is computed as 'Amount * (Interest Rate / 100) * Days'"
+msgstr "Le taux par jour appliqué sur une commande de vente. Valeur entre 0 et 100.\n"
+"L'intérêt est calculé comme suit : 'montant * (taux d'intérêt / 100) * jours'."
+

--- a/sale_payment_term_interest/model/__init__.py
+++ b/sale_payment_term_interest/model/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Authors: Guewen Baconnier
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from . import sale_order
+from . import account_payment_term

--- a/sale_payment_term_interest/model/account_payment_term.py
+++ b/sale_payment_term_interest/model/account_payment_term.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Authors: Guewen Baconnier
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+import openerp.addons.decimal_precision as dp
+from openerp import models, fields, api
+from openerp.tools.float_utils import float_round as round
+
+
+class AccountPaymentTerm(models.Model):
+    _inherit = 'account.payment.term'
+
+    @api.multi
+    def compute_interest(self, value, date_ref=False):
+        if date_ref:
+            date_ref = fields.Date.from_string(date_ref)
+        else:
+            date_ref = datetime.today().date()
+
+        amount = value
+        result = []
+
+        lines_total = 0.0
+        precision_model = self.env['decimal.precision']
+        prec = precision_model.precision_get('Account')
+        for line in self.line_ids:
+            if line.value == 'fixed':
+                line_amount = round(line.value_amount, precision_digits=prec)
+            elif line.value == 'procent':
+                line_amount = round(value * line.value_amount,
+                                    precision_digits=prec)
+            elif line.value == 'balance':
+                line_amount = round(amount, prec)
+            if not line_amount:
+                continue
+            next_date = date_ref + relativedelta(days=line.days)
+            if line.days2 < 0:
+                # Getting 1st of next month
+                next_first_date = next_date + relativedelta(day=1,
+                                                            months=1)
+                next_date = (next_first_date +
+                             relativedelta(days=line.days2))
+            if line.days2 > 0:
+                next_date += relativedelta(day=line.days2, months=1)
+            interest = 0.0
+            if line.interest_rate:
+                days = (next_date - date_ref).days
+                interest = line_amount * (line.interest_rate / 100) * days
+            result.append((fields.Date.to_string(next_date),
+                           line_amount,
+                           interest))
+            amount -= line_amount
+            lines_total += line_amount
+
+        dist = round(value - lines_total, precision_digits=prec)
+        if dist:
+            result.append((fields.Date.today(), dist, 0.0))
+        return result
+
+
+class AccountPaymentTermLine(models.Model):
+    _inherit = 'account.payment.term.line'
+
+    interest_rate = fields.Float(
+        string='Interest Rate',
+        digits=dp.get_precision('Payment Term'),
+        help="The rate per day applied on a sales order. "
+             "Value between 0 and 100.\n"
+             "The interest is computed as "
+             "'Amount * (Interest Rate / 100) * Days'")

--- a/sale_payment_term_interest/model/sale_order.py
+++ b/sale_payment_term_interest/model/sale_order.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Authors: Guewen Baconnier
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from openerp import models, fields, api, exceptions, _
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.multi
+    def _prepare_interest_line(self, interest_amount):
+        product = self.env.ref('sale_payment_term_interest.'
+                               'product_product_sale_order_interest')
+        values = {'product_uom_qty': 1,
+                  'order_id': self.id,
+                  'product_id': product.id,
+                  'interest_line': True,
+                  'sequence': 99999,
+                  }
+        onchanged = self.env['sale.order.line'].product_id_change(
+            self.pricelist_id.id,
+            product.id,
+            qty=1,
+            uom=product.uom_id.id,
+            partner_id=self.partner_id.id,
+            fiscal_position=self.fiscal_position.id)
+        values.update(onchanged['value'])
+        values['price_unit'] = interest_amount
+        return values
+
+    @api.multi
+    def get_interest_value(self):
+        self.ensure_one()
+        term = self.payment_term
+        if not term:
+            return 0.
+        if not any(line.interest_rate for line in term.line_ids):
+            return 0.
+        line = self._get_interest_line()
+        if line:
+            price = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
+            taxes = line.tax_id.compute_all(price,
+                                            line.product_uom_qty,
+                                            product=line.product_id,
+                                            partner=self.partner_id)
+            # remove the interest value from the total if there is a value yet
+            interest = taxes['total_included']
+        else:
+            interest = 0.
+        values = term.compute_interest(self.amount_total - interest,
+                                       date_ref=self.date_order)
+        return sum(interest for __, __, interest in values)
+
+    @api.multi
+    def _get_interest_line(self):
+        for line in self.order_line:
+            if line.interest_line:
+                return line
+        return self.env['sale.order.line'].browse()
+
+    @api.multi
+    def update_interest_line(self):
+        interest_line = self._get_interest_line()
+        interest_amount = self.get_interest_value()
+        values = self._prepare_interest_line(interest_amount)
+
+        if interest_line:
+            if interest_amount:
+                values.pop('name', None)  # keep the current name
+                interest_line.write(values)
+            else:
+                interest_line.unlink()
+        elif interest_amount:
+            self.env['sale.order.line'].create(values)
+
+    @api.multi
+    def check_interest_line(self):
+        self.ensure_one()
+        interest_amount = self.get_interest_value()
+        currency = self.currency_id
+
+        interest_line = self._get_interest_line()
+        current_amount = interest_line.price_unit
+
+        if currency.compare_amounts(current_amount, interest_amount) != 0:
+            raise exceptions.Warning(
+                _('Interest amount differs. Click on "(update interests)" '
+                  'next to the payment terms.')
+            )
+
+    @api.multi
+    def action_button_confirm(self):
+        result = super(SaleOrder, self).action_button_confirm()
+        self.check_interest_line()
+        return result
+
+    @api.model
+    def create(self, vals):
+        record = super(SaleOrder, self).create(vals)
+        record.update_interest_line()
+        return record
+
+    @api.multi
+    def write(self, vals):
+        result = super(SaleOrder, self).write(vals)
+        self.update_interest_line()
+        return result
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    interest_line = fields.Boolean()

--- a/sale_payment_term_interest/tests/__init__.py
+++ b/sale_payment_term_interest/tests/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Authors: Guewen Baconnier
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from . import test_payment_term
+from . import test_sale_order

--- a/sale_payment_term_interest/tests/test_payment_term.py
+++ b/sale_payment_term_interest/tests/test_payment_term.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Authors: Guewen Baconnier
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from operator import itemgetter
+from openerp.tests import common
+
+
+class TestPaymentTerm(common.TransactionCase):
+
+    def test_interest(self):
+        term = self.env['account.payment.term'].create({'name': 'test'})
+        self.env['account.payment.term.line'].create({
+            'payment_id': term.id,
+            'value': 'procent',
+            'value_amount': 0.3333,
+            'days': 10,
+            'interest_rate': 0.0,
+        })
+        self.env['account.payment.term.line'].create({
+            'payment_id': term.id,
+            'value': 'procent',
+            'value_amount': 0.3333,
+            'days': 40,
+            'interest_rate': 0.041666,
+        })
+        self.env['account.payment.term.line'].create({
+            'payment_id': term.id,
+            'value': 'balance',
+            'days': 70,
+            'interest_rate': 0.041666,
+        })
+        terms = term.compute_interest(469.35, date_ref='2015-03-13')
+        self.assertEquals(len(terms), 3)
+        terms = sorted(terms, key=itemgetter(0))
+        line1, line2, line3 = terms
+        self.assertAlmostEqual(line1[1], 156.43)
+        self.assertAlmostEqual(line1[2], 0.0)
+
+        self.assertAlmostEqual(line2[1], 156.43)
+        self.assertAlmostEqual(line2[2], 2.60712495)
+
+        self.assertAlmostEqual(line3[1], 156.49)
+        self.assertAlmostEqual(line3[2], 4.56421864)

--- a/sale_payment_term_interest/tests/test_sale_order.py
+++ b/sale_payment_term_interest/tests/test_sale_order.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+#
+#
+#    Authors: Guewen Baconnier
+#    Copyright 2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+from openerp import exceptions
+from openerp.tests import common
+
+
+class TestSaleOrder(common.TransactionCase):
+
+    def setUp(self):
+        super(TestSaleOrder, self).setUp()
+        payment_term_model = self.env['account.payment.term']
+        self.payment_term = payment_term_model.create({'name': 'test'})
+        self.env['account.payment.term.line'].create({
+            'payment_id': self.payment_term.id,
+            'value': 'procent',
+            'value_amount': 0.3333,
+            'days': 10,
+            'interest_rate': 0.0,
+        })
+        self.env['account.payment.term.line'].create({
+            'payment_id': self.payment_term.id,
+            'value': 'procent',
+            'value_amount': 0.3333,
+            'days': 40,
+            'interest_rate': 0.041666,
+        })
+        self.env['account.payment.term.line'].create({
+            'payment_id': self.payment_term.id,
+            'value': 'balance',
+            'days': 70,
+            'interest_rate': 0.041666,
+        })
+
+    def test_interest(self):
+        product1 = self.env.ref('product.product_product_7')
+        product2 = self.env.ref('product.product_product_9')
+        line1_values = {
+            'product_id': product1.id,
+            'product_uom_qty': 1,
+            'product_uom': product1.uom_id.id,
+            'price_unit': 50,
+        }
+        line2_values = {
+            'product_id': product2.id,
+            'product_uom_qty': 2,
+            'product_uom': product1.uom_id.id,
+            'price_unit': 100,
+        }
+        sale = self.env['sale.order'].create({
+            'partner_id': self.env.ref('base.res_partner_2').id,
+            'payment_term': self.payment_term.id,
+            'order_line': [(0, 0, line1_values), (0, 0, line2_values)],
+        })
+        self.assertEqual(len(sale.order_line), 3)
+        interest_lines = set()
+        for line in sale.order_line:
+            if line.interest_line:
+                interest_lines.add(line)
+        self.assertEqual(len(interest_lines), 1)
+        line = interest_lines.pop()
+        self.assertAlmostEqual(line.price_subtotal, 3.82)
+        self.assertAlmostEqual(sale.amount_total, 253.82)
+        sale.check_interest_line()  # no error
+
+    def test_interest_change_line(self):
+        product1 = self.env.ref('product.product_product_7')
+        product2 = self.env.ref('product.product_product_9')
+        sale = self.env['sale.order'].create({
+            'partner_id': self.env.ref('base.res_partner_2').id,
+            'payment_term': self.payment_term.id,
+        })
+        self.env['sale.order.line'].create({
+            'product_id': product1.id,
+            'product_uom_qty': 1,
+            'product_uom': product1.uom_id.id,
+            'price_unit': 50,
+            'order_id': sale.id,
+        })
+        line2 = self.env['sale.order.line'].create({
+            'product_id': product2.id,
+            'product_uom_qty': 2,
+            'product_uom': product1.uom_id.id,
+            'price_unit': 100,
+            'order_id': sale.id,
+        })
+        self.assertEqual(len(sale.order_line), 2)
+        with self.assertRaises(exceptions.Warning):
+            sale.check_interest_line()
+
+        sale.update_interest_line()
+        sale.check_interest_line()  # no error
+        interest_line = sale._get_interest_line()
+        self.assertAlmostEqual(interest_line.price_subtotal, 3.82)
+        line2.product_uom_qty = 3
+
+        sale.update_interest_line()
+        sale.check_interest_line()  # no error
+        self.assertAlmostEqual(interest_line.price_subtotal, 5.35)
+
+        sale.payment_term = self.env.ref('account.account_payment_term_15days')
+        interest_line = sale._get_interest_line()
+        self.assertFalse(interest_line)
+
+    def test_interest_with_tax(self):
+        product1 = self.env.ref('product.product_product_7')
+        product2 = self.env.ref('product.product_product_9')
+        product_interest = self.env.ref('sale_payment_term_interest.'
+                                        'product_product_sale_order_interest')
+        tax = self.env['account.tax'].create({
+            'name': 'Percent tax',
+            'type': 'percent',
+            'amount': '0.1',
+        })
+        product_interest.taxes_id = [(6, 0, [tax.id])]
+        line1_values = {
+            'product_id': product1.id,
+            'product_uom_qty': 1,
+            'product_uom': product1.uom_id.id,
+            'price_unit': 50,
+            'tax_id': [(6, 0, [tax.id])],
+        }
+        line2_values = {
+            'product_id': product2.id,
+            'product_uom_qty': 2,
+            'product_uom': product1.uom_id.id,
+            'price_unit': 100,
+            'tax_id': [(6, 0, [tax.id])],
+        }
+        sale = self.env['sale.order'].create({
+            'partner_id': self.env.ref('base.res_partner_2').id,
+            'payment_term': self.payment_term.id,
+            'order_line': [(0, 0, line1_values), (0, 0, line2_values)],
+        })
+        self.assertEqual(len(sale.order_line), 3)
+        interest_line = sale._get_interest_line()
+        self.assertAlmostEqual(interest_line.price_subtotal, 4.2)
+        self.assertAlmostEqual(sale.amount_total, 279.2)
+        sale.check_interest_line()  # no error

--- a/sale_payment_term_interest/view/account_payment_term_view.xml
+++ b/sale_payment_term_interest/view/account_payment_term_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data noupdate="0">
+    <record id="view_payment_term_line_tree" model="ir.ui.view">
+      <field name="name">account.payment.term.line.tree</field>
+      <field name="model">account.payment.term.line</field>
+      <field name="inherit_id" ref="account.view_payment_term_line_tree"/>
+      <field name="arch" type="xml">
+        <field name="days2" position="after">
+          <field name="interest_rate"/>
+        </field>
+      </field>
+    </record>
+
+    <record id="view_payment_term_line_form" model="ir.ui.view">
+      <field name="name">account.payment.term.line.form</field>
+      <field name="model">account.payment.term.line</field>
+      <field name="inherit_id" ref="account.view_payment_term_line_form"/>
+      <field name="arch" type="xml">
+        <xpath expr="/form/group/group[1]" position="inside">
+          <field name="interest_rate"/>
+        </xpath>
+      </field>
+    </record>
+  </data>
+</openerp>

--- a/sale_payment_term_interest/view/sale_order_view.xml
+++ b/sale_payment_term_interest/view/sale_order_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data noupdate="0">
+
+    <record id="view_order_form" model="ir.ui.view">
+      <field name="name">sale.order.form</field>
+      <field name="model">sale.order</field>
+      <field name="inherit_id" ref="sale.view_order_form"/>
+      <field name="arch" type="xml">
+        <field name="payment_term" position="replace">
+          <label for="payment_term"/>
+          <div>
+            <field name="payment_term" class="oe_inline" options="{'no_create': True}"/>
+            <button name="update_interest_line" states="draft,proforma2"
+              string="(update interests)" class="oe_link"
+              type="object" help="Recompute interests on payment terms"/>
+          </div>
+        </field>
+      </field>
+    </record>
+  </data>
+</openerp>


### PR DESCRIPTION
This module allows to compute interest fees based on payment terms and
to add a line in the sales orders with the computed amount.
