### PR TITLE
[ADD] add new module to manage usage of advance progressively

### DIFF
--- a/sale_order_partial_advance/README.rst
+++ b/sale_order_partial_advance/README.rst
@@ -1,0 +1,44 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Sale Order Partial Advance
+===========================
+
+This module was written to extend the sale advance management. It allows to
+use an advance amount progressively when you invoices only some order lines.
+
+Example:
+    You create a sale order with 4 differents products for a total amount of 2000.
+    The customer pays an advance of 600. All the products will not be delivered 
+    in the same time and, once you invoice the first delivery,
+    you want to keep a part of the advance as warranty and only deduct 400
+    from the 600 paid.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/server-tools/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/sale_workflow/issues/new?body=module:%20sale_order_partial_advance%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Cédric Pigeon <cedric.pigeon@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/sale_order_partial_advance/README.rst
+++ b/sale_order_partial_advance/README.rst
@@ -4,7 +4,7 @@
 Sale Order Partial Advance
 ===========================
 
-This module was written to extend the sale advance management. It allows to
+This module was written to extend the sale management. It allows to
 use an advance amount progressively when you invoices only some order lines.
 
 Example:
@@ -20,10 +20,51 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/OCA/server-tools/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
-`here <https://github.com/OCA/sale_workflow/issues/new?body=module:%20sale_order_partial_advance%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`here <https://github.com/OCA/sale_workflow/issues/new?body
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==========================
+Sale Order Partial Advance
+==========================
+
+This module extends the functionality of sale management.
+It allows you to use an advance amount progressively when you invoices only some order lines.
+
+Example:
+    You create a sale order with 4 different products for a total amount of 2000.
+    The customer pays an advance of 800. All the products will not be delivered 
+    at once and when you invoice the first delivery of 500,
+    you want to keep a part of the advance as warranty and only deduct 200
+    out of the 800 paid.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/167/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/sale-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/
+sale-workflow/issues/new?body=module:%20
+sale__order_partial_advance%0Aversion:%20
+{branch}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Credits
 =======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
 
 Contributors
 ------------
@@ -33,12 +74,14 @@ Contributors
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
-OCA, or the Odoo Community Association, is a nonprofit organization whose mission is to support the collaborative development of Odoo features and promote its widespread use.
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
 
 To contribute to this module, please visit http://odoo-community.org.

--- a/sale_order_partial_advance/__init__.py
+++ b/sale_order_partial_advance/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import models
+from . import wizard

--- a/sale_order_partial_advance/__openerp__.py
+++ b/sale_order_partial_advance/__openerp__.py
@@ -1,46 +1,18 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#     This file is part of sale_order_partial_advance,
-#     an Odoo module.
-#
-#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#     sale_order_partial_advance is free software:
-#     you can redistribute it and/or modify it under the terms of the GNU
-#     Affero General Public License as published by the Free Software
-#     Foundation,either version 3 of the License, or (at your option) any
-#     later version.
-#
-#     sale_order_partial_advance is distributed
-#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-#     PURPOSE.  See the GNU Affero General Public License for more details.
-#
-#     You should have received a copy of the GNU Affero General Public License
-#     along with sale_order_partial_advance.
-#     If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': "sale_order_partial_advance",
-
     'summary': """
         Sale Order Partial Advance """,
-
-    'author': 'ACSONE SA/NV',
+    'author': 'ACSONE SA/NV, Odoo Community Association (OCA)',
     'website': "http://acsone.eu",
-
     'category': 'Sales Management',
     'version': '8.0.1.0.0',
     'license': 'AGPL-3',
-
-    # any module necessary for this one to work correctly
     'depends': [
         'sale',
     ],
-
-    # always loaded
     'data': [
         'data/product_data.xml',
         'wizard/sale_line_invoice.xml',

--- a/sale_order_partial_advance/__openerp__.py
+++ b/sale_order_partial_advance/__openerp__.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of sale_order_partial_advance,
+#     an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     sale_order_partial_advance is free software:
+#     you can redistribute it and/or modify it under the terms of the GNU
+#     Affero General Public License as published by the Free Software
+#     Foundation,either version 3 of the License, or (at your option) any
+#     later version.
+#
+#     sale_order_partial_advance is distributed
+#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#     PURPOSE.  See the GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the GNU Affero General Public License
+#     along with sale_order_partial_advance.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': "sale_order_partial_advance",
+
+    'summary': """
+        Sale Order Partial Advance """,
+
+    'author': 'ACSONE SA/NV',
+    'website': "http://acsone.eu",
+
+    'category': 'Sales Management',
+    'version': '8.0.1.0.0',
+    'license': 'AGPL-3',
+
+    # any module necessary for this one to work correctly
+    'depends': [
+        'sale',
+    ],
+
+    # always loaded
+    'data': [
+        'data/product_data.xml',
+        'wizard/sale_line_invoice.xml',
+    ],
+}

--- a/sale_order_partial_advance/data/product_data.xml
+++ b/sale_order_partial_advance/data/product_data.xml
@@ -5,7 +5,7 @@
             <field name="list_price">0.0</field>
             <field name="standard_price">0.0</field>
             <field name="type">service</field>
-           <field name="name">Advance product</field>
+            <field name="name">Advance product</field>
             <field name="company_id" />
             <field name="taxes_id" />
             <field name="supplier_taxes_id" />

--- a/sale_order_partial_advance/data/product_data.xml
+++ b/sale_order_partial_advance/data/product_data.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<openerp>
+    <data noupdate="0">
+        <record id="sale.advance_product_0" model="product.product">
+            <field name="list_price">0.0</field>
+            <field name="standard_price">0.0</field>
+            <field name="type">service</field>
+           <field name="name">Advance product</field>
+            <field name="company_id" />
+            <field name="taxes_id" />
+            <field name="supplier_taxes_id" />
+            <field name="sale_ok" eval="0"/>
+        </record>
+    </data>
+</openerp>

--- a/sale_order_partial_advance/i18n/fr.po
+++ b/sale_order_partial_advance/i18n/fr.po
@@ -1,0 +1,88 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_order_partial_advance
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-12-02 08:59+0000\n"
+"PO-Revision-Date: 2015-12-02 08:59+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,advance_amount_available:0
+msgid "Advance Available"
+msgstr "Acompte Disponible"
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,advance_amount_to_use:0
+msgid "Advance To Use"
+msgstr "Montant à prélever"
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,all_lines:0
+msgid "All Sale Order Lines Selected"
+msgstr "Selection de toutes les lignes"
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,create_uid:0
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,create_date:0
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,write_uid:0
+msgid "Last Updated by"
+msgstr "Mis à jour par"
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,write_date:0
+msgid "Last Updated on"
+msgstr "Mis à jour le"
+
+#. module: sale_order_partial_advance
+#: code:addons/sale_order_partial_advance/wizard/sale_line_invoice.py:69
+#, python-format
+msgid "Part of advance (%s %s) used"
+msgstr "Proportion de l'acompte (%s %s) utilisé"
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,order_id:0
+msgid "Sale Order"
+msgstr "Commande de vente"
+
+#. module: sale_order_partial_advance
+#: model:ir.model,name:sale_order_partial_advance.model_sale_order_line_make_invoice
+msgid "Sale OrderLine Make_invoice"
+msgstr "Lignes de vente : Facturer"
+
+#. module: sale_order_partial_advance
+#: field:sale.order.line.make.invoice,order_ids:0
+msgid "Sale Orders"
+msgstr "Commandes de vente"
+
+#. module: sale_order_partial_advance
+#: model:ir.model,name:sale_order_partial_advance.model_sale_order
+msgid "Sales Order"
+msgstr "Bon de commande"
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,wizard_id:0
+msgid "Wizard"
+msgstr "Assistant"
+

--- a/sale_order_partial_advance/i18n/sale_order_partial_advance.pot
+++ b/sale_order_partial_advance/i18n/sale_order_partial_advance.pot
@@ -1,0 +1,88 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_order_partial_advance
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-12-02 08:59+0000\n"
+"PO-Revision-Date: 2015-12-02 08:59+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,advance_amount_available:0
+msgid "Advance Available"
+msgstr ""
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,advance_amount_to_use:0
+msgid "Advance To Use"
+msgstr ""
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,all_lines:0
+msgid "All Sale Order Lines Selected"
+msgstr ""
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,create_uid:0
+msgid "Created by"
+msgstr ""
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,create_date:0
+msgid "Created on"
+msgstr ""
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,id:0
+msgid "ID"
+msgstr ""
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,write_uid:0
+msgid "Last Updated by"
+msgstr ""
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,write_date:0
+msgid "Last Updated on"
+msgstr ""
+
+#. module: sale_order_partial_advance
+#: code:addons/sale_order_partial_advance/wizard/sale_line_invoice.py:69
+#, python-format
+msgid "Part of advance (%s %s) used"
+msgstr ""
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,order_id:0
+msgid "Sale Order"
+msgstr ""
+
+#. module: sale_order_partial_advance
+#: model:ir.model,name:sale_order_partial_advance.model_sale_order_line_make_invoice
+msgid "Sale OrderLine Make_invoice"
+msgstr ""
+
+#. module: sale_order_partial_advance
+#: field:sale.order.line.make.invoice,order_ids:0
+msgid "Sale Orders"
+msgstr ""
+
+#. module: sale_order_partial_advance
+#: model:ir.model,name:sale_order_partial_advance.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: sale_order_partial_advance
+#: field:sale.order.make.invoice,wizard_id:0
+msgid "Wizard"
+msgstr ""
+

--- a/sale_order_partial_advance/models/__init__.py
+++ b/sale_order_partial_advance/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import sale

--- a/sale_order_partial_advance/models/__init__.py
+++ b/sale_order_partial_advance/models/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import sale
+from . import account

--- a/sale_order_partial_advance/models/account.py
+++ b/sale_order_partial_advance/models/account.py
@@ -15,7 +15,8 @@ class AccountInvoice(models.Model):
     def _is_cancelled_by_refund(self):
         cancelled = False
         for move in self.payment_ids:
-            if move.invoice and move.invoice.type == 'out_refund':
+            if move.invoice and move.invoice.type == 'out_refund' and \
+                    move.invoice.origin == self.internal_number:
                 cancelled = True
                 break
         self.cancelled_by_refund = cancelled

--- a/sale_order_partial_advance/models/account.py
+++ b/sale_order_partial_advance/models/account.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# © 2016 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp import api, fields, models
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    cancelled_by_refund = fields.Boolean('Cancelled by refund',
+                                         compute='_is_cancelled_by_refund')
+
+    @api.one
+    @api.depends('payment_ids')
+    def _is_cancelled_by_refund(self):
+        cancelled = False
+        for move in self.payment_ids:
+            if move.invoice and move.invoice.type == 'out_refund':
+                cancelled = True
+                break
+        self.cancelled_by_refund = cancelled

--- a/sale_order_partial_advance/models/sale.py
+++ b/sale_order_partial_advance/models/sale.py
@@ -18,13 +18,13 @@ class SaleOrder(models.Model):
                 continue
             advance_amount += sum([line.price_unit
                                   for line in invoice.invoice_line
-                                  if (line.product_id.id == adv_product_id
-                                      and line.price_unit > 0)])
+                                  if (line.product_id.id == adv_product_id and
+                                      line.price_unit > 0)])
             advance_amount_used -= sum([line.price_unit
                                         for line in invoice.invoice_line
                                         if (line.product_id.id ==
-                                            adv_product_id
-                                            and line.price_unit < 0)])
+                                            adv_product_id and
+                                            line.price_unit < 0)])
         self.advance_amount_available = advance_amount - advance_amount_used
         self.advance_amount = advance_amount
         self.advance_amount_used = advance_amount_used

--- a/sale_order_partial_advance/models/sale.py
+++ b/sale_order_partial_advance/models/sale.py
@@ -1,28 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#     This file is part of sale_order_partial_advance,
-#     an Odoo module.
-#
-#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#     sale_order_partial_advance is free software:
-#     you can redistribute it and/or modify it under the terms of the GNU
-#     Affero General Public License as published by the Free Software
-#     Foundation,either version 3 of the License, or (at your option) any
-#     later version.
-#
-#     sale_order_partial_advance is distributed
-#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-#     PURPOSE.  See the GNU Affero General Public License for more details.
-#
-#     You should have received a copy of the GNU Affero General Public License
-#     along with sale_order_partial_advance.
-#     If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-from openerp import models, api, fields
+# © 2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp import api, fields, models
 
 
 class SaleOrder(models.Model):

--- a/sale_order_partial_advance/models/sale.py
+++ b/sale_order_partial_advance/models/sale.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of sale_order_partial_advance,
+#     an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     sale_order_partial_advance is free software:
+#     you can redistribute it and/or modify it under the terms of the GNU
+#     Affero General Public License as published by the Free Software
+#     Foundation,either version 3 of the License, or (at your option) any
+#     later version.
+#
+#     sale_order_partial_advance is distributed
+#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#     PURPOSE.  See the GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the GNU Affero General Public License
+#     along with sale_order_partial_advance.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import models, api, fields
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.one
+    @api.depends('invoice_ids')
+    def _compute_advance_amounts(self):
+        advance_amount, advance_amount_used = 0, 0
+        adv_product_id =\
+            self.env['sale.advance.payment.inv']._get_advance_product()
+        for invoice in self.invoice_ids:
+            if invoice.state == 'cancel':
+                continue
+            advance_amount += sum([line.price_subtotal
+                                  for line in invoice.invoice_line
+                                  if (line.product_id.id == adv_product_id
+                                      and line.price_subtotal > 0)])
+            advance_amount_used -= sum([line.price_subtotal
+                                        for line in invoice.invoice_line
+                                        if (line.product_id.id ==
+                                            adv_product_id
+                                            and line.price_subtotal < 0)])
+        self.advance_amount_available = advance_amount - advance_amount_used
+        self.advance_amount = advance_amount
+        self.advance_amount_used = advance_amount_used
+
+    @api.model
+    def _prepare_invoice(self, order, lines):
+        adv_product_id =\
+            self.env['sale.advance.payment.inv']._get_advance_product()
+        for invoice_line in self.env['account.invoice.line'].browse(lines):
+            if invoice_line.product_id.id == adv_product_id:
+                if - invoice_line.price_unit > order.advance_amount_available:
+                    invoice_line.write(
+                        {'price_unit': - order.advance_amount_available})
+        return super(SaleOrder, self)._prepare_invoice(order, lines)
+
+    advance_amount = fields.Float('Advance Amount',
+                                  compute='_compute_advance_amounts')
+    advance_amount_available = fields.Float('Advance Available',
+                                            compute='_compute_advance_amounts')
+    advance_amount_used = fields.Float('Advance Used',
+                                       compute='_compute_advance_amounts')

--- a/sale_order_partial_advance/models/sale.py
+++ b/sale_order_partial_advance/models/sale.py
@@ -16,15 +16,15 @@ class SaleOrder(models.Model):
         for invoice in self.invoice_ids:
             if invoice.state == 'cancel':
                 continue
-            advance_amount += sum([line.price_subtotal
+            advance_amount += sum([line.price_unit
                                   for line in invoice.invoice_line
                                   if (line.product_id.id == adv_product_id
-                                      and line.price_subtotal > 0)])
-            advance_amount_used -= sum([line.price_subtotal
+                                      and line.price_unit > 0)])
+            advance_amount_used -= sum([line.price_unit
                                         for line in invoice.invoice_line
                                         if (line.product_id.id ==
                                             adv_product_id
-                                            and line.price_subtotal < 0)])
+                                            and line.price_unit < 0)])
         self.advance_amount_available = advance_amount - advance_amount_used
         self.advance_amount = advance_amount
         self.advance_amount_used = advance_amount_used

--- a/sale_order_partial_advance/tests/__init__.py
+++ b/sale_order_partial_advance/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_sale_order_partial_advance

--- a/sale_order_partial_advance/tests/test_sale_order_partial_advance.py
+++ b/sale_order_partial_advance/tests/test_sale_order_partial_advance.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of sale_order_partial_advance,
+#     an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     sale_order_partial_advance is free software:
+#     you can redistribute it and/or modify it under the terms of the GNU
+#     Affero General Public License as published by the Free Software
+#     Foundation,either version 3 of the License, or (at your option) any
+#     later version.
+#
+#     sale_order_partial_advance is distributed
+#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#     PURPOSE.  See the GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the GNU Affero General Public License
+#     along with sale_order_partial_advance.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.tests import common as test_common
+from uuid import uuid4
+
+
+class TestSaleOrderPartialAdvance(test_common.TransactionCase):
+
+    def setUp(self):
+        super(TestSaleOrderPartialAdvance, self).setUp()
+        self.so_obj = self.env['sale.order']
+        self.data_obj = self.env['ir.model.data']
+        self.partner_id = self.env['res.partner'].create(
+            {'name': '%s' % uuid4()})
+        product1 = self.data_obj.get_object_reference('product',
+                                                      'product_product_28')[1]
+        product2 = self.data_obj.get_object_reference('product',
+                                                      'product_product_29')[1]
+        self.order_lines = [
+            (0, 0, {'product_id': product1,
+                    'name': 'Test',
+                    'product_uom_qty': 10.0,
+                    'price_unit': 100
+                    }),
+            (0, 0, {'product_id': product2,
+                    'name': 'Test',
+                    'product_uom_qty': 5.0,
+                    'price_unit': 120
+                    })]
+
+    def test_sale_order_partial_advance(self):
+        '''
+            Test scenario
+            - Create a sale order with 2 lines
+            - Confirm the sale order
+            - Invoice an advance of 500
+            - Invoice the first order line and use 200 from the advance
+            - Invoice the balance, the 300 remaining from the initial
+              advance should be used automatically
+        '''
+        # ----------------------------------------------
+        # Create and confirm a sale order with 2 lines
+        # ----------------------------------------------
+        vals = {
+            'partner_id': self.partner_id.id,
+            'order_line': self.order_lines,
+        }
+        order = self.so_obj.create(vals)
+        self.assertEqual(order.amount_total, 1600.0)
+        order.action_button_confirm()
+
+        # ----------------------------------------------
+        #    Invoice a deposit of 500.0
+        # ----------------------------------------------
+        adv_wizard = self.env['sale.advance.payment.inv'].create(
+            {'advance_payment_method': 'fixed',
+             'amount': 500.0,
+             })
+        adv_wizard.with_context(active_ids=[order.id]).create_invoices()
+        self.assertTrue(order.invoice_ids)
+        self.assertEqual(order.advance_amount, 500.0)
+        self.assertEqual(order.advance_amount_available, 500.0)
+        self.assertEqual(order.advance_amount_used, 0.0)
+
+        # ---------------------------------------------------------------------
+        #    Invoice the first sale order line and consume 200.0 from
+        #    the deposit
+        # ---------------------------------------------------------------------
+        wizard = self.env['sale.order.line.make.invoice'].with_context(
+            active_ids=[order.order_line[0].id]).create({})
+        wizard.order_ids[0].advance_amount_to_use = 200.0
+        res = wizard.with_context(open_invoices=True).make_invoices()
+        invoice = self.env['account.invoice'].browse(res['res_id'])
+        self.assertEqual(invoice.amount_total, 800.0)
+        self.assertEqual(order.advance_amount, 500.0)
+        self.assertEqual(order.advance_amount_available, 300.0)
+        self.assertEqual(order.advance_amount_used, 200.0)
+
+        # ----------------------------------------------
+        #    Invoice the remaining balance
+        # ----------------------------------------------
+        adv_wizar = self.env['sale.advance.payment.inv'].create(
+            {'advance_payment_method': 'all',
+             })
+        res = adv_wizar.with_context(active_ids=[order.id],
+                                     open_invoices=True).create_invoices()
+        invoice = self.env['account.invoice'].browse(res['res_id'])
+        self.assertEqual(invoice.amount_total, 300.0)
+        self.assertEqual(order.advance_amount, 500.0)
+        self.assertEqual(order.advance_amount_available, 0.0)
+        self.assertEqual(order.advance_amount_used, 500.0)
+
+    def test_sale_order_partial_advance_all_lines(self):
+        '''
+            Test scenario
+            - Create a sale order with 2 lines
+            - Confirm the sale order
+            - Invoice an advance
+            - Invoice the 2 order lines at the same time, the whole advance
+              amount should be used
+        '''
+        # ----------------------------------------------
+        # Create and confirm a sale order with 2 lines
+        # ----------------------------------------------
+        vals = {
+            'partner_id': self.partner_id.id,
+            'order_line': self.order_lines,
+        }
+        order = self.so_obj.create(vals)
+        self.assertEqual(order.amount_total, 1600.0)
+        order.action_button_confirm()
+
+        # ----------------------------------------------
+        #    Invoice a deposit of 500.0
+        # ----------------------------------------------
+        adv_wizard = self.env['sale.advance.payment.inv'].create(
+            {'advance_payment_method': 'fixed',
+             'amount': 500.0,
+             })
+        adv_wizard.with_context(active_ids=[order.id]).create_invoices()
+        self.assertTrue(order.invoice_ids)
+        self.assertEqual(order.advance_amount, 500.0)
+        self.assertEqual(order.advance_amount_available, 500.0)
+        self.assertEqual(order.advance_amount_used, 0.0)
+
+        # ----------------------------------------------------------
+        #    Invoice the 2 sale order line, the whole advance amount
+        #    should be consumed
+        # ----------------------------------------------
+        wizard = self.env['sale.order.line.make.invoice'].with_context(
+            active_ids=order.order_line.ids).create({})
+        res = wizard.with_context(open_invoices=True).make_invoices()
+        invoice = self.env['account.invoice'].browse(res['res_id'])
+        self.assertEqual(invoice.amount_total, 1100.0)
+        self.assertEqual(order.advance_amount, 500.0)
+        self.assertEqual(order.advance_amount_available, 0.0)
+        self.assertEqual(order.advance_amount_used, 500.0)

--- a/sale_order_partial_advance/tests/test_sale_order_partial_advance.py
+++ b/sale_order_partial_advance/tests/test_sale_order_partial_advance.py
@@ -1,27 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#     This file is part of sale_order_partial_advance,
-#     an Odoo module.
-#
-#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#     sale_order_partial_advance is free software:
-#     you can redistribute it and/or modify it under the terms of the GNU
-#     Affero General Public License as published by the Free Software
-#     Foundation,either version 3 of the License, or (at your option) any
-#     later version.
-#
-#     sale_order_partial_advance is distributed
-#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-#     PURPOSE.  See the GNU Affero General Public License for more details.
-#
-#     You should have received a copy of the GNU Affero General Public License
-#     along with sale_order_partial_advance.
-#     If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# © 2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openerp.tests import common as test_common
 from uuid import uuid4
 
@@ -31,13 +10,10 @@ class TestSaleOrderPartialAdvance(test_common.TransactionCase):
     def setUp(self):
         super(TestSaleOrderPartialAdvance, self).setUp()
         self.so_obj = self.env['sale.order']
-        self.data_obj = self.env['ir.model.data']
         self.partner_id = self.env['res.partner'].create(
             {'name': '%s' % uuid4()})
-        product1 = self.data_obj.get_object_reference('product',
-                                                      'product_product_28')[1]
-        product2 = self.data_obj.get_object_reference('product',
-                                                      'product_product_29')[1]
+        product1 = self.ref('product.product_product_28')
+        product2 = self.ref('product.product_product_29')
         self.order_lines = [
             (0, 0, {'product_id': product1,
                     'name': 'Test',

--- a/sale_order_partial_advance/wizard/__init__.py
+++ b/sale_order_partial_advance/wizard/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import sale_line_invoice

--- a/sale_order_partial_advance/wizard/sale_line_invoice.py
+++ b/sale_order_partial_advance/wizard/sale_line_invoice.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#     This file is part of sale_order_partial_advance,
+#     an Odoo module.
+#
+#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
+#
+#     sale_order_partial_advance is free software:
+#     you can redistribute it and/or modify it under the terms of the GNU
+#     Affero General Public License as published by the Free Software
+#     Foundation,either version 3 of the License, or (at your option) any
+#     later version.
+#
+#     sale_order_partial_advance is distributed
+#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#     PURPOSE.  See the GNU Affero General Public License for more details.
+#
+#     You should have received a copy of the GNU Affero General Public License
+#     along with sale_order_partial_advance.
+#     If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import models, api, fields
+from openerp.tools.translate import _
+
+
+class SaleOrderLineMakeInvoice(models.TransientModel):
+    _inherit = 'sale.order.line.make.invoice'
+
+    order_ids = fields.One2many(string='Sale Orders',
+                                comodel_name='sale.order.make.invoice',
+                                inverse_name='wizard_id')
+
+    @api.model
+    def default_get(self, fields_list):
+        defaults = super(SaleOrderLineMakeInvoice,
+                         self).default_get(fields_list)
+        lines = self.env['sale.order.line'].browse(
+            self.env.context.get('active_ids', []))
+        orders = set([line.order_id for line in lines
+                      if line.order_id.advance_amount_available > 0])
+        if orders:
+            order_ids = []
+            for order in orders:
+                all_lines = True
+                res = [line.id for line in order.order_line
+                       if line not in lines and not line.invoiced]
+                if res:
+                    all_lines = False
+                to_use = order.advance_amount_available if all_lines else 0.0
+                order_ids.append(
+                    (0, 0, {'wizard_id': self.id,
+                            'order_id': order.id,
+                            'advance_amount_available':
+                            order.advance_amount_available,
+                            'advance_amount_to_use': to_use,
+                            'all_lines': all_lines}))
+            defaults['order_ids'] = order_ids
+        return defaults
+
+    @api.model
+    def _prepare_invoice(self, order, lines):
+        wizard = order.env.context.get('instance')
+        order_adv_data = wizard.order_ids.filtered(
+            lambda x: x.order_id.id == order.id)
+        if order_adv_data:
+            advance_prod_id =\
+                self.env['sale.advance.payment.inv']._get_advance_product()
+            inv_l_obj = self.env['account.invoice.line']
+            val = inv_l_obj.product_id_change(
+                advance_prod_id, False, partner_id=order.partner_id.id,
+                fposition_id=order.fiscal_position.id,
+                company_id=order.company_id.id)
+            inv_line_values = val['value']
+            inv_line_values['product_id'] = advance_prod_id
+            inv_line_values['name'] = _('Part of advance (%s %s) used'
+                                        % (order.advance_amount,
+                                           order.company_id.currency_id.symbol)
+                                        )
+            inv_line_values['price_unit'] =\
+                -order_adv_data.advance_amount_to_use
+            adv_line = inv_l_obj.create(inv_line_values)
+            lines.append(adv_line.id)
+
+        return super(SaleOrderLineMakeInvoice, self)._prepare_invoice(order,
+                                                                      lines)
+
+    @api.multi
+    def make_invoices(self):
+        self = self.with_context(instance=self)
+        return super(SaleOrderLineMakeInvoice,
+                     self).make_invoices()
+
+
+class SaleOrderMakeInvoice(models.TransientModel):
+    _name = 'sale.order.make.invoice'
+
+    wizard_id = fields.Many2one(string='Wizard',
+                                comodel_name='sale.order.line.make.invoice',
+                                required=True)
+    order_id = fields.Many2one(string='Sale Order',
+                               comodel_name='sale.order',
+                               required=True)
+    advance_amount_available = fields.Float('Advance Available')
+    advance_amount_to_use = fields.Float('Advance To Use',
+                                         required=True,
+                                         default=0.0)
+    all_lines = fields.Boolean('All Sale Order Lines Selected')

--- a/sale_order_partial_advance/wizard/sale_line_invoice.py
+++ b/sale_order_partial_advance/wizard/sale_line_invoice.py
@@ -1,28 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#     This file is part of sale_order_partial_advance,
-#     an Odoo module.
-#
-#     Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#     sale_order_partial_advance is free software:
-#     you can redistribute it and/or modify it under the terms of the GNU
-#     Affero General Public License as published by the Free Software
-#     Foundation,either version 3 of the License, or (at your option) any
-#     later version.
-#
-#     sale_order_partial_advance is distributed
-#     in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-#     even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-#     PURPOSE.  See the GNU Affero General Public License for more details.
-#
-#     You should have received a copy of the GNU Affero General Public License
-#     along with sale_order_partial_advance.
-#     If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-from openerp import models, api, fields
+# © 2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp import api, fields, models
 from openerp.tools.translate import _
 
 
@@ -35,6 +14,15 @@ class SaleOrderLineMakeInvoice(models.TransientModel):
 
     @api.model
     def default_get(self, fields_list):
+        '''
+            Extract all sale orders impacted in order to suggest to the user
+            a table containing:
+            - order reference
+            - advance amount still available
+            - advance amount he wants to use
+            If all the lines of the sale order are selected the advance amount
+            to use is automatically set to the amount available
+        '''
         defaults = super(SaleOrderLineMakeInvoice,
                          self).default_get(fields_list)
         lines = self.env['sale.order.line'].browse(
@@ -62,6 +50,8 @@ class SaleOrderLineMakeInvoice(models.TransientModel):
 
     @api.model
     def _prepare_invoice(self, order, lines):
+        # retrieve the context from order recordset because the method caller
+        # does not pass it
         wizard = order.env.context.get('instance')
         order_adv_data = wizard.order_ids.filtered(
             lambda x: x.order_id.id == order.id)

--- a/sale_order_partial_advance/wizard/sale_line_invoice.py
+++ b/sale_order_partial_advance/wizard/sale_line_invoice.py
@@ -64,6 +64,9 @@ class SaleOrderLineMakeInvoice(models.TransientModel):
                 fposition_id=order.fiscal_position.id,
                 company_id=order.company_id.id)
             inv_line_values = val['value']
+            # Set analytic on new invoice line
+            project_id = order.project_id.id or False
+            inv_line_values['account_analytic_id'] = project_id
             inv_line_values['product_id'] = advance_prod_id
             inv_line_values['name'] = _("Part of advance (%s %s) used") % \
                 (order.advance_amount, order.company_id.currency_id.symbol)

--- a/sale_order_partial_advance/wizard/sale_line_invoice.py
+++ b/sale_order_partial_advance/wizard/sale_line_invoice.py
@@ -71,6 +71,9 @@ class SaleOrderLineMakeInvoice(models.TransientModel):
                                         )
             inv_line_values['price_unit'] =\
                 -order_adv_data.advance_amount_to_use
+            if inv_line_values.get('invoice_line_tax_id', False):
+                inv_line_values['invoice_line_tax_id'] = \
+                    [(6, 0, inv_line_values['invoice_line_tax_id'])]
             adv_line = inv_l_obj.create(inv_line_values)
             lines.append(adv_line.id)
 

--- a/sale_order_partial_advance/wizard/sale_line_invoice.py
+++ b/sale_order_partial_advance/wizard/sale_line_invoice.py
@@ -65,10 +65,8 @@ class SaleOrderLineMakeInvoice(models.TransientModel):
                 company_id=order.company_id.id)
             inv_line_values = val['value']
             inv_line_values['product_id'] = advance_prod_id
-            inv_line_values['name'] = _('Part of advance (%s %s) used'
-                                        % (order.advance_amount,
-                                           order.company_id.currency_id.symbol)
-                                        )
+            inv_line_values['name'] = _("Part of advance (%s %s) used") % \
+                (order.advance_amount, order.company_id.currency_id.symbol)
             inv_line_values['price_unit'] =\
                 -order_adv_data.advance_amount_to_use
             if inv_line_values.get('invoice_line_tax_id', False):

--- a/sale_order_partial_advance/wizard/sale_line_invoice.xml
+++ b/sale_order_partial_advance/wizard/sale_line_invoice.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_sale_order_line_make_invoice" model="ir.ui.view">
+            <field name="name">Sales OrderLine Make Invoice</field>
+            <field name="model">sale.order.line.make.invoice</field>
+            <field name="inherit_id" ref='sale.view_sale_order_line_make_invoice'/>
+            <field name="arch" type="xml">
+                <xpath expr="//footer" position="before">
+                    <group>
+                        <field name="order_ids" nolabel="1" attrs="{'invisible': [('order_ids', '=', False)]}">
+                            <tree create="0" delete="0" editable="bottom">
+                                <field name="order_id" readonly="1"/>
+                                <field name="advance_amount_available" readonly="1"/>
+                                <field name="advance_amount_to_use" attrs="{'readonly': [('all_lines', '=', True)]}"/>
+                                <field name="all_lines" invisible="1"/>
+                            </tree>
+                        </field>
+                    </group>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/setup/sale_order_partial_advance/odoo_addons/__init__.py
+++ b/setup/sale_order_partial_advance/odoo_addons/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/sale_order_partial_advance/odoo_addons/sale_order_partial_advance
+++ b/setup/sale_order_partial_advance/odoo_addons/sale_order_partial_advance
@@ -1,0 +1,1 @@
+../../../sale_order_partial_advance

--- a/setup/sale_order_partial_advance/setup.py
+++ b/setup/sale_order_partial_advance/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module was written to extend the sale advance management. It allows to
use an advance amount progressively when you invoices only some order lines.

Example:
    You create a sale order with 4 differents products for a total amount of 2000.
    The customer pays an advance of 600. All the products will not be delivered 
    in the same time and, once you invoice the first delivery,
    you want to keep a part of the advance as warranty and only deduct 400
    from the 600 paid.
