### PR TITLE
[FIX][10.0]Sale procurement group by line. Get pickings

### DIFF
--- a/sale_procurement_group_by_line/__manifest__.py
+++ b/sale_procurement_group_by_line/__manifest__.py
@@ -7,7 +7,7 @@
 {
     'name': 'Sale Procurement Group by Line',
     'summary': 'Base module for multiple procurement group by Sale order',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     "author": "Camptocamp,"
               "Eficent,"
               "Serpent,"

--- a/sale_procurement_group_by_line/model/sale.py
+++ b/sale_procurement_group_by_line/model/sale.py
@@ -22,7 +22,8 @@ class SaleOrder(models.Model):
 
     @api.multi
     @api.depends('order_line')
-    def _compute_get_picking_ids(self):
+    def _compute_picking_ids(self):
+        super(SaleOrder, self)._compute_picking_ids()
         for sale in self:
             group_ids = set([line.procurement_group_id.id
                              for line in sale.order_line
@@ -33,11 +34,6 @@ class SaleOrder(models.Model):
             sale.picking_ids = self.env['stock.picking'].search(
                 [('group_id', 'in', list(group_ids))])
             sale.delivery_count = len(sale.picking_ids)
-
-    picking_ids = fields.Many2many('stock.picking',
-                                   compute='_compute_get_picking_ids',
-                                   method=True,
-                                   string='Picking associated to this sale')
 
 
 class SaleOrderLine(models.Model):

--- a/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
+++ b/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
@@ -72,7 +72,7 @@ class TestSaleProcurementGroupByLine(TransactionCase):
                          self.line1.product_uom_qty,
                          """The Procurement quantity should
                          match to the quantity ordered""")
-        self.sale._compute_get_picking_ids()
+        self.sale._compute_picking_ids()
         self.picking_ids = self.env['stock.picking'].\
             search([('group_id', 'in', self.line2.procurement_group_id.ids)])
         self.assertTrue(self.picking_ids,


### PR DESCRIPTION
Current behavior: Overwriting the standard completely without calling super
Expected behavior: Call the standard method before introducing changes
