### PR TITLE
[9.0] Add sale_payment

### DIFF
--- a/sale_payment/README.rst
+++ b/sale_payment/README.rst
@@ -1,0 +1,50 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+============
+Sale Payment
+============
+
+This module allows to register payments entries on sales orders.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/167/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/sale-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Florian da Costa <florian.dacosta@akretion.com>
+* Sébastien BEAU <sebastien.beau@akretion.com>
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Mart Raudsepp <mart@stipit.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/sale_payment/__init__.py
+++ b/sale_payment/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2016  Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import model

--- a/sale_payment/__openerp__.py
+++ b/sale_payment/__openerp__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2016  Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    'name': 'Sale Payment',
+    'version': '9.0.1.0.0',
+    'category': 'Sales Management',
+    'author': "Akretion,Odoo Community Association (OCA)",
+    'website': 'http://www.akretion.com',
+    'license': 'AGPL-3',
+    'depends': ['sale'],
+    'data': [
+        'view/sale_view.xml',
+        'view/statement_view.xml'
+    ],
+    'installable': True,
+}

--- a/sale_payment/model/__init__.py
+++ b/sale_payment/model/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2016  Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import account_bank_statement
+from . import sale
+from . import account_move
+from . import account_payment

--- a/sale_payment/model/account_bank_statement.py
+++ b/sale_payment/model/account_bank_statement.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2016  Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields, api
+
+
+class AccountBankStatementLine(models.Model):
+    _inherit = 'account.bank.statement.line'
+
+    sale_ids = fields.Many2many(
+        comodel_name='sale.order',
+        string='Sales Orders')
+
+    def process_reconciliation(self, counterpart_aml_dicts=None,
+                               payment_aml_rec=None, new_aml_dicts=None):
+        if new_aml_dicts and self.sale_ids:
+            for aml_dict in new_aml_dicts:
+                aml_dict['sale_ids'] = [(6, 0, self.sale_ids.ids)]
+        return super(AccountBankStatementLine, self).process_reconciliation(
+            counterpart_aml_dicts=counterpart_aml_dicts,
+            payment_aml_rec=payment_aml_rec, new_aml_dicts=new_aml_dicts)
+
+    @api.onchange('sale_ids')
+    def onchange_sale_ids(self):
+        if self.sale_ids:
+            self.partner_id = self.sale_ids[0].partner_id.id
+            self.account_id = self.partner_id.\
+                property_account_receivable_id.id

--- a/sale_payment/model/account_move.py
+++ b/sale_payment/model/account_move.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2016  Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    sale_ids = fields.Many2many(comodel_name='sale.order',
+                                string='Sales Orders')

--- a/sale_payment/model/account_payment.py
+++ b/sale_payment/model/account_payment.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2016  Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import models, fields, api
+
+
+class AccountPayment(models.Model):
+    _inherit = 'account.payment'
+
+    sale_id = fields.Many2one(
+        'sale.order',
+        string='Sales Order')
+
+    @api.model
+    def default_get(self, fields):
+        rec = super(AccountPayment, self).default_get(fields)
+        if not self.env.context.get('active_model') == 'sale.order':
+            return rec
+        sale_id = self.env.context.get('active_id')
+        sale = self.env['sale.order'].browse(sale_id)
+
+        rec['communication'] = sale.name
+        rec['currency_id'] = sale.currency_id.id
+        rec['payment_type'] = 'inbound'
+        rec['partner_type'] = 'customer'
+        rec['partner_id'] = sale.partner_invoice_id.id
+        rec['amount'] = sale.residual
+        rec['sale_id'] = sale.id
+        return rec
+
+    def _get_counterpart_move_line_vals(self, invoice=False):
+        res = super(AccountPayment, self)._get_counterpart_move_line_vals(
+            invoice=invoice)
+        sale_ids = []
+        if invoice:
+            for inv in invoice:
+                for invoice_line in invoice.invoice_line_ids:
+                    sale_ids += [
+                        sl.order_id.id for sl in invoice_line.sale_line_ids
+                        if sl.order_id.id not in sale_ids]
+        elif self.sale_id:
+            sale_ids.append(self.sale_id.id)
+        res['sale_ids'] = [(6, 0, sale_ids)]
+        return res

--- a/sale_payment/model/sale.py
+++ b/sale_payment/model/sale.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2016  Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import fields, models, api
+import openerp.addons.decimal_precision as dp
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.one
+    def _get_residual(self):
+        paid_amount = 0.0
+        for line in self.payment_ids:
+            amount = line.credit - line.debit
+            if line.currency_id != self.currency_id:
+                from_currency = (line.currency_id and
+                                 line.currency_id.with_context(
+                                     date=line.date)) or \
+                    line.company_id.currency_id.with_context(
+                        date=line.date)
+                amount = from_currency.compute(amount, self.currency_id)
+            paid_amount += amount
+        self.residual = self.amount_total - paid_amount
+        self.amount_paid = paid_amount
+
+    payment_ids = fields.Many2many(
+        comodel_name='account.move.line',
+        string='Payments Entries',
+        domain=[('account_id.internal_type', '=', 'receivable')],
+        copy=False,
+    )
+    residual = fields.Float(
+        compute='_get_residual',
+        digits_compute=dp.get_precision('Account'))
+    amount_paid = fields.Float(
+        compute='_get_residual',
+        digits_compute=dp.get_precision('Account'))

--- a/sale_payment/tests/__init__.py
+++ b/sale_payment/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).-
+
+from . import test_payment

--- a/sale_payment/tests/test_payment.py
+++ b/sale_payment/tests/test_payment.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+from openerp import fields
+
+
+class TestSalePayment(TransactionCase):
+
+    def setUp(self):
+        super(TestSalePayment, self).setUp()
+        sale_obj = self.env['sale.order']
+        partner_values = {'name': 'Test Partner'}
+        partner = self.env['res.partner'].create(partner_values)
+        product_values = {'name': 'Product Test',
+                          'list_price': 50,
+                          'type': 'product'}
+        product = self.env['product.product'].create(product_values)
+        self.product_uom_unit = self.env.ref('product.product_uom_unit')
+        values = {
+            'partner_id': partner.id,
+            'order_line': [(0, 0, {
+                'name': product.name,
+                'product_id': product.id,
+                'product_uom': self.product_uom_unit.id,
+                'price_unit': product.list_price,
+                'product_uom_qty': 1})],
+        }
+        self.sale_order = sale_obj.create(values)
+
+        journal_vals = {
+            'name': 'Test Journal',
+            'type': 'bank',
+            'code': 'test code'
+        }
+        self.journal = self.env['account.journal'].create(journal_vals)
+
+    def test_01_payment(self):
+        """Check if payment is well generated."""
+        payment_obj = self.env['account.payment']
+        vals = payment_obj.with_context(
+            active_id=self.sale_order.id, active_model='sale.order').\
+            default_get([])
+        vals['journal_id'] = self.journal.id
+        payment = payment_obj.new(vals)
+        payment._onchange_journal()
+        vals = payment._convert_to_write(payment._cache)
+        payment = payment_obj.create(vals)
+        payment.post()
+        self.assertEqual(self.sale_order.residual, 0.0)
+        self.assertEqual(
+            self.sale_order.amount_paid, self.sale_order.amount_total)
+        self.assertEqual(len(self.sale_order.payment_ids), 1)
+
+    def test_02_statement_payment(self):
+        """Check if payment is well generated."""
+        statement_obj = self.env['account.bank.statement']
+        statement_line_obj = self.env['account.bank.statement.line']
+        statement_vals = {
+            'journal_id': self.journal.id,
+            'date': fields.Date.today(),
+        }
+        statement = statement_obj.create(statement_vals)
+        line_vals = {
+            'date': fields.Date.today(),
+            'name': 'test memo',
+            'amount': 127,
+            'sale_ids': [(6, 0, [self.sale_order.id])],
+            'statement_id': statement.id,
+        }
+        statement_line = statement_line_obj.new(line_vals)
+        statement_line.onchange_sale_ids()
+        line_vals = statement_line._convert_to_write(statement_line._cache)
+        st_line = statement_line_obj.create(line_vals)
+        statement.write({'balance_end_real': 127})
+        self.assertEqual(st_line.partner_id.name, 'Test Partner')
+        self.assertTrue(st_line.account_id)
+        statement.button_confirm_bank()
+        self.assertTrue(st_line.journal_entry_ids)
+        move_payment_line = st_line.journal_entry_ids.line_ids.filtered(
+            lambda l: l.credit > 0)
+        self.assertEqual(
+            move_payment_line.sale_ids.name, self.sale_order.name)

--- a/sale_payment/view/sale_view.xml
+++ b/sale_payment/view/sale_view.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record id="action_sale_payment" model="ir.actions.act_window">
+            <field name="name">Register Payment</field>
+            <field name="res_model">account.payment</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="account.view_account_payment_invoice_form"/>
+            <field name="target">new</field>
+        </record>
+
+        <record id="view_quotation_sale_payment_form" model="ir.ui.view">
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_quotation_tree" />
+            <field name="arch" type="xml">
+                <field name="amount_total" position="after">
+                    <field name="amount_paid"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="view_register_payment_sale_form" model="ir.ui.view">
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form" />
+            <field name="arch" type="xml">
+                <button name="action_done" position="after">
+                    <field name="residual" invisible="1"/>
+                    <button name="%(action_sale_payment)d" type="action"
+                            attrs="{'invisible': ['|', ('state', 'not in', ('draft', 'sent')), ('residual', '=', 0.0)]}"
+                            string="Register Payment" class="oe_highlight"/>
+                </button>
+                <xpath expr="//page[2]" position="after">        
+                  <page name="payments" string="Payments">
+                    <field name="payment_ids" nolabel="1">
+                        <tree string="Payment">
+                            <field name="date"/>
+                            <field name="journal_id"/>
+                            <field name="partner_id"/>
+                            <field name="debit" sum="Total Debit"/>
+                            <field name="credit" sum="Total Credit"/>
+                        </tree>
+                    </field>
+                  </page>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_sales_order_filter" model="ir.ui.view">
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_sales_order_filter"/>
+            <field name="arch" type="xml">
+                <filter name="my_sale_orders_filter" position="before">
+                    <filter string="With Payment" domain="[('payment_ids','!=',False)]" help="Order With Payment"  name="with_payment"/>
+                    <separator/>
+                </filter>
+            </field>
+        </record>
+
+    </data>
+</odoo>

--- a/sale_payment/view/statement_view.xml
+++ b/sale_payment/view/statement_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+    <data>
+
+        <record id="view_bank_statement_sale_form" model="ir.ui.view">
+            <field name="name">update_partner_button.bank.statement.form</field>
+            <field name="model">account.bank.statement</field>
+            <field name="inherit_id" ref="account.view_bank_statement_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='amount']" position="after">
+                    <field name="sale_ids" widget="many2many_tags"/>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</odoo>


### PR DESCRIPTION
This module aims to replace modules sale_payment_method and sale_quick_payment from v8.

It allows you to to pay add payment on draft sale order, it allows also to link payment to sale order.
It can be a usefull information for user to see if sale order has associated payment and could also be used for  with sale_exceptions for example, to create validation rule if order is paid, etc...