### PR TITLE
[10.0] [IMP]- Move so prd_set to smartbutton header

### DIFF
--- a/sale_product_set/__manifest__.py
+++ b/sale_product_set/__manifest__.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
-
+# Copyright 2015 Anybox
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     'name': 'Sale product set',
     'category': 'Sale',
+    'license': 'AGPL-3',
     'author': 'Anybox, Odoo Community Association (OCA)',
     'version': '10.0.1.0.2',
     'website': 'https://github.com/OCA/sale-workflow',
@@ -21,6 +23,4 @@
         'demo/product_set_line.xml',
     ],
     'installable': True,
-    'application': False,
-    'auto_install': False,
 }

--- a/sale_product_set/__manifest__.py
+++ b/sale_product_set/__manifest__.py
@@ -4,8 +4,7 @@
     'name': 'Sale product set',
     'category': 'Sale',
     'author': 'Anybox, Odoo Community Association (OCA)',
-    'version': '10.0.1.0.1',
-    'sequence': 150,
+    'version': '10.0.1.0.2',
     'website': 'https://github.com/OCA/sale-workflow',
     'summary': "Sale product set",
     'depends': [

--- a/sale_product_set/tests/test_product_set.py
+++ b/sale_product_set/tests/test_product_set.py
@@ -2,11 +2,11 @@
 from odoo.tests import common
 
 
-class test_product_set(common.TransactionCase):
+class TestProductSet(common.TransactionCase):
     """ Test Product set"""
 
     def setUp(self):
-        super(test_product_set, self).setUp()
+        super(TestProductSet, self).setUp()
         self.sale_order = self.env['sale.order']
         self.product_set_add = self.env['product.set.add']
 

--- a/sale_product_set/views/sale_order.xml
+++ b/sale_product_set/views/sale_order.xml
@@ -5,17 +5,14 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//sheet/div[@class='oe_title']/h1" position="before">
-                <div class="oe_right oe_button_box">
-                    <button class="oe_inline oe_stat_button"
+            <xpath expr="//header" position="inside">
+                    <button class="btn-primary"
                             type="action"
                             name="%(act_open_wizard_product_set_add)d"
                             icon="fa-cubes"
                             attrs="{'invisible': [('state','not in',('draft','sent'))]}"
-                            groups="base.group_user">
-                        <div>Add set</div>
-                    </button>
-                </div>
+                            groups="base.group_user"
+                            string="Add set"/>
             </xpath>
         </field>
     </record>

--- a/sale_product_set/wizard/product_set_add.xml
+++ b/sale_product_set/wizard/product_set_add.xml
@@ -12,7 +12,6 @@
                     <footer>
                         <button name="add_set" string="Add set"
                                 type="object" class="oe_highlight"/>
-                         or
                         <button special="cancel" string="Cancel" class="oe_link"/>
                     </footer>
                 </form>


### PR DESCRIPTION
It's way nicer up in the button bar and more close to the guidelines we find in V10.0 
![prd_set_smart_button](https://user-images.githubusercontent.com/3664638/31375671-9a7d90e6-ada2-11e7-913e-684fd7a5f894.jpg) and before https://github.com/OCA/sale-workflow/blob/10.0/sale_product_set/static/description/sale_order.png
