### PR TITLE
[10.0] [ADD] sale_procurement_group_by_requested_date

### DIFF
--- a/sale_procurement_group_by_requested_date/README.rst
+++ b/sale_procurement_group_by_requested_date/README.rst
@@ -1,0 +1,61 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :alt: License: AGPL-3
+
+========================================
+Sale Procurement Group by Requested date
+========================================
+
+This module creates different procurements groups for different requested
+dates in a sale order line when the sale order is confirmed.
+It depends on sale_sourced_by_line so this module will group procurements 
+also by the warehouse in the sale order line.
+
+Installation
+============
+
+This module depends on the modules sale_procurement_group_by_line and
+sale_sourced_by_line.
+
+
+Usage
+=====
+
+#. Add a requested date for a sale order line.
+#. Confirm the sale order
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/167/9.0
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/sale-workflow/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+
+Credits
+=======
+
+Contributors
+------------
+
+* Aaron Henriquez <ahenriquez@eficent.com>
+* Jordi Ballester <jordi.ballester@eficent.com>
+* Darshan Patel <darshan.patel.serpentcs@gmail.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/sale_procurement_group_by_requested_date/README.rst
+++ b/sale_procurement_group_by_requested_date/README.rst
@@ -25,7 +25,7 @@ Usage
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/167/9.0
+   :target: https://runbot.odoo-community.org/runbot/167/10.0
 
 
 Bug Tracker

--- a/sale_procurement_group_by_requested_date/__init__.py
+++ b/sale_procurement_group_by_requested_date/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/sale_procurement_group_by_requested_date/__manifest__.py
+++ b/sale_procurement_group_by_requested_date/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Group procurements by requested date",
     "summary": "Groups pickings based on requested date of order line",
-    "version": "9.0.1.0.0",
+    "version": "10.0.1.0.0",
     "category": "Sales Management",
     "website": "http://www.eficent.com",
     "author": "Eficent , "

--- a/sale_procurement_group_by_requested_date/__openerp__.py
+++ b/sale_procurement_group_by_requested_date/__openerp__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Group procurements by requested date",
+    "summary": "Groups pickings based on requested date of order line",
+    "version": "9.0.1.0.0",
+    "category": "Sales Management",
+    "website": "http://www.eficent.com",
+    "author": "Eficent , "
+              "SerpentCS,"
+              "Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": [
+        "sale_order_line_date",
+        "sale_procurement_group_by_line",
+        "sale_sourced_by_line"
+    ],
+    "installable": True,
+}

--- a/sale_procurement_group_by_requested_date/i18n/ca.po
+++ b/sale_procurement_group_by_requested_date/i18n/ca.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Catalan (https://www.transifex.com/oca/teams/23907/ca/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ca\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Comandes de venda"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Línia de comanda de vendes"

--- a/sale_procurement_group_by_requested_date/i18n/de.po
+++ b/sale_procurement_group_by_requested_date/i18n/de.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: German (https://www.transifex.com/oca/teams/23907/de/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Verkaufsauftrag"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Auftragsposition"

--- a/sale_procurement_group_by_requested_date/i18n/el_GR.po
+++ b/sale_procurement_group_by_requested_date/i18n/el_GR.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# Kostas Goutoudis <goutoudis@gmail.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: Kostas Goutoudis <goutoudis@gmail.com>, 2017\n"
+"Language-Team: Greek (Greece) (https://www.transifex.com/oca/teams/23907/el_GR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: el_GR\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Εντολή Πώλησης"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""

--- a/sale_procurement_group_by_requested_date/i18n/es.po
+++ b/sale_procurement_group_by_requested_date/i18n/es.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Pedidos de venta"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Línea pedido de venta"

--- a/sale_procurement_group_by_requested_date/i18n/es_ES.po
+++ b/sale_procurement_group_by_requested_date/i18n/es_ES.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (Spain) (https://www.transifex.com/oca/teams/23907/es_ES/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_ES\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venta"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""

--- a/sale_procurement_group_by_requested_date/i18n/es_VE.po
+++ b/sale_procurement_group_by_requested_date/i18n/es_VE.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Spanish (Venezuela) (https://www.transifex.com/oca/teams/23907/es_VE/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: es_VE\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Pedidos de venta"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Línea de pedido de venta"

--- a/sale_procurement_group_by_requested_date/i18n/fi.po
+++ b/sale_procurement_group_by_requested_date/i18n/fi.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Finnish (https://www.transifex.com/oca/teams/23907/fi/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fi\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Myyntitilaus"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Myyntitilausrivi"

--- a/sale_procurement_group_by_requested_date/i18n/fr.po
+++ b/sale_procurement_group_by_requested_date/i18n/fr.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: French (https://www.transifex.com/oca/teams/23907/fr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Bon de commande"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Sales Order Line"

--- a/sale_procurement_group_by_requested_date/i18n/hr.po
+++ b/sale_procurement_group_by_requested_date/i18n/hr.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Croatian (https://www.transifex.com/oca/teams/23907/hr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: hr\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Prodajni nalog"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""

--- a/sale_procurement_group_by_requested_date/i18n/hr_HR.po
+++ b/sale_procurement_group_by_requested_date/i18n/hr_HR.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# Bole <bole@dajmi5.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: Bole <bole@dajmi5.com>, 2017\n"
+"Language-Team: Croatian (Croatia) (https://www.transifex.com/oca/teams/23907/hr_HR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: hr_HR\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Prodjani nalog"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""

--- a/sale_procurement_group_by_requested_date/i18n/hu.po
+++ b/sale_procurement_group_by_requested_date/i18n/hu.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Hungarian (https://www.transifex.com/oca/teams/23907/hu/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: hu\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Vevői megrendelés"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""

--- a/sale_procurement_group_by_requested_date/i18n/it.po
+++ b/sale_procurement_group_by_requested_date/i18n/it.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Italian (https://www.transifex.com/oca/teams/23907/it/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Ordini vendita"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Linea d'ordine di vendita"

--- a/sale_procurement_group_by_requested_date/i18n/nl.po
+++ b/sale_procurement_group_by_requested_date/i18n/nl.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Dutch (https://www.transifex.com/oca/teams/23907/nl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: nl\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Verkooporder"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Verkooporderregel"

--- a/sale_procurement_group_by_requested_date/i18n/nl_NL.po
+++ b/sale_procurement_group_by_requested_date/i18n/nl_NL.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# Peter Hageman <hageman.p@gmail.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-08-29 03:28+0000\n"
+"PO-Revision-Date: 2017-08-29 03:28+0000\n"
+"Last-Translator: Peter Hageman <hageman.p@gmail.com>, 2017\n"
+"Language-Team: Dutch (Netherlands) (https://www.transifex.com/oca/teams/23907/nl_NL/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: nl_NL\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Verkooporder"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Verkooporderregel"

--- a/sale_procurement_group_by_requested_date/i18n/pt.po
+++ b/sale_procurement_group_by_requested_date/i18n/pt.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# Daniel Reis <dreis.pt@gmail.com>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: Daniel Reis <dreis.pt@gmail.com>, 2017\n"
+"Language-Team: Portuguese (https://www.transifex.com/oca/teams/23907/pt/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Ordem de Venda"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""

--- a/sale_procurement_group_by_requested_date/i18n/pt_BR.po
+++ b/sale_procurement_group_by_requested_date/i18n/pt_BR.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Portuguese (Brazil) (https://www.transifex.com/oca/teams/23907/pt_BR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Pedido de venda"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Linha pedido de venda"

--- a/sale_procurement_group_by_requested_date/i18n/ro.po
+++ b/sale_procurement_group_by_requested_date/i18n/ro.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Romanian (https://www.transifex.com/oca/teams/23907/ro/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: ro\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Comandă vânzare"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Linie comandă vânzare"

--- a/sale_procurement_group_by_requested_date/i18n/sl.po
+++ b/sale_procurement_group_by_requested_date/i18n/sl.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Slovenian (https://www.transifex.com/oca/teams/23907/sl/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: sl\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Prodajni nalog"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Postavka prodajnega naloga"

--- a/sale_procurement_group_by_requested_date/i18n/tr.po
+++ b/sale_procurement_group_by_requested_date/i18n/tr.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Turkish (https://www.transifex.com/oca/teams/23907/tr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: tr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Sipariş Emri"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Sipariş Kalemi"

--- a/sale_procurement_group_by_requested_date/i18n/tr_TR.po
+++ b/sale_procurement_group_by_requested_date/i18n/tr_TR.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Turkish (Turkey) (https://www.transifex.com/oca/teams/23907/tr_TR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: tr_TR\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Satış emri"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Sipariş emri satırı "

--- a/sale_procurement_group_by_requested_date/i18n/vi_VN.po
+++ b/sale_procurement_group_by_requested_date/i18n/vi_VN.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Vietnamese (Viet Nam) (https://www.transifex.com/oca/teams/23907/vi_VN/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: vi_VN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "Đơn hàng Bán"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""

--- a/sale_procurement_group_by_requested_date/i18n/zh_CN.po
+++ b/sale_procurement_group_by_requested_date/i18n/zh_CN.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * sale_procurement_group_by_requested_date
+# 
+# Translators:
+# OCA Transbot <transbot@odoo-community.org>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 9.0c\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-06-24 01:09+0000\n"
+"PO-Revision-Date: 2017-06-24 01:09+0000\n"
+"Last-Translator: OCA Transbot <transbot@odoo-community.org>, 2017\n"
+"Language-Team: Chinese (China) (https://www.transifex.com/oca/teams/23907/zh_CN/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Language: zh_CN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order
+msgid "Sales Order"
+msgstr "销售订单"
+
+#. module: sale_procurement_group_by_requested_date
+#: model:ir.model,name:sale_procurement_group_by_requested_date.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""

--- a/sale_procurement_group_by_requested_date/models/__init__.py
+++ b/sale_procurement_group_by_requested_date/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import sale_order

--- a/sale_procurement_group_by_requested_date/models/sale_order.py
+++ b/sale_procurement_group_by_requested_date/models/sale_order.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.model
+    def _prepare_procurement_group_by_line(self, line):
+        vals = super(SaleOrder, self)._prepare_procurement_group_by_line(line)
+        # for compatibility with sale_quotation_sourcing
+        req_datetime = fields.Datetime.from_string(line.requested_date)
+        req_date = fields.Date.to_string(req_datetime)
+        if line._get_procurement_group_key()[0] == 12:
+            if line.requested_date:
+                vals['name'] = '/'.join([vals['name'], line.warehouse_id.name,
+                                         req_date])
+        return vals
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    @api.multi
+    def _prepare_order_line_procurement(self, group_id=False):
+        values = super(SaleOrderLine, self).\
+            _prepare_order_line_procurement(group_id=group_id)
+        self.ensure_one()
+        if self.requested_date:
+            req_datetime = fields.Datetime.from_string(self.requested_date)
+            req_date = fields.Date.to_string(req_datetime)
+            values['requested_date'] = req_date
+        return values
+
+    @api.multi
+    def _get_procurement_group_key(self):
+        """ Return a key with priority to be used to regroup lines in multiple
+        procurement groups. The higher the priority number is the more
+        preference the criteria has. E.g. sale_sourced_by_line has 10 priority,
+        that is less priority than the requested date.
+        """
+        priority = 12
+        key = super(SaleOrderLine, self)._get_procurement_group_key()
+        # Check priority
+        if key[0] >= priority:
+            return key
+        req_datetime = fields.Datetime.from_string(self.requested_date)
+        req_date = fields.Date.to_string(req_datetime)
+        if self.warehouse_id and req_date:
+            key = '/'.join([str(self.warehouse_id.id), req_date])
+        return (priority, key)

--- a/sale_procurement_group_by_requested_date/tests/__init__.py
+++ b/sale_procurement_group_by_requested_date/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import test_sale_procurement_group_by_requested_date

--- a/sale_procurement_group_by_requested_date/tests/test_sale_procurement_group_by_requested_date.py
+++ b/sale_procurement_group_by_requested_date/tests/test_sale_procurement_group_by_requested_date.py
@@ -3,8 +3,8 @@
 # Copyright 2017 Serpent Consulting Services Pvt. Ltd.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from openerp.tests.common import TransactionCase
-from openerp import fields
+from odoo.tests.common import TransactionCase
+from odoo import fields
 import datetime
 
 
@@ -26,49 +26,66 @@ class TestSaleMultiPickingByRequestedDate(TransactionCase):
         today = datetime.datetime.now()
         self.dt1 = today
         self.dt2 = today + datetime.timedelta(days=1)
+
         self.sale1 = sale_obj.create({'partner_id': 1})
-        self.sale_line1 = order_line.create({'product_id': p1,
-                                             'name': 'cool product',
-                                             'order_id': self.sale1.id,
-                                             'warehouse_id': self.wh1.id,
-                                             'requested_date': self.dt1})
-        self.sale_line2 = order_line.create({'product_id': p1,
-                                             'name': 'cool product',
-                                             'order_id': self.sale1.id,
-                                             'warehouse_id': self.wh1.id,
-                                             'requested_date': self.dt2})
-        self.sale_line3 = order_line.create({'product_id': p1,
-                                             'name': 'cool product',
-                                             'order_id': self.sale1.id,
-                                             'warehouse_id': self.wh2.id,
-                                             'requested_date': self.dt1})
-        self.sale_line4 = order_line.create({'product_id': p1,
-                                             'name': 'cool product',
-                                             'order_id': self.sale1.id,
-                                             'warehouse_id': self.wh2.id,
-                                             'requested_date': self.dt2})
+        self.sale_line1 = order_line.create({
+            'product_id': p1,
+            'name': 'cool product',
+            'order_id': self.sale1.id,
+            'warehouse_id': self.wh1.id,
+            'requested_date': self.dt1
+        })
+        self.sale_line2 = order_line.create({
+            'product_id': p1,
+            'name': 'cool product',
+            'order_id': self.sale1.id,
+            'warehouse_id': self.wh1.id,
+            'requested_date': self.dt2
+        })
+        self.sale_line3 = order_line.create({
+            'product_id': p1,
+            'name': 'cool product',
+            'order_id': self.sale1.id,
+            'warehouse_id': self.wh2.id,
+            'requested_date': self.dt1
+        })
+        self.sale_line4 = order_line.create({
+            'product_id': p1,
+            'name': 'cool product',
+            'order_id': self.sale1.id,
+            'warehouse_id': self.wh2.id,
+            'requested_date': self.dt2
+        })
 
         self.sale2 = sale_obj.create({'partner_id': 1})
-        self.sale_line5 = order_line.create({'product_id': p1,
-                                             'name': 'cool product',
-                                             'order_id': self.sale2.id,
-                                             'warehouse_id': self.wh1.id,
-                                             'requested_date': self.dt1})
-        self.sale_line6 = order_line.create({'product_id': p1,
-                                             'name': 'cool product',
-                                             'order_id': self.sale2.id,
-                                             'warehouse_id': self.wh1.id,
-                                             'requested_date': self.dt2})
-        self.sale_line7 = order_line.create({'product_id': p1,
-                                             'name': 'cool product',
-                                             'order_id': self.sale2.id,
-                                             'warehouse_id': self.wh1.id,
-                                             'requested_date': self.dt1})
-        self.sale_line8 = order_line.create({'product_id': p1,
-                                             'name': 'cool product',
-                                             'order_id': self.sale2.id,
-                                             'warehouse_id': self.wh1.id,
-                                             'requested_date': self.dt2})
+        self.sale_line5 = order_line.create({
+            'product_id': p1,
+            'name': 'cool product',
+            'order_id': self.sale2.id,
+            'warehouse_id': self.wh1.id,
+            'requested_date': self.dt1
+        })
+        self.sale_line6 = order_line.create({
+            'product_id': p1,
+            'name': 'cool product',
+            'order_id': self.sale2.id,
+            'warehouse_id': self.wh1.id,
+            'requested_date': self.dt2
+        })
+        self.sale_line7 = order_line.create({
+            'product_id': p1,
+            'name': 'cool product',
+            'order_id': self.sale2.id,
+            'warehouse_id': self.wh1.id,
+            'requested_date': self.dt1
+        })
+        self.sale_line8 = order_line.create({
+            'product_id': p1,
+            'name': 'cool product',
+            'order_id': self.sale2.id,
+            'warehouse_id': self.wh1.id,
+            'requested_date': self.dt2
+        })
 
     def test_number_of_groups(self):
         """True when the number of groups created matches the

--- a/sale_procurement_group_by_requested_date/tests/test_sale_procurement_group_by_requested_date.py
+++ b/sale_procurement_group_by_requested_date/tests/test_sale_procurement_group_by_requested_date.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Serpent Consulting Services Pvt. Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+from openerp import fields
+import datetime
+
+
+class TestSaleMultiPickingByRequestedDate(TransactionCase):
+    """Check the _get_shipped method of Sale Order. """
+
+    def setUp(self):
+        """Setup a Sale Order with 4 lines.
+        And prepare procurements
+        """
+        super(TestSaleMultiPickingByRequestedDate, self).setUp()
+        sale_obj = self.env['sale.order']
+        order_line = self.env['sale.order.line']
+        Product = self.env['product.product']
+        Warehouse = self.env['stock.warehouse']
+        self.wh1 = Warehouse.create({'name': 'wh1', 'code': 'wh1'})
+        self.wh2 = Warehouse.create({'name': 'wh2', 'code': 'wh2'})
+        p1 = Product.create({'name': 'p1', 'type': 'product'}).id
+        today = datetime.datetime.now()
+        self.dt1 = today
+        self.dt2 = today + datetime.timedelta(days=1)
+        self.sale1 = sale_obj.create({'partner_id': 1})
+        self.sale_line1 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale1.id,
+                                             'warehouse_id': self.wh1.id,
+                                             'requested_date': self.dt1})
+        self.sale_line2 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale1.id,
+                                             'warehouse_id': self.wh1.id,
+                                             'requested_date': self.dt2})
+        self.sale_line3 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale1.id,
+                                             'warehouse_id': self.wh2.id,
+                                             'requested_date': self.dt1})
+        self.sale_line4 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale1.id,
+                                             'warehouse_id': self.wh2.id,
+                                             'requested_date': self.dt2})
+
+        self.sale2 = sale_obj.create({'partner_id': 1})
+        self.sale_line5 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale2.id,
+                                             'warehouse_id': self.wh1.id,
+                                             'requested_date': self.dt1})
+        self.sale_line6 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale2.id,
+                                             'warehouse_id': self.wh1.id,
+                                             'requested_date': self.dt2})
+        self.sale_line7 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale2.id,
+                                             'warehouse_id': self.wh1.id,
+                                             'requested_date': self.dt1})
+        self.sale_line8 = order_line.create({'product_id': p1,
+                                             'name': 'cool product',
+                                             'order_id': self.sale2.id,
+                                             'warehouse_id': self.wh1.id,
+                                             'requested_date': self.dt2})
+
+    def test_number_of_groups(self):
+        """True when the number of groups created matches the
+        result of multiply the different warehouses with the different
+        requested dates"""
+        ok = False
+        self.sale1.action_confirm()
+        req_date = fields.Date.to_string(self.dt1)
+        g_name = self.sale1.name + '/' + self.wh1.name + '/' + req_date
+        groups = self.env['procurement.group'].search([('name', '=', g_name)])
+
+        for group in groups:
+            if group.name == g_name:
+                procurements = self.env['procurement.order'].search([
+                    ('group_id', '=', group.id)])
+                self.assertEqual(len(procurements), 1)
+                self.assertEqual(len(group), 1)
+                ok = True
+        self.assertTrue(ok)
+
+        ok = False
+        self.sale2.action_confirm()
+        req_date = fields.Date.to_string(self.dt2)
+        g_name = self.sale2.name + '/' + self.wh1.name + '/' + req_date
+        groups = self.env['procurement.group'].search([('name', '=', g_name)])
+
+        for group in groups:
+            if group.name == g_name:
+                procurements = self.env['procurement.order'].search([
+                    ('group_id', '=', group.id)])
+                self.assertEqual(len(procurements), 2)
+                self.assertEqual(len(group), 1)
+                ok = True
+        self.assertEqual(len(groups), 1)
+        g_name = self.sale2.name + '/' + self.wh1.name + '/'
+        groups = self.env['procurement.group'].search([('name', 'ilike',
+                                                        g_name)])
+        self.assertEqual(len(groups), 2)
+        self.assertTrue(ok)


### PR DESCRIPTION
Sale Procurement Group by Requested date
========================================

This module creates different procurements groups for different requested dates in a sale order line when the sale order is confirmed. It depends on sale_sourced_by_line so this module will group procurements 
also by the warehouse in the sale order line.