### PR TITLE
[FIX] change product id with qty # of 0

### DIFF
--- a/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
+++ b/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
@@ -36,8 +36,8 @@ class TestSaleOrderLotSelection(test_common.SingleTransactionCase):
 
         """
         super(TestSaleOrderLotSelection, self).setUp()
-        self.product_57 = self.env.ref('product.product_product_57')
-        self.product_46 = self.env.ref('product.product_product_46')
+        self.product_57 = self.env.ref('product.product_product_6')
+        self.product_46 = self.env.ref('product.product_product_17')
         self.product_12 = self.env.ref('product.product_product_12')
         self.product_57.write({'tracking': 'lot', 'type': 'product'})
         self.product_46.write({'tracking': 'lot', 'type': 'product'})


### PR DESCRIPTION
When I migrated the module sale_order_lot_selection to v 10.0, I did change some product ids that were removed in 10.0. This products have broken the test. 
The reason is that odoo don't take into account the lot quantity available but the product quantity available.
So, as the product 'product.product_product_57' has not available quantity, the test was OK. 
With product 'product.product_product_6' test fails. Even the lot is delivered odoo reserve move for the same lot because product is available.
This behaviour come from this method :
https://github.com/OCA/OCB/blob/10.0/addons/stock/models/stock_quant.py#L437 
first odoo check reservation with a lot, if the lot is not available, it check with lot_id = False (by product).

The question is if we should keep the method _check_move_state or not (at least in v10) ? 
Or 
Drop this part of test 
        # I'll try to confirm it to check lot reservation:
        # lot10 was delivered by order1
        with self.assertRaises(Warning):
            self.order3.action_confirm()
I create this PR to reproduce the same error of the PR #412

