### PR TITLE
[FIX][9.0] Fix sale exception menu child of sales settings that make …

### DIFF
--- a/sale_exception/views/sale_view.xml
+++ b/sale_exception/views/sale_view.xml
@@ -50,7 +50,7 @@
                   <field name="context">{'active_test': False}</field>
               </record>
 
-        <menuitem action="action_sale_test_tree" id="menu_sale_test" parent="base.menu_sale_general_settings" />
+        <menuitem action="action_sale_test_tree" id="menu_sale_test" parent="base.menu_sales_config" />
 
 
         <record id="view_order_form" model="ir.ui.view">


### PR DESCRIPTION
Now sale exception menu is child of sales settings and makes sale settings menu un clickeable on enterprise interface. We change it to be a child of sales config menu

Now:
![seleccion_006](https://cloud.githubusercontent.com/assets/3016656/21201923/8642ac46-c22b-11e6-95ed-3ed78018fe3f.png)

Whit this PR:
![seleccion_007](https://cloud.githubusercontent.com/assets/3016656/21201933/943c824a-c22b-11e6-85f9-791d60073a9e.png)
