### PR TITLE
IMP add exceptions in quotation tree view

### DIFF
--- a/sale_exceptions/sale_view.xml
+++ b/sale_exceptions/sale_view.xml
@@ -87,6 +87,17 @@
             </field>
         </record>
 
+        <record id="view_quotation_tree" model="ir.ui.view">
+            <field name="name">sale_exceptions.view_order_tree</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_quotation_tree"/>
+            <field name="arch" type="xml">
+                <field name="state" position="after">
+                    <field name="main_exception_id"/>
+                </field>
+            </field>
+        </record>
+
         <record id="view_sales_order_filter" model="ir.ui.view">
             <field name="name">sale_exceptions.view_sales_order_filter</field>
             <field name="model">sale.order</field>


### PR DESCRIPTION
Actually main exception is only visible on confirmed sale orders tree view. This PR add it also in draft sale order tree view.

Thanks for this incredible module!
