### PR TITLE
[FIX] sale_order_revision #184

### DIFF
--- a/sale_order_revision/model/sale_order.py
+++ b/sale_order_revision/model/sale_order.py
@@ -55,10 +55,6 @@ class sale_order(models.Model):
     def copy_quotation(self):
         self.ensure_one()
 
-        # store existing procurement group id, unset it on new revision
-        procurement_group_id = self.procurement_group_id.id
-        self.write({'procurement_group_id': None})
-
         revision_self = self.with_context(new_sale_revision=True)
         action = super(sale_order, revision_self).copy_quotation()
         old_revision = self.browse(action['res_id'])
@@ -73,9 +69,6 @@ class sale_order(models.Model):
         msg = _('New revision created: %s') % self.name
         self.message_post(body=msg)
         old_revision.message_post(body=msg)
-
-        # set stored procurement group id on old order
-        old_revision.write({'procurement_group_id': procurement_group_id})
 
         # swap order lines of old and new order
         so_line = self.env['sale.order.line']

--- a/sale_order_revision/model/sale_order.py
+++ b/sale_order_revision/model/sale_order.py
@@ -54,6 +54,11 @@ class sale_order(models.Model):
     @api.multi
     def copy_quotation(self):
         self.ensure_one()
+
+        # store existing procurement group id, unset it on new revision
+        procurement_group_id = self.procurement_group_id.id
+        self.write({'procurement_group_id': None})
+
         revision_self = self.with_context(new_sale_revision=True)
         action = super(sale_order, revision_self).copy_quotation()
         old_revision = self.browse(action['res_id'])
@@ -69,15 +74,15 @@ class sale_order(models.Model):
         self.message_post(body=msg)
         old_revision.message_post(body=msg)
 
-        # cancel order lines for old revision
-        line = self.pool.get('sale.order.line')
-        line.write(self._cr, self._uid,
-                   [line.id for line in old_revision.order_line],
-                   {'state': 'cancel'}, context=self._context)
-        # for current revision, set them to draft
-        line.write(self._cr, self._uid,
-                   [line.id for line in self.order_line],
-                   {'state': 'draft'}, context=self._context)
+        # set stored procurement group id on old order
+        old_revision.write({'procurement_group_id': procurement_group_id})
+
+        # swap order lines of old and new order
+        so_line = self.env['sale.order.line']
+        old_lines = so_line.browse(old_revision.order_line.ids)
+        new_lines = so_line.browse(self.order_line.ids)
+        old_lines.write({'order_id': self.id})
+        new_lines.write({'order_id': old_revision.id})
 
         return action
 

--- a/sale_order_revision/model/sale_order.py
+++ b/sale_order_revision/model/sale_order.py
@@ -79,8 +79,8 @@ class sale_order(models.Model):
 
         # swap order lines of old and new order
         so_line = self.env['sale.order.line']
-        old_lines = so_line.browse(old_revision.order_line.ids)
-        new_lines = so_line.browse(self.order_line.ids)
+        old_lines = old_revision.order_line
+        new_lines = self.order_line
         old_lines.write({'order_id': self.id})
         new_lines.write({'order_id': old_revision.id})
 

--- a/sale_order_revision/model/sale_order.py
+++ b/sale_order_revision/model/sale_order.py
@@ -68,6 +68,17 @@ class sale_order(models.Model):
         msg = _('New revision created: %s') % self.name
         self.message_post(body=msg)
         old_revision.message_post(body=msg)
+
+        # cancel order lines for old revision
+        line = self.pool.get('sale.order.line')
+        line.write(self._cr, self._uid,
+                   [line.id for line in old_revision.order_line],
+                   {'state': 'cancel'}, context=self._context)
+        # for current revision, set them to draft
+        line.write(self._cr, self._uid,
+                   [line.id for line in self.order_line],
+                   {'state': 'draft'}, context=self._context)
+
         return action
 
     @api.returns('self', lambda value: value.id)

--- a/sale_order_revision/test/sale_order.yml
+++ b/sale_order_revision/test/sale_order.yml
@@ -3,9 +3,15 @@
 -
   !record {model: sale.order, id: sale_order_1}:
     partner_id: base.res_partner_2
+    partner_invoice_id: base.res_partner_2
+    partner_shipping_id: base.res_partner_2
     order_line:
       - product_id: product.product_product_15
         product_uom_qty: 15.0
+-
+  I confirm the SO
+-
+  !workflow {model: sale.order, action: order_confirm, ref: sale_order_1}
 -
   I cancel the SO
 -
@@ -24,5 +30,6 @@
      assert new_so.name.endswith('-01')
      assert not new_so.order_line[0].procurement_ids
      assert all(line.state == 'draft' for line in new_so.order_line)
+     assert len(new_so.procurement_group_id.ids) == 0
      old_so = new_so.old_revision_ids[0]
      assert all(line.state == 'cancel' for line in old_so.order_line)

--- a/sale_order_revision/test/sale_order.yml
+++ b/sale_order_revision/test/sale_order.yml
@@ -23,3 +23,6 @@
      assert new_so.revision_number == 1
      assert new_so.name.endswith('-01')
      assert not new_so.order_line[0].procurement_ids
+     assert all(line.state == 'draft' for line in new_so.order_line)
+     old_so = new_so.old_revision_ids[0]
+     assert all(line.state == 'cancel' for line in old_so.order_line)


### PR DESCRIPTION
Fix: set new order lines to draft and old ones to cancel.

Rationale: the way this module creates a new revision is that the old, cancelled revision is renamed to the new revision, then a copy is created and named after the old revision. As a result the lines of the old revision (copy) have state "draft" (the default) and the lines of the new revision have state "cancel". It should be the other way around. So, this fix switches the states around.
