### PR TITLE
sale_automatic_workflow: ship only available goods

### DIFF
--- a/sale_automatic_workflow/__openerp__.py
+++ b/sale_automatic_workflow/__openerp__.py
@@ -22,7 +22,7 @@
 
 {
     'name': 'Sale Automatic Workflow',
-    'version': '8.0.0.2.0',
+    'version': '8.0.0.3.0',
     'category': 'Generic Modules/Others',
     'license': 'AGPL-3',
     'author': "Akretion,Camptocamp,Odoo Community Association (OCA)",

--- a/sale_automatic_workflow/sale_workflow_process.py
+++ b/sale_automatic_workflow/sale_workflow_process.py
@@ -68,6 +68,11 @@ class SaleWorkflowProcess(models.Model):
     )
     validate_invoice = fields.Boolean(string='Validate Invoice')
     validate_picking = fields.Boolean(string='Confirm and Close Picking')
+    ship_only_available = fields.Boolean(
+        string='Ship only available goods',
+        help="When checked, the available quantity is shipped, and if a "
+        "backorder is created with the rest"
+    )
     invoice_date_is_order_date = fields.Boolean(
         string='Force Invoice Date',
         help="When checked, the invoice date will be "

--- a/sale_automatic_workflow/sale_workflow_process.py
+++ b/sale_automatic_workflow/sale_workflow_process.py
@@ -70,8 +70,8 @@ class SaleWorkflowProcess(models.Model):
     validate_picking = fields.Boolean(string='Confirm and Close Picking')
     ship_only_available = fields.Boolean(
         string='Ship only available goods',
-        help="When checked, the available quantity is shipped, and if a "
-        "backorder is created with the rest"
+        help="When checked, the available quantity is shipped, and if so, a "
+        "backorder is created with the rest."
     )
     invoice_date_is_order_date = fields.Boolean(
         string='Force Invoice Date',

--- a/sale_automatic_workflow/sale_workflow_process_view.xml
+++ b/sale_automatic_workflow/sale_workflow_process_view.xml
@@ -26,7 +26,7 @@
                     <group string="Workflow Options">
                         <field name="validate_order"/>
                         <field name="validate_picking"/>
-                        <field name="ship_only_available"/>
+                        <field name="ship_only_available" attrs="{'invisible': [('validate_picking', '=', False)]}" />
                         <field name="create_invoice_on" attrs="{'readonly': [('order_policy', '!=', 'manual')]}" />
                         <field name="validate_invoice"/>
                         <field name="invoice_date_is_order_date"/>

--- a/sale_automatic_workflow/sale_workflow_process_view.xml
+++ b/sale_automatic_workflow/sale_workflow_process_view.xml
@@ -26,6 +26,7 @@
                     <group string="Workflow Options">
                         <field name="validate_order"/>
                         <field name="validate_picking"/>
+                        <field name="ship_only_available"/>
                         <field name="create_invoice_on" attrs="{'readonly': [('order_policy', '!=', 'manual')]}" />
                         <field name="validate_invoice"/>
                         <field name="invoice_date_is_order_date"/>

--- a/sale_automatic_workflow/stock_picking.py
+++ b/sale_automatic_workflow/stock_picking.py
@@ -40,6 +40,14 @@ class StockPicking(models.Model):
 
     @api.multi
     def validate_picking(self):
-        self.force_assign()
-        self.do_transfer()
+        only_available = self.filtered(
+            'workflow_process_id.ship_only_available')
+        to_force = self - only_available
+        if only_available:
+            only_available.action_assign()
+            only_available.do_prepare_partial()
+            only_available.do_transfer()
+        if to_force:
+            to_force.force_assign()
+            to_force.do_transfer()
         return True


### PR DESCRIPTION
This is a new option that will ship what is available, and create a
backorder or the rest, like when we check availability and transfer from
the picking. The default is still as before: all the quantity is shipped
even if it is not available.

This supersedes OCA/e-commerce#80.
