### PR TITLE
[9.0][sale_automatic_workflow]Add possibility to invoice service automatically on delivery

### DIFF
--- a/sale_automatic_workflow/models/sale.py
+++ b/sale_automatic_workflow/models/sale.py
@@ -41,3 +41,14 @@ class SaleOrder(models.Model):
             warning = {'title': _('Workflow Warning'),
                        'message': workflow.warning}
             return {'warning': warning}
+
+    @api.multi
+    def action_invoice_create(self, grouped=False, final=False):
+        for order in self:
+            if not order.workflow_process_id.invoice_service_delivery:
+                continue
+            for line in order.order_line:
+                if line.qty_delivered_updateable and not line.qty_delivered:
+                    line.write({'qty_delivered': line.product_uom_qty})
+        return super(SaleOrder, self).action_invoice_create(grouped=grouped,
+                                                            final=final)

--- a/sale_automatic_workflow/models/sale_workflow_process.py
+++ b/sale_automatic_workflow/models/sale_workflow_process.py
@@ -61,6 +61,12 @@ class SaleWorkflowProcess(models.Model):
              "the same than the order's date"
     )
 
+    invoice_service_delivery = fields.Boolean(
+        string='Invoice Service on delivery',
+        help="If this box is checked, when the first invoice is created "
+             "The service sale order lines will be included and will be "
+             "marked as delivered"
+    )
     sale_done = fields.Boolean(string='Sale Done')
     sale_done_filter_domain = fields.Char(
         string='Sale Done Filter Domain',

--- a/sale_automatic_workflow/views/sale_workflow_process_view.xml
+++ b/sale_automatic_workflow/views/sale_workflow_process_view.xml
@@ -65,7 +65,6 @@
                                 <field name="validate_invoice_filter_id" domain="[('model_id', '=', 'account.invoice')]" class="oe_inline" context="{'default_model_id': 'account.invoice', 'default_active': False, 'active_test': False}" can_create="true" can_write="true" />
                             </div>
                         </div>
-
                         <field name="sale_done" />
                         <label for="sale_done_filter_id" attrs="{'required':[('sale_done','=',True)], 'invisible':[('sale_done','!=',True)]}"/>
                         <div attrs="{'required':[('sale_done','=',True)], 'invisible':[('sale_done','!=',True)]}">
@@ -79,6 +78,7 @@
                     </group>
                     <group>
                         <field name="invoice_date_is_order_date"/>
+                        <field name="invoice_service_delivery" />
                         <field name="property_journal_id" groups="account.group_account_invoice"
                                domain="[('type', '=', 'sale')]"/>
                         <field name="warning"/>


### PR DESCRIPTION
The case is when I want to automatically invoice my sale orders at delivery.
Product service must be marked as shipped manually, but when we use sale automatic workflow, we do not want to make manual actions.

So I propose to add an option to automatically fill delivered quantity on sale order line if the product is a service. It will be automatically filled during the first invoice creation.
One comon use case is the shipping fee, we want to invoice it together with the other products.

@guewen 
