### PR TITLE
FIX sale_procurement_group_by_line

### DIFF
--- a/sale_procurement_group_by_line/__init__.py
+++ b/sale_procurement_group_by_line/__init__.py
@@ -19,3 +19,12 @@
 #
 #
 from . import model
+
+
+def populate_old_procurement_group_id(cr, registry):
+    line_registry = registry['sale.order.line']
+    line_ids = line_registry.search(cr, 1, [])
+    for line in line_registry.browse(cr, 1, line_ids):
+        line.write({
+            'procurement_group_id': line.order_id.procurement_group_id.id
+            })

--- a/sale_procurement_group_by_line/__openerp__.py
+++ b/sale_procurement_group_by_line/__openerp__.py
@@ -35,4 +35,5 @@
  'test': [],
  'auto_install': False,
  'installable': True,
+ 'post_init_hook': 'populate_old_procurement_group_id',
  }


### PR DESCRIPTION
When installed on DB with existing sale orders, old order lines have empty procurement_group_id,
preventing 'view delivery order' button to be displayed
