### PR TITLE
[ADD] add module to deliver when creating invoice

### DIFF
--- a/sale_invoice_auto_deliver/README.rst
+++ b/sale_invoice_auto_deliver/README.rst
@@ -1,0 +1,76 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==============
+Sale Invoice Automatic Deliver
+==============
+
+The goal of this module is to automatically deliver products when an user create an invoice.
+On Sale Order when an user choose to create an invoice, he can use the option : "Invoice the whole sales order + Automatic Deliver"
+in order to deliver products at the same time than the invoice. This functionality can be useful in the case where products are already take out of the stock.
+
+Consider as pre-requirement that all products must be available.
+
+Installation
+============
+
+To install this module, you need to:
+
+* Click on install button
+
+Usage
+=====
+
+To use this module, you need to:
+
+* Go to ...
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/167/8.0
+
+Known issues / Roadmap
+======================
+
+* ...
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/sale-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/
+sale-workflow/issues/new?body=module:%20
+sale_invoice_auto_deliver%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Laetitia Gangloff <laetitia.gangloff@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/sale_invoice_auto_deliver/README.rst
+++ b/sale_invoice_auto_deliver/README.rst
@@ -10,6 +10,8 @@ The goal of this module is to automatically deliver products when an user create
 On Sale Order when an user choose to create an invoice, he can use the option : "Invoice the whole sales order + Automatic Deliver"
 in order to deliver products at the same time than the invoice. This functionality can be useful in the case where products are already take out of the stock.
 
+When invoice sale order line it is possible to choose the option : "Create Invoice + Automatic Deliver" to deliver the product and invoice it.
+
 Consider as pre-requirement that all products must be available.
 
 Installation

--- a/sale_invoice_auto_deliver/__init__.py
+++ b/sale_invoice_auto_deliver/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/sale_invoice_auto_deliver/__openerp__.py
+++ b/sale_invoice_auto_deliver/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2016  Laetitia Gangloff, Acsone SA/NV (http://www.acsone.eu)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Sale Invoice Automatic Deliver",
+    "version": "8.0.1.0.0",
+    'author': "Acsone SA/NV,Odoo Community Association (OCA)",
+    "category": "Sales Management",
+    "website": "http://www.acsone.eu",
+    "depends": ["sale",
+                "sale_stock",
+                "stock",
+                ],
+    "data": [],
+    "license": "AGPL-3",
+    "installable": True,
+    "application": False,
+}

--- a/sale_invoice_auto_deliver/__openerp__.py
+++ b/sale_invoice_auto_deliver/__openerp__.py
@@ -12,7 +12,7 @@
                 "sale_stock",
                 "stock",
                 ],
-    "data": [],
+    "data": ["views/sale_line_invoice_views.xml"],
     "license": "AGPL-3",
     "installable": True,
     "application": False,

--- a/sale_invoice_auto_deliver/i18n/fr.po
+++ b/sale_invoice_auto_deliver/i18n/fr.po
@@ -1,0 +1,34 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_invoice_auto_deliver
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-17 17:45+0000\n"
+"PO-Revision-Date: 2016-03-17 17:45+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_invoice_auto_deliver
+#: code:addons/sale_invoice_auto_deliver/models/sale_make_invoice_advance.py:12
+#, python-format
+msgid "Invoice the whole sales order + Automatic Deliver"
+msgstr "Facturer toute la commande et livrer"
+
+#. module: sale_invoice_auto_deliver
+#: model:ir.model,name:sale_invoice_auto_deliver.model_sale_advance_payment_inv
+msgid "Sales Advance Payment Invoice"
+msgstr "Facture de paiement d'avance"
+
+#. module: sale_invoice_auto_deliver
+#: code:addons/sale_invoice_auto_deliver/models/sale_make_invoice_advance.py:38
+#, python-format
+msgid "You cannot automatic deliver this order, some products are not available"
+msgstr "Vous ne pouvez pas livrer cette commande automatiquement, certains produits ne sont pas disponibles"
+

--- a/sale_invoice_auto_deliver/i18n/fr.po
+++ b/sale_invoice_auto_deliver/i18n/fr.po
@@ -6,14 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-17 17:45+0000\n"
-"PO-Revision-Date: 2016-03-17 17:45+0000\n"
+"POT-Creation-Date: 2016-03-21 12:23+0000\n"
+"PO-Revision-Date: 2016-03-21 12:23+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: sale_invoice_auto_deliver
+#: model:ir.actions.act_window,name:sale_invoice_auto_deliver.action_view_sale_order_line_make_invoice_auto_deliver
+msgid "Create Invoice + Automatic Deliver"
+msgstr "Facturer et livrer"
 
 #. module: sale_invoice_auto_deliver
 #: code:addons/sale_invoice_auto_deliver/models/sale_make_invoice_advance.py:12
@@ -25,6 +30,12 @@ msgstr "Facturer toute la commande et livrer"
 #: model:ir.model,name:sale_invoice_auto_deliver.model_sale_advance_payment_inv
 msgid "Sales Advance Payment Invoice"
 msgstr "Facture de paiement d'avance"
+
+#. module: sale_invoice_auto_deliver
+#: code:addons/sale_invoice_auto_deliver/models/sale_line_invoice.py:32
+#, python-format
+msgid "You cannot automatic deliver these order lines, some products are not available"
+msgstr "Vous ne pouvez pas livrer ces lignes de commande automatiquement, certains produits ne sont pas disponibles"
 
 #. module: sale_invoice_auto_deliver
 #: code:addons/sale_invoice_auto_deliver/models/sale_make_invoice_advance.py:38

--- a/sale_invoice_auto_deliver/i18n/sale_invoice_auto_deliver.pot
+++ b/sale_invoice_auto_deliver/i18n/sale_invoice_auto_deliver.pot
@@ -1,0 +1,34 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_invoice_auto_deliver
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-17 17:50+0000\n"
+"PO-Revision-Date: 2016-03-17 17:50+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_invoice_auto_deliver
+#: code:addons/sale_invoice_auto_deliver/models/sale_make_invoice_advance.py:12
+#, python-format
+msgid "Invoice the whole sales order + Automatic Deliver"
+msgstr ""
+
+#. module: sale_invoice_auto_deliver
+#: model:ir.model,name:sale_invoice_auto_deliver.model_sale_advance_payment_inv
+msgid "Sales Advance Payment Invoice"
+msgstr ""
+
+#. module: sale_invoice_auto_deliver
+#: code:addons/sale_invoice_auto_deliver/models/sale_make_invoice_advance.py:38
+#, python-format
+msgid "You cannot automatic deliver this order, some products are not available"
+msgstr ""
+

--- a/sale_invoice_auto_deliver/i18n/sale_invoice_auto_deliver.pot
+++ b/sale_invoice_auto_deliver/i18n/sale_invoice_auto_deliver.pot
@@ -6,14 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-17 17:50+0000\n"
-"PO-Revision-Date: 2016-03-17 17:50+0000\n"
+"POT-Creation-Date: 2016-03-21 12:23+0000\n"
+"PO-Revision-Date: 2016-03-21 12:23+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: sale_invoice_auto_deliver
+#: model:ir.actions.act_window,name:sale_invoice_auto_deliver.action_view_sale_order_line_make_invoice_auto_deliver
+msgid "Create Invoice + Automatic Deliver"
+msgstr ""
 
 #. module: sale_invoice_auto_deliver
 #: code:addons/sale_invoice_auto_deliver/models/sale_make_invoice_advance.py:12
@@ -24,6 +29,12 @@ msgstr ""
 #. module: sale_invoice_auto_deliver
 #: model:ir.model,name:sale_invoice_auto_deliver.model_sale_advance_payment_inv
 msgid "Sales Advance Payment Invoice"
+msgstr ""
+
+#. module: sale_invoice_auto_deliver
+#: code:addons/sale_invoice_auto_deliver/models/sale_line_invoice.py:32
+#, python-format
+msgid "You cannot automatic deliver these order lines, some products are not available"
 msgstr ""
 
 #. module: sale_invoice_auto_deliver

--- a/sale_invoice_auto_deliver/models/__init__.py
+++ b/sale_invoice_auto_deliver/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import sale_make_invoice_advance

--- a/sale_invoice_auto_deliver/models/__init__.py
+++ b/sale_invoice_auto_deliver/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
+from . import sale_line_invoice
 from . import sale_make_invoice_advance

--- a/sale_invoice_auto_deliver/models/sale_line_invoice.py
+++ b/sale_invoice_auto_deliver/models/sale_line_invoice.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# © 2016  Laetitia Gangloff, Acsone SA/NV (http://www.acsone.eu)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, exceptions, models, _
+
+
+class saleOrderLineMakeInvoice(models.TransientModel):
+    _inherit = "sale.order.line.make.invoice"
+
+    @api.model
+    def _get_move_domain(self):
+        return [('procurement_id.sale_line_id', 'in',
+                 self.env.context.get('active_ids', [])),
+                ('state', '=', 'assigned')]
+
+    @api.multi
+    def make_invoices(self):
+        self.ensure_one()
+        if self.env.context.get('auto_deliver'):
+            # try to deliver all selected line
+            # if all is delivered, make invoice
+            # else raise exception
+            move_not_done = True
+            moves = self.env['stock.move'].search(self._get_move_domain())
+            if moves:
+                moves.action_done()
+                move_not_done = moves.filtered(lambda x: x.state != 'done')
+            if move_not_done:
+                raise exceptions.Warning(
+                    _("You cannot automatic deliver these order lines, "
+                      "some products are not available"))
+
+        return super(saleOrderLineMakeInvoice, self).make_invoices()

--- a/sale_invoice_auto_deliver/models/sale_make_invoice_advance.py
+++ b/sale_invoice_auto_deliver/models/sale_make_invoice_advance.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# © 2016  Laetitia Gangloff, Acsone SA/NV (http://www.acsone.eu)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, exceptions, fields, models, _
+
+
+class SaleAdvancePaymentInv(models.TransientModel):
+    _inherit = "sale.advance.payment.inv"
+
+    advance_payment_method = fields.Selection(
+        selection_add=[('all_auto', _('Invoice the whole sales order + '
+                        'Automatic Deliver'))])
+
+    @api.model
+    def _get_pickings(self, sale_ids):
+        res = self.env['stock.picking']
+        for so in self.env['sale.order'].browse(sale_ids):
+            res += so.picking_ids
+        return res
+
+    @api.multi
+    def create_invoices(self):
+        self.ensure_one()
+        if self.advance_payment_method == 'all_auto':
+            # try to finalize sale pickings
+            # if finalize is ok, set advance_payment_method to all
+            # else raise exception
+            sale_ids = self.env.context.get('active_ids', [])
+            pickings = self._get_pickings(sale_ids)
+            picking_not_done = True
+            if pickings:
+                pickings.do_transfer()
+                picking_not_done = pickings.filtered(
+                    lambda x: x.state != 'done')
+            if picking_not_done:
+                raise exceptions.Warning(
+                    _("You cannot automatic deliver this order, "
+                      "some products are not available"))
+            else:
+                self.advance_payment_method = 'all'
+        return super(SaleAdvancePaymentInv, self).create_invoices()

--- a/sale_invoice_auto_deliver/tests/__init__.py
+++ b/sale_invoice_auto_deliver/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_sale_invoice_auto_deliver

--- a/sale_invoice_auto_deliver/tests/test_sale_invoice_auto_deliver.py
+++ b/sale_invoice_auto_deliver/tests/test_sale_invoice_auto_deliver.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# © 2016  Laetitia Gangloff, Acsone SA/NV (http://www.acsone.eu)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+import openerp.tests.common as common
+
+
+class TestSaleInvoiceAutoDeliver(common.TransactionCase):
+
+    def test_sale_invoice_auto_deliver(self):
+        """ Create SO
+            Create invoice
+            Validate invoice + Auto Deliver
+            Check picking are done
+        """
+        so = self.env["sale.order"].create(
+            {"partner_id": self.env.ref("base.res_partner_2").id})
+        self.env['sale.order.line'].create(
+            {'order_id': so.id,
+             'product_id': self.env.ref("product.product_product_35").id})
+        so.action_button_confirm()
+        adv_wizard = self.env['sale.advance.payment.inv'].create(
+            {'advance_payment_method': 'all_auto'})
+        adv_wizard.with_context(active_ids=[so.id]).create_invoices()
+        self.assertEquals(so.picking_ids.state, 'done')

--- a/sale_invoice_auto_deliver/tests/test_sale_invoice_auto_deliver.py
+++ b/sale_invoice_auto_deliver/tests/test_sale_invoice_auto_deliver.py
@@ -24,3 +24,21 @@ class TestSaleInvoiceAutoDeliver(common.TransactionCase):
             {'advance_payment_method': 'all_auto'})
         adv_wizard.with_context(active_ids=[so.id]).create_invoices()
         self.assertEquals(so.picking_ids.state, 'done')
+
+    def test_sale_invoice_line_auto_deliver(self):
+        """ Create SO
+            Create invoice
+            Validate invoice + Auto Deliver
+            Check picking are done
+        """
+        so = self.env["sale.order"].create(
+            {"partner_id": self.env.ref("base.res_partner_2").id})
+        sol = self.env['sale.order.line'].create(
+            {'order_id': so.id,
+             'product_id': self.env.ref("product.product_product_35").id})
+        so.action_button_confirm()
+        so.picking_ids.force_assign()
+        adv_wizard = self.env['sale.order.line.make.invoice'].create({})
+        adv_wizard.with_context(active_ids=[sol.id],
+                                auto_deliver=True).make_invoices()
+        self.assertEquals(so.picking_ids.state, 'done')

--- a/sale_invoice_auto_deliver/views/sale_line_invoice_views.xml
+++ b/sale_invoice_auto_deliver/views/sale_line_invoice_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="action_view_sale_order_line_make_invoice_auto_deliver" model="ir.actions.act_window">
+            <field name="name">Create Invoice + Automatic Deliver</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">sale.order.line.make.invoice</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="sale.view_sale_order_line_make_invoice"/>
+            <field name="target">new</field>
+            <field name="context">{'auto_deliver': True}</field>
+        </record>
+
+        <record model="ir.values" id="sale_order_line_make_invoice_auto_deliver">
+            <field name="model_id" ref="sale.model_sale_order_line" />
+            <field name="name">Make Invoices + Automatic Deliver</field>
+            <field name="key2">client_action_multi</field>
+            <field name="value" eval="'ir.actions.act_window,' + str(ref('action_view_sale_order_line_make_invoice_auto_deliver'))" />
+            <field name="key">action</field>
+            <field name="model">sale.order.line</field>
+        </record>
+    </data>
+</openerp>

--- a/setup/sale_invoice_auto_deliver/odoo_addons/__init__.py
+++ b/setup/sale_invoice_auto_deliver/odoo_addons/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/sale_invoice_auto_deliver/odoo_addons/sale_invoice_auto_deliver
+++ b/setup/sale_invoice_auto_deliver/odoo_addons/sale_invoice_auto_deliver
@@ -1,0 +1,1 @@
+../../../sale_invoice_auto_deliver

--- a/setup/sale_invoice_auto_deliver/setup.py
+++ b/setup/sale_invoice_auto_deliver/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
In sale advance payment, add option to deliver at the same time than invoice.
If picking are not validable, an error is raised.
