### PR TITLE
[FIX] <sale_order_type> Invoice state from type not applied in pickings

### DIFF
--- a/sale_order_type/models/sale_order.py
+++ b/sale_order_type/models/sale_order.py
@@ -42,6 +42,13 @@ class SaleOrder(models.Model):
         return super(SaleOrder, self).create(vals)
 
     @api.model
+    def _prepare_order_line_procurement(self, order, line, group_id=False):
+        vals = super(SaleOrder, self)._prepare_order_line_procurement(
+            order, line, group_id=group_id)
+        vals['invoice_state'] = order.type_id.invoice_state
+        return vals
+
+    @api.model
     def _prepare_invoice(self, order, line_ids):
         res = super(SaleOrder, self)._prepare_invoice(order, line_ids)
         if order.type_id.journal_id:

--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -11,10 +11,7 @@ class TestSaleOrderType(common.TransactionCase):
         super(TestSaleOrderType, self).setUp()
         self.sale_type_model = self.env['sale.order.type']
         self.sale_order_model = self.env['sale.order']
-        self.stock_picking_model = self.env['stock.picking']
-        self.picking_type_out = self.env.ref('stock.picking_type_out')
-        self.sale_line_model = self.env['sale.order.line']
-        self.picking_model = self.env['stock.picking']
+        self.invoice_model = self.env['account.invoice']
         self.partner = self.env.ref('base.res_partner_1')
         self.sequence = self.env['ir.sequence'].create({
             'name': 'Test Sales Order',
@@ -70,10 +67,11 @@ class TestSaleOrderType(common.TransactionCase):
         for picking in sale_order.picking_ids:
             self.assertEqual(self.sale_type.invoice_state,
                              picking.invoice_state)
-
-    def test_stock_picking_create(self):
-        self.picking_out = self.picking_model.create({
-            'partner_id': self.partner.id,
-            'picking_type_id': self.picking_type_out.id
-        })
-        self.assertTrue(self.picking_out.id)
+            for move in picking.move_lines:
+                self.assertEqual(self.sale_type.invoice_state,
+                                 move.invoice_state)
+            invoices = picking.action_invoice_create(
+                self.journal, group=False, type='out_invoice')
+            for invoice in self.invoice_model.browse(invoices):
+                self.assertEqual(
+                    self.sale_type.journal_id, invoice.journal_id)


### PR DESCRIPTION
When a picking is assigned to a stock.move if this has invoice_state = 'to2invoiced' but the picking had 'none' it updates the value in picking to 'to2invoiced'
