### PR TITLE
 [ADD][8.0] Sale procurement group by requested date

### DIFF
--- a/sale_procurement_group_by_requested_date/README.rst
+++ b/sale_procurement_group_by_requested_date/README.rst
@@ -1,0 +1,53 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :alt: License: AGPL-3
+
+========================================
+Sale Procurement Group by Requested date
+========================================
+
+This module creates different procurements groups for different requested
+dates in a sale order line when the sale order is confirmed.
+It depends on sale_sourced_by_line so this module will group procurements
+the warehouse in the sale order_line also.
+
+Installation
+============
+
+This module depends on the modules sale_procurement_group_by_line and
+sale_sourced_by_line.
+
+
+Configuration
+=============
+
+No special configuration is required.
+
+Usage
+=====
+
+* Add a requested date for a sale order line.
+* Confirm the sale order
+
+Credits
+=======
+
+Contributors
+------------
+
+* Aaron Henriquez <ahenriquez@eficent.com>
+* Jordi Ballester <jordi.ballester@eficent.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/sale_procurement_group_by_requested_date/__init__.py
+++ b/sale_procurement_group_by_requested_date/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/sale_procurement_group_by_requested_date/__openerp__.py
+++ b/sale_procurement_group_by_requested_date/__openerp__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Group procurements by requested date",
+    "summary": "Groups pickings based on requested date of order line",
+    "version": "8.0.0.0.1",
+    "category": "Sales Management",
+    "website": "http://www.eficent.com",
+    "author": "Eficent, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "sale_order_line_dates",
+        "sale_procurement_group_by_line",
+        "sale_sourced_by_line"
+    ],
+}

--- a/sale_procurement_group_by_requested_date/models/__init__.py
+++ b/sale_procurement_group_by_requested_date/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import sale_order

--- a/sale_procurement_group_by_requested_date/models/sale_order.py
+++ b/sale_procurement_group_by_requested_date/models/sale_order.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def _prepare_order_line_procurement(self, cr, uid, order, line,
+                                        group_id=False, context=None):
+        values = super(SaleOrder, self)._prepare_order_line_procurement(
+            cr, uid, order, line, group_id=group_id, context=context)
+        if line.requested_date:
+            req_datetime = fields.Datetime.from_string(line.requested_date)
+            req_date = fields.Date.to_string(req_datetime)
+            values['requested_date'] = req_date
+        return values
+
+    @api.model
+    def _prepare_procurement_group_by_line(self, line):
+        vals = super(SaleOrder, self)._prepare_procurement_group_by_line(line)
+        # for compatibility with sale_quotation_sourcing
+        req_datetime = fields.Datetime.from_string(line.requested_date)
+        req_date = fields.Date.to_string(req_datetime)
+        if line._get_procurement_group_key()[0] == 9:
+            if line.requested_date:
+                vals['name'] = '/'.join([vals['name'], line.warehouse_id.name,
+                                         req_date])
+        return vals
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    @api.multi
+    def _get_procurement_group_key(self):
+        """ Return a key with priority to be used to regroup lines in multiple
+        procurement groups. The higher the priority number is the more
+        preference the criteria has. E.g. sale_sourced_by_line has 8 priority,
+        that is less priority than the requested date.
+        """
+        priority = 9
+        key = super(SaleOrderLine, self)._get_procurement_group_key()
+        # Check priority
+        if key[0] >= priority:
+            return key
+        req_datetime = fields.Datetime.from_string(self.requested_date)
+        req_date = fields.Date.to_string(req_datetime)
+        key = '/'.join([str(self.warehouse_id.id), req_date])
+        return (priority, key)

--- a/sale_procurement_group_by_requested_date/tests/__init__.py
+++ b/sale_procurement_group_by_requested_date/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 - Eficent http://www.eficent.com/
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import test_sale_procurement_group_by_requested_date

--- a/sale_procurement_group_by_requested_date/tests/test_sale_procurement_group_by_requested_date.py
+++ b/sale_procurement_group_by_requested_date/tests/test_sale_procurement_group_by_requested_date.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+# © 2016 - Eficent http://www.eficent.com/
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+from openerp import fields
+import datetime
+
+
+class TestSaleMultiPickingByRequestedDate(TransactionCase):
+    """Check the _get_shipped method of Sale Order. """
+
+    def setUp(self):
+        """Setup a Sale Order with 4 lines.
+        And prepare procurements
+        """
+        super(TestSaleMultiPickingByRequestedDate, self).setUp()
+        SO = self.env['sale.order']
+        SOL = self.env['sale.order.line']
+        Product = self.env['product.product']
+        Warehouse = self.env['stock.warehouse']
+        self.wh1 = Warehouse.create({'name': 'wh1', 'code': 'wh1'})
+        self.wh2 = Warehouse.create({'name': 'wh2', 'code': 'wh2'})
+        p1 = Product.create({'name': 'p1', 'type': 'product'}).id
+        today = datetime.datetime.now()
+        self.dt1 = today
+        self.dt2 = today + datetime.timedelta(days=1)
+        self.sale1 = SO.create({'partner_id': 1})
+        self.sale_line1 = SOL.create({'product_id': p1,
+                                      'name': 'cool product',
+                                      'order_id': self.sale1.id,
+                                      'warehouse_id': self.wh1.id,
+                                      'requested_date': self.dt1})
+        self.sale_line2 = SOL.create({'product_id': p1,
+                                      'name': 'cool product',
+                                      'order_id': self.sale1.id,
+                                      'warehouse_id': self.wh1.id,
+                                      'requested_date': self.dt2})
+        self.sale_line3 = SOL.create({'product_id': p1,
+                                      'name': 'cool product',
+                                      'order_id': self.sale1.id,
+                                      'warehouse_id': self.wh2.id,
+                                      'requested_date': self.dt1})
+        self.sale_line4 = SOL.create({'product_id': p1,
+                                      'name': 'cool product',
+                                      'order_id': self.sale1.id,
+                                      'warehouse_id': self.wh2.id,
+                                      'requested_date': self.dt2})
+
+        self.sale2 = SO.create({'partner_id': 1})
+        self.sale_line5 = SOL.create({'product_id': p1,
+                                      'name': 'cool product',
+                                      'order_id': self.sale2.id,
+                                      'warehouse_id': self.wh1.id,
+                                      'requested_date': self.dt1})
+        self.sale_line6 = SOL.create({'product_id': p1,
+                                      'name': 'cool product',
+                                      'order_id': self.sale2.id,
+                                      'warehouse_id': self.wh1.id,
+                                      'requested_date': self.dt2})
+        self.sale_line7 = SOL.create({'product_id': p1,
+                                      'name': 'cool product',
+                                      'order_id': self.sale2.id,
+                                      'warehouse_id': self.wh1.id,
+                                      'requested_date': self.dt1})
+        self.sale_line8 = SOL.create({'product_id': p1,
+                                      'name': 'cool product',
+                                      'order_id': self.sale2.id,
+                                      'warehouse_id': self.wh1.id,
+                                      'requested_date': self.dt2})
+
+    def test_number_of_groups(self):
+        """True when the number of groups created matches the
+        result of multiply the different warehouses with the different
+        requested dates"""
+        ok = False
+        self.sale1.action_button_confirm()
+        req_date = fields.Date.to_string(self.dt1)
+        g_name = self.sale1.name + '/' + self.wh1.name + '/' + req_date
+        groups = self.env['procurement.group'].search([('name', '=', g_name)])
+
+        for group in groups:
+            if group.name == g_name:
+                procurements = self.env['procurement.order'].search([
+                    ('group_id', '=', group.id)])
+                self.assertEqual(len(procurements), 1)
+                self.assertEqual(len(group), 1)
+                ok = True
+        self.assertTrue(ok)
+
+        ok = False
+        self.sale2.action_button_confirm()
+        req_date = fields.Date.to_string(self.dt2)
+        g_name = self.sale2.name + '/' + self.wh1.name + '/' + req_date
+        groups = self.env['procurement.group'].search([('name', '=', g_name)])
+
+        for group in groups:
+            if group.name == g_name:
+                procurements = self.env['procurement.order'].search([
+                    ('group_id', '=', group.id)])
+                self.assertEqual(len(procurements), 2)
+                self.assertEqual(len(group), 1)
+                ok = True
+        self.assertEqual(len(groups), 1)
+        g_name = self.sale2.name + '/' + self.wh1.name + '/'
+        groups = self.env['procurement.group'].search([('name', 'ilike',
+                                                        g_name)])
+        self.assertEqual(len(groups), 2)
+        self.assertTrue(ok)


### PR DESCRIPTION
# Sale Procurement Group by Requested date

This module creates different procurements groups for different requested dates in a sale order line when the sale order is confirmed. It depends on sale_sourced_by_line so this module will group procurements also by the warehouse in the sale order_line.
### Installation

This module depends on the modules sale_procurement_group_by_line and
sale_sourced_by_line.
### Configuration

No special configuration is required.
### Usage
- Add a requested date for a sale order line.
- Confirmthe sale order
