### PR TITLE
[FIX] sale_order_type: empty currency

### DIFF
--- a/sale_order_type/models/sale_order.py
+++ b/sale_order_type/models/sale_order.py
@@ -37,7 +37,7 @@ class SaleOrder(models.Model):
             self.pricelist_id = self.type_id.pricelist_id.id
             res = self.onchange_pricelist_id(
                 self.pricelist_id.id, self.order_line.ids)
-            self.currency_id = res['value']['currency_id']
+            self.update(res.get('value', {}))
         if self.type_id.incoterm_id:
             self.incoterm = self.type_id.incoterm_id.id
 

--- a/sale_order_type/models/sale_order.py
+++ b/sale_order_type/models/sale_order.py
@@ -35,6 +35,9 @@ class SaleOrder(models.Model):
             self.payment_term = self.type_id.payment_term_id.id
         if self.type_id.pricelist_id:
             self.pricelist_id = self.type_id.pricelist_id.id
+            res = self.onchange_pricelist_id(
+                self.pricelist_id.id, self.order_line.ids)
+            self.currency_id = res['value']['currency_id']
         if self.type_id.incoterm_id:
             self.incoterm = self.type_id.incoterm_id.id
 

--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -59,6 +59,8 @@ class TestSaleOrderType(common.TransactionCase):
         self.assertEqual(self.sale_type.payment_term_id,
                          sale_order.payment_term)
         self.assertEqual(self.sale_type.pricelist_id, sale_order.pricelist_id)
+        self.assertEqual(
+            sale_order.pricelist_id.currency_id, sale_order.currency_id)
         self.assertEqual(self.sale_type.incoterm_id, sale_order.incoterm)
 
     def test_sale_order_confirm(self):


### PR DESCRIPTION
When type_id is changed the pricelist_id changed but the onchange of the pricelist is not executed. So it does not fill currency_id field. 