### PR TITLE
[FIX][9.0] sale_automatic_workflow: Singleton error on automatic work…

### DIFF
--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -69,9 +69,9 @@ class AutomaticWorkflowJob(models.Model):
         picking_obj = self.env['stock.picking']
         pickings = picking_obj.search(picking_filter)
         _logger.debug('Pickings to validate: %s', pickings.ids)
-        if pickings:
+        for picking in pickings:
             with commit(self.env.cr):
-                pickings.validate_picking()
+                picking.validate_picking()
 
     @api.model
     def _sale_done(self, sale_done_filter):


### PR DESCRIPTION
Singleton error on automatic workflow when transferring multiple pickings.

Worflow settings:
Enable "**Confirm and Transfer Picking**" on workflow.

There is a constraint [[1]](https://github.com/odoo/odoo/blob/9.0/addons/delivery/models/stock_picking.py#L85) [[2]](https://github.com/odoo/odoo/blob/10.0/addons/delivery/models/stock_picking.py#L113) on `do_transfer` method in delivery module which was introduced from `V9` onwards.

So the multiple pickings cannot be transferred using the automatic workflow.

This makes the problem worse when using with `sale_sourced_by_line` [[3]](https://github.com/OCA/sale-workflow/tree/10.0/sale_sourced_by_line) since it will create separate pickings for each warehouse.

Need to apply the same fix for `V10`

```
Traceback:
2017-09-26 03:11:43,731 31230 ERROR odoo10 odoo.addons.sale_automatic_workflow.models.automatic_workflow_job: Error during an automatic workflow action.
Traceback (most recent call last):
  File "/opt/community_modules/sale-workflow/sale_automatic_workflow/models/automatic_workflow_job.py", line 23, in savepoint
    yield
  File "/opt/community_modules/sale-workflow/sale_automatic_workflow/models/automatic_workflow_job.py", line 70, in _validate_pickings
    pickings.validate_picking()
  File "/opt/community_modules/sale-workflow/sale_automatic_workflow/models/stock_picking.py", line 21, in validate_picking
    self.do_transfer()
  File "/opt/community_modules/connector-ecommerce/connector_ecommerce/models/stock.py", line 34, in do_transfer
    result = super(StockPicking, self_context).do_transfer()
  File "/opt/odoo/addons/delivery/models/stock_picking.py", line 113, in do_transfer
    self.ensure_one()
  File "/opt/odoo/odoo/models.py", line 4826, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: stock.picking(51, 52, 53, 54)
```