### PR TITLE
[8.0] sale_payment_method : use partner_invoice instead of partner

### DIFF
--- a/sale_payment_method/sale.py
+++ b/sale_payment_method/sale.py
@@ -174,7 +174,7 @@ class SaleOrder(models.Model):
     @api.multi
     def _prepare_payment_move_lines(self, move_name, journal, period,
                                     amount, date):
-        partner = self.partner_id.commercial_partner_id
+        partner = self.partner_invoice_id.commercial_partner_id
         company = journal.company_id
 
         currency = self.env['res.currency'].browse()


### PR DESCRIPTION
When add payment to sale order, use partner_invoice_id instead of partner_id.

If partner_id and partner_invoice_id are different, invoice can not be reconciled with the payment.

Forward port of https://github.com/OCA/e-commerce/pull/100
