### PR TITLE
[ADD] Added wizard for sorting purchase order lines

### DIFF
--- a/purchase_order_reorder_lines_wizard/__init__.py
+++ b/purchase_order_reorder_lines_wizard/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 initOS GmbH (<http://www.initos.com>).
+#    Author Andreas Zoellner <andreas.zoellner at initos.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import models
+from . import wizards

--- a/purchase_order_reorder_lines_wizard/__openerp__.py
+++ b/purchase_order_reorder_lines_wizard/__openerp__.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 initOS GmbH (<http://www.initos.com>).
+#    Author Andreas Zoellner <andreas.zoellner at initos.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Purchase Order Reorder Lines Wizard',
+    'version': '0.1',
+    'category': 'Purchases',
+    'author': 'initOS GmbH, Odoo Community Association (OCA)',
+    'website': 'http://www.initos.com',
+    'description': """
+A wizard for sorting purchase order lines.
+""",
+    'license': 'AGPL-3',
+    'depends': [
+        'purchase',
+        'purchase_order_reorder_lines',
+    ],
+    'data': [
+        'views/purchase.xml',
+        'wizards/sorting_wizard_view.xml',
+    ],
+    'active': False,
+    'installable': True,
+    'auto_install': True,
+}

--- a/purchase_order_reorder_lines_wizard/models/__init__.py
+++ b/purchase_order_reorder_lines_wizard/models/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 initOS GmbH (<http://www.initos.com>).
+#    Author Andreas Zoellner <andreas.zoellner at initos.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import purchase

--- a/purchase_order_reorder_lines_wizard/models/purchase.py
+++ b/purchase_order_reorder_lines_wizard/models/purchase.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 initOS GmbH (<http://www.initos.com>).
+#    Author Andreas Zoellner <andreas.zoellner at initos.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import orm
+
+
+class PurchaseOrderLine(orm.Model):
+    _inherit = 'purchase.order.line'
+
+    # max. 'sequence' of current order's lines, set by on_change_order_line()
+    max_sequence = 0
+
+    def _get_sequence_default(self, cr, uid, context=None):
+        return (PurchaseOrderLine.max_sequence or 0) + 1
+
+    _defaults = {
+        'sequence': _get_sequence_default,
+    }
+
+
+class PurchaseOrder(orm.Model):
+    _name = 'purchase.order'
+    _inherit = 'purchase.order'
+
+    def ask_ordering(self, cr, uid, ids, context=None):
+        if context is None:
+            context = {}
+        if not ids:
+            return True
+        view_ref = self.pool['ir.model.data'].get_object_reference(
+            cr, uid,
+            'purchase_order_reorder_lines_wizard',
+            'purchase_order_sorting_wizard'
+        )
+        view_id = view_ref and view_ref[1] or False
+        # create wizard
+        return {
+            'type': 'ir.actions.act_window',
+            'name': 'Sorting options',
+            'view_mode': 'form',
+            'view_type': 'form',
+            'view_id': view_id,
+            'res_model': 'purchase.order.sorting.wizard',
+            'nodestroy': True,
+            'target': 'new',
+            'context': context,
+        }
+
+    @staticmethod
+    def sort_order_lines(order_lines, sort_option):
+        key = sort_option['key']
+        dir = sort_option['dir']
+
+        if key == 'name':
+            fun = lambda x: x.product_id.name
+        elif key == 'description':
+            fun = lambda x: x.name
+        elif key == 'quantity':
+            fun = lambda x: x.product_qty
+        else:
+            # possibly default: sort by generated purchase.order.line's ID
+            # fun = lambda x: x.id
+            return order_lines
+
+        return sorted(order_lines, key=fun, reverse=(dir == 'descending'))
+
+    def do_sort(self, cr, uid, ids, sort_options, context=None):
+        """Sort order lines according to sorting wizard."""
+        for order in self.browse(cr, uid, ids, context=context):
+            # Starting with Python 2.2, sorts are guaranteed to be stable.
+            # This is required here in order to apply multiple sort options.
+            order_lines = order.order_line
+            for sort_option in reversed(sort_options):
+                order_lines = self.sort_order_lines(order_lines, sort_option)
+            purchase_order_line_obj = self.pool['purchase.order.line']
+            for index, line in enumerate(order_lines):
+                # set 1-based sorting index
+                purchase_order_line_obj.write(
+                    cr, uid, line.id, {'sequence': index + 1}, context=context
+                )
+        return True
+
+    def on_change_order_line(self, cr, uid, ids, order_lines, context=None):
+        # determine current max. sequence of order_lines
+        max_seq = 0
+        for line in order_lines:
+            line_id = line[1]
+            if line_id:
+                # currently stored value
+                line_rec = self.pool['purchase.order.line'].browse(
+                    cr, uid, line_id, context=context
+                )
+                if line_rec and line_rec.sequence:
+                    max_seq = max(max_seq, line_rec.sequence)
+            vals = line[2]
+            if vals and vals.get('sequence'):
+                # added or changed value
+                max_seq = max(max_seq, vals.get('sequence'))
+        # hand over to PurchaseOrderLine
+        PurchaseOrderLine.max_sequence = max_seq
+        return True

--- a/purchase_order_reorder_lines_wizard/views/purchase.xml
+++ b/purchase_order_reorder_lines_wizard/views/purchase.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="purchase_order_form_ordering">
+            <field name="name">purchase.order.form.ordering</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase.purchase_order_form"/>
+            <field name="arch" type="xml">
+                <header>
+                    <!-- states: draft,sent,confirmed,approved,except_picking,except_invoice,done,cancel -->
+                    <!-- since field 'order_line' is readonly in states 'done' and 'approved', we also exclude these here -->
+                    <button name="ask_ordering" string="Sort lines..." type="object" states="draft,sent,confirmed,except_picking,except_invoice,cancel" />
+                </header>
+
+                <xpath expr="//field[@name='order_line']" position="attributes">
+                    <attribute name="on_change">on_change_order_line(order_line)</attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/purchase_order_reorder_lines_wizard/wizards/__init__.py
+++ b/purchase_order_reorder_lines_wizard/wizards/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 initOS GmbH (<http://www.initos.com>).
+#    Author Andreas Zoellner <andreas.zoellner at initos.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import sorting_wizard

--- a/purchase_order_reorder_lines_wizard/wizards/sorting_wizard.py
+++ b/purchase_order_reorder_lines_wizard/wizards/sorting_wizard.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 initOS GmbH (<http://www.initos.com>).
+#    Author Andreas Zoellner <andreas.zoellner at initos.com>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import orm, fields
+
+
+class PurchaseOrderSortingWizard(orm.TransientModel):
+    _name = 'purchase.order.sorting.wizard'
+
+    # note: each sort key needs an associated lambda function
+    # in PurchaseOrderSorting.sort_order_lines()
+    sort_keys = [
+        ('name', 'Name'),
+        ('description', 'Description'),
+        ('quantity', 'Quantity'),
+    ]
+
+    sort_dirs = [
+        ('ascending', 'ascending'),
+        ('descending', 'descending'),
+    ]
+
+    _columns = {
+        'key1': fields.selection(sort_keys, 'First by', required=False),
+        'dir1': fields.selection(sort_dirs, 'direction', required=True),
+        'key2': fields.selection(sort_keys, 'Then by', required=False),
+        'dir2': fields.selection(sort_dirs, 'direction', required=True),
+    }
+
+    last_key1 = None
+    last_dir1 = 'ascending'
+    last_key2 = None
+    last_dir2 = 'ascending'
+
+    _defaults = {
+        'key1': lambda s, cr, uid, c: PurchaseOrderSortingWizard.last_key1,
+        'dir1': lambda s, cr, uid, c: PurchaseOrderSortingWizard.last_dir1,
+        'key2': lambda s, cr, uid, c: PurchaseOrderSortingWizard.last_key2,
+        'dir2': lambda s, cr, uid, c: PurchaseOrderSortingWizard.last_dir2,
+    }
+
+    def do_sort(self, cr, uid, ids, context=None):
+        if context is None:
+            context = {}
+        po_ids = context.get('active_ids')
+        if po_ids is None:
+            return
+        assert len(ids) == 1,\
+            'Exactly one set of sorting options can be used at a time.'
+        wiz = self.browse(cr, uid, ids, context=context)[0]
+
+        PurchaseOrderSortingWizard.last_key1 = wiz.key1
+        PurchaseOrderSortingWizard.last_dir1 = wiz.dir1
+        PurchaseOrderSortingWizard.last_key2 = wiz.key2
+        PurchaseOrderSortingWizard.last_dir2 = wiz.dir2
+
+        self.pool['purchase.order'].do_sort(cr, uid, po_ids, [
+            {'key': wiz.key1, 'dir': wiz.dir1},
+            {'key': wiz.key2, 'dir': wiz.dir2},
+        ], context=context)
+        return {'type': 'ir.actions.act_window_close'}

--- a/purchase_order_reorder_lines_wizard/wizards/sorting_wizard_view.xml
+++ b/purchase_order_reorder_lines_wizard/wizards/sorting_wizard_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="purchase_order_sorting_wizard" model="ir.ui.view">
+            <field name="name">purchase.order.sorting.wizard.form</field>
+            <field name="model">purchase.order.sorting.wizard</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Sorting" version="7.0">
+                    <group col="4">
+                        <field name="key1" colspan="2" />
+                        <field name="dir1" colspan="2" />
+                    </group>
+                    <group col="4">
+                        <field name="key2" colspan="2" />
+                        <field name="dir2" colspan="2" />
+                    </group>
+                    <footer>
+                        <button name="do_sort" string="Do sort" type="object" class="oe_highlight" />
+                        <button special="cancel" string="Cancel" class="oe_link" />
+                    </footer>
+                </form>
+            </field>
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
A wizard for sorting purchase order lines.

Usage: In the `purchase.order` form view, press the newly added `Sort lines...` button to start the wizard. In the wizard, select the key(s) and direction(s) for sorting and press the `Do sort` button to sort the purchase order lines.
