### PR TITLE
FIX sale_properties_dynamic_fields and sale_order_lot_selection tests

### DIFF
--- a/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
+++ b/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
@@ -158,7 +158,8 @@ class TestSaleOrderLotSelection(test_common.SingleTransactionCase):
             'active_model': 'stock.picking',
             'active_ids': [picking_in.id],
             'active_id': picking_in.id,
-            'default_picking_type_id': picking_in.id}).create({})
+            'default_picking_type_id': picking_in.id}).create({
+                'picking_id': picking_in.id})
         for item in pick_wizard.item_ids:
             if item.product_id == self.product_14:
                 item.lot_id = self.lot10
@@ -167,7 +168,6 @@ class TestSaleOrderLotSelection(test_common.SingleTransactionCase):
             if item.product_id == self.product_12:
                 item.lot_id = self.lot12
         pick_wizard.do_detailed_transfer()
-        picking_in.do_transfer()
 
         # check quantities
         lot10_qty = self._stock_quantity(

--- a/sale_properties_dynamic_fields/mrp_property_group.py
+++ b/sale_properties_dynamic_fields/mrp_property_group.py
@@ -82,6 +82,9 @@ class MrpPropertyGroup(orm.Model):
             context = {}
         res = super(MrpPropertyGroup, self).write(
             cr, uid, ids, vals, context=context)
+        if 'draw_dynamically' not in vals:
+            # update field_id only when changing draw_dynamically field
+            return res
         field_pool = self.pool['ir.model.fields']
         for group in self.browse(cr, uid, ids, context=context):
             if group.draw_dynamically and not group.field_id:

--- a/sale_properties_dynamic_fields/mrp_property_group.py
+++ b/sale_properties_dynamic_fields/mrp_property_group.py
@@ -97,7 +97,8 @@ class MrpPropertyGroup(orm.Model):
                 }, context=context)
             if not group.draw_dynamically and group.field_id:
                 context['_force_unlink'] = True
-                group.field_id.unlink(context=context)
+                field_pool.unlink(
+                    cr, uid, [group.field_id.id], context=context)
         return res
 
     def unlink(self, cr, uid, ids, context=None):

--- a/sale_properties_dynamic_fields/test/properties.yml
+++ b/sale_properties_dynamic_fields/test/properties.yml
@@ -1,23 +1,15 @@
 -
-  I modify the property group Length
--
-  !record {model: mrp.property.group, id: sale_properties_easy_creation.length_group, view: mrp.mrp_property_group_form_view}:
-    draw_dynamically: True
--
-  I check the created field
+  I modify the property group Length and check the created field
 -
   !python {model: mrp.property.group}: |
+    self.write(cr, uid, [ref('sale_properties_easy_creation.length_group')], {'draw_dynamically': True}, context=context)
     group = self.browse(cr, uid, ref('sale_properties_easy_creation.length_group'), context=context)
     assert group.field_id.name == 'x_length', "Field name must be 'x_length', %s found" % group.field_id.name
 -
-  I remove the draw_dynamically field
--
-  !record {model: mrp.property.group, id: sale_properties_easy_creation.length_group, view: mrp.mrp_property_group_form_view}:
-    draw_dynamically: False
--
-  I check the removed field
+  I remove the draw_dynamically field and check the removed field
 -
   !python {model: mrp.property.group}: |
+    self.write(cr, uid, [ref('sale_properties_easy_creation.length_group')], {'draw_dynamically': False}, context=context)
     group = self.browse(cr, uid, ref('sale_properties_easy_creation.length_group'), context=context)
     assert not group.field_id, "field_id must be empty"
 -
@@ -41,14 +33,10 @@
         context=context)
     assert not field_ids, "No x_depth field must be present"
 -
-  I modify the property group Width
--
-  !record {model: mrp.property.group, id: sale_properties_easy_creation.width_group, view: mrp.mrp_property_group_form_view}:
-    draw_dynamically: True
--
-  I check the created field
+  I modify the property group Width and check the created field
 -
   !python {model: mrp.property.group}: |
+    self.write(cr, uid, [ref('sale_properties_easy_creation.width_group')], {'draw_dynamically': True}, context=context)
     group = self.browse(cr, uid, ref('sale_properties_easy_creation.width_group'), context=context)
     assert group.field_id.name == 'x_width', "Field name must be 'x_width', %s found" % group.field_id.name
     assert group.field_id.model == 'sale.order.line', "Field model must be 'sale.order.line', %s found" % group.field_id.model


### PR DESCRIPTION
As it seems something does wrong with writing mrp.property.group field with '!record' YAML statement

This avoids 'Field name must be 'x_length', False found'

Also: https://github.com/OCA/sale-workflow/commit/a34789f1971abd76e98c751bd70f37b325f2f3d0
