### PR TITLE
Disable 'Transfer Picking' on automatic workflow

### DIFF
--- a/sale_automatic_workflow/data/automatic_workflow_data.xml
+++ b/sale_automatic_workflow/data/automatic_workflow_data.xml
@@ -53,7 +53,7 @@
             <field name="validate_invoice" eval="1" />
             <field name="validate_invoice_filter_id" eval="automatic_workflow_validate_invoice_filter"/>
             <field name="invoice_date_is_order_date" eval="0" />
-            <field name="validate_picking" eval="1" />
+            <field name="validate_picking" eval="0" />
             <field name="picking_filter_id" eval="automatic_workflow_picking_filter"/>
             <field name="sale_done" eval="0"/>
             <field name="sale_done_filter_id" eval="automatic_workflow_sale_done_filter"/>


### PR DESCRIPTION
Back in 7.0, this option was not active by default on the automatic
workflow and I think it was better: this option is useful for some use
cases but is not really the _default_ thing we want to do on an
automatic workflow.
