### PR TITLE
[FIX] Bypass of exceptions through the sent state

### DIFF
--- a/sale_exceptions/sale_workflow.xml
+++ b/sale_exceptions/sale_workflow.xml
@@ -5,5 +5,9 @@
             <field name="signal">order_confirm</field>
             <field name="condition">test_exceptions()</field>
         </record>
+        <record id="sale.trans_sent_router" model="workflow.transition">
+            <field name="signal">order_confirm</field>
+            <field name="condition">test_exceptions()</field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
It is possible to skip sale exceptions checking if sending an email first, then confirming.
