### PR TITLE
[9.0][ADD][sale_order_cancel_invoice] Cancel draft invoices when cancelling sale order

### DIFF
--- a/sale_order_cancel_invoice/README.rst
+++ b/sale_order_cancel_invoice/README.rst
@@ -1,0 +1,16 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=================
+Sale order cancel
+=================
+
+- Cancel all draft invoices link to a sale order when cancel sale order
+- Cancel all draft invoices link to a sale order when sale order line change
+
+Contributors
+------------
+
+* Noviat SA
+* Benjamin Henquet <benjamin.henquet@noviat.com>

--- a/sale_order_cancel_invoice/__init__.py
+++ b/sale_order_cancel_invoice/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/sale_order_cancel_invoice/__init__.py
+++ b/sale_order_cancel_invoice/__init__.py
@@ -1,2 +1,4 @@
 # -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import models

--- a/sale_order_cancel_invoice/__openerp__.py
+++ b/sale_order_cancel_invoice/__openerp__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Noviat.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Sale order cancel',
+    'version': '9.0.0.0.1',
+    'license': 'AGPL-3',
+    'author': 'Noviat',
+    'category': 'Sale',
+    'depends': [
+        'sale',
+    ],
+    'data': [
+    ],
+    'installable': True,
+}

--- a/sale_order_cancel_invoice/__openerp__.py
+++ b/sale_order_cancel_invoice/__openerp__.py
@@ -6,7 +6,7 @@
     'name': 'Sale order cancel',
     'version': '9.0.0.0.1',
     'license': 'AGPL-3',
-    'author': 'Noviat',
+    'author': 'Noviat,Odoo Community Association (OCA)',
     'category': 'Sale',
     'depends': [
         'sale',

--- a/sale_order_cancel_invoice/models/__init__.py
+++ b/sale_order_cancel_invoice/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import sale_order

--- a/sale_order_cancel_invoice/models/__init__.py
+++ b/sale_order_cancel_invoice/models/__init__.py
@@ -1,2 +1,4 @@
 # -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from . import sale_order

--- a/sale_order_cancel_invoice/models/sale_order.py
+++ b/sale_order_cancel_invoice/models/sale_order.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Noviat.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp import api, models, _
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.multi
+    def action_cancel(self):
+        for order in self:
+            order.cancel_draft_invoice()
+        return super(SaleOrder, self).action_cancel()
+
+    def cancel_draft_invoice(self):
+        for invoice in self.invoice_ids:
+            if not invoice.number and (invoice.state == 'draft' or invoice.state == 'proforma' or invoice.state == 'proforma2'):
+                invoice.signal_workflow('invoice_cancel')
+
+    @api.multi
+    def write(self, values):
+        for order in self:
+            if 'order_line' in values:
+                order.cancel_draft_invoice()
+        res = super(SaleOrder, self).write(values)
+        return res

--- a/sale_order_cancel_invoice/models/sale_order.py
+++ b/sale_order_cancel_invoice/models/sale_order.py
@@ -24,5 +24,4 @@ class SaleOrder(models.Model):
         for order in self:
             if 'order_line' in values:
                 order.cancel_draft_invoice()
-        res = super(SaleOrder, self).write(values)
-        return res
+        return super(SaleOrder, self).write(values)

--- a/sale_order_cancel_invoice/models/sale_order.py
+++ b/sale_order_cancel_invoice/models/sale_order.py
@@ -16,7 +16,8 @@ class SaleOrder(models.Model):
 
     def cancel_draft_invoice(self):
         for invoice in self.invoice_ids:
-            if not invoice.number and (invoice.state == 'draft' or invoice.state == 'proforma' or invoice.state == 'proforma2'):
+            if not invoice.number and (
+                        invoice.state == 'draft' or invoice.state == 'proforma' or invoice.state == 'proforma2'):
                 invoice.signal_workflow('invoice_cancel')
 
     @api.multi

--- a/sale_order_cancel_invoice/tests/__init__.py
+++ b/sale_order_cancel_invoice/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Vicent Cubells
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_sale_order

--- a/sale_order_cancel_invoice/tests/test_sale_order.py
+++ b/sale_order_cancel_invoice/tests/test_sale_order.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Noviat
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import openerp.tests
+
+
+class TestSaleOrderCancelInvoice(openerp.tests.TransactionCase):
+
+    def setUp(self):
+        super(TestSaleOrderCancelInvoice, self).setUp()
+        self.sale_order_model = self.env['sale.order']
+        self.sale_order_line_model = self.env['sale.order.line']
+
+        # Data
+        self.product = self.env['product.product'].create({
+            'name': 'test product',
+        })
+        self.customer = self.env['res.partner'].create({
+            'name': 'test Customer',
+            'customer': True,
+        })
+
+    def _create_invoice_from_sale(self, sale):
+        payment = self.env['sale.advance.payment.inv'].create({
+            'advance_payment_method': 'all'
+        })
+        sale_context = {
+            'active_id': sale.id,
+            'active_ids': sale.ids,
+            'active_model': 'sale.order',
+            'open_invoices': True,
+        }
+        payment.with_context(sale_context).create_invoices()
+
+    @openerp.tests.common.at_install(True)
+    @openerp.tests.common.post_install(True)
+    def test_sales_order(self):
+
+        sale_order = self.sale_order_model.create({
+            'partner_id': self.customer.id,
+        })
+        sale_order_line = self.sale_order_line_model.create({
+            'product_id': self.product.id,
+            'product_uom_qty': 1,
+            'order_id': sale_order.id
+        })
+
+        # confirm quotation
+        sale_order.action_confirm()
+
+        self.assertEquals(sale_order.invoice_status, 'to invoice',
+                          "The invoice status should be To Invoice")
+
+        self._create_invoice_from_sale(sale_order)
+        self.assertEquals(sale_order.invoice_status, 'invoiced',
+                          "The invoice status should be Invoiced")
+
+        sale_order.action_cancel()
+        self.assertEquals(sale_order.invoice_ids.state, 'cancel',
+                          "The invoice status should be 'cancel'")
+
+        sale_order.action_confirm()
+        self.assertEquals(sale_order.invoice_status, 'to invoice',
+                          "The invoice status should be To Invoice")
+        self._create_invoice_from_sale(sale_order)
+        self.assertEquals(sale_order.invoice_status, 'invoiced',
+                          "The invoice status should be Invoiced")
+
+        values = {
+            'order_line': [(1, sale_order_line.id, {'product_uom_qty': 2})],
+        }
+        sale_order.write(values)
+        self.assertEquals(sale_order.invoice_ids[-1].state, 'cancel',
+                          "The invoice status should be 'cancel'")
+        self.assertEquals(sale_order.invoice_status, 'to invoice',
+                          "The invoice status should be To Invoice")


### PR DESCRIPTION
This module cancel all invoices generated by a Sale order when we cancel this sale order AND those invoices have no number AND are in state draft, proforma or proforma2 