### PR TITLE
[IMP] sale_order_invoicing_finished_task

### DIFF
--- a/sale_order_invoicing_finished_task/README.rst
+++ b/sale_order_invoicing_finished_task/README.rst
@@ -36,6 +36,10 @@ To use this module, you need to:
 
    .. image:: static/description/task_view_invoicefinishedtask.png
 
+   If the product is configured with an invoicing policy = Order, then the
+   delivered quantity is set to the ordered quantity. Otherwise, the time spent
+   on the task is used.
+
 6. Optional: if you want to use project stages to control this Go To
    Project -> Settings -> Stage -> You have to set true the field Invoiceable
    in the stages that you consider are invoiceable. Event to use stages for

--- a/sale_order_invoicing_finished_task/__manifest__.py
+++ b/sale_order_invoicing_finished_task/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Sale Order Invoicing Finished Task",
     "summary": "Control invoice order lines if his task has been finished",
-    "version": "10.0.1.0.1",
+    "version": "10.0.1.0.2",
     "category": "Sales",
     "website": "https://github.com/OCA/sale-workflow",
     "author": "Tecnativa, "

--- a/sale_order_invoicing_finished_task/models/project.py
+++ b/sale_order_invoicing_finished_task/models/project.py
@@ -46,6 +46,9 @@ class ProjectTask(models.Model):
                                   "no Sale Order Line or if it has been "
                                   "invoiced."))
             task.invoiceable = not task.invoiceable
+            if task.sale_line_id and task.sale_line_id.product_id.invoice_policy == 'order':
+                task.sale_line_id.qty_delivered = task.sale_line_id.product_uom_qty
+
 
     @api.multi
     def write(self, vals):

--- a/sale_order_invoicing_finished_task/models/project.py
+++ b/sale_order_invoicing_finished_task/models/project.py
@@ -38,17 +38,17 @@ class ProjectTask(models.Model):
     @api.multi
     def toggle_invoiceable(self):
         for task in self:
+            sale_line = task.sale_line_id
             # We dont' want to modify when the related SOLine is invoiced
-            if (not task.sale_line_id or
-                    task.sale_line_id.state in ('done', 'cancel') or
-                    task.sale_line_id.invoice_status in ('invoiced',)):
+            if (not sale_line or
+                    sale_line.state in ('done', 'cancel') or
+                    sale_line.invoice_status in ('invoiced',)):
                 raise UserError(_("You cannot modify the status if there is "
                                   "no Sale Order Line or if it has been "
                                   "invoiced."))
             task.invoiceable = not task.invoiceable
-            if task.sale_line_id and task.sale_line_id.product_id.invoice_policy == 'order':
-                task.sale_line_id.qty_delivered = task.sale_line_id.product_uom_qty
-
+            if sale_line and sale_line.product_id.invoice_policy == 'order':
+                sale_line.qty_delivered = sale_line.product_uom_qty
 
     @api.multi
     def write(self, vals):


### PR DESCRIPTION
When the product has an invoicing policy Ordered Quantity, setting the task
as Invoiceable will set the delivered qty on the sale order line to the ordered quantity.