### PR TITLE
[10.0][FIX] sale_automatic_workflow_payment_mode: Failed invoice bloc…

### DIFF
--- a/sale_automatic_workflow_payment_mode/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow_payment_mode/models/automatic_workflow_job.py
@@ -38,7 +38,7 @@ class AutomaticWorkflowJob(models.Model):
                 _logger.debug('Unable to Register Payment for invoice %s: '
                               'Payment mode %s must have fixed journal',
                               invoice.id, payment_mode.id)
-                return
+                continue
 
             with savepoint(self.env.cr):
                 payment = self.env['account.payment'].create({


### PR DESCRIPTION
Failed invoice blocking the other invoices execution.

The following log shows the issue. 
Invoice 19 was stuck and it blocks the other invoices without proceeding further in a loop.

```
2017-09-26 08:10:13,352 11132 DEBUG odoo10 odoo.addons.sale_automatic_workflow_payment_mode.models.automatic_workflow_job: Invoices to Register Payment: [19, 20, 13, 14, 12]
2017-09-26 08:10:13,369 11132 DEBUG odoo10 odoo.addons.sale_automatic_workflow_payment_mode.models.automatic_workflow_job: Unable to Register Payment for invoice 19: Payment mode 4 must have fixed journal
2017-09-26 08:10:13,370 11132 DEBUG odoo10 odoo.addons.base.ir.ir_cron: 0.211s (automatic.workflow.job, run)
```

```
2017-09-26 08:10:53,661 11132 DEBUG odoo10 odoo.addons.sale_automatic_workflow_payment_mode.models.automatic_workflow_job: Invoices to Register Payment: [19, 20, 13, 14, 12]
2017-09-26 08:10:53,670 11132 DEBUG odoo10 odoo.addons.sale_automatic_workflow_payment_mode.models.automatic_workflow_job: Unable to Register Payment for invoice 19: Payment mode 4 must have fixed journal
2017-09-26 08:10:53,670 11132 DEBUG odoo10 odoo.addons.base.ir.ir_cron: 0.068s (automatic.workflow.job, run)
```

This is due to the `return` statement inside the loop instead of `continue` statement.
