### PR TITLE
[FIX] populate the 'Return Stock Move' field; module version

### DIFF
--- a/sale_rental/README.rst
+++ b/sale_rental/README.rst
@@ -64,6 +64,7 @@ Contributors
 ------------
 
 * Alexis de Lattre <alexis.delattre@akretion.com>
+* Javi Melendez <javi.melendez@algios.com>
 
 Maintainer
 ----------

--- a/sale_rental/__openerp__.py
+++ b/sale_rental/__openerp__.py
@@ -23,11 +23,11 @@
 
 {
     'name': 'Rental',
-    'version': '8.0.0.1.0',
+    'version': '8.0.1.0.0',
     'category': 'Sales Management',
     'license': 'AGPL-3',
     'summary': 'Manage Rental of Products',
-    'author': 'Akretion',
+    'author': 'Akretion, Odoo Community Association (OCA)',
     'website': 'http://www.akretion.com',
     'depends': ['sale_start_end_dates', 'stock'],
     'data': [

--- a/sale_rental/rental.py
+++ b/sale_rental/rental.py
@@ -357,8 +357,7 @@ class SaleRental(models.Model):
                 for move in procurement.move_ids:
                     if move.move_dest_id:
                         out_move = move
-                    else:
-                        in_move = move
+                        in_move = move.move_dest_id
             if (
                     self.sell_order_line_ids and
                     self.sell_order_line_ids[0].procurement_ids):


### PR DESCRIPTION
When creating the rental record, 'Return Stock Move' field was not
taking the corresponding reference to the incoming stock.move

Also fixed the version number and added Odoo Community Association (OCA)
to author list
