### PR TITLE
[ADD] sale_procurement_group_by_requested_date v9

### DIFF
--- a/sale_procurement_group_by_requested_date/README.rst
+++ b/sale_procurement_group_by_requested_date/README.rst
@@ -1,0 +1,61 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :alt: License: AGPL-3
+
+========================================
+Sale Procurement Group by Requested date
+========================================
+
+This module creates different procurements groups for different requested
+dates in a sale order line when the sale order is confirmed.
+It depends on sale_sourced_by_line so this module will group procurements 
+also by the warehouse in the sale order line.
+
+Installation
+============
+
+This module depends on the modules sale_procurement_group_by_line and
+sale_sourced_by_line.
+
+
+Usage
+=====
+
+#. Add a requested date for a sale order line.
+#. Confirm the sale order
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/167/9.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/sale-workflow/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+
+Credits
+=======
+
+Contributors
+------------
+
+* Aaron Henriquez <ahenriquez@eficent.com>
+* Jordi Ballester <jordi.ballester@eficent.com>
+* Darshan Patel <darshan.patel.serpentcs@gmail.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/sale_procurement_group_by_requested_date/__init__.py
+++ b/sale_procurement_group_by_requested_date/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/sale_procurement_group_by_requested_date/__openerp__.py
+++ b/sale_procurement_group_by_requested_date/__openerp__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Group procurements by requested date",
+    "summary": "Groups pickings based on requested date of order line",
+    "version": "9.0.1.0.0",
+    "category": "Sales Management",
+    "website": "http://www.eficent.com",
+    "author": "Eficent , "
+              "SerpentCS,"
+              "Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": [
+        "sale_order_line_date",
+        "sale_procurement_group_by_line",
+        "sale_sourced_by_line"
+    ],
+    "installable": True,
+}

--- a/sale_procurement_group_by_requested_date/models/__init__.py
+++ b/sale_procurement_group_by_requested_date/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import sale_order

--- a/sale_procurement_group_by_requested_date/models/sale_order.py
+++ b/sale_procurement_group_by_requested_date/models/sale_order.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.model
+    def _prepare_procurement_group_by_line(self, line):
+        vals = super(SaleOrder, self)._prepare_procurement_group_by_line(line)
+        # for compatibility with sale_quotation_sourcing
+        req_datetime = fields.Datetime.from_string(line.requested_date)
+        req_date = fields.Date.to_string(req_datetime)
+        if line._get_procurement_group_key()[0] == 12:
+            if line.requested_date:
+                vals['name'] = '/'.join([vals['name'], line.warehouse_id.name,
+                                         req_date])
+        return vals
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    @api.multi
+    def _prepare_order_line_procurement(self, group_id=False):
+        values = super(SaleOrderLine, self).\
+            _prepare_order_line_procurement(group_id=group_id)
+        self.ensure_one()
+        if self.requested_date:
+            req_datetime = fields.Datetime.from_string(self.requested_date)
+            req_date = fields.Date.to_string(req_datetime)
+            values['requested_date'] = req_date
+        return values
+
+    @api.multi
+    def _get_procurement_group_key(self):
+        """ Return a key with priority to be used to regroup lines in multiple
+        procurement groups. The higher the priority number is the more
+        preference the criteria has. E.g. sale_sourced_by_line has 10 priority,
+        that is less priority than the requested date.
+        """
+        priority = 12
+        key = super(SaleOrderLine, self)._get_procurement_group_key()
+        # Check priority
+        if key[0] >= priority:
+            return key
+        req_datetime = fields.Datetime.from_string(self.requested_date)
+        req_date = fields.Date.to_string(req_datetime)
+        if self.warehouse_id and req_date:
+            key = '/'.join([str(self.warehouse_id.id), req_date])
+        return (priority, key)

--- a/sale_procurement_group_by_requested_date/tests/__init__.py
+++ b/sale_procurement_group_by_requested_date/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import test_sale_procurement_group_by_requested_date

--- a/sale_procurement_group_by_requested_date/tests/test_sale_procurement_group_by_requested_date.py
+++ b/sale_procurement_group_by_requested_date/tests/test_sale_procurement_group_by_requested_date.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+from openerp import fields
+import datetime
+
+
+class TestSaleMultiPickingByRequestedDate(TransactionCase):
+    """Check the _get_shipped method of Sale Order. """
+
+    def setUp(self):
+        """Setup a Sale Order with 4 lines.
+        And prepare procurements
+        """
+        super(TestSaleMultiPickingByRequestedDate, self).setUp()
+        sale_obj = self.env['sale.order']
+        order_line = self.env['sale.order.line']
+        Product = self.env['product.product']
+        Warehouse = self.env['stock.warehouse']
+        self.wh1 = Warehouse.create({'name': 'wh1', 'code': 'wh1'})
+        self.wh2 = Warehouse.create({'name': 'wh2', 'code': 'wh2'})
+        p1 = Product.create({'name': 'p1', 'type': 'product'}).id
+        today = datetime.datetime.now()
+        self.dt1 = today
+        self.dt2 = today + datetime.timedelta(days=1)
+        self.sale1 = sale_obj.create({'partner_id': 1})
+        self.sale_line1 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale1.id,
+                                             'warehouse_id': self.wh1.id,
+                                             'requested_date': self.dt1})
+        self.sale_line2 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale1.id,
+                                             'warehouse_id': self.wh1.id,
+                                             'requested_date': self.dt2})
+        self.sale_line3 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale1.id,
+                                             'warehouse_id': self.wh2.id,
+                                             'requested_date': self.dt1})
+        self.sale_line4 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale1.id,
+                                             'warehouse_id': self.wh2.id,
+                                             'requested_date': self.dt2})
+
+        self.sale2 = sale_obj.create({'partner_id': 1})
+        self.sale_line5 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale2.id,
+                                             'warehouse_id': self.wh1.id,
+                                             'requested_date': self.dt1})
+        self.sale_line6 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale2.id,
+                                             'warehouse_id': self.wh1.id,
+                                             'requested_date': self.dt2})
+        self.sale_line7 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale2.id,
+                                             'warehouse_id': self.wh1.id,
+                                             'requested_date': self.dt1})
+        self.sale_line8 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale2.id,
+                                             'warehouse_id': self.wh1.id,
+                                             'requested_date': self.dt2})
+
+    def test_number_of_groups(self):
+        """True when the number of groups created matches the
+        result of multiply the different warehouses with the different
+        requested dates"""
+        ok = False
+        self.sale1.action_confirm()
+        req_date = fields.Date.to_string(self.dt1)
+        g_name = self.sale1.name + '/' + self.wh1.name + '/' + req_date
+        groups = self.env['procurement.group'].search([('name', '=', g_name)])
+
+        for group in groups:
+            if group.name == g_name:
+                procurements = self.env['procurement.order'].search([
+                    ('group_id', '=', group.id)])
+                self.assertEqual(len(procurements), 1)
+                self.assertEqual(len(group), 1)
+                ok = True
+        self.assertTrue(ok)
+
+        ok = False
+        self.sale2.action_confirm()
+        req_date = fields.Date.to_string(self.dt2)
+        g_name = self.sale2.name + '/' + self.wh1.name + '/' + req_date
+        groups = self.env['procurement.group'].search([('name', '=', g_name)])
+
+        for group in groups:
+            if group.name == g_name:
+                procurements = self.env['procurement.order'].search([
+                    ('group_id', '=', group.id)])
+                self.assertEqual(len(procurements), 2)
+                self.assertEqual(len(group), 1)
+                ok = True
+        self.assertEqual(len(groups), 1)
+        g_name = self.sale2.name + '/' + self.wh1.name + '/'
+        groups = self.env['procurement.group'].search([('name', 'ilike',
+                                                        g_name)])
+        self.assertEqual(len(groups), 2)
+        self.assertTrue(ok)


### PR DESCRIPTION
Sale Procurement Group by Requested date
========================================

- This module creates different procurements groups for different requested
dates in a sale order line when the sale order is confirmed.
- It depends on sale_sourced_by_line so this module will group procurements also
by the warehouse in the sale order line.