### PR TITLE
[8.0][FIX] sale_order_type:fix sale_type_id field

### DIFF
--- a/sale_order_type/models/account_invoice.py
+++ b/sale_order_type/models/account_invoice.py
@@ -47,7 +47,7 @@ class AccountInvoice(models.Model):
             partner = self.env['res.partner'].browse(partner_id)
             if partner.sale_type:
                 res['value'].update({
-                    'type_id': partner.sale_type.id,
+                    'sale_type_id': partner.sale_type.id,
                 })
         return res
 

--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -102,4 +102,4 @@ class TestSaleOrderType(common.TransactionCase):
         onchange_partner = self.invoice_model.onchange_partner_id(
             'out_invoice', self.partner.id)
         self.assertEqual(self.sale_type.id,
-                         onchange_partner['value']['type_id'])
+                         onchange_partner['value']['sale_type_id'])


### PR DESCRIPTION
onchange_partner_id function gets wrong value for field sale_type_id, taking type_id instead of sale_type_id