### PR TITLE
ADD margin percent in sales

### DIFF
--- a/sale_order_margin_percent/README.rst
+++ b/sale_order_margin_percent/README.rst
@@ -1,0 +1,89 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=========================
+Sale Order Margin Percent
+=========================
+
+This module show the margin profit in sales and invoicing.
+It can be used both in budgets and in sales orders,
+in the sales section and for invoicing can also be used.
+
+============
+Installation
+============
+
+To install this module, you need to:
+
+- First Add in the addons path the module and install in your Odoo.
+  And install the dependencies of the module
+
+=============
+Configuration
+=============
+
+To configure this module, you need to:
+
+- First Add in the sales configuration the option
+  "Show margins in quotes and sales orders" then you can get the margin field
+  for the operations.
+
+=====
+Usage
+=====
+
+To use this module, you need to:
+
+#. Go to sales and enter in sale order section,
+#. create a sale order then add products,
+#. You can get the percent because you have values in the field margin and
+amount untaxed.
+#. For the invoicing is the same enter an create a new one.
+
+===========
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/sale-workflow/issues>`_. In case of trouble,
+please check there if your issue has already been reported. If you spotted it
+first, help us smash it by providing detailed and welcomed feedback.
+
+=======
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon
+<https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Luis Adan Jiménez Hernádez <luis.jimenez@pesol.es>
+* Ángel Moya <angel.moya@pesol.es>
+
+Funders
+-------
+
+The development of this module has been financially supported by:
+
+* PESOL
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/sale_order_margin_percent/README.rst
+++ b/sale_order_margin_percent/README.rst
@@ -6,28 +6,7 @@
 Sale Order Margin Percent
 =========================
 
-This module show the margin profit in sales and invoicing.
-It can be used both in budgets and in sales orders,
-in the sales section and for invoicing can also be used.
-
-============
-Installation
-============
-
-To install this module, you need to:
-
-- First Add in the addons path the module and install in your Odoo, And install
-  the dependencies of the module.
-
-=============
-Configuration
-=============
-
-To configure this module, you need to:
-
-- First Add in the sales configuration the option
-  "Show margins in quotes and sales orders" then you can get the margin field
-  for the operations.
+This module shows the margin profit percentage in sales orders.
 
 =====
 Usage
@@ -35,17 +14,17 @@ Usage
 
 To use this module, you need to:
 
-#. Go to sales and enter in sale order section.
-#. create a sale order then add products.
-#. You can get the percent because you have values in the field margin and amount untaxed.
-#. For the invoicing is the same enter an create a new one.
+#. Go to sales and enter in sale order section,
+#. create a sale order then add products,
+#. You can get the percent because you have values in the field margin and
+amount untaxed.
 
 ===========
 Bug Tracker
 ===========
 
 Bugs are tracked on `GitHub Issues
-<https://github.com/OCA/project_task_analytic_tag/issues>`_. In case of trouble,
+<https://github.com/OCA/sale-workflow/issues>`_. In case of trouble,
 please check there if your issue has already been reported. If you spotted it
 first, help us smash it by providing detailed and welcomed feedback.
 

--- a/sale_order_margin_percent/README.rst
+++ b/sale_order_margin_percent/README.rst
@@ -16,8 +16,8 @@ Installation
 
 To install this module, you need to:
 
-- First Add in the addons path the module and install in your Odoo.
-  And install the dependencies of the module
+- First Add in the addons path the module and install in your Odoo, And install
+  the dependencies of the module.
 
 =============
 Configuration
@@ -35,10 +35,9 @@ Usage
 
 To use this module, you need to:
 
-#. Go to sales and enter in sale order section,
-#. create a sale order then add products,
-#. You can get the percent because you have values in the field margin and
-amount untaxed.
+#. Go to sales and enter in sale order section.
+#. create a sale order then add products.
+#. You can get the percent because you have values in the field margin and amount untaxed.
 #. For the invoicing is the same enter an create a new one.
 
 ===========
@@ -46,7 +45,7 @@ Bug Tracker
 ===========
 
 Bugs are tracked on `GitHub Issues
-<https://github.com/OCA/sale-workflow/issues>`_. In case of trouble,
+<https://github.com/OCA/project_task_analytic_tag/issues>`_. In case of trouble,
 please check there if your issue has already been reported. If you spotted it
 first, help us smash it by providing detailed and welcomed feedback.
 

--- a/sale_order_margin_percent/__init__.py
+++ b/sale_order_margin_percent/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/sale_order_margin_percent/__manifest__.py
+++ b/sale_order_margin_percent/__manifest__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Sale Order Margin Percent",
+    "summary": "Show Percent in sale order",
+    "version": "10.0.1.0.0",
+    "category": "Sales",
+    "website": "http://www.pesol.es",
+    "author": "PESOL",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        'sale',
+        'sale_margin'
+    ],
+    "data": [
+        'views/sale_order_margin_percent_view.xml',
+
+    ]
+}

--- a/sale_order_margin_percent/__manifest__.py
+++ b/sale_order_margin_percent/__manifest__.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+# Copyright 2017 PESOL (http://pesol.es)
+#                Luis Adan Jimenez Hernandez (luis.jimenez@pesol.es)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Sale Order Margin Percent",
     "summary": "Show Percent in sale order",
@@ -15,6 +18,5 @@
     ],
     "data": [
         'views/sale_order_margin_percent_view.xml',
-
     ]
 }

--- a/sale_order_margin_percent/i18n/es.po
+++ b/sale_order_margin_percent/i18n/es.po
@@ -1,0 +1,26 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_order_margin_percent
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-05-09 15:32+0000\n"
+"PO-Revision-Date: 2017-05-09 15:32+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_order_margin_percent
+#: model:ir.model.fields,field_description:sale_order_margin_percent.field_sale_order_percent
+msgid "Percent"
+msgstr "Porcentaje"
+
+#. module: sale_order_margin_percent
+#: model:ir.model,name:sale_order_margin_percent.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"

--- a/sale_order_margin_percent/models/__init__.py
+++ b/sale_order_margin_percent/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import sale_order_margin

--- a/sale_order_margin_percent/models/sale_order_margin.py
+++ b/sale_order_margin_percent/models/sale_order_margin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from openerp import models, api, fields, _
+from odoo import models, api, fields
 
 
 class SaleOrder(models.Model):

--- a/sale_order_margin_percent/models/sale_order_margin.py
+++ b/sale_order_margin_percent/models/sale_order_margin.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+from openerp import models, api, fields, _
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    percent = fields.Float(
+        string='Percent',
+        compute='_compute_percent')
+
+    @api.depends('margin', 'amount_untaxed')
+    def _compute_percent(self):
+        if self.margin and self.amount_untaxed:
+            self.percent = (self.margin / self.amount_untaxed) * 100

--- a/sale_order_margin_percent/views/sale_order_margin_percent_view.xml
+++ b/sale_order_margin_percent/views/sale_order_margin_percent_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_sale_order_margin_percent_form" model="ir.ui.view">
+        <field name="name">view.sale.order.margin.percent.form</field>
+        <field name="model">sale.order</field>
+        <field name='inherit_id' ref='sale_margin.sale_margin_sale_order'/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='margin']" position="after">
+                <field name="percent" widget="progressbar"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION

Sale Order Margin Percent
=========================

This module show the margin profit in sales and invoicing.
It can be used both in budgets and in sales orders,
in the sales section and for invoicing can also be used.