### PR TITLE
[MIG] sale_sourced_by_line: Migrated to 9.0

### DIFF
--- a/sale_sourced_by_line/README.rst
+++ b/sale_sourced_by_line/README.rst
@@ -1,6 +1,7 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
    :alt: License: AGPL-3
 
+====================
 Sale Sourced by Line
 ====================
 
@@ -13,30 +14,45 @@ order lines.
 It will only supports routes such as MTO and Drop Shipping.
 
 
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/167/9.0
+
+
 Bug Tracker
 ===========
 
 Bugs are tracked on `GitHub Issues <https://github.com/OCA/sale-workflow/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
-`here <https://github.com/OCA/sale-workflow/issues/new?body=module:%20sale_sourced_by_line%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback.
 
 
 Credits
 =======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
 
 Contributors
 ------------
 
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * Yannick Vaucher <yannick.vaucher@camptocamp.com>
+* Eficent Business and IT Consulting Services S.L. <contact@eficent.com>
+* Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 
 Maintainer
 ----------
 
-.. image:: http://odoo-community.org/logo.png
+.. image:: https://odoo-community.org/logo.png
    :alt: Odoo Community Association
-   :target: http://odoo-community.org
+   :target: https://odoo-community.org
 
 This module is maintained by the OCA.
 
@@ -44,6 +60,6 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.
 
 

--- a/sale_sourced_by_line/__init__.py
+++ b/sale_sourced_by_line/__init__.py
@@ -1,22 +1,7 @@
 # -*- coding: utf-8 -*-
-#
-#
-#    Author: Guewen Baconnier
-#    Copyright 2013 Camptocamp SA
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#
+# Copyright 2013-2014 Camptocamp SA - Guewen Baconnier
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import model

--- a/sale_sourced_by_line/__openerp__.py
+++ b/sale_sourced_by_line/__openerp__.py
@@ -1,62 +1,26 @@
 # -*- coding: utf-8 -*-
-#
-#
-#    Author: Guewen Baconnier
-#    Copyright 2013-2014 Camptocamp SA
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#
+# Copyright 2013-2014 Camptocamp SA - Guewen Baconnier
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-{'name': 'Sale Sourced by Line',
- 'summary': 'Multiple warehouse source locations for Sale order',
- 'version': '8.0.1.1.0',
- 'author': "Camptocamp,Odoo Community Association (OCA)",
- 'category': 'Warehouse',
- 'license': 'AGPL-3',
- 'complexity': 'expert',
- 'images': [],
- 'website': "http://www.camptocamp.com",
- 'description': """
-Sale Sourced by Line
-====================
-
-Adds the possibility to source a line of sale order from a specific
-warehouse instead of using the warehouse of the sale order.
-
-This will create one procurement group per warehouse set in sale
-order lines.
-
-It will only supports routes such as MTO and Drop Shipping.
-
-Contributors
-------------
-
-* Guewen Baconnier <guewen.baconnier@camptocamp.com>
-* Yannick Vaucher <yannick.vaucher@camptocamp.com>
-
-""",
- 'depends': ['sale_stock',
-             'sale_procurement_group_by_line',
-             ],
- 'demo': [],
- 'data': ['view/sale_view.xml',
-          ],
- 'test': ['test/sale_order_source.yml',
-          'test/sale_order_multi_source.yml',
-          'test/sale_order_not_sourced.yml',
-          ],
- 'auto_install': False,
- 'installable': False,
- }
+{
+    'name': 'Sale Sourced by Line',
+    'summary': 'Multiple warehouse source locations for Sale order',
+    'version': '9.0.1.0.0',
+    "author": "Camptocamp,"
+              "Eficent,"
+              "SerpentCS,"
+              "Odoo Community Association (OCA)",
+    'category': 'Warehouse',
+    'license': 'AGPL-3',
+    'website': "http://www.camptocamp.com",
+    'depends': ['sale_stock',
+                'sale_procurement_group_by_line',
+                ],
+    'data': [
+        'view/sale_view.xml'
+    ],
+    'auto_install': False,
+    'installable': True,
+}

--- a/sale_sourced_by_line/model/__init__.py
+++ b/sale_sourced_by_line/model/__init__.py
@@ -1,23 +1,7 @@
 # -*- coding: utf-8 -*-
-#
-#
-#    Author: Guewen Baconnier
-#    Copyright 2013-2014 Camptocamp SA
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#
+# Copyright 2013-2014 Camptocamp SA - Guewen Baconnier
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import sale
-from . import stock

--- a/sale_sourced_by_line/tests/__init__.py
+++ b/sale_sourced_by_line/tests/__init__.py
@@ -1,21 +1,8 @@
 # -*- coding: utf-8 -*-
-#
-#
-#    Author: Yannick Vaucher
-#    Copyright 2014 Camptocamp SA
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#
-from . import test_sale_is_delivered
+# Copyright 2013-2014 Camptocamp SA - Guewen Baconnier
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+from . import test_sale_sourced_by_line

--- a/sale_sourced_by_line/tests/test_sale_sourced_by_line.py
+++ b/sale_sourced_by_line/tests/test_sale_sourced_by_line.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+# Copyright 2013-2014 Camptocamp SA - Guewen Baconnier
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+
+
+class TestSaleSourcedByLine(TransactionCase):
+
+    def setUp(self):
+        super(TestSaleSourcedByLine, self).setUp()
+        self.sale_order_model = self.env['sale.order']
+        self.sale_order_line_model = self.env['sale.order.line']
+        self.stock_move_model = self.env['stock.move']
+
+        # Refs
+        self.customer = self.env.ref('base.res_partner_2')
+        self.product_1 = self.env.ref('product.product_product_32')
+        self.product_2 = self.env.ref('product.product_product_24')
+        self.warehouse_shop0 = self.env.ref('stock.stock_warehouse_shop0')
+        self.warehouse0 = self.env.ref('stock.warehouse0')
+
+    def test_sales_order_multi_source(self):
+        so = self.sale_order_model.create({
+            'partner_id': self.customer.id,
+        })
+        self.sale_order_line_model.create({
+            'product_id': self.product_1.id,
+            'product_uom_qty': 8,
+            'warehouse_id': self.warehouse_shop0.id,
+            'order_id': so.id
+        })
+        self.sale_order_line_model.create({
+            'product_id': self.product_2.id,
+            'product_uom_qty': 8,
+            'warehouse_id': self.warehouse0.id,
+            'order_id': so.id
+        })
+        # confirm quotation
+        so.action_confirm()
+        self.assertEquals(len(so.picking_ids), 2,
+                          "2 delivery orders expected. Got %s instead" %
+                          len(so.picking_ids))
+        for line in so.order_line:
+            self.assertEquals(line.procurement_group_id.name,
+                              line.order_id.name + '/' +
+                              line.warehouse_id.name,
+                              "The name of the procurement group is not "
+                              "correct.")
+            for procurement in line.procurement_ids:
+                moves = self.stock_move_model.search([('procurement_id', '=',
+                                                       procurement.id)])
+                for move in moves:
+                    self.assertEquals(move.group_id,
+                                      line.procurement_group_id,
+                                      "The group in the stock move does not "
+                                      "match with the procurement group in "
+                                      "the sales order line.")
+                    self.assertEquals(move.picking_id.group_id,
+                                      line.procurement_group_id,
+                                      "The group in the stock picking does "
+                                      "not match with the procurement group "
+                                      "in the sales order line.")
+
+    def test_sales_order_no_source(self):
+        so = self.sale_order_model.create({
+            'partner_id': self.customer.id,
+            'warehouse_id': self.warehouse_shop0.id,
+        })
+        self.sale_order_line_model.create({
+            'product_id': self.product_1.id,
+            'product_uom_qty': 8,
+            'order_id': so.id
+        })
+        self.sale_order_line_model.create({
+            'product_id': self.product_2.id,
+            'product_uom_qty': 8,
+            'order_id': so.id
+        })
+        # confirm quotation
+        so.action_confirm()
+        self.assertEquals(len(so.picking_ids), 1,
+                          "1 delivery order expected. Got %s instead" %
+                          len(so.picking_ids))
+
+    def test_sale_order_source(self):
+        so = self.sale_order_model.create({
+            'partner_id': self.customer.id,
+        })
+        self.sale_order_line_model.create({
+            'product_id': self.product_1.id,
+            'product_uom_qty': 8,
+            'warehouse_id': self.warehouse_shop0.id,
+            'order_id': so.id
+        })
+        self.sale_order_line_model.create({
+            'product_id': self.product_2.id,
+            'product_uom_qty': 8,
+            'warehouse_id': self.warehouse0.id,
+            'order_id': so.id
+        })
+        # confirm quotation
+        so.action_confirm()
+        for line in so.order_line:
+            for procurement in line.procurement_ids:
+                self.assertEquals(procurement.warehouse_id,
+                                  line.warehouse_id,
+                                  "The warehouse in the procurement does not "
+                                  "match with the Sales order line.")

--- a/sale_sourced_by_line/view/sale_view.xml
+++ b/sale_sourced_by_line/view/sale_view.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-    <data noupdate="0">
         <record id="view_order_form" model="ir.ui.view">
             <field name="name">sale.order.form</field>
             <field name="model">sale.order</field>
@@ -15,7 +14,7 @@
         <record id="view_order_form_form" model="ir.ui.view">
             <field name="name">sale.order.form</field>
             <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale_stock.view_order_form_inherit"/>
+            <field name="inherit_id" ref="sale_stock.view_order_form_inherit_sale_stock"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='order_line']/form//field[@name='route_id']"
                   position="before">
@@ -26,5 +25,4 @@
                 </xpath>
             </field>
         </record>
-    </data>
 </openerp>


### PR DESCRIPTION
Sale Sourced by Line
====================

This module adds the possibility to source a line of sale order from a specific
warehouse instead of using the warehouse of the sale order.

This will create one procurement group per warehouse set in sale
order lines.

It will only supports routes such as MTO and Drop Shipping.

Supersedes https://github.com/OCA/sale-workflow/pull/350