### PR TITLE
Option to set sale order done consider shipping

### DIFF
--- a/sale_automatic_workflow/data/automatic_workflow_data.xml
+++ b/sale_automatic_workflow/data/automatic_workflow_data.xml
@@ -39,7 +39,7 @@
         <record id="automatic_workflow_sale_done_filter" model="ir.filters">
             <field name="name">Automatic Workflow Sale Done Filter</field>
             <field name="model_id">sale.order</field>
-            <field name="domain">[('state', '=', 'sale'),('invoice_status','=','invoiced')]</field>
+            <field name="domain">[('state', '=', 'sale'),('invoice_status','=','invoiced'),('all_qty_delivered', '=', True)]</field>
             <field name="user_id" ref="base.user_root"/>
         </record>
                         

--- a/sale_automatic_workflow/models/sale.py
+++ b/sale_automatic_workflow/models/sale.py
@@ -5,6 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import models, fields, api, _
+from openerp.tools import float_compare
 
 
 class SaleOrder(models.Model):
@@ -15,6 +16,24 @@ class SaleOrder(models.Model):
         string='Automatic Workflow',
         ondelete='restrict'
     )
+    all_qty_delivered = fields.Boolean(
+        compute='_compute_all_qty_delivered',
+        string='All quantities delivered',
+        store=True,  # for searchs
+    )
+
+    @api.depends('order_line.qty_delivered', 'order_line.product_uom_qty')
+    def _compute_all_qty_delivered(self):
+        precision = self.env['decimal.precision'].precision_get(
+            'Product Unit of Measure'
+        )
+        for order in self:
+            order.all_qty_delivered = all(
+                l.product_id.type not in ('product', 'consu') or
+                float_compare(l.qty_delivered, l.product_uom_qty,
+                              precision_digits=precision) == 0
+                for l in order.order_line
+            )
 
     def _prepare_invoice(self):
         invoice_vals = super(SaleOrder, self)._prepare_invoice()

--- a/sale_automatic_workflow/models/sale_workflow_process.py
+++ b/sale_automatic_workflow/models/sale_workflow_process.py
@@ -64,7 +64,8 @@ class SaleWorkflowProcess(models.Model):
     sale_done = fields.Boolean(string='Sale Done')
     sale_done_filter_domain = fields.Char(
         string='Sale Done Filter Domain',
-        default="[('state', '=', 'sale'),('invoice_status','=','invoiced')]"
+        default="[('state', '=', 'sale'),('invoice_status','=','invoiced'),"
+                "('all_qty_delivered', '=', True)]"
     )
     warning = fields.Text(
         'Warning Message', translate=True,

--- a/sale_automatic_workflow/views/sale_view.xml
+++ b/sale_automatic_workflow/views/sale_view.xml
@@ -21,4 +21,15 @@
         </xpath>
       </field>
     </record>
+
+    <record id="view_order_form_inherit_sale_stock" model="ir.ui.view">
+        <field name="name">sale.order.form.sale.stock</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale_stock.view_order_form_inherit_sale_stock"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='sale_shipping']" position="inside">
+                <field name="all_qty_delivered"/>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
The option to automatically set the sales order as 'done' currently
filters only the sales orders in state 'sale' and invoiced.

I propose to change the default filter to 'all is invoiced AND all is
delivered' which emulates the behaviour of the previous versions of
Odoo.

This is a backward compatible change: as the filter has `noupdate="1"`,
existing installations will keep their domains and new installations
will get the new one.