### PR TITLE
[ADD] [9.0] sale_delivery_block

### DIFF
--- a/sale_delivery_block/README.rst
+++ b/sale_delivery_block/README.rst
@@ -1,0 +1,74 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===================
+Sale Delivery Block
+===================
+
+This module extends the functionality of sales to allow you to block the
+creation of deliveries from a sale order and give a reason.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to 'Sales > Configuration > Sales > Delivery Block Reason'.
+#. Create the different reasons that can lead to block the deliveries of a
+   sales order.
+#. Add some users to the group 'Release Delivery Block in Sales Orders'.
+
+.. figure:: path/to/local/image.png
+   :alt: alternative description
+   :width: 600 px
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Create a new sales order and provide a 'Delivery Block Reason'.
+#. Confirm Sale (No delivery would be created).
+#. Release Delivery Block when it is time to create the deliveries for
+   the sale order.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/167/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/purchase-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Lois Rilo <lois.rilo@eficent.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/sale_delivery_block/README.rst
+++ b/sale_delivery_block/README.rst
@@ -19,10 +19,6 @@ To configure this module, you need to:
    sales order.
 #. Add some users to the group 'Release Delivery Block in Sales Orders'.
 
-.. figure:: path/to/local/image.png
-   :alt: alternative description
-   :width: 600 px
-
 Usage
 =====
 

--- a/sale_delivery_block/README.rst
+++ b/sale_delivery_block/README.rst
@@ -7,7 +7,7 @@ Sale Delivery Block
 ===================
 
 This module extends the functionality of sales to allow you to block the
-creation of deliveries from a sale order and give a reason.
+creation of deliveries from a sales order and give a reason.
 
 Configuration
 =============
@@ -19,6 +19,14 @@ To configure this module, you need to:
    sales order.
 #. Add some users to the group 'Release Delivery Block in Sales Orders'.
 
+Additionally, you can set a customer with a 'Default Delivery Block Reason'
+policy to add that delivery block to his sales by default:
+
+#. Go to 'Sales > Sales > Customers'.
+#. In the 'Sales & Purchases' add a 'Default Delivery Block Reason'.
+#. The 'Default Delivery Block Reason' will be added
+   automatically when creating a new sales order for the customer.
+
 Usage
 =====
 
@@ -27,7 +35,7 @@ To use this module, you need to:
 #. Create a new sales order and provide a 'Delivery Block Reason'.
 #. Confirm Sale (No delivery would be created).
 #. Release Delivery Block when it is time to create the deliveries for
-   the sale order.
+   the sales order.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
@@ -37,7 +45,7 @@ Bug Tracker
 ===========
 
 Bugs are tracked on `GitHub Issues
-<https://github.com/OCA/purchase-workflow/issues>`_. In case of trouble, please
+<https://github.com/OCA/sale-workflow/issues>`_. In case of trouble, please
 check there if your issue has already been reported. If you spotted it first,
 help us smash it by providing detailed and welcomed feedback.
 

--- a/sale_delivery_block/__init__.py
+++ b/sale_delivery_block/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/sale_delivery_block/__openerp__.py
+++ b/sale_delivery_block/__openerp__.py
@@ -16,6 +16,7 @@
     "data": [
         'security/ir.model.access.csv',
         'security/sale_delivery_block_security.xml',
+        'data/sale_delivery_block_reason_data.xml',
         'views/sale_delivery_block_reason_view.xml',
         'views/sale_order_view.xml',
     ],

--- a/sale_delivery_block/__openerp__.py
+++ b/sale_delivery_block/__openerp__.py
@@ -12,7 +12,7 @@
               "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "category": "Sales",
-    "depends": ["sale"],
+    "depends": ["sale_stock"],
     "data": [
         'security/ir.model.access.csv',
         'security/sale_delivery_block_security.xml',

--- a/sale_delivery_block/__openerp__.py
+++ b/sale_delivery_block/__openerp__.py
@@ -19,6 +19,7 @@
         'data/sale_delivery_block_reason_data.xml',
         'views/sale_delivery_block_reason_view.xml',
         'views/sale_order_view.xml',
+        'views/res_partner_view.xml',
     ],
     "license": "AGPL-3",
     'installable': True,

--- a/sale_delivery_block/__openerp__.py
+++ b/sale_delivery_block/__openerp__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Sale Delivery Block",
+    "summary": "Allow you to block the creation of deliveries "
+               "from a sale order.",
+    "version": "9.0.1.0.0",
+    "author": "Eficent, "
+              "Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/sale-workflow",
+    "category": "Sales",
+    "depends": ["sale"],
+    "data": [
+        'security/ir.model.access.csv',
+        'security/sale_delivery_block_security.xml',
+        'views/sale_delivery_block_reason_view.xml',
+        'views/sale_order_view.xml',
+    ],
+    "license": "AGPL-3",
+    'installable': True,
+    'application': False,
+}

--- a/sale_delivery_block/data/sale_delivery_block_reason_data.xml
+++ b/sale_delivery_block/data/sale_delivery_block_reason_data.xml
@@ -3,7 +3,7 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 
 <odoo noupdate="1">
-    <record id="my_data_record" model="sale.delivery.block.reason">
+    <record id="pay_before_delivery" model="sale.delivery.block.reason">
         <field name="name">Pay Before Delivery</field>
         <field name="description">Used to block the creation of deliveries until the customer pays.
 Since you are not creating any procurement nor move, no demand will be generated or stock assigned to fulfill this sales order.

--- a/sale_delivery_block/data/sale_delivery_block_reason_data.xml
+++ b/sale_delivery_block/data/sale_delivery_block_reason_data.xml
@@ -2,9 +2,9 @@
 <!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 
-<odoo>
+<odoo noupdate="1">
     <record id="my_data_record" model="sale.delivery.block.reason">
-        <field name="name">Pay Before Deliver</field>
+        <field name="name">Pay Before Delivery</field>
         <field name="description">Used to block the creation of deliveries until the customer pays.
 Since you are not creating any procurement nor move, no demand will be generated or stock assigned to fulfill this sales order.
         </field>

--- a/sale_delivery_block/data/sale_delivery_block_reason_data.xml
+++ b/sale_delivery_block/data/sale_delivery_block_reason_data.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+    <record id="my_data_record" model="sale.delivery.block.reason">
+        <field name="name">Pay Before Deliver</field>
+        <field name="description">Used to block the creation of deliveries until the customer pays.
+Since you are not creating any procurement nor move, no demand will be generated or stock assigned to fulfill this sales order.
+        </field>
+    </record>
+</odoo>

--- a/sale_delivery_block/models/__init__.py
+++ b/sale_delivery_block/models/__init__.py
@@ -5,3 +5,4 @@
 
 from . import sale_order
 from . import sale_delivery_block_reason
+from . import res_partner

--- a/sale_delivery_block/models/__init__.py
+++ b/sale_delivery_block/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import sale_order
+from . import sale_delivery_block_reason

--- a/sale_delivery_block/models/res_partner.py
+++ b/sale_delivery_block/models/res_partner.py
@@ -3,7 +3,7 @@
 #   (http://www.eficent.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from openerp import fields, models
+from openerp import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -14,3 +14,9 @@ class ResPartner(models.Model):
         string='Default Delivery Block Reason',
         help="Set a reason to block by default the deliveries in this "
              "customer sales orders.")
+
+    @api.model
+    def _commercial_fields(self):
+        commercial_fields = super(ResPartner, self)._commercial_fields()
+        commercial_fields.append('default_delivery_block')
+        return commercial_fields

--- a/sale_delivery_block/models/res_partner.py
+++ b/sale_delivery_block/models/res_partner.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    default_delivery_block = fields.Many2one(
+        comodel_name='sale.delivery.block.reason',
+        string='Default Delivery Block Reason',
+        help="Set a reason to block by default the deliveries in this "
+             "customer sales orders.")

--- a/sale_delivery_block/models/sale_delivery_block_reason.py
+++ b/sale_delivery_block/models/sale_delivery_block_reason.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import fields, models
+
+
+class SaleDeliveryBlockReason(models.Model):
+    _name = 'sale.delivery.block.reason'
+
+    name = fields.Char(string='Name', required=True)
+    description = fields.Text(string='Description')
+    sale_order_ids = fields.One2many(comodel_name='sale.order',
+                                     inverse_name='delivery_block_id',
+                                     string='Sale Orders',
+                                     readonly=True)

--- a/sale_delivery_block/models/sale_order.py
+++ b/sale_delivery_block/models/sale_order.py
@@ -30,8 +30,8 @@ class SaleOrder(models.Model):
         """Add the 'Default Delivery Block Reason' if set in the partner."""
         res = super(SaleOrder, self).onchange_partner_id()
         for so in self:
-            if so.partner_id.default_delivery_block:
-                so.delivery_block_id = so.partner_id.default_delivery_block
+            so.delivery_block_id = so.partner_id.default_delivery_block or \
+                False
         return res
 
     @api.multi
@@ -40,6 +40,15 @@ class SaleOrder(models.Model):
         self.write({'delivery_block_id': False})
         for order in self:
             order.order_line._action_procurement_create()
+
+    @api.multi
+    def copy(self, default=None):
+        new_so = super(SaleOrder, self).copy(default=default)
+        for so in new_so:
+            if (so.partner_id.default_delivery_block and not
+                    so.delivery_block_id):
+                so.delivery_block_id = so.partner_id.default_delivery_block
+        return new_so
 
 
 class SaleOrderLine(models.Model):

--- a/sale_delivery_block/models/sale_order.py
+++ b/sale_delivery_block/models/sale_order.py
@@ -38,6 +38,11 @@ class SaleOrderLine(models.Model):
     @api.multi
     def _action_procurement_create(self):
         new_procs = self.env['procurement.order']
+        # When module 'sale_procurement_group_by_line_is installed' we do not
+        #  want to use this method but call super. See module
+        # 'sale_delivery_block_proc_group_by_line
+        if 'group_by_line' in self.env.context:
+            return super(SaleOrderLine, self)._action_procurement_create()
         for line in self:
             if not line.order_id.delivery_block_id:
                 new_procs += super(SaleOrderLine,

--- a/sale_delivery_block/models/sale_order.py
+++ b/sale_delivery_block/models/sale_order.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, fields, models, _
+from openerp.exceptions import UserError
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.model
+    @api.constrains('delivery_block_id')
+    def _check_not_auto_done(self):
+        if self.delivery_block_id and self.env['ir.values'].get_default(
+                'sale.config.settings', 'auto_done_setting'):
+            raise UserError(
+                _('You cannot block a sale order with "auto_done_setting" '
+                  'active.'))
+
+    delivery_block_id = fields.Many2one(
+        comodel_name='sale.delivery.block.reason',
+        string='Delivery Block Reason', readonly=True,
+        states={'draft': [('readonly', False)]})
+
+    @api.multi
+    def action_remove_delivery_block(self):
+        """Remove the delivery block and create procurements as usual."""
+        self.write({'delivery_block_id': False})
+        for order in self:
+            order.order_line._action_procurement_create()
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    @api.multi
+    def _action_procurement_create(self):
+        new_procs = self.env['procurement.order']
+        for line in self:
+            if not line.order_id.delivery_block_id:
+                new_procs += super(SaleOrderLine,
+                                   line)._action_procurement_create()
+        return new_procs

--- a/sale_delivery_block/models/sale_order.py
+++ b/sale_delivery_block/models/sale_order.py
@@ -10,14 +10,15 @@ from openerp.exceptions import UserError
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    @api.model
+    @api.multi
     @api.constrains('delivery_block_id')
     def _check_not_auto_done(self):
-        if self.delivery_block_id and self.env['ir.values'].get_default(
-                'sale.config.settings', 'auto_done_setting'):
-            raise UserError(
-                _('You cannot block a sale order with "auto_done_setting" '
-                  'active.'))
+        for so in self:
+            if so.delivery_block_id and self.env['ir.values'].get_default(
+                    'sale.config.settings', 'auto_done_setting'):
+                raise UserError(
+                    _('You cannot block a sale order with "auto_done_setting" '
+                      'active.'))
 
     delivery_block_id = fields.Many2one(
         comodel_name='sale.delivery.block.reason', track_visibility='always',

--- a/sale_delivery_block/models/sale_order.py
+++ b/sale_delivery_block/models/sale_order.py
@@ -20,7 +20,7 @@ class SaleOrder(models.Model):
                   'active.'))
 
     delivery_block_id = fields.Many2one(
-        comodel_name='sale.delivery.block.reason',
+        comodel_name='sale.delivery.block.reason', track_visibility='always',
         string='Delivery Block Reason', readonly=True,
         states={'draft': [('readonly', False)], 'sent': [('readonly', False)]})
 

--- a/sale_delivery_block/models/sale_order.py
+++ b/sale_delivery_block/models/sale_order.py
@@ -22,7 +22,7 @@ class SaleOrder(models.Model):
     delivery_block_id = fields.Many2one(
         comodel_name='sale.delivery.block.reason',
         string='Delivery Block Reason', readonly=True,
-        states={'draft': [('readonly', False)]})
+        states={'draft': [('readonly', False)], 'sent': [('readonly', False)]})
 
     @api.multi
     def action_remove_delivery_block(self):

--- a/sale_delivery_block/models/sale_order.py
+++ b/sale_delivery_block/models/sale_order.py
@@ -25,6 +25,16 @@ class SaleOrder(models.Model):
         states={'draft': [('readonly', False)], 'sent': [('readonly', False)]})
 
     @api.multi
+    @api.onchange('partner_id')
+    def onchange_partner_id(self):
+        """Add the 'Default Delivery Block Reason' if set in the partner."""
+        res = super(SaleOrder, self).onchange_partner_id()
+        for so in self:
+            if so.partner_id.default_delivery_block:
+                so.delivery_block_id = so.partner_id.default_delivery_block
+        return res
+
+    @api.multi
     def action_remove_delivery_block(self):
         """Remove the delivery block and create procurements as usual."""
         self.write({'delivery_block_id': False})

--- a/sale_delivery_block/models/sale_order.py
+++ b/sale_delivery_block/models/sale_order.py
@@ -38,9 +38,10 @@ class SaleOrderLine(models.Model):
     @api.multi
     def _action_procurement_create(self):
         new_procs = self.env['procurement.order']
-        # When module 'sale_procurement_group_by_line_is installed' we do not
-        #  want to use this method but call super. See module
-        # 'sale_delivery_block_proc_group_by_line
+        # When module 'sale_procurement_group_by_line' is installed we do not
+        # want to use this method but call super. See module
+        # 'sale_delivery_block_proc_group_by_line'. This solves a inheritance
+        # order issue.
         if 'group_by_line' in self.env.context:
             return super(SaleOrderLine, self)._action_procurement_create()
         for line in self:

--- a/sale_delivery_block/security/ir.model.access.csv
+++ b/sale_delivery_block/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sale_delivery_block_reason_user,sale.delivery.block.reason user,model_sale_delivery_block_reason,base.group_sale_salesman,1,0,0,0
+access_sale_delivery_block_reason_manager,sale.delivery.block.reason manager,model_sale_delivery_block_reason,base.group_sale_manager,1,1,1,1

--- a/sale_delivery_block/security/sale_delivery_block_security.xml
+++ b/sale_delivery_block/security/sale_delivery_block_security.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo noupdate="1">
+    <record id="group_sale_delivery_block" model="res.groups">
+        <field name="name">Release Delivery Block in Sales Orders</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+        <field name="users" eval="[(4, ref('base.user_root'))]"/>
+        <field name="comment">
+            The user will be able to release deliveries that have been blocked
+            in a sale order.
+        </field>
+    </record>
+</odoo>

--- a/sale_delivery_block/tests/__init__.py
+++ b/sale_delivery_block/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import test_sale_delivery_block

--- a/sale_delivery_block/tests/test_sale_delivery_block.py
+++ b/sale_delivery_block/tests/test_sale_delivery_block.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+from openerp.tests import common
+from openerp.exceptions import ValidationError
+
+
+class TestSaleDeliveryBlock(common.TransactionCase):
+
+    def setUp(self):
+        super(TestSaleDeliveryBlock, self).setUp()
+        self.so_model = self.env['sale.order']
+        self.sol_model = self.env['sale.order.line']
+        self.usr_model = self.env['res.users']
+        self.block_model = self.env['sale.delivery.block.reason']
+        group_ids = [
+            self.env.ref('sale_delivery_block.group_sale_delivery_block').id,
+            self.env.ref('base.group_sale_manager').id,
+        ]
+        user_dict = {
+            'name': 'User test',
+            'login': 'tua@example.com',
+            'password': 'base-test-passwd',
+            'email': 'armande.hruser@example.com',
+            'groups_id': [(6, 0, group_ids)],
+        }
+        self.user_test = self.usr_model.create(user_dict)
+        # Create product:
+        prod_dict = {
+            'name': 'test product',
+            'type': 'product',
+        }
+        product = self.env['product.product'].sudo(self.user_test).create(
+            prod_dict)
+        # Create Sales order and lines:
+        so_dict = {
+            'partner_id': self.env.ref('base.res_partner_1').id,
+        }
+        self.sale_order = self.so_model.sudo(self.user_test).create(so_dict)
+        sol_dict = {
+            'order_id': self.sale_order.id,
+            'product_id': product.id,
+            'product_uom_qty': 1.0,
+        }
+        self.sale_order_line = self.sol_model.create(sol_dict)
+
+    def test_check_auto_done(self):
+        # Set active auto done configuration
+        self.env['ir.values'].set_default('sale.config.settings',
+                                          'auto_done_setting', 1)
+        block_reason = self.block_model.sudo(self.user_test).create({
+            'name': 'Test Block.'})
+        so = self.sale_order
+        # Check settings constraints
+        with self.assertRaises(ValidationError):
+            so.write({
+                'delivery_block_id': block_reason.id,
+            })
+
+    def procurement_comp(self, so):
+        """count created procurements"""
+        count = 0
+        for line in so.order_line:
+            count += len(line.procurement_ids)
+        return count
+
+    def test_no_block(self):
+        """Tests if normal behaviour without block."""
+        so = self.sale_order
+        so.action_confirm()
+        proc = self.procurement_comp(so)
+        self.assertNotEqual(proc, 0, 'A procurement order should have been '
+                                     'made')
+
+    def test_sale_delivery_block(self):
+        # Create Sales order block reason:
+        block_reason = self.block_model.sudo(self.user_test).create({
+            'name': 'Test Block.'})
+        so = self.sale_order
+        so.write({
+            'delivery_block_id': block_reason.id,
+        })
+        so.action_confirm()
+        self.procurement_comp(so)
+        proc = self.procurement_comp(so)
+        self.assertEqual(proc, 0, 'The procurement should have been blocked')
+        # Remove block
+        so.action_remove_delivery_block()
+        proc = self.procurement_comp(so)
+        self.assertNotEqual(proc, 0, 'A procurement order should have been '
+                                     'made')

--- a/sale_delivery_block/views/res_partner_view.xml
+++ b/sale_delivery_block/views/res_partner_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="name">res.partner.form</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <field name="user_id" position="after">
+                <field name="default_delivery_block"
+                    attrs="{'invisible': ['|', ('customer', '!=', True), ('is_company', '=', False), ('parent_id', '!=', False)]}"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/sale_delivery_block/views/sale_delivery_block_reason_view.xml
+++ b/sale_delivery_block/views/sale_delivery_block_reason_view.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record id="sale_delivery_block_reason_tree_view" model="ir.ui.view">
+        <field name="name">sale.delivery.block.reason.tree</field>
+        <field name="model">sale.delivery.block.reason</field>
+        <field name="arch" type="xml">
+            <tree string="Sale Order Delivery Block Reason">
+                <field name="name"/>
+                <field name="description"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="sale_delivery_block_reason_form_view" model="ir.ui.view">
+        <field name="name">sale.delivery.block.reason.form</field>
+        <field name="model">sale.delivery.block.reason</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group name="top">
+                        <group>
+                            <field name="name"/>
+                        </group>
+                        <group name="specific rule fields">
+                            <field name="description"/>
+                        </group>
+                    </group>
+
+                    <notebook>
+                        <page string="Applied to">
+                            <field name="sale_order_ids"/>
+                        </page>
+                    </notebook>
+                </sheet>
+
+            </form>
+        </field>
+    </record>
+
+    <act_window id="action_sale_delivery_block_reason"
+                name="Sale Delivery Block Reason"
+                res_model="sale.delivery.block.reason"
+                view_mode="tree,form" />
+
+    <menuitem id="menu_sale_delivery_block_reason"
+              name="Delivery Block Reason"
+              parent="base.menu_sales_config"
+              action="action_sale_delivery_block_reason" />
+
+</odoo>

--- a/sale_delivery_block/views/sale_order_view.xml
+++ b/sale_delivery_block/views/sale_order_view.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 Eficent Business and IT Consulting Services S.L.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="name">sale.order.form - sale_delivery_block extension</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <field name="payment_term_id" position="after">
+                <field name="delivery_block_id"/>
+            </field>
+            <xpath expr="//header/button[@name='action_quotation_send']"
+                   position="before">
+                <button name="action_remove_delivery_block"
+                        string="Release Delivery Block"
+                        type="object" class="btn-primary"
+                        groups="sale_delivery_block.group_sale_delivery_block"
+                        attrs="{'invisible': ['|',('delivery_block_id', '=', False),('state', '!=', 'sale')]}"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_sales_order_filter" model="ir.ui.view">
+        <field name="name">sale.order.list.select</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_sales_order_filter"/>
+        <field name="arch" type="xml">
+            <field name="product_id" position="after">
+                <field name="delivery_block_id"/>
+            </field>
+            <filter name="sales" position="after">
+                <filter string="Delivery Blocked Sales" name="blocked_sales"
+                        domain="[('delivery_block_id', '!=', False)]"/>
+            </filter>
+        </field>
+    </record>
+</odoo>

--- a/sale_delivery_block_proc_group_by_line/README.rst
+++ b/sale_delivery_block_proc_group_by_line/README.rst
@@ -1,0 +1,70 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===================
+Sale Delivery Block
+===================
+
+This module extends the functionality of sales to allow you to block the
+creation of deliveries from a sale order and give a reason.
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Go to 'Sales > Configuration > Sales > Delivery Block Reason'.
+#. Create the different reasons that can lead to block the deliveries of a
+   sales order.
+#. Add some users to the group 'Release Delivery Block in Sales Orders'.
+
+Usage
+=====
+
+To use this module, you need to:
+
+#. Create a new sales order and provide a 'Delivery Block Reason'.
+#. Confirm Sale (No delivery would be created).
+#. Release Delivery Block when it is time to create the deliveries for
+   the sale order.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/167/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/purchase-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Lois Rilo <lois.rilo@eficent.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/sale_delivery_block_proc_group_by_line/README.rst
+++ b/sale_delivery_block_proc_group_by_line/README.rst
@@ -2,36 +2,25 @@
    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
    :alt: License: AGPL-3
 
-===================
-Sale Delivery Block
-===================
+=============================================
+Sale Delivery Block Procurement Group By Line
+=============================================
 
-This module extends the functionality of sales to allow you to block the
-creation of deliveries from a sale order and give a reason.
-
-Configuration
-=============
-
-To configure this module, you need to:
-
-#. Go to 'Sales > Configuration > Sales > Delivery Block Reason'.
-#. Create the different reasons that can lead to block the deliveries of a
-   sales order.
-#. Add some users to the group 'Release Delivery Block in Sales Orders'.
-
-Usage
-=====
-
-To use this module, you need to:
-
-#. Create a new sales order and provide a 'Delivery Block Reason'.
-#. Confirm Sale (No delivery would be created).
-#. Release Delivery Block when it is time to create the deliveries for
-   the sale order.
+This module make `sale_delivery_block` compatible with
+`sale_procurement_group_by_line`.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
    :target: https://runbot.odoo-community.org/runbot/167/9.0
+
+Installation
+============
+
+This module will be automatically installed in a database with the following
+modules installed:
+
+* Sale Delivery Block (sale_delivery_block).
+* Sale Procurement Group by line (sale_procurement_group_by_line).
 
 Bug Tracker
 ===========
@@ -53,6 +42,7 @@ Contributors
 ------------
 
 * Lois Rilo <lois.rilo@eficent.com>
+* Jordi Ballester <jordi.ballester@eficent.com>
 
 Maintainer
 ----------

--- a/sale_delivery_block_proc_group_by_line/__init__.py
+++ b/sale_delivery_block_proc_group_by_line/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/sale_delivery_block_proc_group_by_line/__openerp__.py
+++ b/sale_delivery_block_proc_group_by_line/__openerp__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Sale Delivery Block Procurement Group By Line",
+    "summary": "Module that allows module sale_delivery_block to work with "
+               "sale_procurement_group_by_line",
+    "version": "9.0.1.0.0",
+    "author": "Eficent, "
+              "Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/sale-workflow",
+    "category": "Sales",
+    "depends": [
+        "sale_procurement_group_by_line",
+        "sale_delivery_block"
+    ],
+    "auto_install": True,
+    "license": "AGPL-3",
+    "installable": True,
+    "application": False,
+}

--- a/sale_delivery_block_proc_group_by_line/models/__init__.py
+++ b/sale_delivery_block_proc_group_by_line/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import sale_order

--- a/sale_delivery_block_proc_group_by_line/models/sale_order.py
+++ b/sale_delivery_block_proc_group_by_line/models/sale_order.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, fields, models, _
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    @api.multi
+    def _action_procurement_create(self):
+        new_procs = self.env['procurement.order']
+        for line in self:
+            if not line.order_id.delivery_block_id:
+                new_procs += super(
+                    SaleOrderLine, line.with_context(
+                        group_by_line=True))._action_procurement_create()
+        return new_procs

--- a/sale_delivery_block_proc_group_by_line/models/sale_order.py
+++ b/sale_delivery_block_proc_group_by_line/models/sale_order.py
@@ -3,7 +3,7 @@
 #   (http://www.eficent.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from openerp import api, fields, models, _
+from openerp import api, models
 
 
 class SaleOrderLine(models.Model):


### PR DESCRIPTION
Sale Delivery Block
===================

This module extends the functionality of sales to allow you to block the
creation of deliveries from a sales order and give a reason.

Configuration
=============

To configure this module, you need to:

#. Go to 'Sales > Configuration > Sales > Delivery Block Reason'.
#. Create the different reasons that can lead to block the deliveries of a
   sales order.
#. Add some users to the group 'Release Delivery Block in Sales Orders'.

Additionally, you can set a customer with a 'Default Delivery Block Reason'
policy to add that delivery block to his sales by default:

#. Go to 'Sales > Sales > Customers'.
#. In the 'Sales & Purchases' add a 'Default Delivery Block Reason'.
#. The 'Default Delivery Block Reason' will be added
   automatically when creating a new sales order for the customer.

Usage
=====

To use this module, you need to:

#. Create a new sales order and provide a 'Delivery Block Reason'.
#. Confirm Sale (No delivery would be created).
#. Release Delivery Block when it is time to create the deliveries for
   the sales order.