### PR TITLE
use ownership for exceptions, if any

### DIFF
--- a/sale_exception_nostock/__openerp__.py
+++ b/sale_exception_nostock/__openerp__.py
@@ -19,7 +19,7 @@
 #
 #
 {'name': 'Sale stock exception',
- 'version': '1.1',
+ 'version': '1.2',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'maintainer': 'Camptocamp',
  'category': 'sale',
@@ -43,6 +43,12 @@ The second test will only look for stock moves that pass by the line location,
 so if your stock have children or if you have configured automated stock
 actions they must pass by the location related to the SO line, else they will
 be ignored.
+
+If the module sale_owner_stock_sourcing is installed, each sale order line can
+specify a stock owner. In that case, the owner will be used when computing the
+virtual stock availability. For this to work correctly,
+https://github.com/odoo/odoo/issues/5814 needs to be fixed (fixes are proposed
+both for odoo and OCB).
 
 **Warning:**
 

--- a/sale_exception_nostock/model/sale.py
+++ b/sale_exception_nostock/model/sale.py
@@ -169,6 +169,13 @@ class SaleOrderLine(models.Model):
             'compute_child': True,
             'location': location.id,
             }
+
+        try:
+            ctx['owner_id'] = self.stock_owner_id.id
+        except AttributeError:
+            # module sale_owner_stock_sourcing not installed, fine
+            pass
+
         # Virtual qty is made on all childs of chosen location
         prod_for_virtual_qty = (self.product_id
                                 .with_context(ctx)
@@ -232,6 +239,13 @@ class SaleOrderLine(models.Model):
             'compute_child': True,
             'location_id': location.id,
             }
+
+        try:
+            ctx['owner_id'] = self.stock_owner_id.id
+        except AttributeError:
+            # module sale_owner_stock_sourcing not installed, fine
+            pass
+
         # Virtual qty is made on all childs of chosen location
         dates = self._get_affected_dates(location.id, self.product_id.id,
                                          delivery_date)

--- a/sale_owner_stock_sourcing/tests/test_propagate_owner_to_move.py
+++ b/sale_owner_stock_sourcing/tests/test_propagate_owner_to_move.py
@@ -37,10 +37,16 @@ class TestPropagateOwner(TransactionCase):
         super(TestPropagateOwner, self).setUp()
         self.SO = self.env['sale.order']
         self.SOL = self.env['sale.order.line']
-
-        # this product has some stock in demo data
-        product = self.env.ref('product.product_product_6')
         self.partner = self.env.ref('base.res_partner_2')
+
+        # this product already has some stock with no owner in demo data
+        product = self.env.ref('product.product_product_6')
+        self.env['stock.quant'].create({
+            'qty': 5000,
+            'location_id': self.ref('stock.stock_location_stock'),
+            'product_id': product.id,
+            'owner_id': self.partner.id,
+        })
 
         self.so = self.env['sale.order'].create({
             'partner_id': self.env.ref('base.res_partner_2').id,

--- a/sale_owner_stock_sourcing/tests/test_propagate_owner_to_move.py
+++ b/sale_owner_stock_sourcing/tests/test_propagate_owner_to_move.py
@@ -35,8 +35,6 @@ class TestPropagateOwner(TransactionCase):
 
     def setUp(self):
         super(TestPropagateOwner, self).setUp()
-        self.SO = self.env['sale.order']
-        self.SOL = self.env['sale.order.line']
         self.partner = self.env.ref('base.res_partner_2')
 
         # this product already has some stock with no owner in demo data


### PR DESCRIPTION
Ownership is introduced in module sale_owner_stock_sourcing. It is not a
dependency, and the field is used if found.

This needs a fix to https://github.com/odoo/odoo/issues/5814 to work
correctly.
