### PR TITLE
[8.0][FIX][sale_order_type] Fix Journal Invoice on Returned Picking

### DIFF
--- a/sale_order_type/models/stock_picking.py
+++ b/sale_order_type/models/stock_picking.py
@@ -13,7 +13,10 @@ class StockPicking(models.Model):
     def _create_invoice_from_picking(self, picking, vals):
         if picking and picking.sale_id:
             sale = picking.sale_id
-            if sale.type_id and sale.type_id.journal_id:
-                vals['journal_id'] = sale.type_id.journal_id.id
+            if sale.type_id:
+                if vals['type'] == 'out_invoice' and sale.type_id.journal_id:
+                    vals['journal_id'] = sale.type_id.journal_id.id
+                elif vals['type'] == 'out_refund' and sale.type_id.refund_journal_id:
+                    vals['journal_id'] = sale.type_id.refund_journal_id.id
         return super(StockPicking, self)._create_invoice_from_picking(picking,
                                                                       vals)

--- a/sale_order_type/models/stock_picking.py
+++ b/sale_order_type/models/stock_picking.py
@@ -14,9 +14,8 @@ class StockPicking(models.Model):
         if picking and picking.sale_id:
             sale = picking.sale_id
             if sale.type_id:
-                if vals['type'] == 'out_invoice' and sale.type_id.journal_id:
-                    vals['journal_id'] = sale.type_id.journal_id.id
-                elif vals['type'] == 'out_refund' and sale.type_id.refund_journal_id:
-                    vals['journal_id'] = sale.type_id.refund_journal_id.id
+                vals['journal_id'] = (sale.type_id.journal_id.id if
+                                      vals['type'] == 'out_invoice' else
+                                      sale.type_id.refund_journal_id.id)
         return super(StockPicking, self)._create_invoice_from_picking(picking,
                                                                       vals)


### PR DESCRIPTION
when you create an invoice from a returned picking of a sale order
with a sale type,the journal to get is the 'refund_journal_id' of
the sale type, instead of the 'journal_id'.
