### PR TITLE
[IMP] add multi-company support in module sale_exceptions + faulty de…

### DIFF
--- a/sale_exceptions/__openerp__.py
+++ b/sale_exceptions/__openerp__.py
@@ -53,6 +53,7 @@ Contributors
           'sale_exceptions_data.xml',
           'wizard/sale_exception_confirm_view.xml',
           'security/ir.model.access.csv',
+          'security/ir_rule.xml',
           'settings/sale.exception.csv'],
  'installable': True,
  }

--- a/sale_exceptions/sale.py
+++ b/sale_exceptions/sale.py
@@ -72,7 +72,6 @@ class SaleException(models.Model):
         default=lambda self: self.env['res.company']._company_default_get())
 
 
-
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 

--- a/sale_exceptions/sale.py
+++ b/sale_exceptions/sale.py
@@ -66,6 +66,11 @@ class SaleException(models.Model):
         'sale_order_exception_rel', 'exception_id', 'sale_order_id',
         string='Sale Orders',
         readonly=True)
+    company_id = fields.Many2one(
+        'res.company',
+        'Company',
+        default=lambda self: self.env['res.company']._company_default_get())
+
 
 
 class SaleOrder(models.Model):

--- a/sale_exceptions/sale_view.xml
+++ b/sale_exceptions/sale_view.xml
@@ -24,6 +24,8 @@
                     <group colspan="4" col="2">
                         <field name="name"/>
                         <field name="description"/>
+                        <field name="company_id"
+                               groups="base.group_multi_company"/>
                     </group>
                     <group col="4" colspan="4" groups="base.group_sale_manager">
                         <field name="active"/>

--- a/sale_exceptions/security/ir_rule.xml
+++ b/sale_exceptions/security/ir_rule.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data noupdate="1">
+    <record model="ir.rule" id="sale_exception__comp_rule">
+      <field name="name">Sale exception multi-company</field>
+      <field name="model_id" ref="model_sale_exception"/>
+      <field name="global" eval="True"/>
+      <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+    </record>
+  </data>
+</openerp>


### PR DESCRIPTION
…fault function signature

This commit is part of 7.0 branch for 2 years and could benefit to 8.0 too.

Not having "company_id" field in sale.exception model leads to the following error when opening or creating a sale order after migration from 7.0 to 8.0 :

`ValueError: Invalid field 'company_id' in leaf "<osv.ExtendedLeaf: ('company_id', '=', False) on sale_exception (ctx: )>"`