### PR TITLE
Activate 'sale layout' with sale_product_set_layout

### DIFF
--- a/sale_product_set_layout/__manifest__.py
+++ b/sale_product_set_layout/__manifest__.py
@@ -12,6 +12,7 @@
     ],
     'data': [
         'views/product_set.xml',
+        'security/groups.xml',
     ],
     'demo': [
         'demo/product_set.xml',

--- a/sale_product_set_layout/security/groups.xml
+++ b/sale_product_set_layout/security/groups.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record model="res.groups" id="base.group_user">
+        <field name="implied_ids"
+               eval="[(4, ref('sale.group_sale_layout'))]"/>
+    </record>
+
+</odoo>


### PR DESCRIPTION
If you install this addon, it means you want to use sale layouts so it
makes sense to activate the feature.