### PR TITLE
[MIG ] [9.0] sale order line date

### DIFF
--- a/sale_order_line_date/README.rst
+++ b/sale_order_line_date/README.rst
@@ -1,0 +1,62 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+====================
+Sale order line date
+====================
+
+This module adds requested date to a sales order lines and propagate it to
+stock moves and procurements.
+When the requested date of the whole sale order is modified the requested date
+of the lines change to match.
+
+Usage
+=====
+
+Create a Quotation or a Sales Order and fill the requested date in the sale
+order line
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/213/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/sale-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+* Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
+* Esther Martín <esthermartin@avanzosc.es>
+* Pedro M. Baeza <pedro.baeza@tecnativa.com>
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Jordi Ballester <jordi.ballester@eficent.com>
+* Aaron Henriquez <ahenriquez@eficent.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/sale_order_line_date/README.rst
+++ b/sale_order_line_date/README.rst
@@ -14,12 +14,12 @@ of the lines change to match.
 Usage
 =====
 
-Create a Quotation or a Sales Order and fill the requested date in the sale
+Create a Quotation or a Sales Order and it fills the requested date in the sale
 order line
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/213/8.0
+   :target: https://runbot.odoo-community.org/runbot/167/9.0
 
 Bug Tracker
 ===========
@@ -45,6 +45,7 @@ Contributors
 * Ana Juaristi <anajuaristi@avanzosc.es>
 * Jordi Ballester <jordi.ballester@eficent.com>
 * Aaron Henriquez <ahenriquez@eficent.com>
+* Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 
 Maintainer
 ----------

--- a/sale_order_line_date/__init__.py
+++ b/sale_order_line_date/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# © 2016 OdooMRP team
+# © 2016 AvanzOSC
+# © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2016 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/sale_order_line_date/__openerp__.py
+++ b/sale_order_line_date/__openerp__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# © 2016 OdooMRP team
+# © 2016 AvanzOSC
+# © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2016 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Sale Order Line Date",
+    "version": "8.0.1.0.0",
+    "author": "OdooMRP team,"
+              "AvanzOSC,"
+              "Serv. Tecnol. Avanzados - Pedro M. Baeza,"
+              "Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/sale-workflow/",
+    "category": "Sales Management",
+    "license": "AGPL-3",
+    "depends": [
+        "sale_order_dates",
+    ],
+    "data": [
+        "views/sale_order_view.xml",
+    ],
+    "installable": True,
+}

--- a/sale_order_line_date/__openerp__.py
+++ b/sale_order_line_date/__openerp__.py
@@ -7,7 +7,7 @@
 
 {
     "name": "Sale Order Line Date",
-    "version": "8.0.1.0.0",
+    "version": "9.0.1.0.0",
     "author": "OdooMRP team,"
               "AvanzOSC,"
               "Serv. Tecnol. Avanzados - Pedro M. Baeza,"

--- a/sale_order_line_date/i18n/es.po
+++ b/sale_order_line_date/i18n/es.po
@@ -1,0 +1,39 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_order_line_date
+# 
+# Translators:
+# Pedro M. Baeza <pedro.baeza@gmail.com>, 2015
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-07 10:45+0000\n"
+"PO-Revision-Date: 2015-10-09 10:59+0000\n"
+"Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>\n"
+"Language-Team: Spanish (http://www.transifex.com/oca/odoomrp-wip-8-0/language/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_order_line_date
+#: field:sale.order.line,requested_date:0
+msgid "Requested Date"
+msgstr "Fecha solicitada"
+
+#. module: sale_order_line_date
+#: model:ir.model,name:sale_order_line_date.model_sale_order
+msgid "Sales Order"
+msgstr "Pedidos de venta"
+
+#. module: sale_order_line_date
+#: model:ir.model,name:sale_order_line_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Línea pedido de venta"
+
+#. module: sale_order_line_date
+#: view:sale.order:sale_order_line_date.sale_order_requested_date_form_view
+msgid "{'default_requested_date':requested_date}"
+msgstr ""

--- a/sale_order_line_date/i18n/pt_BR.po
+++ b/sale_order_line_date/i18n/pt_BR.po
@@ -1,0 +1,39 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_order_line_date
+# 
+# Translators:
+# danimaribeiro <danimaribeiro@gmail.com>, 2015
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-07 10:45+0000\n"
+"PO-Revision-Date: 2015-10-09 03:29+0000\n"
+"Last-Translator: danimaribeiro <danimaribeiro@gmail.com>\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/oca/odoomrp-wip-8-0/language/pt_BR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: sale_order_line_date
+#: field:sale.order.line,requested_date:0
+msgid "Requested Date"
+msgstr "Data requisitada"
+
+#. module: sale_order_line_date
+#: model:ir.model,name:sale_order_line_date.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venda"
+
+#. module: sale_order_line_date
+#: model:ir.model,name:sale_order_line_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Linha pedido de venda"
+
+#. module: sale_order_line_date
+#: view:sale.order:sale_order_line_date.sale_order_requested_date_form_view
+msgid "{'default_requested_date':requested_date}"
+msgstr "{'default_requested_date':requested_date}"

--- a/sale_order_line_date/i18n/ro.po
+++ b/sale_order_line_date/i18n/ro.po
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_order_line_date
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-11-20 18:11+0000\n"
+"PO-Revision-Date: 2015-09-10 16:42+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Romanian (http://www.transifex.com/oca/odoomrp-wip-8-0/language/ro/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ro\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+
+#. module: sale_order_line_date
+#: field:sale.order.line,requested_date:0
+msgid "Requested Date"
+msgstr ""
+
+#. module: sale_order_line_date
+#: model:ir.model,name:sale_order_line_date.model_sale_order
+msgid "Sales Order"
+msgstr "Comandă vânzare"
+
+#. module: sale_order_line_date
+#: model:ir.model,name:sale_order_line_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Linie comandă vânzare"
+
+#. module: sale_order_line_date
+#: view:sale.order:sale_order_line_date.sale_order_requested_date_form_view
+msgid "{'default_requested_date':requested_date}"
+msgstr ""

--- a/sale_order_line_date/i18n/sl.po
+++ b/sale_order_line_date/i18n/sl.po
@@ -1,0 +1,39 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_order_line_date
+# 
+# Translators:
+# Matjaž Mozetič <m.mozetic@matmoz.si>, 2015
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-07 10:45+0000\n"
+"PO-Revision-Date: 2015-09-20 19:05+0000\n"
+"Last-Translator: Matjaž Mozetič <m.mozetic@matmoz.si>\n"
+"Language-Team: Slovenian (http://www.transifex.com/oca/odoomrp-wip-8-0/language/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: sale_order_line_date
+#: field:sale.order.line,requested_date:0
+msgid "Requested Date"
+msgstr "Zahtevani datum"
+
+#. module: sale_order_line_date
+#: model:ir.model,name:sale_order_line_date.model_sale_order
+msgid "Sales Order"
+msgstr "Prodajni nalog"
+
+#. module: sale_order_line_date
+#: model:ir.model,name:sale_order_line_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Postavka prodajnega naloga"
+
+#. module: sale_order_line_date
+#: view:sale.order:sale_order_line_date.sale_order_requested_date_form_view
+msgid "{'default_requested_date':requested_date}"
+msgstr "{'default_requested_date':requested_date}"

--- a/sale_order_line_date/models/__init__.py
+++ b/sale_order_line_date/models/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# © 2016 OdooMRP team
+# © 2016 AvanzOSC
+# © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2016 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import sale_order

--- a/sale_order_line_date/models/sale_order.py
+++ b/sale_order_line_date/models/sale_order.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# © 2016 OdooMRP team
+# © 2016 AvanzOSC
+# © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2016 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.multi
+    def onchange_requested_date(self, requested_date, commitment_date):
+        """Warn if the requested dates is sooner than the commitment date"""
+        result = super(SaleOrder, self).onchange_requested_date(
+            requested_date, commitment_date)
+        if not self:
+            return result
+        self.ensure_one()
+        if 'warning' not in result:
+            lines = []
+            for line in self.order_line:
+                lines.append((1, line.id, {'requested_date': requested_date}))
+            result['value'] = {'order_line': lines}
+        return result
+
+    @api.model
+    def _get_date_planned(self, order, line, start_date):
+        if line.requested_date:
+            return line.requested_date
+        else:
+            return super(SaleOrder, self)._get_date_planned(
+                order, line, start_date)
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    requested_date = fields.Datetime(string='Requested Date')

--- a/sale_order_line_date/models/sale_order.py
+++ b/sale_order_line_date/models/sale_order.py
@@ -5,7 +5,7 @@
 # © 2016 Eficent Business and IT Consulting Services, S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from openerp import models, fields, api
+from openerp import api, fields, models
 
 
 class SaleOrder(models.Model):
@@ -26,16 +26,17 @@ class SaleOrder(models.Model):
             result['value'] = {'order_line': lines}
         return result
 
-    @api.model
-    def _get_date_planned(self, order, line, start_date):
-        if line.requested_date:
-            return line.requested_date
-        else:
-            return super(SaleOrder, self)._get_date_planned(
-                order, line, start_date)
-
 
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
-    requested_date = fields.Datetime(string='Requested Date')
+    requested_date = fields.Datetime()
+
+    @api.multi
+    def _prepare_order_line_procurement(self, group_id=False):
+        self.ensure_one()
+        vals = super(SaleOrderLine, self).\
+            _prepare_order_line_procurement(group_id)
+        if self.requested_date:
+            vals.update({'date_planned': self.requested_date})
+        return vals

--- a/sale_order_line_date/tests/__init__.py
+++ b/sale_order_line_date/tests/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# © 2016 OdooMRP team
+# © 2016 AvanzOSC
+# © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2016 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import test_sale_order_line_date

--- a/sale_order_line_date/tests/test_sale_order_line_date.py
+++ b/sale_order_line_date/tests/test_sale_order_line_date.py
@@ -19,13 +19,15 @@ class TestSaleOrderLineDates(TransactionCase):
         """
         super(TestSaleOrderLineDates, self).setUp()
         customer = self.env.ref('base.res_partner_3')
+        self.product_ctg_model = self.env['product.category']
+        self.company = self.env.ref('base.main_company')
         price = 100.0
-        p1 = self._create_product(price)
         qty = 1000
+        p1 = self._create_product(price)
         self._update_qty(p1, qty)
         today = datetime.datetime.now()
-        dt1 = today + datetime.timedelta(days=1)
-        dt2 = today + datetime.timedelta(days=7)
+        dt1 = today + datetime.timedelta(days=9)
+        dt2 = today + datetime.timedelta(days=10)
         self.dt3 = today + datetime.timedelta(days=3)
         self.sale1 = self._create_sale_order(customer, dt2)
         self.sale_line1 = self._create_sale_order_line(
@@ -43,7 +45,6 @@ class TestSaleOrderLineDates(TransactionCase):
             'standard_price': price,
             'list_price': price,
             'categ_id': category.id,
-            'valuation': 'real_time',
         })
         return product
 
@@ -77,7 +78,7 @@ class TestSaleOrderLineDates(TransactionCase):
 
     def test_procurement_scheduled_date(self):
         """True when matches the requested date in the sale_order_line"""
-        self.sale1.action_button_confirm()
+        self.sale1.action_confirm()
         procurements = self.env['procurement.order'].search([
             ('origin', '=', self.sale1.name),
             ('date_planned', '=', self.sale_line1.requested_date)])

--- a/sale_order_line_date/tests/test_sale_order_line_date.py
+++ b/sale_order_line_date/tests/test_sale_order_line_date.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+# © 2016 OdooMRP team
+# © 2016 AvanzOSC
+# © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
+# © 2016 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+from openerp import fields
+import datetime
+
+
+class TestSaleOrderLineDates(TransactionCase):
+    """Check the _get_shipped method of Sale Order. """
+
+    def setUp(self):
+        """Setup a Sale Order with 4 lines.
+        And prepare procurements
+        """
+        super(TestSaleOrderLineDates, self).setUp()
+        customer = self.env.ref('base.res_partner_3')
+        price = 100.0
+        p1 = self._create_product(price)
+        qty = 1000
+        self._update_qty(p1, qty)
+        today = datetime.datetime.now()
+        dt1 = today + datetime.timedelta(days=1)
+        dt2 = today + datetime.timedelta(days=7)
+        self.dt3 = today + datetime.timedelta(days=3)
+        self.sale1 = self._create_sale_order(customer, dt2)
+        self.sale_line1 = self._create_sale_order_line(
+            self.sale1, p1, qty, price, dt1
+        )
+        self.sale_line2 = self._create_sale_order_line(
+            self.sale1, p1, qty, price, dt2
+        )
+
+    def _create_product(self, price):
+        category = self.env.ref('product.product_category_1')
+        product = self.env['product.product'].create({
+            'name': 'test_product',
+            'type': 'product',
+            'standard_price': price,
+            'list_price': price,
+            'categ_id': category.id,
+            'valuation': 'real_time',
+        })
+        return product
+
+    def _create_sale_order(self, customer, date):
+        sale = self.env['sale.order'].create({
+            'partner_id': customer.id,
+            'partner_invoice_id': customer.id,
+            'partner_shipping_id': customer.id,
+            'requested_date': date
+        })
+        return sale
+
+    def _create_sale_order_line(self, sale, product, qty, price, date):
+        sale_line = self.env['sale.order.line'].create({
+            'product_id': product.id,
+            'name': 'cool product',
+            'order_id': sale.id,
+            'price_unit': price,
+            'product_uom_qty': qty,
+            'requested_date': date})
+        return sale_line
+
+    def _update_qty(self, product, qty):
+        location_stock = self.env.ref('stock.stock_location_stock')
+        wiz_obj = self.env['stock.change.product.qty']
+        wiz = wiz_obj.create({'product_id': product.id,
+                              'new_quantity': qty,
+                              'location_id':  location_stock.id,
+                              })
+        wiz.change_product_qty()
+
+    def test_procurement_scheduled_date(self):
+        """True when matches the requested date in the sale_order_line"""
+        self.sale1.action_button_confirm()
+        procurements = self.env['procurement.order'].search([
+            ('origin', '=', self.sale1.name),
+            ('date_planned', '=', self.sale_line1.requested_date)])
+        self.assertEqual(len(procurements), 1)
+        procurements = self.env['procurement.order'].search([
+            ('origin', '=', self.sale1.name),
+            ('date_planned', '=', self.sale_line2.requested_date)])
+        self.assertEqual(len(procurements), 1)
+
+    def test_on_change_requested_date(self):
+        """True when the requested date in the sale_order_line
+        matches the requested date in the sale order"""
+        req_date = fields.Datetime.to_string(self.dt3)
+        self.sale1.write({'requested_date': self.dt3})
+        result = self.sale1.onchange_requested_date(self.sale1.requested_date,
+                                                    self.sale1.commitment_date)
+        for line in result['value']['order_line']:
+            self.assertEqual(line[2]['requested_date'], req_date)

--- a/sale_order_line_date/views/sale_order_view.xml
+++ b/sale_order_line_date/views/sale_order_view.xml
@@ -4,7 +4,7 @@
         <record model="ir.ui.view" id="sale_order_requested_date_form_view">
             <field name="name">sale.order.requested.date.form</field>
             <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale_order_dates.view_sale_orderfor"/>
+            <field name="inherit_id" ref="sale_order_dates.view_order_form_inherit_sale_stock_inherit_sale_order_dates"/>
             <field name="arch" type="xml">
                 <field name="order_line" position="attributes">
                     <attribute name="context">{'default_requested_date':requested_date}</attribute>
@@ -22,7 +22,7 @@
             <field name="model">sale.order.line</field>
             <field name="inherit_id" ref="sale.view_order_line_tree" />
             <field name="arch" type="xml">
-                <field name="state" position="after">
+                <field name="name" position="after">
                     <field name="requested_date"/>
                 </field>
             </field>

--- a/sale_order_line_date/views/sale_order_view.xml
+++ b/sale_order_line_date/views/sale_order_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="sale_order_requested_date_form_view">
+            <field name="name">sale.order.requested.date.form</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale_order_dates.view_sale_orderfor"/>
+            <field name="arch" type="xml">
+                <field name="order_line" position="attributes">
+                    <attribute name="context">{'default_requested_date':requested_date}</attribute>
+                </field>
+                <xpath expr="//field[@name='order_line']/form//field[@name='tax_id']" position="after">
+                    <field name="requested_date" />
+                </xpath>
+                <xpath expr="//field[@name='order_line']/tree/field[@name='price_unit']" position="after">
+                    <field name="requested_date"/>
+                </xpath>
+            </field>
+        </record>
+        <record id="sale_order_line_ext_tree_view" model="ir.ui.view">
+            <field name="name">sale.order.line.ext.tree</field>
+            <field name="model">sale.order.line</field>
+            <field name="inherit_id" ref="sale.view_order_line_tree" />
+            <field name="arch" type="xml">
+                <field name="state" position="after">
+                    <field name="requested_date"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/sale_order_line_dates/README.rst
+++ b/sale_order_line_dates/README.rst
@@ -1,0 +1,19 @@
+=====================
+Sale order line dates
+=====================
+
+
+This module adds requested date to a sales order lines and propagate it to
+stock moves.
+
+
+Credits
+=======
+
+
+Contributors
+------------
+* Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
+* Esther Martín <esthermartin@avanzosc.es>
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <anajuaristi@avanzosc.es>

--- a/sale_order_line_dates/__init__.py
+++ b/sale_order_line_dates/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import models

--- a/sale_order_line_dates/__openerp__.py
+++ b/sale_order_line_dates/__openerp__.py
@@ -1,0 +1,43 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+{
+    "name": "Dates on Sales Order",
+    "version": "1.0",
+    "depends": [
+        "sale_order_dates",
+    ],
+    "author": "OdooMRP team",
+    "contributors": [
+        "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
+    ],
+    "category": "Sales Management",
+    "website": "http://www.odoomrp.com",
+    "summary": "",
+    "description": """
+Add additional date information to the sales order.
+===================================================
+You can add the following additional dates to a sales order lines:
+------------------------------------------------------------------
+    * Requested Date
+    """,
+    "data": [
+        "views/sale_order_view.xml",
+    ],
+    "installable": True,
+}

--- a/sale_order_line_dates/__openerp__.py
+++ b/sale_order_line_dates/__openerp__.py
@@ -18,26 +18,22 @@
 
 {
     "name": "Dates on Sales Order",
-    "version": "1.0",
-    "depends": [
-        "sale_order_dates",
-    ],
+    "version": "8.0.1.0.0",
     "author": "OdooMRP team,"
               "AvanzOSC,"
               "Serv. Tecnol. Avanzados - Pedro M. Baeza",
+    "website": "http://www.odoomrp.com",
+    "category": "Sales Management",
+    "license": "AGPL-3",
     "contributors": [
         "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
+        "Esther Martín <esthermartin@avanzosc.es>",
+        "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
     ],
-    "category": "Sales Management",
-    "website": "http://www.odoomrp.com",
-    "summary": "",
-    "description": """
-Add additional date information to the sales order.
-===================================================
-You can add the following additional dates to a sales order lines:
-------------------------------------------------------------------
-    * Requested Date
-    """,
+    "depends": [
+        "sale_order_dates",
+    ],
     "data": [
         "views/sale_order_view.xml",
     ],

--- a/sale_order_line_dates/__openerp__.py
+++ b/sale_order_line_dates/__openerp__.py
@@ -22,7 +22,9 @@
     "depends": [
         "sale_order_dates",
     ],
-    "author": "OdooMRP team",
+    "author": "OdooMRP team,"
+              "AvanzOSC,"
+              "Serv. Tecnol. Avanzados - Pedro M. Baeza",
     "contributors": [
         "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
     ],

--- a/sale_order_line_dates/i18n/es.po
+++ b/sale_order_line_dates/i18n/es.po
@@ -1,0 +1,39 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_order_line_dates
+# 
+# Translators:
+# Pedro M. Baeza <pedro.baeza@gmail.com>, 2015
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-07 10:45+0000\n"
+"PO-Revision-Date: 2015-10-09 10:59+0000\n"
+"Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>\n"
+"Language-Team: Spanish (http://www.transifex.com/oca/odoomrp-wip-8-0/language/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_order_line_dates
+#: field:sale.order.line,requested_date:0
+msgid "Requested Date"
+msgstr "Fecha solicitada"
+
+#. module: sale_order_line_dates
+#: model:ir.model,name:sale_order_line_dates.model_sale_order
+msgid "Sales Order"
+msgstr "Pedidos de venta"
+
+#. module: sale_order_line_dates
+#: model:ir.model,name:sale_order_line_dates.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Línea pedido de venta"
+
+#. module: sale_order_line_dates
+#: view:sale.order:sale_order_line_dates.sale_order_requested_date_form_view
+msgid "{'default_requested_date':requested_date}"
+msgstr ""

--- a/sale_order_line_dates/i18n/pt_BR.po
+++ b/sale_order_line_dates/i18n/pt_BR.po
@@ -1,0 +1,39 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_order_line_dates
+# 
+# Translators:
+# danimaribeiro <danimaribeiro@gmail.com>, 2015
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-07 10:45+0000\n"
+"PO-Revision-Date: 2015-10-09 03:29+0000\n"
+"Last-Translator: danimaribeiro <danimaribeiro@gmail.com>\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/oca/odoomrp-wip-8-0/language/pt_BR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: sale_order_line_dates
+#: field:sale.order.line,requested_date:0
+msgid "Requested Date"
+msgstr "Data requisitada"
+
+#. module: sale_order_line_dates
+#: model:ir.model,name:sale_order_line_dates.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venda"
+
+#. module: sale_order_line_dates
+#: model:ir.model,name:sale_order_line_dates.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Linha pedido de venda"
+
+#. module: sale_order_line_dates
+#: view:sale.order:sale_order_line_dates.sale_order_requested_date_form_view
+msgid "{'default_requested_date':requested_date}"
+msgstr "{'default_requested_date':requested_date}"

--- a/sale_order_line_dates/i18n/ro.po
+++ b/sale_order_line_dates/i18n/ro.po
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_order_line_dates
+# 
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-11-20 18:11+0000\n"
+"PO-Revision-Date: 2015-09-10 16:42+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: Romanian (http://www.transifex.com/oca/odoomrp-wip-8-0/language/ro/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ro\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+
+#. module: sale_order_line_dates
+#: field:sale.order.line,requested_date:0
+msgid "Requested Date"
+msgstr ""
+
+#. module: sale_order_line_dates
+#: model:ir.model,name:sale_order_line_dates.model_sale_order
+msgid "Sales Order"
+msgstr "Comandă vânzare"
+
+#. module: sale_order_line_dates
+#: model:ir.model,name:sale_order_line_dates.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Linie comandă vânzare"
+
+#. module: sale_order_line_dates
+#: view:sale.order:sale_order_line_dates.sale_order_requested_date_form_view
+msgid "{'default_requested_date':requested_date}"
+msgstr ""

--- a/sale_order_line_dates/i18n/sl.po
+++ b/sale_order_line_dates/i18n/sl.po
@@ -1,0 +1,39 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_order_line_dates
+# 
+# Translators:
+# Matjaž Mozetič <m.mozetic@matmoz.si>, 2015
+msgid ""
+msgstr ""
+"Project-Id-Version: odoomrp-wip (8.0)\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-10-07 10:45+0000\n"
+"PO-Revision-Date: 2015-09-20 19:05+0000\n"
+"Last-Translator: Matjaž Mozetič <m.mozetic@matmoz.si>\n"
+"Language-Team: Slovenian (http://www.transifex.com/oca/odoomrp-wip-8-0/language/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: sale_order_line_dates
+#: field:sale.order.line,requested_date:0
+msgid "Requested Date"
+msgstr "Zahtevani datum"
+
+#. module: sale_order_line_dates
+#: model:ir.model,name:sale_order_line_dates.model_sale_order
+msgid "Sales Order"
+msgstr "Prodajni nalog"
+
+#. module: sale_order_line_dates
+#: model:ir.model,name:sale_order_line_dates.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Postavka prodajnega naloga"
+
+#. module: sale_order_line_dates
+#: view:sale.order:sale_order_line_dates.sale_order_requested_date_form_view
+msgid "{'default_requested_date':requested_date}"
+msgstr "{'default_requested_date':requested_date}"

--- a/sale_order_line_dates/models/__init__.py
+++ b/sale_order_line_dates/models/__init__.py
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from . import sale_order

--- a/sale_order_line_dates/models/sale_order.py
+++ b/sale_order_line_dates/models/sale_order.py
@@ -28,7 +28,7 @@ class SaleOrder(models.Model):
         self.ensure_one()
         result = super(SaleOrder, self).onchange_requested_date(
             requested_date, commitment_date)
-        if not 'warning' in result:
+        if 'warning' not in result:
             lines = []
             for line in self.order_line:
                 lines.append((1, line.id, {'requested_date': requested_date}))

--- a/sale_order_line_dates/models/sale_order.py
+++ b/sale_order_line_dates/models/sale_order.py
@@ -39,7 +39,11 @@ class SaleOrder(models.Model):
 
     @api.model
     def _get_date_planned(self, order, line, start_date):
-        return line.requested_date
+        if line.requested_date:
+            return line.requested_date
+        else:
+            return super(SaleOrder, self)._get_date_planned(
+                order, line, start_date)
 
 
 class SaleOrderLine(models.Model):

--- a/sale_order_line_dates/models/sale_order.py
+++ b/sale_order_line_dates/models/sale_order.py
@@ -25,9 +25,11 @@ class SaleOrder(models.Model):
     @api.multi
     def onchange_requested_date(self, requested_date, commitment_date):
         """Warn if the requested dates is sooner than the commitment date"""
-        self.ensure_one()
         result = super(SaleOrder, self).onchange_requested_date(
             requested_date, commitment_date)
+        if not self:
+            return result
+        self.ensure_one()
         if 'warning' not in result:
             lines = []
             for line in self.order_line:

--- a/sale_order_line_dates/models/sale_order.py
+++ b/sale_order_line_dates/models/sale_order.py
@@ -22,7 +22,18 @@ from openerp import models, fields, api
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    
+    @api.multi
+    def onchange_requested_date(self, requested_date, commitment_date):
+        """Warn if the requested dates is sooner than the commitment date"""
+        self.ensure_one()
+        result = super(SaleOrder, self).onchange_requested_date(
+            requested_date, commitment_date)
+        if not 'warning' in result:
+            lines = []
+            for line in self.order_line:
+                lines.append((1, line.id, {'requested_date': requested_date}))
+            result['value'] = {'order_line': lines}
+        return result
 
 
 class SaleOrderLine(models.Model):

--- a/sale_order_line_dates/models/sale_order.py
+++ b/sale_order_line_dates/models/sale_order.py
@@ -1,0 +1,31 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as published
+#    by the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see http://www.gnu.org/licenses/.
+#
+##############################################################################
+
+from openerp import models, fields, api
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    requested_date = fields.Date(string='Requested Date')

--- a/sale_order_line_dates/models/sale_order.py
+++ b/sale_order_line_dates/models/sale_order.py
@@ -37,6 +37,10 @@ class SaleOrder(models.Model):
             result['value'] = {'order_line': lines}
         return result
 
+    @api.model
+    def _get_date_planned(self, order, line, start_date):
+        return line.requested_date
+
 
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'

--- a/sale_order_line_dates/models/sale_order.py
+++ b/sale_order_line_dates/models/sale_order.py
@@ -41,4 +41,4 @@ class SaleOrder(models.Model):
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
-    requested_date = fields.Date(string='Requested Date')
+    requested_date = fields.Datetime(string='Requested Date')

--- a/sale_order_line_dates/views/sale_order_view.xml
+++ b/sale_order_line_dates/views/sale_order_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="sale_order_requested_date_form_view">
+            <field name="name">sale.order.requested.date.form</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale_order_dates.view_sale_orderfor"/>
+            <field name="arch" type="xml">
+                <field name="order_line" position="attributes">
+                    <attribute name="context">{'default_requested_date':requested_date}</attribute>
+                </field>
+                <xpath expr="//field[@name='order_line']/form//field[@name='tax_id']" position="after">
+                    <field name="requested_date" />
+                </xpath>
+            </field>
+        </record>
+    
+    </data>
+</openerp>

--- a/sale_order_line_dates/views/sale_order_view.xml
+++ b/sale_order_line_dates/views/sale_order_view.xml
@@ -12,8 +12,20 @@
                 <xpath expr="//field[@name='order_line']/form//field[@name='tax_id']" position="after">
                     <field name="requested_date" />
                 </xpath>
+                <xpath expr="//field[@name='order_line']/tree/field[@name='price_unit']" position="after">
+                    <field name="requested_date"/>
+                </xpath>
             </field>
         </record>
-    
+        <record id="sale_order_line_ext_tree_view" model="ir.ui.view">
+            <field name="name">sale.order.line.ext.tree</field>
+            <field name="model">sale.order.line</field>
+            <field name="inherit_id" ref="sale.view_order_line_tree" />
+            <field name="arch" type="xml">
+                <field name="state" position="after">
+                    <field name="requested_date"/>
+                </field>
+            </field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
# Sale order line date

This module adds requested date to a sales order lines and propagate it to
stock moves and procurement.

When the requested date of the whole sale order is modified the requested date
of the lines change to match.

# Usage

Add a requested date for a sale order line. Confirm the sale. The scheduled date of the procurement will be the same as in the sale order line.