### PR TITLE
[9.0][MIG] sale_partner_incoterm: migrate to 9.0

### DIFF
--- a/sale_partner_incoterm/README.rst
+++ b/sale_partner_incoterm/README.rst
@@ -1,0 +1,58 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==================================
+Default sales incoterm per partner
+==================================
+
+This module adds a field on the Sales & Purchases tab of the partner form where
+you can register the default incoterms for new sales orders for this customer.
+
+The field is only visible for customers. It is considered a commercial field,
+so it is synchronized between the company partner and all its contacts.
+
+When the partner is selected on a new quotation, the incoterm is retrieved from
+the partner record.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/167/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/
+{sale-workflow}/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/
+{sale-workflow}/issues/new?body=module:%20
+{sale_partner_incoterm}%0Aversion:%20
+{8.0.1.0.0}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Stefan Rijnhart <stefan@opener.am>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/sale_partner_incoterm/README.rst
+++ b/sale_partner_incoterm/README.rst
@@ -26,12 +26,12 @@ Bug Tracker
 ===========
 
 Bugs are tracked on `GitHub Issues <https://github.com/OCA/
-{sale-workflow}/issues>`_.
+sale-workflow/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/
-{sale-workflow}/issues/new?body=module:%20
-{sale_partner_incoterm}%0Aversion:%20
-{8.0.1.0.0}%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+sale-workflow/issues/new?body=module:%20
+sale_partner_incoterm%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 
 Credits

--- a/sale_partner_incoterm/README.rst
+++ b/sale_partner_incoterm/README.rst
@@ -9,8 +9,8 @@ Default sales incoterm per partner
 This module adds a field on the Sales & Purchases tab of the partner form where
 you can register the default incoterms for new sales orders for this customer.
 
-The field is only visible for customers. It is considered a commercial field,
-so it is synchronized between the company partner and all its contacts.
+The field is only visible for customers (company partners and contacts). A
+different incoterm can be set per contact within the same company.
 
 When the partner is selected on a new quotation, the incoterm is retrieved from
 the partner record.

--- a/sale_partner_incoterm/README.rst
+++ b/sale_partner_incoterm/README.rst
@@ -20,7 +20,7 @@ Usage
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/167/8.0
+   :target: https://runbot.odoo-community.org/runbot/167/9.0
 
 Bug Tracker
 ===========
@@ -28,11 +28,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/OCA/
 sale-workflow/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and welcomed feedback `here <https://github.com/OCA/
-sale-workflow/issues/new?body=module:%20
-sale_partner_incoterm%0Aversion:%20
-8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
-
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback.
 
 Credits
 =======

--- a/sale_partner_incoterm/__init__.py
+++ b/sale_partner_incoterm/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_partner_incoterm/__init__.py
+++ b/sale_partner_incoterm/__init__.py
@@ -1,1 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from . import models

--- a/sale_partner_incoterm/__openerp__.py
+++ b/sale_partner_incoterm/__openerp__.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Opener B.V. (<https://opener.am>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Default sales incoterm per partner',
+    'version': '8.0.1.0.0',
+    'category': 'Sales Management',
+    'license': 'AGPL-3',
+    'summary': "Set the customer preferred incoterm on each sales order",
+    'author': "Opener B.V.,Odoo Community Association (OCA)",
+    'website': 'https://github.com/oca/sale-workflow',
+    'depends': ['sale_stock'],
+    'data': [
+        'views/res_partner.xml',
+    ],
+    'installable': True,
+}

--- a/sale_partner_incoterm/__openerp__.py
+++ b/sale_partner_incoterm/__openerp__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015 Opener B.V. (<https://opener.am>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 {
     'name': 'Default sales incoterm per partner',
     'version': '9.0.1.0.0',

--- a/sale_partner_incoterm/__openerp__.py
+++ b/sale_partner_incoterm/__openerp__.py
@@ -1,23 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2015 Opener B.V. (<https://opener.am>)
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-
+# Copyright 2015 Opener B.V. (<https://opener.am>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Default sales incoterm per partner',
     'version': '9.0.1.0.0',

--- a/sale_partner_incoterm/__openerp__.py
+++ b/sale_partner_incoterm/__openerp__.py
@@ -20,7 +20,7 @@
 
 {
     'name': 'Default sales incoterm per partner',
-    'version': '8.0.1.0.0',
+    'version': '9.0.1.0.0',
     'category': 'Sales Management',
     'license': 'AGPL-3',
     'summary': "Set the customer preferred incoterm on each sales order",

--- a/sale_partner_incoterm/i18n/de.po
+++ b/sale_partner_incoterm/i18n/de.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_partner_incoterm
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-15 13:53+0000\n"
+"PO-Revision-Date: 2015-10-15 13:53+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_partner_incoterm
+#: field:res.partner,sale_incoterm_id:0
+msgid "Default Sales Incoterm"
+msgstr "Lieferbedingungen Verkäufe"
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_res_partner
+msgid "Partner"
+msgstr "Partner"
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_sale_order
+msgid "Sales Order"
+msgstr "Verkaufsauftrag"
+
+#. module: sale_partner_incoterm
+#: help:res.partner,sale_incoterm_id:0
+msgid "The default incoterm for new sales orders for this customer."
+msgstr "Die Standard-Lieferbedingungen für neue Kundenaufträge für diesen Kunden."
+

--- a/sale_partner_incoterm/i18n/es.po
+++ b/sale_partner_incoterm/i18n/es.po
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_partner_incoterm
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: sale-workflow (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-23 08:14+0000\n"
+"PO-Revision-Date: 2015-10-23 08:15+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Spanish (http://www.transifex.com/oca/OCA-sale-workflow-8-0/language/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_partner_incoterm
+#: field:res.partner,sale_incoterm_id:0
+msgid "Default Sales Incoterm"
+msgstr ""
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_res_partner
+msgid "Partner"
+msgstr "Empresa"
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"
+
+#. module: sale_partner_incoterm
+#: help:res.partner,sale_incoterm_id:0
+msgid "The default incoterm for new sales orders for this customer."
+msgstr ""

--- a/sale_partner_incoterm/i18n/fi.po
+++ b/sale_partner_incoterm/i18n/fi.po
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_partner_incoterm
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: sale-workflow (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-23 08:14+0000\n"
+"PO-Revision-Date: 2015-10-23 08:15+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Finnish (http://www.transifex.com/oca/OCA-sale-workflow-8-0/language/fi/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fi\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_partner_incoterm
+#: field:res.partner,sale_incoterm_id:0
+msgid "Default Sales Incoterm"
+msgstr ""
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_res_partner
+msgid "Partner"
+msgstr ""
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_sale_order
+msgid "Sales Order"
+msgstr "Myyntitilaus"
+
+#. module: sale_partner_incoterm
+#: help:res.partner,sale_incoterm_id:0
+msgid "The default incoterm for new sales orders for this customer."
+msgstr ""

--- a/sale_partner_incoterm/i18n/fr.po
+++ b/sale_partner_incoterm/i18n/fr.po
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_partner_incoterm
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: sale-workflow (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-23 08:14+0000\n"
+"PO-Revision-Date: 2015-10-23 08:15+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: French (http://www.transifex.com/oca/OCA-sale-workflow-8-0/language/fr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: sale_partner_incoterm
+#: field:res.partner,sale_incoterm_id:0
+msgid "Default Sales Incoterm"
+msgstr ""
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_res_partner
+msgid "Partner"
+msgstr "Partenaire"
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_sale_order
+msgid "Sales Order"
+msgstr "Bon de commande"
+
+#. module: sale_partner_incoterm
+#: help:res.partner,sale_incoterm_id:0
+msgid "The default incoterm for new sales orders for this customer."
+msgstr ""

--- a/sale_partner_incoterm/i18n/it.po
+++ b/sale_partner_incoterm/i18n/it.po
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_partner_incoterm
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: sale-workflow (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-23 08:14+0000\n"
+"PO-Revision-Date: 2015-10-23 08:15+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Italian (http://www.transifex.com/oca/OCA-sale-workflow-8-0/language/it/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_partner_incoterm
+#: field:res.partner,sale_incoterm_id:0
+msgid "Default Sales Incoterm"
+msgstr ""
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_res_partner
+msgid "Partner"
+msgstr ""
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_sale_order
+msgid "Sales Order"
+msgstr "Ordini vendita"
+
+#. module: sale_partner_incoterm
+#: help:res.partner,sale_incoterm_id:0
+msgid "The default incoterm for new sales orders for this customer."
+msgstr ""

--- a/sale_partner_incoterm/i18n/it.po
+++ b/sale_partner_incoterm/i18n/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sale-workflow (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-23 08:14+0000\n"
+"POT-Creation-Date: 2016-03-12 01:52+0000\n"
 "PO-Revision-Date: 2015-10-23 08:15+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: Italian (http://www.transifex.com/oca/OCA-sale-workflow-8-0/language/it/)\n"
@@ -25,7 +25,7 @@ msgstr ""
 #. module: sale_partner_incoterm
 #: model:ir.model,name:sale_partner_incoterm.model_res_partner
 msgid "Partner"
-msgstr ""
+msgstr "Partner"
 
 #. module: sale_partner_incoterm
 #: model:ir.model,name:sale_partner_incoterm.model_sale_order

--- a/sale_partner_incoterm/i18n/nl.po
+++ b/sale_partner_incoterm/i18n/nl.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_partner_incoterm
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-15 13:53+0000\n"
+"PO-Revision-Date: 2015-10-15 13:53+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_partner_incoterm
+#: field:res.partner,sale_incoterm_id:0
+msgid "Default Sales Incoterm"
+msgstr "Leveringscondities verkoop"
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_res_partner
+msgid "Partner"
+msgstr "Relatie"
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_sale_order
+msgid "Sales Order"
+msgstr "Verkooporder"
+
+#. module: sale_partner_incoterm
+#: help:res.partner,sale_incoterm_id:0
+msgid "The default incoterm for new sales orders for this customer."
+msgstr "De standaard leveringscondities op nieuwe verkooporders voor deze klant."
+

--- a/sale_partner_incoterm/i18n/sale_partner_incoterm.pot
+++ b/sale_partner_incoterm/i18n/sale_partner_incoterm.pot
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_partner_incoterm
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-15 13:53+0000\n"
+"PO-Revision-Date: 2015-10-15 13:53+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_partner_incoterm
+#: field:res.partner,sale_incoterm_id:0
+msgid "Default Sales Incoterm"
+msgstr ""
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_res_partner
+msgid "Partner"
+msgstr ""
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: sale_partner_incoterm
+#: help:res.partner,sale_incoterm_id:0
+msgid "The default incoterm for new sales orders for this customer."
+msgstr ""
+

--- a/sale_partner_incoterm/i18n/sl.po
+++ b/sale_partner_incoterm/i18n/sl.po
@@ -1,0 +1,39 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_partner_incoterm
+# 
+# Translators:
+# Matjaž Mozetič <m.mozetic@matmoz.si>, 2015
+msgid ""
+msgstr ""
+"Project-Id-Version: sale-workflow (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-23 08:14+0000\n"
+"PO-Revision-Date: 2015-10-23 12:20+0000\n"
+"Last-Translator: Matjaž Mozetič <m.mozetic@matmoz.si>\n"
+"Language-Team: Slovenian (http://www.transifex.com/oca/OCA-sale-workflow-8-0/language/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: sale_partner_incoterm
+#: field:res.partner,sale_incoterm_id:0
+msgid "Default Sales Incoterm"
+msgstr "Privzeti prodajni Incoterm"
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_res_partner
+msgid "Partner"
+msgstr "Partner"
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_sale_order
+msgid "Sales Order"
+msgstr "Prodajni nalog"
+
+#. module: sale_partner_incoterm
+#: help:res.partner,sale_incoterm_id:0
+msgid "The default incoterm for new sales orders for this customer."
+msgstr "Privzeti Incoterm za nove prodajne naloge tega kupca."

--- a/sale_partner_incoterm/i18n/tr.po
+++ b/sale_partner_incoterm/i18n/tr.po
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_partner_incoterm
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: sale-workflow (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-12-05 23:35+0000\n"
+"PO-Revision-Date: 2015-10-23 08:15+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Turkish (http://www.transifex.com/oca/OCA-sale-workflow-8-0/language/tr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: tr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: sale_partner_incoterm
+#: field:res.partner,sale_incoterm_id:0
+msgid "Default Sales Incoterm"
+msgstr ""
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_res_partner
+msgid "Partner"
+msgstr "İş ortağı"
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_sale_order
+msgid "Sales Order"
+msgstr "Sipariş Emri"
+
+#. module: sale_partner_incoterm
+#: help:res.partner,sale_incoterm_id:0
+msgid "The default incoterm for new sales orders for this customer."
+msgstr ""

--- a/sale_partner_incoterm/i18n/zh_CN.po
+++ b/sale_partner_incoterm/i18n/zh_CN.po
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_partner_incoterm
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: sale-workflow (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-23 08:14+0000\n"
+"PO-Revision-Date: 2015-10-23 08:15+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Chinese (China) (http://www.transifex.com/oca/OCA-sale-workflow-8-0/language/zh_CN/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: zh_CN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: sale_partner_incoterm
+#: field:res.partner,sale_incoterm_id:0
+msgid "Default Sales Incoterm"
+msgstr ""
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_res_partner
+msgid "Partner"
+msgstr ""
+
+#. module: sale_partner_incoterm
+#: model:ir.model,name:sale_partner_incoterm.model_sale_order
+msgid "Sales Order"
+msgstr "销售订单"
+
+#. module: sale_partner_incoterm
+#: help:res.partner,sale_incoterm_id:0
+msgid "The default incoterm for new sales orders for this customer."
+msgstr ""

--- a/sale_partner_incoterm/models/__init__.py
+++ b/sale_partner_incoterm/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_partner
+from . import sale_order

--- a/sale_partner_incoterm/models/__init__.py
+++ b/sale_partner_incoterm/models/__init__.py
@@ -1,2 +1,5 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from . import res_partner
 from . import sale_order

--- a/sale_partner_incoterm/models/res_partner.py
+++ b/sale_partner_incoterm/models/res_partner.py
@@ -17,7 +17,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from openerp import models, fields, api
+from openerp import models, fields
 
 
 class Partner(models.Model):
@@ -27,7 +27,3 @@ class Partner(models.Model):
         string='Default Sales Incoterm',
         comodel_name='stock.incoterms',
         help="The default incoterm for new sales orders for this customer.")
-
-    @api.model
-    def _commercial_fields(self):
-        return super(Partner, self)._commercial_fields() + ['sale_incoterm_id']

--- a/sale_partner_incoterm/models/res_partner.py
+++ b/sale_partner_incoterm/models/res_partner.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Opener B.V. (<https://opener.am>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import models, fields, api
+
+
+class Partner(models.Model):
+    _inherit = 'res.partner'
+
+    sale_incoterm_id = fields.Many2one(
+        string='Default Sales Incoterm',
+        comodel_name='stock.incoterms',
+        help="The default incoterm for new sales orders for this customer.")
+
+    @api.model
+    def _commercial_fields(self):
+        return super(Partner, self)._commercial_fields() + ['sale_incoterm_id']

--- a/sale_partner_incoterm/models/res_partner.py
+++ b/sale_partner_incoterm/models/res_partner.py
@@ -1,22 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2015 Opener B.V. (<https://opener.am>)
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2015 Opener B.V. (<https://opener.am>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from openerp import models, fields
 
 

--- a/sale_partner_incoterm/models/sale_order.py
+++ b/sale_partner_incoterm/models/sale_order.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Opener B.V. (<https://opener.am>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import models, api
+
+
+class Sale(models.Model):
+    _inherit = 'sale.order'
+
+    @api.multi
+    def onchange_partner_id(self, partner_id):
+        res = super(Sale, self).onchange_partner_id(partner_id)
+        if partner_id:
+            res['value']['incoterm'] = self.env['res.partner'].browse(
+                partner_id).sale_incoterm_id.id
+        return res

--- a/sale_partner_incoterm/models/sale_order.py
+++ b/sale_partner_incoterm/models/sale_order.py
@@ -20,13 +20,15 @@
 from openerp import models, api
 
 
-class Sale(models.Model):
+class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
     @api.multi
-    def onchange_partner_id(self, partner_id):
-        res = super(Sale, self).onchange_partner_id(partner_id)
-        if partner_id:
-            res['value']['incoterm'] = self.env['res.partner'].browse(
-                partner_id).sale_incoterm_id.id
+    @api.onchange('partner_id')
+    def onchange_partner_id(self):
+        res = super(SaleOrder, self).onchange_partner_id()
+        if not self.partner_id:
+            self.incoterm = False
+            return res
+        self.incoterm = self.partner_id.sale_incoterm_id
         return res

--- a/sale_partner_incoterm/models/sale_order.py
+++ b/sale_partner_incoterm/models/sale_order.py
@@ -1,22 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2015 Opener B.V. (<https://opener.am>)
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2015 Opener B.V. (<https://opener.am>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from openerp import models, api
 
 

--- a/sale_partner_incoterm/tests/__init__.py
+++ b/sale_partner_incoterm/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_partner_incoterm

--- a/sale_partner_incoterm/tests/__init__.py
+++ b/sale_partner_incoterm/tests/__init__.py
@@ -1,1 +1,4 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from . import test_sale_partner_incoterm

--- a/sale_partner_incoterm/tests/test_sale_partner_incoterm.py
+++ b/sale_partner_incoterm/tests/test_sale_partner_incoterm.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Opener B.V. (<https://opener.am>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.tests.common import TransactionCase
+
+
+class TestSalePartnerIncoterm(TransactionCase):
+    def test_sale_partner_incoterm(self):
+        """ Check that the customer's default incoterm is retrieved in the \
+sales order's onchange """
+        customer = self.env['res.partner'].search(
+            [('customer', '=', True)], limit=1)
+        incoterm = self.env['stock.incoterms'].search([], limit=1)
+        customer.write({'sale_incoterm_id': incoterm.id})
+        res = self.env['sale.order'].onchange_partner_id(customer.id)['value']
+        self.assertEqual(res['incoterm'], incoterm.id)

--- a/sale_partner_incoterm/tests/test_sale_partner_incoterm.py
+++ b/sale_partner_incoterm/tests/test_sale_partner_incoterm.py
@@ -1,22 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2015 Opener B.V. (<https://opener.am>)
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2015 Opener B.V. (<https://opener.am>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
 from openerp.tests.common import TransactionCase
 
 

--- a/sale_partner_incoterm/tests/test_sale_partner_incoterm.py
+++ b/sale_partner_incoterm/tests/test_sale_partner_incoterm.py
@@ -28,5 +28,7 @@ sales order's onchange """
             [('customer', '=', True)], limit=1)
         incoterm = self.env['stock.incoterms'].search([], limit=1)
         customer.write({'sale_incoterm_id': incoterm.id})
-        res = self.env['sale.order'].onchange_partner_id(customer.id)['value']
-        self.assertEqual(res['incoterm'], incoterm.id)
+        sale_order = self.env['sale.order'].create({
+            'partner_id': customer.id})
+        sale_order.onchange_partner_id()
+        self.assertEqual(sale_order.incoterm, incoterm)

--- a/sale_partner_incoterm/views/res_partner.xml
+++ b/sale_partner_incoterm/views/res_partner.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_partner_property_form" model="ir.ui.view">
+            <field name="name">Add default sales incoterm to partner form</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="stock.view_partner_property_form"/>
+            <field name="arch" type="xml">
+                <field name="user_id" position="after">
+                    <field name="sale_incoterm_id"
+                           attrs="{'invisible': [('customer', '!=', True)]}" />
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>
+

--- a/sale_partner_incoterm/views/res_partner.xml
+++ b/sale_partner_incoterm/views/res_partner.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2015 Opener B.V. (<https://opener.am>)
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
 <odoo>
     <record id="view_partner_property_form" model="ir.ui.view">
         <field name="name">Add default sales incoterm to partner form</field>

--- a/sale_partner_incoterm/views/res_partner.xml
+++ b/sale_partner_incoterm/views/res_partner.xml
@@ -1,19 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
-
-        <record id="view_partner_property_form" model="ir.ui.view">
-            <field name="name">Add default sales incoterm to partner form</field>
-            <field name="model">res.partner</field>
-            <field name="inherit_id" ref="stock.view_partner_property_form"/>
-            <field name="arch" type="xml">
-                <field name="user_id" position="after">
-                    <field name="sale_incoterm_id"
-                           attrs="{'invisible': [('customer', '!=', True)]}" />
-                </field>
+<odoo>
+    <record id="view_partner_property_form" model="ir.ui.view">
+        <field name="name">Add default sales incoterm to partner form</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="stock.view_partner_stock_form"/>
+        <field name="arch" type="xml">
+            <field name="user_id" position="after">
+                <field name="sale_incoterm_id"
+                       attrs="{'invisible': [('customer', '!=', True)]}" />
             </field>
-        </record>
-
-    </data>
-</openerp>
+        </field>
+    </record>
+</odoo>
 


### PR DESCRIPTION
Migrate the module "sale_partner_incoterm" from v8 to v9 (not yet in v9 branch because added after).