### PR TITLE
[9.0][IMP][sale_automatic_workflow_payment_mode] use date invoice as date of payment

### DIFF
--- a/sale_automatic_workflow_payment_mode/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow_payment_mode/models/automatic_workflow_job.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import logging
-from openerp import models, api, fields
+from openerp import models, api
 from openerp.tools.safe_eval import safe_eval
 from openerp.addons.sale_automatic_workflow.models.automatic_workflow_job \
     import commit

--- a/sale_automatic_workflow_payment_mode/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow_payment_mode/models/automatic_workflow_job.py
@@ -37,7 +37,7 @@ class AutomaticWorkflowJob(models.Model):
                 payment = self.env['account.payment'].create({
                     'invoice_ids': [(6, 0, invoice.ids)],
                     'amount': invoice.residual,
-                    'payment_date': fields.Date.context_today(self),
+                    'payment_date': invoice.date_invoice,
                     'communication': invoice.reference or invoice.number,
                     'partner_id': invoice.partner_id.id,
                     'partner_type': partner_type,

--- a/sale_rental/models/stock.py
+++ b/sale_rental/models/stock.py
@@ -31,7 +31,7 @@ class StockWarehouse(models.Model):
         route_obj = self.env['stock.location.route']
         try:
             rental_route = self.env.ref('sale_rental.route_warehouse0_rental')
-        except:
+        except Exception:
             rental_routes = route_obj.search([('name', '=', _('Rent'))])
             rental_route = rental_routes and rental_routes[0] or False
         if not rental_route:
@@ -39,7 +39,7 @@ class StockWarehouse(models.Model):
         try:
             sell_rented_product_route = self.env.ref(
                 'sale_rental.route_warehouse0_sell_rented_product')
-        except:
+        except Exception:
             sell_rented_product_routes = route_obj.search(
                 [('name', '=', _('Sell Rented Product'))])
             sell_rented_product_route =\


### PR DESCRIPTION
In some case automatic payment is activated after a few month.
If you have invoice in currency you can have a different rate, between the invoice date and the payment date
so my proposition is to take the date_invoice as payment date instead of current date



