### PR TITLE
FIX sale_order_revision: reference to old procurements

### DIFF
--- a/sale_order_revision/model/sale_order.py
+++ b/sale_order_revision/model/sale_order.py
@@ -62,6 +62,9 @@ class sale_order(models.Model):
         self.create_workflow()
         self.write({'state': 'draft'})
         self.order_line.write({'state': 'draft'})
+        # remove old procurements
+        self.mapped('order_line.procurement_ids').write(
+            {'sale_line_id': False})
         msg = _('New revision created: %s') % self.name
         self.message_post(body=msg)
         old_revision.message_post(body=msg)

--- a/sale_order_revision/test/sale_order.yml
+++ b/sale_order_revision/test/sale_order.yml
@@ -22,3 +22,4 @@
      assert all(so.active == False for so in new_so.old_revision_ids)
      assert new_so.revision_number == 1
      assert new_so.name.endswith('-01')
+     assert not new_so.order_line[0].procurement_ids


### PR DESCRIPTION
FIX https://github.com/OCA/sale-workflow/issues/267

When creating a new revision, remove link to old procurements, otherwise the sale order will use old quantities
