### PR TITLE
[8.0][FIX] sale order lines of old revision must be in state cancel -…

### DIFF
--- a/sale_order_revision/model/sale_order.py
+++ b/sale_order_revision/model/sale_order.py
@@ -68,6 +68,7 @@ class sale_order(models.Model):
         msg = _('New revision created: %s') % self.name
         self.message_post(body=msg)
         old_revision.message_post(body=msg)
+        old_revision.order_line.write({'state': 'cancel'})
         return action
 
     @api.returns('self', lambda value: value.id)


### PR DESCRIPTION
… if not they result in statistics as sale