### PR TITLE
[FIX] <sale_order_back2draft>

### DIFF
--- a/sale_order_back2draft/models/sale_order.py
+++ b/sale_order_back2draft/models/sale_order.py
@@ -18,6 +18,8 @@ class SaleOrder(models.Model):
                     _("You can't back any order that it's not on cancel "
                       "state. Order: %s" % order.name))
             order.order_line.write({'state': 'draft'})
+            order.procurement_group_id.unlink()
+            order.order_line.procurement_ids.unlink()
             order.write({'state': 'draft'})
             order.delete_workflow()
             order.create_workflow()

--- a/sale_order_back2draft/models/sale_order.py
+++ b/sale_order_back2draft/models/sale_order.py
@@ -19,7 +19,8 @@ class SaleOrder(models.Model):
                       "state. Order: %s" % order.name))
             order.order_line.write({'state': 'draft'})
             order.procurement_group_id.unlink()
-            order.order_line.procurement_ids.unlink()
+            for line in order.order_line:
+                line.procurement_ids.unlink()
             order.write({'state': 'draft'})
             order.delete_workflow()
             order.create_workflow()


### PR DESCRIPTION
Delete procurement orders and group to avoid problems when changing partner
- If a sale.order is restarted, and changed the partner, when creating the picking it takes the old partners address instead the new one.
