### PR TITLE
[FIX][9.0] sale_rental_fix

### DIFF
--- a/sale_rental/models/product.py
+++ b/sale_rental/models/product.py
@@ -20,7 +20,7 @@ class ProductProduct(models.Model):
         string='Related Rental Services')
 
     @api.one
-    @api.constrains('rented_product_id', 'must_have_dates', 'type', 'uom_id')
+    @api.constrains('rented_product_id')
     def _check_rental(self):
         if self.rented_product_id and self.type != 'service':
             raise ValidationError(_(


### PR DESCRIPTION
 must_have_dates, type and uom_id fields are readonly. sale_rental module is using them in a constraint wrongly. There's an issue created: https://github.com/OCA/sale-workflow/issues/420


This is causing this PR to fail: https://github.com/OCA/sale-workflow/pull/418 :confused: