### PR TITLE
Allow to define a minimum interest amount

### DIFF
--- a/sale_payment_term_interest/i18n/fr.po
+++ b/sale_payment_term_interest/i18n/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-04-22 08:16+0000\n"
+"POT-Creation-Date: 2015-04-29 08:05+0000\n"
 "PO-Revision-Date: 2015-03-16 13:56+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
@@ -27,7 +27,7 @@ msgid "Interest Rate"
 msgstr "Taux d'intérêt"
 
 #. module: sale_payment_term_interest
-#: code:addons/sale_payment_term_interest/model/sale_order.py:107
+#: code:addons/sale_payment_term_interest/model/sale_order.py:109
 #, python-format
 msgid ""
 "Interest amount differs. Click on \"(update interests)\" next to the payment "
@@ -40,6 +40,11 @@ msgstr ""
 #: field:sale.order.line,interest_line:0
 msgid "Interest line"
 msgstr "Ligne d'intérêt"
+
+#. module: sale_payment_term_interest
+#: field:account.payment.term,interest_min:0
+msgid "Minimum Interest Amount"
+msgstr "Montant d'intérêt minimum"
 
 #. module: sale_payment_term_interest
 #: model:ir.model,name:sale_payment_term_interest.model_account_payment_term
@@ -80,5 +85,10 @@ msgid ""
 msgstr ""
 "Le taux d'intérêt annuel appliqué sur une commande de vente. Valeur entre 0 "
 "et 100.\n"
-"L'intérêt est calculé comme suit : 'montant * (taux d'intérêt / 100 / (12 mois * "
-"30 jours) * jours des conditions de paiement'."
+"L'intérêt est calculé comme suit : 'montant * (taux d'intérêt / 100 / (12 "
+"mois * 30 jours) * jours des conditions de paiement'."
+
+#. module: sale_payment_term_interest
+#: help:account.payment.term,interest_min:0
+msgid "The minimum amount of interest added to a sales order."
+msgstr "Le montant d'intérêt minimum ajouté à la commande."

--- a/sale_payment_term_interest/i18n/sale_payment_term_interest.pot
+++ b/sale_payment_term_interest/i18n/sale_payment_term_interest.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-04-22 08:16+0000\n"
-"PO-Revision-Date: 2015-04-22 08:16+0000\n"
+"POT-Creation-Date: 2015-04-29 08:05+0000\n"
+"PO-Revision-Date: 2015-04-29 08:05+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -26,7 +26,7 @@ msgid "Interest Rate"
 msgstr ""
 
 #. module: sale_payment_term_interest
-#: code:addons/sale_payment_term_interest/model/sale_order.py:107
+#: code:addons/sale_payment_term_interest/model/sale_order.py:109
 #, python-format
 msgid "Interest amount differs. Click on \"(update interests)\" next to the payment terms."
 msgstr ""
@@ -34,6 +34,11 @@ msgstr ""
 #. module: sale_payment_term_interest
 #: field:sale.order.line,interest_line:0
 msgid "Interest line"
+msgstr ""
+
+#. module: sale_payment_term_interest
+#: field:account.payment.term,interest_min:0
+msgid "Minimum Interest Amount"
 msgstr ""
 
 #. module: sale_payment_term_interest
@@ -70,5 +75,10 @@ msgstr ""
 #: help:account.payment.term.line,interest_rate:0
 msgid "The annual interest rate applied on a sales order. Value between 0 and 100.\n"
 "The interest is computed as: 'Amount * (Interest Rate / 100 /  (12 months * 30 days)) * Term Days'"
+msgstr ""
+
+#. module: sale_payment_term_interest
+#: help:account.payment.term,interest_min:0
+msgid "The minimum amount of interest added to a sales order."
 msgstr ""
 

--- a/sale_payment_term_interest/model/sale_order.py
+++ b/sale_payment_term_interest/model/sale_order.py
@@ -63,12 +63,13 @@ class SaleOrder(models.Model):
                                             product=line.product_id,
                                             partner=self.partner_id)
             # remove the interest value from the total if there is a value yet
-            interest = taxes['total_included']
+            current_interest = taxes['total_included']
         else:
-            interest = 0.
-        values = term.compute_interest(self.amount_total - interest,
-                                       date_ref=self.date_order)
-        return sum(interest for __, __, interest in values)
+            current_interest = 0.
+        interest = term.compute_total_interest(
+            self.amount_total - current_interest,
+        )
+        return interest
 
     @api.multi
     def _get_interest_line(self):

--- a/sale_payment_term_interest/view/account_payment_term_view.xml
+++ b/sale_payment_term_interest/view/account_payment_term_view.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
   <data noupdate="0">
+
+    <record id="view_payment_term_form" model="ir.ui.view">
+      <field name="name">account.payment.term.form</field>
+      <field name="model">account.payment.term</field>
+      <field name="inherit_id" ref="account.view_payment_term_form"/>
+      <field name="arch" type="xml">
+        <field name="name" position="after">
+            <field name="interest_min"/>
+        </field>
+      </field>
+    </record>
+
     <record id="view_payment_term_line_tree" model="ir.ui.view">
       <field name="name">account.payment.term.line.tree</field>
       <field name="model">account.payment.term.line</field>


### PR DESCRIPTION
New feature in the module sale_payment_term_interest: a minimum interest amount
can be defined on the payment term.
