### PR TITLE
[FIX] sale_order_type: Fixed bug when picking is created from a purchase order

### DIFF
--- a/sale_order_type/README.rst
+++ b/sale_order_type/README.rst
@@ -38,6 +38,7 @@ Contributors
 * Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Ana Juaristi <anajuaristi@avanzosc.es>
+* Daniel Campos <danielcampos@avanzosc.es>
 
 Maintainer
 ----------

--- a/sale_order_type/models/__init__.py
+++ b/sale_order_type/models/__init__.py
@@ -8,3 +8,4 @@ from . import sale_order_type
 from . import sale_order
 from . import stock_picking
 from . import res_partner
+from . import stock_move

--- a/sale_order_type/models/stock_move.py
+++ b/sale_order_type/models/stock_move.py
@@ -1,0 +1,18 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+# For copyright and license notices, see __openerp__.py file in root directory
+##############################################################################
+
+from openerp import api, models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    @api.model
+    def _prepare_picking_assign(self, move):
+        values = super(StockMove, self)._prepare_picking_assign(move)
+        if move.procurement_id.sale_line_id:
+            sale = move.procurement_id.sale_line_id.order_id
+            values['invoice_state'] = sale.type_id.invoice_state
+        return values

--- a/sale_order_type/models/stock_picking.py
+++ b/sale_order_type/models/stock_picking.py
@@ -10,15 +10,6 @@ class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     @api.model
-    def create(self, values):
-        origin = values.get('origin', False)
-        if origin:
-            sale_obj = self.env['sale.order']
-            sale = sale_obj.search([('name', '=', origin)], limit=1)
-            values.update({'invoice_state': sale.type_id.invoice_state})
-        return super(StockPicking, self).create(values)
-
-    @api.model
     def _create_invoice_from_picking(self, picking, vals):
         if picking and picking.sale_id:
             sale = picking.sale_id

--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -11,6 +11,8 @@ class TestSaleOrderType(common.TransactionCase):
         super(TestSaleOrderType, self).setUp()
         self.sale_type_model = self.env['sale.order.type']
         self.sale_order_model = self.env['sale.order']
+        self.stock_picking_model = self.env['stock.picking']
+        self.picking_type_out = self.env.ref('stock.picking_type_out')
         self.sale_line_model = self.env['sale.order.line']
         self.picking_model = self.env['stock.picking']
         self.partner = self.env.ref('base.res_partner_1')
@@ -68,3 +70,10 @@ class TestSaleOrderType(common.TransactionCase):
         for picking in sale_order.picking_ids:
             self.assertEqual(self.sale_type.invoice_state,
                              picking.invoice_state)
+
+    def test_stock_picking_create(self):
+        self.picking_out = self.picking_model.create({
+            'partner_id': self.partner.id,
+            'picking_type_id': self.picking_type_out.id
+        })
+        self.assertTrue(self.picking_out.id)


### PR DESCRIPTION
When the stock.picking is created the 'invoice_state' field cannot be null.
