### PR TITLE
Display reset button on SO when state == sent

### DIFF
--- a/sale_order_price_recalculation/views/sale_order_view.xml
+++ b/sale_order_price_recalculation/views/sale_order_view.xml
@@ -10,11 +10,11 @@
                 <field name="order_line" position="after">
                     <button name="recalculate_prices"
                             string="Recalculate prices"
-                            attrs="{'invisible': [('state', '!=', 'draft')]}"
+                            attrs="{'invisible': [('state', 'not in', ['draft', 'sent'])]}"
                             type="object" colspan="4" class="oe_inline"/>
                     <button name="recalculate_names"
                             string="Reset descriptions"
-                            attrs="{'invisible': [('state', '!=', 'draft')]}"
+                            attrs="{'invisible': [('state', 'not in', ['draft', 'sent'])]}"
                             type="object" colspan="4" class="oe_inline"/>
                 </field>
             </field>


### PR DESCRIPTION
PR #214 restricted buttons visibilities to `draft` state. As long prices and descriptions are settable at `sent` state I think those buttons should be visible at this stage.
