### PR TITLE
FIX sale_order_type in multi company env

### DIFF
--- a/sale_order_type/__openerp__.py
+++ b/sale_order_type/__openerp__.py
@@ -22,7 +22,7 @@
 
 {
     "name": "Sale Order Types",
-    "version": "8.0.1.0.1",
+    "version": "8.0.1.1.0",
     "category": "Sales Management",
     "author": "OdooMRP team, "
               "Grupo Vermon, "

--- a/sale_order_type/migrations/8.0.1.1.0/pre-migration.py
+++ b/sale_order_type/migrations/8.0.1.1.0/pre-migration.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Lorenzo Battistini - Agile Business Group
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import SUPERUSER_ID
+from datetime import datetime
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    cr.execute(
+        "SELECT id, sale_type FROM res_partner WHERE sale_type IS NOT NULL")
+    partners = cr.fetchall()
+    cr.execute(
+        "SELECT f.id "
+        "FROM ir_model_fields f "
+        "JOIN ir_model m ON m.id = f.model_id "
+        "WHERE m.model = 'res.partner' AND f.name = 'sale_type'")
+    type_fields = cr.fetchall()
+    if len(type_fields) != 1:
+        raise Exception("Can't find 1 'sale_type' field")
+    cr.execute(
+        "SELECT id FROM res_company")
+    companies = cr.fetchall()
+    for partner in partners:
+        for company in companies:
+            utcnow = str(datetime.utcnow())
+            cr.execute(
+                "INSERT INTO ir_property("
+                "create_date, create_uid, write_date, name, company_id, type, "
+                "fields_id, res_id, value_reference) "
+                "VALUES ('%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s')"
+                % (
+                    utcnow, SUPERUSER_ID, utcnow, 'sale_type', company[0],
+                    'many2one', type_fields[0][0],
+                    'res.partner,%s' % partner[0],
+                    'sale.order.type,%s' % partner[1]
+                )
+            )

--- a/sale_order_type/models/res_partner.py
+++ b/sale_order_type/models/res_partner.py
@@ -10,4 +10,5 @@ class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     sale_type = fields.Many2one(
-        comodel_name='sale.order.type', string='Sale Order Type')
+        comodel_name='sale.order.type', string='Sale Order Type',
+        company_dependent=True)


### PR DESCRIPTION
In a multi company env, when partners are shared between companies, default order type configured on partner should be variable according to the current company,
just like receivalbe and payable accounts.

9.0: https://github.com/OCA/sale-workflow/pull/488