### PR TITLE
[10.0] Auto configure sale_rental module via post_install.py script

### DIFF
--- a/sale_rental/README.rst
+++ b/sale_rental/README.rst
@@ -32,6 +32,9 @@ order lines. For that, you must add your user to one of these groups:
 * Manage Product Packaging
 * Properties on lines
 
+Upon module installation, all users are automatically added to the group
+*Properties on lines*.
+
 Usage
 =====
 

--- a/sale_rental/__init__.py
+++ b/sale_rental/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 
+from .post_install import add_users_to_group_mrp_properties
 from . import models
 from . import wizard

--- a/sale_rental/__manifest__.py
+++ b/sale_rental/__manifest__.py
@@ -23,6 +23,7 @@
         'security/ir.model.access.csv',
         'security/sale_rental_security.xml',
     ],
+    'post_init_hook': 'add_users_to_group_mrp_properties',
     'demo': ['demo/rental_demo.xml'],
     'installable': True,
 }

--- a/sale_rental/post_install.py
+++ b/sale_rental/post_install.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# © 2016-2017 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, SUPERUSER_ID
+
+
+def add_users_to_group_mrp_properties(cr, registry):
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        users = env['res.users'].search(
+            ['|', ('active', '=', True), ('active', '=', False)])
+        users.write({
+            'groups_id': [(4, env.ref('sale.group_mrp_properties').id)]})
+    return


### PR DESCRIPTION
Idea taken from the user experience described in bug #472 (before the rename of the bug report)