### PR TITLE
[FIX] sale_order_type: load refund journal when invoice type is 'out_refund'

### DIFF
--- a/sale_order_type/README.rst
+++ b/sale_order_type/README.rst
@@ -39,6 +39,7 @@ Contributors
 * Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
 * Ana Juaristi <anajuaristi@avanzosc.es>
 * Daniel Campos <danielcampos@avanzosc.es>
+* Ainara Galdona <ainaragaldona@avanzosc.es>
 
 Maintainer
 ----------

--- a/sale_order_type/models/stock_picking.py
+++ b/sale_order_type/models/stock_picking.py
@@ -13,7 +13,11 @@ class StockPicking(models.Model):
     def _create_invoice_from_picking(self, picking, vals):
         if picking and picking.sale_id:
             sale = picking.sale_id
-            if sale.type_id and sale.type_id.journal_id:
+            if (vals.get('type', '') == 'out_invoice' and
+                    sale.type_id.journal_id):
                 vals['journal_id'] = sale.type_id.journal_id.id
+            elif (vals.get('type', '') == 'out_refund' and
+                    sale.type_id.refund_journal_id):
+                vals['journal_id'] = sale.type_id.refund_journal_id.id
         return super(StockPicking, self)._create_invoice_from_picking(picking,
                                                                       vals)


### PR DESCRIPTION
When an invoice of type 'out_refund' is created it takes the Sale Journal instead of the Refund Journal defined in the sale order type. So with this change we fix that error.
