### PR TITLE
[9.0][FIX] sale_order_variant_mgmt: Allow one variant dimension

### DIFF
--- a/sale_order_variant_mgmt/tests/test_sale_order_variant_mgmt.py
+++ b/sale_order_variant_mgmt/tests/test_sale_order_variant_mgmt.py
@@ -5,6 +5,8 @@
 from openerp.tests import common
 
 
+@common.at_install(False)
+@common.post_install(True)
 class TestSaleOrderVariantMgmt(common.SavepointCase):
     @classmethod
     def setUpClass(cls):
@@ -59,6 +61,10 @@ class TestSaleOrderVariantMgmt(common.SavepointCase):
         wizard.button_transfer_to_order()
         self.assertEqual(len(self.order.order_line), 4,
                          "There should be 4 lines in the sale order")
+        self.assertEqual(self.order.order_line[0].product_uom_qty, 1)
+        self.assertEqual(self.order.order_line[1].product_uom_qty, 2)
+        self.assertEqual(self.order.order_line[2].product_uom_qty, 3)
+        self.assertEqual(self.order.order_line[3].product_uom_qty, 4)
 
     def test_modify_variants(self):
         product1 = self.product_tmpl.product_variant_ids[0]

--- a/sale_order_variant_mgmt/wizard/sale_manage_variant.py
+++ b/sale_order_variant_mgmt/wizard/sale_manage_variant.py
@@ -82,6 +82,7 @@ class SaleManageVariant(models.TransientModel):
             elif line.product_uom_qty:
                 order_line = OrderLine.new({
                     'product_id': line.product_id.id,
+                    'product_uom': line.product_id.uom_id,
                     'product_uom_qty': line.product_uom_qty,
                     'order_id': sale_order.id,
                 })


### PR DESCRIPTION
This PR fix the correct qtys propagation to sale order lines

cc @Tecnativa
