### PR TITLE
[9.0][sale_product_set] Fix incompatibility with sale_margin

### DIFF
--- a/sale_product_set/__openerp__.py
+++ b/sale_product_set/__openerp__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Sale product set',
     'summary': "Sale product set",
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.1',
     'category': 'Sales',
     "website": "https://odoo-community.org/",
     'author': 'Anybox, Odoo Community Association (OCA)',

--- a/sale_product_set/wizard/product_set_add.py
+++ b/sale_product_set/wizard/product_set_add.py
@@ -38,6 +38,7 @@ class ProductSetAdd(models.TransientModel):
         return {
             'order_id': sale_order_id,
             'product_id': set_line.product_id.id,
+            'product_uom': set_line.product_id.uom_id.id,
             'product_uom_qty': set_line.quantity * self.quantity,
             'sequence': max_sequence + set_line.sequence,
         }

--- a/sale_product_set/wizard/product_set_add.py
+++ b/sale_product_set/wizard/product_set_add.py
@@ -35,10 +35,13 @@ class ProductSetAdd(models.TransientModel):
 
     def prepare_sale_order_line_data(self, sale_order_id, set, set_line,
                                      max_sequence=0):
-        return {
+        sale_line = self.env['sale.order.line'].new({
             'order_id': sale_order_id,
             'product_id': set_line.product_id.id,
             'product_uom': set_line.product_id.uom_id.id,
             'product_uom_qty': set_line.quantity * self.quantity,
             'sequence': max_sequence + set_line.sequence,
-        }
+        })
+        sale_line.product_id_change()
+        line_values = sale_line._convert_to_write(sale_line._cache)
+        return line_values


### PR DESCRIPTION
When module `sale_product_set` is installed together with `sale_margin` the following error occurs when you try to add a set to a sales order.

  File "/opt/ao-odoo-buildout/parts/sale-workflow9/sale_product_set/wizard/product_set_add.py", line 34, in add_set
    max_sequence=max_sequence))
  File "/opt/ao-odoo-buildout/parts/odoo9/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/ao-odoo-buildout/parts/odoo9/addons/sale_margin/sale_margin.py", line 47, in create
    product_uom_id = self.env['product.uom'].browse(vals['product_uom'])
KeyError: 'product_uom'
