### PR TITLE
[IMP] Update sale_isolated_quotation

### DIFF
--- a/sale_exception/models/sale.py
+++ b/sale_exception/models/sale.py
@@ -47,10 +47,10 @@ class SaleOrder(models.Model):
 
     @api.multi
     def action_confirm(self):
-        if self.detect_exceptions():
-            return self._popup_exceptions()
-        else:
-            return super(SaleOrder, self).action_confirm()
+        for order in self:
+            if order.detect_exceptions():
+                return order._popup_exceptions()
+        return super(SaleOrder, self).action_confirm()
 
     @api.multi
     def action_draft(self):

--- a/sale_exception/wizard/sale_exception_confirm.py
+++ b/sale_exception/wizard/sale_exception_confirm.py
@@ -14,7 +14,7 @@ class SaleExceptionConfirm(models.TransientModel):
 
     @api.multi
     def action_confirm(self):
-        self.ensure_one()
-        if self.ignore:
-            self.related_model_id.ignore_exception = True
+        for order in self:
+            if order.ignore:
+                order.related_model_id.ignore_exception = True
         return super(SaleExceptionConfirm, self).action_confirm()

--- a/sale_isolated_quotation/__manifest__.py
+++ b/sale_isolated_quotation/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Sales - Isolated Quotation',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'author': 'Ecosoft,Odoo Community Association (OCA)',
     'category': 'Sales',
     'website': 'http://ecosoft.co.th',

--- a/sale_isolated_quotation/models/sale.py
+++ b/sale_isolated_quotation/models/sale.py
@@ -64,7 +64,7 @@ class SaleOrder(models.Model):
             'client_order_ref': self.client_order_ref,
         })
         self.order_id = order.id  # Reference from this quotation to order
-        if self.state == 'draft':
+        if self.state in ('draft', 'sent'):
             self.action_done()
         return self.open_sale_order()
 
@@ -83,3 +83,31 @@ class SaleOrder(models.Model):
             'domain': "[('is_order', '=', True)]",
             'res_id': self.order_id and self.order_id.id or False,
         }
+
+    # noinspection PyMethodFirstArgAssignment
+    @api.multi
+    def action_confirm(self):
+        for order in self:
+            # The accept workflow of website_sale_quote does nothing else so
+            # no return is suitable.  Other cases should not get here but
+            # if so, difficult at this level to determine where the call came
+            # from and what action is suitable.
+            if not order.is_order:
+                order.action_convert_to_order()
+                self -= order
+        if self:
+            return super(SaleOrder, self).action_confirm()
+        return True
+
+    @api.model
+    def search(self, args, offset=0, limit=None, order=None, count=False):
+        if 'website_id' in self._context:
+            # mangle state fields
+            # TODO Make this less fragile but only over alternative
+            # was a big cut and paste from web Controller
+            if args and args[-1] == ('state', 'in', ['sent', 'cancel']):
+                args.append(('is_order', '=', False))
+            elif args and args[-1] == ('state', 'in', ['sale', 'done']):
+                args.append(('is_order', '=', True))
+        return super(SaleOrder, self).search(args, offset=offset, limit=limit,
+                                             order=order, count=count)

--- a/sale_isolated_quotation/models/sale.py
+++ b/sale_isolated_quotation/models/sale.py
@@ -12,7 +12,7 @@ class SaleOrder(models.Model):
         string='Is Order',
         readonly=True,
         index=True,
-        default=lambda self: self._context.get('is_order', False),
+        default=lambda self: self._context.get('is_order', True),
     )
     quote_id = fields.Many2one(
         'sale.order',

--- a/sale_isolated_quotation/tests/test_sale_isolated_quotation.py
+++ b/sale_isolated_quotation/tests/test_sale_isolated_quotation.py
@@ -6,13 +6,6 @@ from odoo.tests.common import TransactionCase
 
 class TestSaleIsolatedQuotation(TransactionCase):
 
-    def create_orders(self):
-        vals = {'partner_id': self.partner.id,
-                'is_order': False}
-        self.quotation = self.env['sale.order'].create(vals)
-        vals.update({'is_order': True})
-        self.sale_order = self.env['sale.order'].create(vals)
-
     def quotation_assertions(self):
         self.assertEqual(self.quotation.state, 'done')
         self.sale_order = self.quotation.order_id
@@ -28,7 +21,6 @@ class TestSaleIsolatedQuotation(TransactionCase):
           - New sale.order of is_order = True created
         - Quotation can refer to Order and Order can refer to Quotation
         """
-        self.create_orders()
         self.quotation.action_convert_to_order()
         self.quotation_assertions()
 
@@ -38,7 +30,6 @@ class TestSaleIsolatedQuotation(TransactionCase):
         that the quotation is converted to an order.
         :return:
         """
-        self.create_orders()
         self.quotation.action_confirm()
         self.quotation_assertions()
 
@@ -47,7 +38,6 @@ class TestSaleIsolatedQuotation(TransactionCase):
         When a sales order is converted to an order we need to ensure that
         behaviour of sale module is unchanged
         """
-        self.create_orders()
         self.quotation.is_order = True
         self.quotation.action_confirm()
         self.assertFalse(self.quotation.quote_id)
@@ -60,7 +50,6 @@ class TestSaleIsolatedQuotation(TransactionCase):
         upstream function we test fully for any change to its behaviour.
         """
         # At start of search both orders are in draft state.
-        self.create_orders()
         sale_obj = self.env['sale.order']
         search = sale_obj.search
         web_search = self.env['sale.order'].with_context(website_id=1).search
@@ -96,3 +85,8 @@ class TestSaleIsolatedQuotation(TransactionCase):
     def setUp(self):
         super(TestSaleIsolatedQuotation, self).setUp()
         self.partner = self.env.ref('base.res_partner_2')
+        vals = {'partner_id': self.partner.id,
+                'is_order': False}
+        self.quotation = self.env['sale.order'].new(vals)
+        vals.update({'is_order': True})
+        self.sale_order = self.env['sale.order'].new(vals)

--- a/sale_isolated_quotation/tests/test_sale_isolated_quotation.py
+++ b/sale_isolated_quotation/tests/test_sale_isolated_quotation.py
@@ -6,14 +6,14 @@ from odoo.tests.common import TransactionCase
 
 class TestSaleIsolatedQuotation(TransactionCase):
 
-    def test_quotation_convert_to_order(self):
-        """
-        - When quotation is converted to order
-          - Status chagned to 'done'
-          - New sale.order of is_order = True created
-        - Quotation can refer to Order and Order can refer to Quotation
-        """
-        self.quotation.action_convert_to_order()
+    def create_orders(self):
+        vals = {'partner_id': self.partner.id,
+                'is_order': False}
+        self.quotation = self.env['sale.order'].create(vals)
+        vals.update({'is_order': True})
+        self.sale_order = self.env['sale.order'].create(vals)
+
+    def quotation_assertions(self):
         self.assertEqual(self.quotation.state, 'done')
         self.sale_order = self.quotation.order_id
         self.assertTrue(self.sale_order.is_order)
@@ -21,10 +21,78 @@ class TestSaleIsolatedQuotation(TransactionCase):
         self.assertEqual(self.sale_order.partner_id, self.partner)
         self.assertEqual(self.sale_order.quote_id, self.quotation)
 
+    def test_quotation_convert_to_order(self):
+        """
+        - When quotation is converted to order
+          - Status chagned to 'done'
+          - New sale.order of is_order = True created
+        - Quotation can refer to Order and Order can refer to Quotation
+        """
+        self.create_orders()
+        self.quotation.action_convert_to_order()
+        self.quotation_assertions()
+
+    def test_quotation_confirm_order(self):
+        """
+        When confirm order is called on a quotation we need to ensure
+        that the quotation is converted to an order.
+        :return:
+        """
+        self.create_orders()
+        self.quotation.action_confirm()
+        self.quotation_assertions()
+
+    def test_sale_confirm_order(self):
+        """
+        When a sales order is converted to an order we need to ensure that
+        behaviour of sale module is unchanged
+        """
+        self.create_orders()
+        self.quotation.is_order = True
+        self.quotation.action_confirm()
+        self.assertFalse(self.quotation.quote_id)
+        self.assertFalse(self.quotation.order_id)
+        self.assertFalse(self.quotation.state in ('draft', 'sent', 'cancel'))
+
+    def test_quotation_search(self):
+        """
+        Because the amendment to search is highly dependent on hardcoded
+        upstream function we test fully for any change to its behaviour.
+        """
+        # At start of search both orders are in draft state.
+        self.create_orders()
+        sale_obj = self.env['sale.order']
+        search = sale_obj.search
+        web_search = self.env['sale.order'].with_context(website_id=1).search
+        orders = self.quotation + self.sale_order
+        self.assertEqual(len(search([('id', '=', self.quotation.id)])), 1)
+        # A typical backend search
+        self.assertEqual(
+            len(search([('id', 'in', orders.ids),
+                       ('state', 'in', ['sent', 'cancel'])])), 0)
+        self.assertEqual(
+            len(web_search([('id', 'in', orders.ids),
+                           ('state', 'in', ['sent', 'cancel'])])), 0)
+        # Test sent state - 2 should appear in backend, only 1 in website
+        orders.write({'state': 'sent'})
+        self.assertEqual(
+            len(search([('id', 'in', orders.ids),
+                       ('state', 'in', ['sent', 'cancel'])])), 2)
+        web_quotes = web_search([('id', 'in', orders.ids),
+                                ('state', 'in', ['sent', 'cancel'])])
+        self.assertEqual(len(web_quotes), 1)
+        self.assertTrue(web_quotes.id == self.quotation.id)
+
+        # Test sale, done state
+        orders.action_confirm()
+        self.assertEqual(
+            len(search([('id', 'in', orders.ids),
+                       ('state', 'in', ['sale', 'done'])])), 2)
+        web_orders = web_search([('id', 'in', orders.ids),
+                                ('state', 'in', ['sale', 'done'])])
+        self.assertEqual(len(web_orders), 1)
+        self.assertTrue(web_orders.id == self.sale_order.id)
+
     def setUp(self):
         super(TestSaleIsolatedQuotation, self).setUp()
         self.partner = self.env.ref('base.res_partner_2')
-        vals = {'partner_id': self.partner.id,
-                'is_order': False,
-                }
-        self.quotation = self.env['sale.order'].create(vals)

--- a/sale_isolated_quotation/tests/test_sale_isolated_quotation.py
+++ b/sale_isolated_quotation/tests/test_sale_isolated_quotation.py
@@ -6,6 +6,13 @@ from odoo.tests.common import TransactionCase
 
 class TestSaleIsolatedQuotation(TransactionCase):
 
+    def create_orders(self):
+        vals = {'partner_id': self.partner.id,
+                'is_order': False}
+        self.quotation = self.env['sale.order'].create(vals)
+        vals.update({'is_order': True})
+        self.sale_order = self.env['sale.order'].create(vals)
+
     def quotation_assertions(self):
         self.assertEqual(self.quotation.state, 'done')
         self.sale_order = self.quotation.order_id
@@ -21,6 +28,7 @@ class TestSaleIsolatedQuotation(TransactionCase):
           - New sale.order of is_order = True created
         - Quotation can refer to Order and Order can refer to Quotation
         """
+        self.create_orders()
         self.quotation.action_convert_to_order()
         self.quotation_assertions()
 
@@ -30,6 +38,7 @@ class TestSaleIsolatedQuotation(TransactionCase):
         that the quotation is converted to an order.
         :return:
         """
+        self.create_orders()
         self.quotation.action_confirm()
         self.quotation_assertions()
 
@@ -38,6 +47,7 @@ class TestSaleIsolatedQuotation(TransactionCase):
         When a sales order is converted to an order we need to ensure that
         behaviour of sale module is unchanged
         """
+        self.create_orders()
         self.quotation.is_order = True
         self.quotation.action_confirm()
         self.assertFalse(self.quotation.quote_id)
@@ -50,6 +60,7 @@ class TestSaleIsolatedQuotation(TransactionCase):
         upstream function we test fully for any change to its behaviour.
         """
         # At start of search both orders are in draft state.
+        self.create_orders()
         sale_obj = self.env['sale.order']
         search = sale_obj.search
         web_search = self.env['sale.order'].with_context(website_id=1).search
@@ -85,8 +96,3 @@ class TestSaleIsolatedQuotation(TransactionCase):
     def setUp(self):
         super(TestSaleIsolatedQuotation, self).setUp()
         self.partner = self.env.ref('base.res_partner_2')
-        vals = {'partner_id': self.partner.id,
-                'is_order': False}
-        self.quotation = self.env['sale.order'].new(vals)
-        vals.update({'is_order': True})
-        self.sale_order = self.env['sale.order'].new(vals)

--- a/sale_isolated_quotation/views/sale_views.xml
+++ b/sale_isolated_quotation/views/sale_views.xml
@@ -12,17 +12,39 @@
             <xpath expr="/form/header" position="after">
                 <header name="quotation"
                   attrs="{'invisible': [('is_order','=',True)]}">
-                    <button name="action_convert_to_order"
+                    <button name="action_quotation_send"
+                      string="Send by Email"
+                      type="object"
                       states="draft"
-                      class="oe_highlight"
+                      class="btn-primary"/>
+                    <button name="print_quotation"
+                      string="Print"
+                      type="object"
+                      states="draft"
+                      class="btn-primary"/>
+                    <button name="action_convert_to_order"
+                      states="draft,sent"
+                      class="btn-primary"
                       type="object"
                       string="Convert to Order"/>
+                    <button name="print_quotation"
+                      string="Print"
+                      type="object"
+                      states="sent"/>
+                    <button name="action_quotation_send"
+                      string="Send by Email"
+                      type="object"
+                      states="sent"/>
                     <button name="action_cancel"
-                      states="draft" type="object"
+                      states="draft,sent" type="object"
                       string="Cancel"/>
+                    <button name="action_draft"
+                      states="cancel"
+                      type="object"
+                      string="Set to Quotation"/>
                     <field name="state2"
                       widget="statusbar"
-                      statusbar_visible="draft,done"
+                      statusbar_visible="draft,sent,done"
                       invisible="context.get('is_order', False)"/>
                 </header>
             </xpath>

--- a/sale_order_lot_generator/models/sale.py
+++ b/sale_order_lot_generator/models/sale.py
@@ -22,8 +22,8 @@ class SaleOrder(models.Model):
 
     @api.multi
     def action_confirm(self):
-        self.ensure_one()
-        self.generate_prodlot()
+        for order in self:
+            order.generate_prodlot()
         return super(SaleOrder, self).action_confirm()
 
     @api.model

--- a/sale_order_lot_selection/model/sale.py
+++ b/sale_order_lot_selection/model/sale.py
@@ -72,6 +72,7 @@ class SaleOrder(models.Model):
     @api.multi
     def action_confirm(self):
         res = super(SaleOrder, self).action_confirm()
-        for line in self.order_line:
-            self._check_move_state(line)
+        for order in self:
+            for line in order.order_line:
+                order._check_move_state(line)
         return res


### PR DESCRIPTION
- allow to print, email and publish on website_portal
- attempt to at least make website_portal_sale make sense
- override action_confirm behaviour so website_quote cannot confirm quotations
- update backend header to v10 classes as used in view_order_form.

Hi,

I like this module but it faces a lot of limitations when working with website_* modules.  I wouldn't say this update is complete, but it is definitely an improvement.  Still needs to consider things like payments, url redirects on acceptance etc but at least now frontend and backend will behave about the same.