### PR TITLE
[sale_exceptions] Count stock from selected Warehouse

### DIFF
--- a/sale_exceptions/settings/sale.exception.csv
+++ b/sale_exceptions/settings/sale.exception.csv
@@ -1,5 +1,5 @@
 "id","name","description","sequence","model","code","active"
 "excep_no_zip","No ZIP code on destination",,50,"sale.order","if not order.partner_shipping_id.zip:
     failed=True",False
-"excep_no_stock","Not Enough Virtual Stock",,50,"sale.order.line","if line.product_id and line.product_id.type == 'product' and line.product_id.virtual_available < line.product_uom_qty:
+"excep_no_stock","Not Enough Virtual Stock",,50,"sale.order.line","if line.product_id and line.product_id.type == 'product' and line.product_id.with_context(warehouse=line.order_id.warehouse_id.id).virtual_available < line.product_uom_qty:
     failed=True",False


### PR DESCRIPTION
Rule should only count available stock from selected warehouse from sale order.
Without warehouse in context, it currently sums all stock available in all warehouses.