### PR TITLE
[10.0] Fix sale_exception constraint raising Singleton error

### DIFF
--- a/sale_exception/models/sale.py
+++ b/sale_exception/models/sale.py
@@ -36,8 +36,9 @@ class SaleOrder(models.Model):
 
     @api.constrains('ignore_exception', 'order_line', 'state')
     def sale_check_exception(self):
-        if self.state == 'sale':
-            self._check_exception()
+        orders = self.filtered(lambda s: s.state == 'sale')
+        if orders:
+            orders._check_exception()
 
     @api.onchange('order_line')
     def onchange_ignore_exception(self):


### PR DESCRIPTION
when you have a recordset with multiple sale order. This restore the capability to write on multiple sale.order