### PR TITLE
[9.0][FIX] Sale order lines not set to draft

### DIFF
--- a/sale_order_revision/model/sale_order.py
+++ b/sale_order_revision/model/sale_order.py
@@ -61,6 +61,7 @@ class sale_order(models.Model):
         self.delete_workflow()
         self.create_workflow()
         self.write({'state': 'draft'})
+        self.order_line.write({'state': 'draft'})
         msg = _('New revision created: %s') % self.name
         self.message_post(body=msg)
         old_revision.message_post(body=msg)


### PR DESCRIPTION
When creating a new revision of a cancelled sale order, the sale order is set to the state draft, but the order lines are not updated to draft.
The lines are still in state cancelled and cannot be updated.
