### PR TITLE
Do not use computed value for new computation

### DIFF
--- a/sale_payment_term_interest/model/sale_order.py
+++ b/sale_payment_term_interest/model/sale_order.py
@@ -58,7 +58,7 @@ class SaleOrder(models.Model):
         if not any(line.interest_rate for line in term.line_ids):
             return 0.
         for line in [line for line in self.order_line
-                     if not line.interest_line]:
+                     if not line == self._get_interest_line()]:
             price = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
             taxes = line.tax_id.compute_all(price,
                                             line.product_uom_qty,

--- a/sale_payment_term_interest/model/sale_order.py
+++ b/sale_payment_term_interest/model/sale_order.py
@@ -50,26 +50,23 @@ class SaleOrder(models.Model):
 
     @api.multi
     def get_interest_value(self):
+        current_total = 0.
         self.ensure_one()
         term = self.payment_term
         if not term:
             return 0.
         if not any(line.interest_rate for line in term.line_ids):
             return 0.
-        line = self._get_interest_line()
-        if line:
+        for line in [line for line in self.order_line
+                     if not line.interest_line]:
             price = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
             taxes = line.tax_id.compute_all(price,
                                             line.product_uom_qty,
                                             product=line.product_id,
                                             partner=self.partner_id)
             # remove the interest value from the total if there is a value yet
-            current_interest = taxes['total_included']
-        else:
-            current_interest = 0.
-        interest = term.compute_total_interest(
-            self.amount_total - current_interest,
-        )
+            current_total += taxes['total_included']
+        interest = term.compute_total_interest(current_total)
         return interest
 
     @api.multi


### PR DESCRIPTION
This PR is to fix a small "edge case" I had with a customer : basically, the line's old value was used to recompute the value itself.
In that particular case, the taxes and total amount made it so that the small amount variation was over/under 3.815, which meant that:
- if the line had a value of 3.81, the computed value was 3.82,
- then, when the line had a value of 3.81, the computed value was 3.81.

That means, in the method https://github.com/OCA/sale-workflow/blob/8.0/sale_payment_term_interest/model/sale_order.py#L99 , the 2 values were always different by 0.01.

The fix is straight-forward : instead of substracting the interest line's amount to the total amount, all non-interest lines are added (meaning the value used as a basis remains constant).
