### PR TITLE
[MIG] sale_order_revision: Migration to 10.0

### DIFF
--- a/sale_order_revision/README.rst
+++ b/sale_order_revision/README.rst
@@ -4,7 +4,7 @@
 Revisions for sale orders (and quotations)
 ==========================================
 
-On cancelled orders, you can click on the "New copy of Quotation" button. This
+On cancelled orders, you can click on the "New Revision of Quotation" button. This
 will create a new revision of the quotation, with the same base number and a
 '-revno' suffix appended. A message is added in the chatter saying that a new
 revision was created.
@@ -24,6 +24,7 @@ Contributors
 * Lorenzo Battistini <lorenzo.battistini@agilebg.com>
 * Raphael Valyi <rvalyi@akretion.com>
 * Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
+* Kitti U. <kittiu@ecosoft.co.th>
 
 Maintainer
 ----------

--- a/sale_order_revision/__init__.py
+++ b/sale_order_revision/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-
+# © 2013 Agile Business Group sagl (<http://www.agilebg.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import model
 
 

--- a/sale_order_revision/__manifest__.py
+++ b/sale_order_revision/__manifest__.py
@@ -1,42 +1,25 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2013 Agile Business Group sagl (<http://www.agilebg.com>)
-#    @author Lorenzo Battistini <lorenzo.battistini@agilebg.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-
+# © 2013 Agile Business Group sagl (<http://www.agilebg.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
-    'name': "Sale order revisions",
-    'version': '8.0.0.1.0',
+    'name': 'Sale order revisions',
+    'version': '10.0.0.1.0',
     'category': 'Sale Management',
     'author': 'Agile Business Group,'
               'Camptocamp,'
               'Akretion,'
+              'Ecosoft,'
               'Odoo Community Association (OCA)',
     'website': 'http://www.agilebg.com',
     'license': 'AGPL-3',
-    "depends": ['sale'],
-    "data": [
+    'depends': ['sale'],
+    'data': [
         'view/sale_order.xml',
-        ],
-    "test": [
+    ],
+    'test': [
         'test/sale_order.yml',
-        ],
-    "active": False,
-    'installable': False,
-    "post_init_hook": 'populate_unrevisioned_name',
+    ],
+    'installable': True,
+    'auto_install': False,
+    'post_init_hook': 'populate_unrevisioned_name',
 }

--- a/sale_order_revision/model/__init__.py
+++ b/sale_order_revision/model/__init__.py
@@ -1,22 +1,4 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2013 Agile Business Group sagl (<http://www.agilebg.com>)
-#    @author Lorenzo Battistini <lorenzo.battistini@agilebg.com>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as published
-#    by the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-
+# © 2013 Agile Business Group sagl (<http://www.agilebg.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from . import sale_order

--- a/sale_order_revision/test/sale_order.yml
+++ b/sale_order_revision/test/sale_order.yml
@@ -4,20 +4,22 @@
   !record {model: sale.order, id: sale_order_1}:
     partner_id: base.res_partner_2
     order_line:
-      - product_id: product.product_product_15
+      - product_id: product.product_product_11
         product_uom_qty: 15.0
 -
   I cancel the SO
 -
    !python {model: sale.order}: |
-     self.action_cancel(cr, uid, [ref('sale_order_1')])
+     so = self.browse(ref('sale_order_1'))
+     so.action_cancel()
 -
   I create a new revision
 -
    !python {model: sale.order}: |
-     action = self.copy_quotation(cr, uid, [ref('sale_order_1')])
+     so = self.browse(ref('sale_order_1'))
+     action = so.action_revision()
      assert action['res_id'] == ref('sale_order_1')
-     new_so = self.browse(cr, uid, ref('sale_order_1'))
+     new_so = self.browse(ref('sale_order_1'))
      assert new_so.old_revision_ids, "Old revisions not set"
      assert all(so.active == False for so in new_so.old_revision_ids)
      assert new_so.revision_number == 1

--- a/sale_order_revision/view/sale_order.xml
+++ b/sale_order_revision/view/sale_order.xml
@@ -1,28 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
-        <record id="sale_order_form" model="ir.ui.view">
-            <field name="name">sale.order.form</field>
-            <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.view_order_form"></field>
-            <field name="arch" type="xml">
-                <notebook position="inside">
-                    <page string="Revisions">
-                        <field name="old_revision_ids" >
-                            <tree>
-                                <field name='name'/>
-                                <field name='create_date' string="Superseeded on"/>
-                                <field name='create_uid' string="Superseeded by"/>
-                                <field name='state' invisible='1'/>
-                            </tree>
-                        </field>
-                        <group attrs="{'invisible': [('active', '=', True)]}">
-                            <field name="current_revision_id"/>
-                            <field name="active" invisible="1"/>
-                        </group>
-                    </page>
-                </notebook>
-            </field>
-        </record>
-    </data>
-</openerp>
+<odoo>
+    <record id="sale_order_form" model="ir.ui.view">
+        <field name="name">sale.order.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"></field>
+        <field name="arch" type="xml">
+            <button name="action_cancel" position="before">
+                <button name="action_revision" states="cancel" string="New Revision of Quotation" type="object"/>
+            </button>
+            <notebook position="inside">
+                <page string="Revisions">
+                    <field name="old_revision_ids">
+                        <tree>
+                            <field name='name'/>
+                            <field name='create_date' string="Superseeded on"/>
+                            <field name='create_uid' string="Superseeded by"/>
+                            <field name='state' invisible='1'/>
+                        </tree>
+                    </field>
+                    <group attrs="{'invisible': [('active', '=', True)]}">
+                        <field name="current_revision_id"/>
+                        <field name="active" invisible="1"/>
+                    </group>
+                </page>
+            </notebook>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
On thing different from 8.0
Since 8.0 already has the button "New Copy of Quotation" but 10.0 do not have. So, I add a button for it but rename it to "New Revision of Quotation".