### PR TITLE
[10.0] [FIX] Fix issue on account.invoice about workflow_process_id

### DIFF
--- a/sale_automatic_workflow/__manifest__.py
+++ b/sale_automatic_workflow/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Sale Automatic Workflow',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Sales Management',
     'license': 'AGPL-3',
     'author': "Akretion,Camptocamp,Sodexis,Odoo Community Association (OCA)",

--- a/sale_automatic_workflow/models/account_invoice.py
+++ b/sale_automatic_workflow/models/account_invoice.py
@@ -3,7 +3,6 @@
 # © 2013 Camptocamp SA (author: Guewen Baconnier)
 # © 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
 from odoo import models, fields
 
 
@@ -12,5 +11,6 @@ class AccountInvoice(models.Model):
 
     workflow_process_id = fields.Many2one(
         comodel_name='sale.workflow.process',
-        string='Sale Workflow Process'
+        string='Sale Workflow Process',
+        copy=False,
     )


### PR DESCRIPTION
Bug on the field workflow_process_id in some case.
**Steps to reproduce:**
1) Duplicate an invoice with this field filled;
2) The automatic flow validate the accounting document (it's automatic, nothing to do);
3) Then the user change the Tax amount;
4) The VAT amount of this invoice and the Accounting document are differents.

**Solution:**
1) By disabling the copy of this field during the duplicate, the automatic validation is not done so no bug anymore.