### PR TITLE
[FIX] don't rename parameters in product_id_change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: python
 sudo: false
 cache: pip
 
@@ -7,26 +8,22 @@ addons:
       - expect-dev  # provides unbuffer utility
       - python-lxml # because pip installation is slow
 
-language: python
-
 python:
   - "2.7"
 
 env:
+  global:
+  - VERSION="7.0" TESTS="0" LINT_CHECK="0" TRANSIFEX="0"
+  matrix:
+  - LINT_CHECK=1
   # exclude tests of modules which doesn't depends on sale_stock
-  - VERSION="7.0" ODOO_REPO="odoo/odoo" EXCLUDE="last_sale_price"
-  - VERSION="7.0" ODOO_REPO="odoo/odoo" INCLUDE="last_sale_price"
-
-  - VERSION="7.0" ODOO_REPO="OCA/OCB" EXCLUDE="last_sale_price"
-  - VERSION="7.0" ODOO_REPO="OCA/OCB" INCLUDE="last_sale_price"
+  - TESTS=1 ODOO_REPO="odoo/odoo" EXCLUDE="last_sale_price"
+  - TESTS=1 ODOO_REPO="odoo/odoo" INCLUDE="last_sale_price"
+  - TESTS=1 ODOO_REPO="OCA/OCB" EXCLUDE="last_sale_price"
+  - TESTS=1 ODOO_REPO="OCA/OCB" INCLUDE="last_sale_price"
 
 virtualenv:
   system_site_packages: true
-
-before_install:
-  - git clone https://github.com/OCA/product-attribute $HOME/product-attribute -b ${VERSION}
-  - git clone https://github.com/OCA/purchase-workflow $HOME/purchase-workflow -b ${VERSION}
-  - git clone https://github.com/OCA/server-tools.git $HOME/server-tools -b ${VERSION}
 
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
@@ -37,4 +34,4 @@ script:
   - travis_run_tests
 
 after_success:
-  coveralls
+  - travis_after_tests_success

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,3 @@
+product-attribute
+purchase-workflow
+server-tools

--- a/sale_line_description/sale.py
+++ b/sale_line_description/sale.py
@@ -26,19 +26,19 @@ class sale_order_line(orm.Model):
     _inherit = "sale.order.line"
 
     def product_id_change(
-        self, cr, uid, ids, pricelist, product_id, qty=0,
+        self, cr, uid, ids, pricelist, product, qty=0,
         uom=False, qty_uos=0, uos=False, name='', partner_id=False,
         lang=False, update_tax=True, date_order=False, packaging=False,
         fiscal_position=False, flag=False, context=None
     ):
         res = super(sale_order_line, self).product_id_change(
-            cr, uid, ids, pricelist, product_id, qty=qty, uom=uom,
+            cr, uid, ids, pricelist, product, qty=qty, uom=uom,
             qty_uos=qty_uos, uos=uos, name='', partner_id=partner_id,
             lang=lang, update_tax=update_tax, date_order=date_order,
             packaging=packaging, fiscal_position=fiscal_position,
             flag=flag, context=context
         )
-        if product_id:
+        if product:
             user = self.pool.get('res.users').browse(
                 cr, uid, uid, context=context)
             user_groups = [g.id for g in user.groups_id]
@@ -51,7 +51,7 @@ class sale_order_line(orm.Model):
                 if group_id in user_groups:
                     product_obj = self.pool.get('product.product')
                     product = product_obj.browse(
-                        cr, uid, product_id, context=context)
+                        cr, uid, product, context=context)
                     if (
                         product and
                         product.description and

--- a/sale_line_quantity_properties_based/sale_order_line.py
+++ b/sale_line_quantity_properties_based/sale_order_line.py
@@ -31,13 +31,13 @@ class SaleOrderLine(orm.Model):
     _inherit = 'sale.order.line'
 
     def product_id_change(
-        self, cr, uid, ids, pricelist, product_id, qty=0,
+        self, cr, uid, ids, pricelist, product, qty=0,
         uom=False, qty_uos=0, uos=False, name='', partner_id=False,
         lang=False, update_tax=True, date_order=False, packaging=False,
         fiscal_position=False, flag=False, context=None
     ):
         res = super(SaleOrderLine, self).product_id_change(
-            cr, uid, ids, pricelist, product_id, qty=qty,
+            cr, uid, ids, pricelist, product, qty=qty,
             uom=uom, qty_uos=qty_uos, uos=uos,
             name=name, partner_id=partner_id,
             lang=lang, update_tax=update_tax,
@@ -49,9 +49,9 @@ class SaleOrderLine(orm.Model):
         prop_ctx = context.copy()
         if 'lang' in prop_ctx:
             del prop_ctx['lang']
-        if product_id and property_ids and qty_uos:
+        if product and property_ids and qty_uos:
             product = self.pool['product.product'].browse(
-                cr, uid, product_id, context=context)
+                cr, uid, product, context=context)
             if product.quantity_formula_id:
                 prop_dict = {}
                 prop_pool = self.pool['mrp.property']
@@ -75,7 +75,7 @@ class SaleOrderLine(orm.Model):
                     'uid': uid,
                     'properties': prop_dict,
                     'qty_uos': qty_uos,
-                    'product_id': product_id,
+                    'product_id': product.id,
                 }
                 try:
                     exec product.quantity_formula_id.formula_text in localdict


### PR DESCRIPTION
some addons such as sale_stock call it with named arguments
and this will cause a crash if you rename e.g. the product arg
to product_id.
