### PR TITLE
[9.0] [FIX] Wrong Import in test cases for sale_validity

### DIFF
--- a/sale_validity/tests/test_sale_validity.py
+++ b/sale_validity/tests/test_sale_validity.py
@@ -2,7 +2,7 @@
 # © 2017 Akretion (Alexis de Lattre <alexis.delattre@akretion.com>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests.common import TransactionCase
+from openerp.tests.common import TransactionCase
 
 
 class TestSaleValidity(TransactionCase):


### PR DESCRIPTION
Wrong Import in test cases for sale_validity for v9.0