### PR TITLE
[9.0] ADD sequence to order sale order type in tree view

### DIFF
--- a/sale_order_type/__openerp__.py
+++ b/sale_order_type/__openerp__.py
@@ -8,7 +8,7 @@
 
 {
     "name": "Sale Order Types",
-    "version": "9.0.1.1.0",
+    "version": "9.0.1.2.0",
     "category": "Sales Management",
     "author": "Grupo Vermon,"
               "AvanzOSC,"

--- a/sale_order_type/models/sale_order_type.py
+++ b/sale_order_type/models/sale_order_type.py
@@ -9,6 +9,7 @@ from openerp import api, fields, models
 class SaleOrderTypology(models.Model):
     _name = 'sale.order.type'
     _description = 'Type of sale order'
+    _order = "sequence asc"
 
     @api.model
     def _get_domain_sequence_id(self):
@@ -44,3 +45,7 @@ class SaleOrderTypology(models.Model):
     payment_term_id = fields.Many2one('account.payment.term', 'Payment Term')
     pricelist_id = fields.Many2one('product.pricelist', 'Pricelist')
     incoterm_id = fields.Many2one('stock.incoterms', 'Incoterm')
+    sequence = fields.Integer(
+        'Sequence',
+        required=True,
+        default=10)

--- a/sale_order_type/views/sale_order_type_view.xml
+++ b/sale_order_type/views/sale_order_type_view.xml
@@ -43,6 +43,7 @@
             <field name="model">sale.order.type</field>
             <field name="arch" type="xml">
                 <tree string="Type">
+                    <field name="sequence" widget="handle"/>
                     <field name="name"/>
                     <field name="warehouse_id"/>
                     <field name="sequence_id"/>


### PR DESCRIPTION
This correction is for these reasons:

- To be able to prioritize the one that is intended to be used by default.
- To be able to prioritize the ones most used