### PR TITLE
8.0 sale_rental :  Fix tax on sale order lines

### DIFF
--- a/sale_rental/sale_view.xml
+++ b/sale_rental/sale_view.xml
@@ -39,7 +39,7 @@
     <field name="inherit_id" ref="sale_stock.view_order_form_inherit" />
     <field name="arch" type="xml">
         <xpath expr="//field[@name='order_line']/form//field[@name='product_id']" position="attributes">
-            <attribute name="on_change">product_id_change_with_wh_with_rental(parent.pricelist_id,product_id,product_uom_qty,product_uom,product_uos_qty,False,name,parent.partner_id, False, False, parent.date_order, product_packaging, parent.fiscal_position, True, parent.warehouse_id, rental_type, rental_qty, context)</attribute>
+            <attribute name="on_change">product_id_change_with_wh_with_rental(parent.pricelist_id, product_id, product_uom_qty, product_uom, product_uos_qty, False, name, parent.partner_id, False, True, parent.date_order, product_packaging, parent.fiscal_position, False, parent.warehouse_id, rental_type, rental_qty, context)</attribute>
         </xpath>
         <xpath expr="//field[@name='order_line']/form//field[@name='product_uom_qty']" position="attributes">
             <attribute name="on_change">product_id_change_with_wh_with_rental(parent.pricelist_id,product_id,product_uom_qty,product_uom,product_uos_qty,False,name,parent.partner_id, False, False, parent.date_order, product_packaging, parent.fiscal_position, True, parent.warehouse_id, rental_type, rental_qty, context)</attribute>


### PR DESCRIPTION
Without this fix, when the module sale_rental is installed, the taxes are not set in the sale order lines...
