### PR TITLE
[FIX] sale_*: Fix parent menu

### DIFF
--- a/sale_automatic_workflow/__openerp__.py
+++ b/sale_automatic_workflow/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Sale Automatic Workflow',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.1.0',
     'category': 'Sales Management',
     'license': 'AGPL-3',
     'author': "Akretion,Camptocamp,Sodexis,Odoo Community Association (OCA)",

--- a/sale_automatic_workflow/views/sale_workflow_process_view.xml
+++ b/sale_automatic_workflow/views/sale_workflow_process_view.xml
@@ -111,6 +111,17 @@
             <field name="view_mode">tree,form</field>
         </record>
 
-        <menuitem action="act_sale_workflow_process_form" id="menu_act_sale_workflow_process_form" parent="base.menu_sale_general_settings" sequence="20"/>
+        <menuitem
+                id="menu_sale_workflow_parent"
+                parent="base.menu_sale_config"
+                sequence="20"
+                name="Automatic Workflow"
+        />
+
+        <menuitem
+                action="act_sale_workflow_process_form"
+                id="menu_act_sale_workflow_process_form"
+                parent="menu_sale_workflow_parent"
+        />
 
 </odoo>

--- a/sale_exception/__openerp__.py
+++ b/sale_exception/__openerp__.py
@@ -4,7 +4,7 @@
 
 {'name': 'Sale Exception',
  'summary': 'Custom exceptions on sale order',
- 'version': '9.0.1.0.0',
+ 'version': '9.0.1.1.0',
  'category': 'Generic Modules/Sale',
  'author': "Akretion, Sodexis, Odoo Community Association (OCA)",
  'website': 'http://www.akretion.com',

--- a/sale_exception/views/sale_view.xml
+++ b/sale_exception/views/sale_view.xml
@@ -50,7 +50,19 @@
                   <field name="context">{'active_test': False}</field>
               </record>
 
-        <menuitem action="action_sale_test_tree" id="menu_sale_test" parent="base.menu_sale_general_settings" />
+        <menuitem
+                id="menu_sale_exception_parent"
+                parent="base.menu_sale_config"
+                sequence="20"
+                name="Exceptions"
+        />
+
+
+        <menuitem
+                action="action_sale_test_tree"
+                id="menu_sale_test"
+                parent="menu_sale_exception_parent"
+        />
 
 
         <record id="view_order_form" model="ir.ui.view">


### PR DESCRIPTION
The previous parent menu has an action attached, and with these modules, it can't be clicked.