### PR TITLE
[8.0][FIX] sale_order_type: Manager security overwrited with same Id in Salesman security

### DIFF
--- a/sale_order_type/security/ir.model.access.csv
+++ b/sale_order_type/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_sale_order_type,access_sale_order_type,model_sale_order_type,base.group_sale_manager,1,1,1,1
-access_sale_order_type,access_sale_order_type,model_sale_order_type,base.group_sale_salesman,1,0,0,0
+access_sale_order_type_manager,access_sale_order_type_manager,model_sale_order_type,base.group_sale_manager,1,1,1,1
+access_sale_order_type_salesman,access_sale_order_type_salesman,model_sale_order_type,base.group_sale_salesman,1,0,0,0


### PR DESCRIPTION
Cherry-picked https://github.com/OCA/sale-workflow/commit/8702ef9a2f9044159b570943314bcec950de4216 and amended its commit message.