### PR TITLE
[sale_exceptions] Count stock from selected Warehouse

### DIFF
--- a/sale_exception/data/sale_exception_data.xml
+++ b/sale_exception/data/sale_exception_data.xml
@@ -30,7 +30,7 @@
             <field name="description">Not Enough Virtual Stock</field>
             <field name="sequence">50</field>
             <field name="model">sale.order.line</field>
-            <field name="code">if line.product_id and line.product_id.type == 'product' and line.product_id.virtual_available &lt; line.product_uom_qty:
+            <field name="code">if line.product_id and line.product_id.type == 'product' and line.product_id.with_context(warehouse=line.order_id.warehouse_id.id).virtual_available &lt; line.product_uom_qty:
     failed=True</field>
             <field name="active" eval="False"/>
         </record>


### PR DESCRIPTION
Rule should only count available stock from selected warehouse from sale order.
Without warehouse in context, it currently sums all stock available in all warehouses.