### PR TITLE
[10.0][FIX] sale_triple_discount: case taxes globally rounded

### DIFF
--- a/sale_triple_discount/__manifest__.py
+++ b/sale_triple_discount/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Sale Triple Discount',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Sales Management',
     'author': 'ADHOC SA, '
               'Agile Business Group, '

--- a/sale_triple_discount/models/__init__.py
+++ b/sale_triple_discount/models/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-from . import sale_order_line
+from . import sale_order

--- a/sale_triple_discount/models/sale_order.py
+++ b/sale_triple_discount/models/sale_order.py
@@ -18,27 +18,22 @@ class SaleOrder(models.Model):
         Compute the total amounts of the SO.
         """
         for order in self:
-            if not order.company_id.tax_calculation_rounding_method == (
-                    'round_globally'):
-                return super(SaleOrder, self)._amount_all()
-            amount_untaxed = amount_tax = 0.0
+            prev_price_unit = {}
             for line in order.order_line:
-                amount_untaxed += line.price_subtotal
-                taxes = line.tax_id.compute_all(
-                    line.price_reduce,
-                    line.order_id.currency_id,
-                    line.product_uom_qty,
-                    product=line.product_id,
-                    partner=order.partner_shipping_id,
-                )
-                amount_tax += sum(
-                    t.get('amount', 0.0) for t in taxes.get('taxes', []))
-            order.update({
-                'amount_untaxed': order.pricelist_id.currency_id.round(
-                    amount_untaxed),
-                'amount_tax': order.pricelist_id.currency_id.round(amount_tax),
-                'amount_total': amount_untaxed + amount_tax,
-            })
+                prev_price_unit['line.id'] = line.price_unit
+                prev_price_subtotal = line.price_subtotal
+                price_unit = line.price_unit * (
+                    1 - (line.discount2 or 0.0) / 100.0)
+                price_unit *= (1 - (line.discount3 or 0.0) / 100.0)
+                line.update({
+                    'price_unit': price_unit,
+                    'price_subtotal': prev_price_subtotal
+                })
+            super(SaleOrder, self)._amount_all()
+            for line in order.order_line:
+                line.update({
+                    'price_unit': prev_price_unit['line.id'],
+                })
 
 
 class SaleOrderLine(models.Model):

--- a/sale_triple_discount/tests/test_sale_triple_discount.py
+++ b/sale_triple_discount/tests/test_sale_triple_discount.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Tecnativa - David Vidal
-# Copyright 2017 Tecnativa - Luis M. Ontalba
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.tests import common
@@ -112,13 +111,3 @@ class TestSaleOrder(common.SavepointCase):
         self.assertEqual(self.so_line2.discount3,
                          invoice.invoice_line_ids[1].discount3)
         self.assertEqual(self.order.amount_total, invoice.amount_total)
-
-    def test_05_sale_order_triple_discount_globally_rounding(self):
-        self.order.company_id.tax_calculation_rounding_method == (
-            'round_globally')
-        self.so_line1.discount = 50.0
-        self.so_line1.discount2 = 50.0
-        self.so_line1.discount3 = 50.0
-        self.assertEqual(self.so_line1.price_subtotal, 75.0)
-        self.assertEqual(self.order.amount_untaxed, 675.0)
-        self.assertEqual(self.order.amount_tax, 101.25)

--- a/sale_triple_discount/tests/test_sale_triple_discount.py
+++ b/sale_triple_discount/tests/test_sale_triple_discount.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Tecnativa - David Vidal
+# Copyright 2017 Tecnativa - Luis M. Ontalba
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.tests import common
@@ -111,3 +112,13 @@ class TestSaleOrder(common.SavepointCase):
         self.assertEqual(self.so_line2.discount3,
                          invoice.invoice_line_ids[1].discount3)
         self.assertEqual(self.order.amount_total, invoice.amount_total)
+
+    def test_05_sale_order_triple_discount_globally_rounding(self):
+        self.order.company_id.tax_calculation_rounding_method == (
+            'round_globally')
+        self.so_line1.discount = 50.0
+        self.so_line1.discount2 = 50.0
+        self.so_line1.discount3 = 50.0
+        self.assertEqual(self.so_line1.price_subtotal, 75.0)
+        self.assertEqual(self.order.amount_untaxed, 675.0)
+        self.assertEqual(self.order.amount_tax, 101.25)


### PR DESCRIPTION
This PR fixes calculation of tax amount in case company tax calculation rounding method is "Round globally".

This is the error:

![errorsaletriplediscount](https://user-images.githubusercontent.com/5930419/31381759-be04ebaa-adb5-11e7-9971-99fc407d0086.png)
