### PR TITLE
[8.0] FIX sale_order_revision, security rule error

### DIFF
--- a/sale_order_revision/model/sale_order.py
+++ b/sale_order_revision/model/sale_order.py
@@ -85,12 +85,13 @@ class sale_order(models.Model):
             default.update({
                 'name': prev_name,
                 'revision_number': revno,
-                'active': False,
                 'state': 'cancel',
                 'current_revision_id': self.id,
                 'unrevisioned_name': self.unrevisioned_name,
             })
-        return super(sale_order, self).copy(default=default)
+        res = super(sale_order, self).copy(default=default)
+        res.write({'active': False})
+        return res
 
     @api.model
     def create(self, values):


### PR DESCRIPTION
If user login as user group "see own lead", whose security is controlled by a RULE.
On copy() with default {'active': False}, will throw error 
`Access Denied (Document type: Sales Order Line, Operation: create)`
I don't know the reason behind, but the fix will work.
Note: Already 10.0 has this similar fix.