### PR TITLE
 [ADD] 'sale_discount_limit'

### DIFF
--- a/sale_discount_limit/README.rst
+++ b/sale_discount_limit/README.rst
@@ -1,0 +1,59 @@
+Sale Discount Limit
+===================
+
+This module was created to extend the sales process. It allows to
+set a maximum permitted sales discount % on each product on a sale quotation.
+
+A sales user cannot approve a sales quotation if any of the items contain a
+sales discount % above the maximum allowed.
+
+A user can manually initiate the maximum discount limit check when the quote
+is in status draft or sent.
+
+Users belonging to the group 'Sales Quotation Discount Block Releaser' will
+have the permission to override this rule and approve the sales quotation.
+
+
+Installation
+============
+
+No specific installation steps are required.
+
+Configuration
+=============
+
+No specific configuration steps are required.
+
+Usage
+=====
+
+No specific usage instructions are required.
+
+
+Known issues / Roadmap
+======================
+
+No issues have been identified with this module.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/sale_discount_limit/__init__.py
+++ b/sale_discount_limit/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import model

--- a/sale_discount_limit/__openerp__.py
+++ b/sale_discount_limit/__openerp__.py
@@ -27,6 +27,7 @@
     'version': '1.0',
     'author': 'Eficent, Odoo Community Association (OCA)',
     'website': 'http://www.eficent.com',
+    "license": "AGPL-3",
     'depends': ['sale'],
     'init_xml': [],
     'update_xml': [

--- a/sale_discount_limit/__openerp__.py
+++ b/sale_discount_limit/__openerp__.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Sistemas Adhoc
+#    Copyright (C) 2014 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+{
+    'name': 'Sale Discount Limit',
+    'summary': "Set a maximum allowed discount for sales quotations",
+    'version': '1.0',
+    'author': 'Eficent, Odoo Community Association (OCA)',
+    'website': 'http://www.eficent.com',
+    'depends': ['sale'],
+    'init_xml': [],
+    'update_xml': [
+        'security/sale_discount_limit_security.xml',
+        'security/ir.model.access.csv',
+        'view/sale_workflow.xml',
+        'view/sale_view.xml',
+        'view/product_view.xml',
+    ],
+    'demo_xml': [],
+    'test': [],
+    'installable': True,
+}

--- a/sale_discount_limit/i18n/es.po
+++ b/sale_discount_limit/i18n/es.po
@@ -1,0 +1,76 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* sale_discount_limit
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-05-07 08:01+0000\n"
+"PO-Revision-Date: 2015-05-07 08:01+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_discount_limit
+#: model:ir.model,name:sale_discount_limit.model_product_product
+msgid "Product"
+msgstr "Producto"
+
+#. module: sale_discount_limit
+#: help:product.product,max_sale_discount:0
+msgid "Maximum sales discount defined for this product. Sales quotations containing products where the discount of the line exceeds the discount defined in the product will be blocked."
+msgstr "Máximo descuento de venta definido para este producto. Los presupuestos que contengan líneas con un descuento superior al del producto no podrán ser aprobadas."
+
+#. module: sale_discount_limit
+#: model:res.groups,comment:sale_discount_limit.group_so_discount_block_releaser
+msgid "The user will have permission to confirm sales quotations where the maximum allowed discount has been exceeded in at least one item."
+msgstr "El usuario tendrá permisos para confirmar presupuestos donde el descuento máximo permitido se ha superado en al menos una línea."
+
+#. module: sale_discount_limit
+#: view:sale.order:0
+msgid "Check discount limit"
+msgstr "Comprobar validez del descuento"
+
+#. module: sale_discount_limit
+#: model:res.groups,name:sale_discount_limit.group_so_discount_block_releaser
+msgid "Sales Quotation Discount Block Releaser"
+msgstr "Aprobador de Presupuestos bloqueados por límite de descuento excedido"
+
+#. module: sale_discount_limit
+#: field:product.product,max_sale_discount:0
+msgid "Maximum Discount (%)"
+msgstr "Máximo Descuento (%)"
+
+#. module: sale_discount_limit
+#: model:ir.model,name:sale_discount_limit.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"
+
+#. module: sale_discount_limit
+#: code:addons/sale_discount_limit/model/sale.py:50
+#, python-format
+msgid "Maximum permitted discount exceeded."
+msgstr "Se ha excedido el máximo descuento permitido."
+
+#. module: sale_discount_limit
+#: code:addons/sale_discount_limit/model/sale.py:51
+#, python-format
+msgid ""
+"Cannot confirm the quotation. The maximum allowed "
+"discount for '%s' is %s %%. Only a user "
+"that belongs to group 'Sales Quotation Discount "
+"Block Releaser' can approve the quotation."
+msgstr ""
+"No se puede confirmar la Oferta. El máximo descuento permitido "
+"para '%s' es %s %%. Solamente un usuario "
+"que pertenezca al grupo 'Aprobador de Presupuestos bloqueados "
+"por límite de descuento excedido' puede aprobar la Oferta."
+
+
+
+
+

--- a/sale_discount_limit/i18n/es.po
+++ b/sale_discount_limit/i18n/es.po
@@ -1,10 +1,10 @@
-# Translation of OpenERP Server.
+# Translation of Odoo Server.
 # This file contains the translation of the following modules:
 #	* sale_discount_limit
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: OpenERP Server 7.0\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-05-07 08:01+0000\n"
 "PO-Revision-Date: 2015-05-07 08:01+0000\n"
@@ -65,10 +65,10 @@ msgid ""
 "that belongs to group 'Sales Quotation Discount "
 "Block Releaser' can approve the quotation."
 msgstr ""
-"No se puede confirmar la Oferta. El máximo descuento permitido "
+"No se puede confirmar el Presupuesto. El máximo descuento permitido "
 "para '%s' es %s %%. Solamente un usuario "
 "que pertenezca al grupo 'Aprobador de Presupuestos bloqueados "
-"por límite de descuento excedido' puede aprobar la Oferta."
+"por límite de descuento excedido' puede aprobar el Presupuesto."
 
 
 

--- a/sale_discount_limit/i18n/sale_discount_limit.po
+++ b/sale_discount_limit/i18n/sale_discount_limit.po
@@ -1,10 +1,10 @@
-# Translation of OpenERP Server.
+# Translation of Odoo Server.
 # This file contains the translation of the following modules:
 #	* sale_discount_limit
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: OpenERP Server 7.0\n"
+"Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-05-07 08:18+0000\n"
 "PO-Revision-Date: 2015-05-07 08:18+0000\n"

--- a/sale_discount_limit/i18n/sale_discount_limit.po
+++ b/sale_discount_limit/i18n/sale_discount_limit.po
@@ -1,0 +1,67 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* sale_discount_limit
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-05-07 08:18+0000\n"
+"PO-Revision-Date: 2015-05-07 08:18+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_discount_limit
+#: model:ir.model,name:sale_discount_limit.model_product_product
+msgid "Product"
+msgstr ""
+
+#. module: sale_discount_limit
+#: help:product.product,max_sale_discount:0
+msgid "Maximum sales discount defined for this product. Sales quotations containing products where the discount of the line exceeds the discount defined in the product will be blocked."
+msgstr ""
+
+#. module: sale_discount_limit
+#: model:res.groups,comment:sale_discount_limit.group_so_discount_block_releaser
+msgid "The user will have permission to confirm sales quotations where the maximum allowed discount has been exceeded in at least one item."
+msgstr ""
+
+#. module: sale_discount_limit
+#: view:sale.order:0
+msgid "Check discount limit"
+msgstr ""
+
+#. module: sale_discount_limit
+#: model:res.groups,name:sale_discount_limit.group_so_discount_block_releaser
+msgid "Sales Quotation Discount Block Releaser"
+msgstr ""
+
+#. module: sale_discount_limit
+#: field:product.product,max_sale_discount:0
+msgid "Maximum Discount (%)"
+msgstr ""
+
+#. module: sale_discount_limit
+#: model:ir.model,name:sale_discount_limit.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: sale_discount_limit
+#: code:addons/sale_discount_limit/model/sale.py:50
+#, python-format
+msgid "Maximum permitted discount exceeded."
+msgstr ""
+
+#. module: sale_discount_limit
+#: code:addons/sale_discount_limit/model/sale.py:51
+#, python-format
+msgid ""
+"Cannot confirm the quotation. The maximum allowed "
+"discount for '%s' is %s %%. Only a user "
+"that belongs to group 'Sales Quotation Discount "
+"Block Releaser' can approve the quotation."
+msgstr ""

--- a/sale_discount_limit/model/__init__.py
+++ b/sale_discount_limit/model/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import sale
+from . import product

--- a/sale_discount_limit/model/product.py
+++ b/sale_discount_limit/model/product.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields, api, _
+import openerp.addons.decimal_precision as dp
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    max_sale_discount = fields.Float(
+        'Maximum Discount (%)', digits_compute=dp.get_precision('Discount'),
+        help="Maximum sales discount defined for this product. Sales "
+             "quotations containing products where the discount of the "
+             "line exceeds the discount defined in the product will be "
+             "blocked.")

--- a/sale_discount_limit/model/sale.py
+++ b/sale_discount_limit/model/sale.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Eficent (<http://www.eficent.com/>)
+#              <contact@eficent.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields, api, exceptions, _
+from openerp.tools.translate import _
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.multi
+    def check_discount_limit(self):
+        model_data_obj = self.env['ir.model.data']
+        res_groups_obj = self.env['res.groups']
+        xml_id = model_data_obj._get_id('sale_discount_limit',
+                                        'group_so_discount_block_releaser')
+        group_user_ids = []
+        if xml_id:
+            group_releaser_model = model_data_obj.browse(xml_id)
+            group_releaser_id = group_releaser_model.res_id
+            group_releaser = res_groups_obj.browse(group_releaser_id)
+            group_user_ids = [user.id for user
+                              in group_releaser.users]
+        for order in self:
+            for line in order.order_line:
+                max_discount = 0.0
+                if line.product_id:
+                    max_discount = line.product_id.max_sale_discount
+                if line.product_id and line.discount > max_discount \
+                        and self.env.uid not in group_user_ids:
+                    raise exceptions.Warning(
+                        _('Maximum permitted discount exceeded.'),
+                        _("Cannot confirm the quotation. The maximum allowed "
+                          "discount for '%s' is %s %%. Only a user "
+                          "that belongs to group 'Sales Quotation Discount "
+                          "Block Releaser' can approve the quotation.")
+                        % (line.name, max_discount))
+        return True

--- a/sale_discount_limit/security/ir.model.access.csv
+++ b/sale_discount_limit/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+"id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
+"access_so_discount_block_releaser","access.so.discount.block.releaser","model_sale_order","group_so_discount_block_releaser",1,1,1,1

--- a/sale_discount_limit/security/sale_discount_limit_security.xml
+++ b/sale_discount_limit/security/sale_discount_limit_security.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+	<data>
+
+		<record id="group_so_discount_block_releaser" model="res.groups">
+        	<field name="name">Sales Quotation Discount Block Releaser</field>
+			<field name="category_id" ref="base.module_category_sales_management"/>
+			<field name="comment">The user will have permission to confirm sales quotations where the maximum allowed discount has been exceeded in at least one item.</field>
+    	</record>
+
+    </data>
+</openerp>

--- a/sale_discount_limit/view/product_view.xml
+++ b/sale_discount_limit/view/product_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="product_template_form_view" model="ir.ui.view">
+            <field name="name">product.template.form.inherit</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_form_view"/>
+            <field name="arch" type="xml">
+                <xpath expr="//group[@name='sale_condition']"
+                       position="inside">
+                    <field name="max_sale_discount"/>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/sale_discount_limit/view/sale_view.xml
+++ b/sale_discount_limit/view/sale_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_order_form" model="ir.ui.view">
+            <field name="name">sale.order.form</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form"/>
+            <field name="arch" type="xml">
+                <button name="print_quotation" position="after">
+                    <button name="check_discount_limit"
+                            string="Check discount limit" type="object" states="draft,sent" groups="sale.group_discount_per_so_line"/>
+                </button>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/sale_discount_limit/view/sale_workflow.xml
+++ b/sale_discount_limit/view/sale_workflow.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="sale.trans_draft_router" model="workflow.transition">
+            <field name="act_from" ref="sale.act_draft"/>
+            <field name="act_to" ref="sale.act_router"/>
+            <field name="signal">order_confirm</field>
+            <field name="condition">check_discount_limit()</field>
+        </record>
+
+        <record id="sale.trans_sent_router" model="workflow.transition">
+            <field name="act_from" ref="sale.act_sent"/>
+            <field name="act_to" ref="sale.act_router"/>
+            <field name="signal">order_confirm</field>
+            <field name="condition">check_discount_limit()</field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
This module was created to extend the sales process. It allows to
set a maximum permitted sales discount % on each product on a sale quotation.

A sales user cannot approve a sales quotation if any of the items contain a
sales discount % above the maximum allowed.

A user can manually initiate the maximum discount limit check when the quote
is in status draft or sent.

Users belonging to the group 'Sales Quotation Discount Block Releaser' will
have the permission to override this rule and approve the sales quotation.
