### PR TITLE
FIX sale_order_lot_selection: Not working for multiline sale orders

### DIFF
--- a/sale_order_lot_selection/model/sale.py
+++ b/sale_order_lot_selection/model/sale.py
@@ -102,7 +102,7 @@ class SaleOrder(models.Model):
 
     @api.model
     def action_ship_create(self):
-        super(SaleOrder, self).action_ship_create()
+        res = super(SaleOrder, self).action_ship_create()
         for line in self.order_line:
             self._check_move_state(line)
-            return True
+        return res


### PR DESCRIPTION
https://github.com/OCA/sale-workflow/issues/269

Steps to reproduce:

1.- Create a new Sale Order with 2 or more lines of products
2.- Assign lot to every line (ensure lot has stock available)
3.- Confirm the Sale Order
4.- Go to the Delivery Order

Result:

Only the first line in the Delivery Order is in state "Available" and reserved, the rest of the lines are in state "Waiting Availability" and not reserved
