### PR TITLE
[8.0] Add copy=False on field date_validity

### DIFF
--- a/sale_validity/model/sale_order.py
+++ b/sale_validity/model/sale_order.py
@@ -26,7 +26,7 @@ class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
     date_validity = fields.Date(
-        string='Valid Until', readonly=True,
+        string='Valid Until', readonly=True, copy=False,
         help="Define date until when quotation is valid",
         states={
             'draft': [('readonly', False)],


### PR DESCRIPTION
The field "date_order" has copy=False (cf https://github.com/odoo/odoo/blob/8.0/addons/sale/sale.py#L204), so it should be the same for the field "date_validity".

When you duplicate an old sale order, the "Date" field is automatically set to today, so the validity date should also be reset and put to its default value.