### PR TITLE
[FIX] pass proper context to ir_sequence.next_by_id()

### DIFF
--- a/sale_payment_method/sale.py
+++ b/sale_payment_method/sale.py
@@ -140,21 +140,15 @@ class SaleOrder(models.Model):
 
     @api.model
     def _get_payment_move_name(self, journal, period):
-        sequence = journal.sequence_id
+        sequence = journal.sequence_id.with_context(
+            fiscalyear_id=period.fiscalyear_id.id)
         if not sequence:
             raise exceptions.Warning(_('Please define a sequence on the '
                                        'journal %s.') % journal.name)
         if not sequence.active:
             raise exceptions.Warning(_('Please activate the sequence of the '
                                        'journal %s.') % journal.name)
-
-        sequence = sequence.with_context(fiscalyear_id=period.fiscalyear_id.id)
-        # next_by_id not compatible with new api
-        sequence_model = self.pool['ir.sequence']
-        name = sequence_model.next_by_id(self.env.cr, self.env.uid,
-                                         sequence.id,
-                                         context=sequence.env.context)
-        return name
+        return sequence.next_by_id(sequence.id)
 
     @api.multi
     def _prepare_payment_move(self, move_name, journal, period, date):

--- a/sale_payment_method/sale.py
+++ b/sale_payment_method/sale.py
@@ -153,7 +153,7 @@ class SaleOrder(models.Model):
         sequence_model = self.pool['ir.sequence']
         name = sequence_model.next_by_id(self.env.cr, self.env.uid,
                                          sequence.id,
-                                         context=self.env.context)
+                                         context=sequence.env.context)
         return name
 
     @api.multi


### PR DESCRIPTION
A proper sequence object is created with the context 'fiscalyear_id', but
the default context is used in the old-api-style call.

When using the OCA module 'account_auto_fy_sequence', this leads to an error
'The system tried to access a fiscal year sequence without specifying the actual fiscal year.'
