### PR TITLE
10.0 FIX automatic validation of pickings if the domain returns more than one.

### DIFF
--- a/sale_automatic_workflow/__manifest__.py
+++ b/sale_automatic_workflow/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Sale Automatic Workflow',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Sales Management',
     'license': 'AGPL-3',
     'author': "Akretion,Camptocamp,Sodexis,Odoo Community Association (OCA)",

--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -78,9 +78,9 @@ class AutomaticWorkflowJob(models.Model):
         picking_obj = self.env['stock.picking']
         pickings = picking_obj.search(picking_filter)
         _logger.debug('Pickings to validate: %s', pickings.ids)
-        if pickings:
+        for picking in pickings:
             with savepoint(self.env.cr):
-                pickings.validate_picking()
+                picking.validate_picking()
 
     @api.model
     def _sale_done(self, sale_done_filter):

--- a/sale_automatic_workflow/models/stock_picking.py
+++ b/sale_automatic_workflow/models/stock_picking.py
@@ -17,6 +17,7 @@ class StockPicking(models.Model):
 
     @api.multi
     def validate_picking(self):
-        self.force_assign()
-        self.do_transfer()
+        for picking in self:
+            picking.force_assign()
+            picking.do_transfer()
         return True


### PR DESCRIPTION
If you have your automatic workflow setup to validate pickings (e.g. import some retail/POS orders), the current method will give the following error.

```
ERROR test10113 odoo.addons.sale_automatic_workflow.models.automatic_workflow_job: Error during an automatic workflow action.
 Traceback (most recent call last):
   File "/opt/odoo/addons/sale_automatic_workflow/models/automatic_workflow_job.py", line 23, in savepoint
     yield
   File "/opt/odoo/addons/sale_automatic_workflow/models/automatic_workflow_job.py", line 83, in _validate_pickings
     pickings.validate_picking()
   File "/opt/odoo/addons/sale_automatic_workflow/models/stock_picking.py", line 21, in validate_picking
     self.do_transfer()
   File "/opt/odoo/addons/connector_ecommerce/models/stock.py", line 34, in do_transfer
     result = super(StockPicking, self_context).do_transfer()
   File "/opt/odoo/odoo/addons/delivery/models/stock_picking.py", line 113, in do_transfer
     self.ensure_one()
   File "/usr/local/lib/python2.7/site-packages/odoo/models.py", line 4823, in ensure_one
     raise ValueError("Expected singleton: %s" % self)
 ValueError: Expected singleton: stock.picking(17626, 17627,...)
```