### PR TITLE
[9.0][IMP] sale_order_type: Remove required fields to make it more flexible

### DIFF
--- a/sale_order_type/__openerp__.py
+++ b/sale_order_type/__openerp__.py
@@ -3,6 +3,7 @@
 # Copyright 2015-2016 Oihane Crucelaegui <oihane@avanzosc.com>
 # Copyright 2015-2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # Copyright 2016 Lorenzo Battistini
+# Copyright 2016 Carlos Dauden <carlos.dauden@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {

--- a/sale_order_type/models/sale_order.py
+++ b/sale_order_type/models/sale_order.py
@@ -26,8 +26,10 @@ class SaleOrder(models.Model):
     @api.one
     @api.onchange('type_id')
     def onchange_type_id(self):
-        self.warehouse_id = self.type_id.warehouse_id
-        self.picking_policy = self.type_id.picking_policy
+        if self.type_id.warehouse_id:
+            self.warehouse_id = self.type_id.warehouse_id
+        if self.type_id.picking_policy:
+            self.picking_policy = self.type_id.picking_policy
         if self.type_id.payment_term_id:
             self.payment_term_id = self.type_id.payment_term_id.id
         if self.type_id.pricelist_id:

--- a/sale_order_type/models/sale_order_type.py
+++ b/sale_order_type/models/sale_order_type.py
@@ -34,10 +34,10 @@ class SaleOrderTypology(models.Model):
         comodel_name='account.journal', string='Billing Journal',
         domain=[('type', '=', 'sale')])
     warehouse_id = fields.Many2one(
-        comodel_name='stock.warehouse', string='Warehouse', required=True)
+        comodel_name='stock.warehouse', string='Warehouse')
     picking_policy = fields.Selection(
         selection='_get_selection_picking_policy', string='Shipping Policy',
-        required=True, default=default_picking_policy)
+        default=default_picking_policy)
     company_id = fields.Many2one(
         'res.company',
         related='warehouse_id.company_id', store=True, readonly=True)


### PR DESCRIPTION
Remove those required fields does not affect to actual use and improves more flexibility.

@Tecnativa