### PR TITLE
7.0 fix sale visible tax view

### DIFF
--- a/sale_visible_tax/sale_view.xml
+++ b/sale_visible_tax/sale_view.xml
@@ -9,10 +9,10 @@
             <field eval="200" name="priority"/>
             <field name="type">form</field>
             <field name="arch" type="xml">
-                <field name="price_subtotal" position="after">
+                <xpath expr="//field[@name='order_line']/tree//field[@name='price_subtotal']" position="after">
                     <field name="vat_subtotal"/>
                     <field name="price_subtotal_taxinc"/>
-                </field>
+                </xpath>
             </field>
         </record>
 

--- a/sale_visible_tax/sale_view.xml
+++ b/sale_visible_tax/sale_view.xml
@@ -6,7 +6,6 @@
         <record id="sale_order_view_form" model="ir.ui.view">
             <field name="model">sale.order</field>
             <field name="inherit_id" ref="sale.view_order_form" />
-            <field eval="200" name="priority"/>
             <field name="type">form</field>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='order_line']/tree//field[@name='price_subtotal']" position="after">


### PR DESCRIPTION
Without this fix, the two new fields are not displayed in sale order form view.
This path fixes the bug.

Kind regard.
