### PR TITLE
[9.0][sale_order_variant_mgmt] FIX error in view

### DIFF
--- a/sale_order_variant_mgmt/views/sale_order_view.xml
+++ b/sale_order_variant_mgmt/views/sale_order_view.xml
@@ -17,6 +17,9 @@
                     />
                 </div>
             </xpath>
+            <xpath expr="//field[@name='order_line']//form" position="inside">
+                <field name="product_attribute_value_ids" invisible="1"/>
+            </xpath>
             <xpath expr="//field[@name='order_line']//tree" position="inside">
                 <field name="product_tmpl_id_sale_order_variant_mgmt" invisible="1"/>
                 <field name="product_attribute_value_ids" invisible="1"/>
@@ -31,6 +34,7 @@
                         attrs="{'invisible': ['|', ('state', 'not in', ('draft', 'sent')), ('product_attribute_value_ids', '=', [])]}"
                 />
             </xpath>
+
             <xpath expr="//field[@name='order_line']" position="attributes">
                 <attribute name="options">{'reload_on_button': true}</attribute>
             </xpath>


### PR DESCRIPTION
When the user is in group 'Technical Settings / Properties on lines', installs module 'sale_order_variant_mgmt' and tries to create a quote, at the time of entering a line in the quote and saving she will get this error: 

![image](https://cloud.githubusercontent.com/assets/7683926/23356692/225facac-fcdb-11e6-91b1-573425e346c3.png)

This PR provides the fix for that.