### PR TITLE
[10.0][ADD] sale_blanket_order

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -7,3 +7,4 @@ manufacture
 account-invoicing
 product-attribute
 partner-contact
+web

--- a/sale_blanket_order/README.rst
+++ b/sale_blanket_order/README.rst
@@ -1,0 +1,69 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+==============
+Blanket Orders
+==============
+
+A blanket order is a pre-agreement to sell a certain number of quantities of
+products at a specific price. From a confirmed blanket order, the users can
+create new sale orders at such price, until the blanket order expires, either
+due to reaching the validity date or exhausting all the quantities of products.
+
+Usage
+=====
+
+A new menu in the Sale area is created, allowing users to create new blanket
+orders.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/167/11.0
+
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/sale-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://odoo-community.org/logo.png>`_.
+
+Contributors
+------------
+
+* André Pereira <github@andreparames.com> (https://www.acsone.eu/)
+
+Do not contact contributors directly about support or help with technical issues.
+
+Funders
+-------
+
+The development of this module has been financially supported by:
+
+* Acsone SA/NV
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/sale_blanket_order/__init__.py
+++ b/sale_blanket_order/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/sale_blanket_order/__manifest__.py
+++ b/sale_blanket_order/__manifest__.py
@@ -1,0 +1,28 @@
+# coding: utf-8
+# Copyright 2018 Acsone
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    'name': 'Blanket Orders',
+    'category': 'Sale',
+    'license': 'AGPL-3',
+    'author': 'Acsone SA/NV,Odoo Community Association (OCA)',
+    'version': '10.0.1.0.0',
+    'website': 'https://github.com/OCA/sale-workflow',
+    'summary': "Blanket Orders",
+    'depends': [
+        'sale',
+        'web_action_conditionable',
+    ],
+    'data': [
+        'data/sequence.xml',
+        'data/ir_cron.xml',
+        'security/ir.model.access.csv',
+        'security/security.xml',
+        'wizard/create_sale_orders.xml',
+        'views/blanket_orders.xml',
+        'views/sale_orders.xml',
+        'report/templates.xml',
+        'report/report.xml',
+    ],
+    'installable': True,
+}

--- a/sale_blanket_order/__manifest__.py
+++ b/sale_blanket_order/__manifest__.py
@@ -14,6 +14,7 @@
         'web_action_conditionable',
     ],
     'data': [
+        'views/sale_config_settings.xml',
         'data/sequence.xml',
         'data/ir_cron.xml',
         'security/ir.model.access.csv',

--- a/sale_blanket_order/__manifest__.py
+++ b/sale_blanket_order/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     'name': 'Blanket Orders',
-    'category': 'Sale',
+    'category': 'Sales',
     'license': 'AGPL-3',
     'author': 'Acsone SA/NV,Odoo Community Association (OCA)',
     'version': '10.0.1.0.0',

--- a/sale_blanket_order/data/ir_cron.xml
+++ b/sale_blanket_order/data/ir_cron.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo noupdate="1">
+
+    <record forcecreate="True" id="expired_blanket_orders_cron"
+            model="ir.cron">
+        <field name="name">Expire Blanket Orders</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="nextcall" eval="(DateTime.now() + relativedelta(hour=00, minute=01, second=0)).strftime('%Y-%m-%d %H:%M:%S')" />
+        <field name="numbercall">-1</field>
+        <field name="doall" eval="False"/>
+        <field name="model">sale.blanket.order</field>
+        <field name="function">expire_orders</field>
+        <field name="args">()</field>
+    </record>
+
+</odoo>

--- a/sale_blanket_order/data/sequence.xml
+++ b/sale_blanket_order/data/sequence.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <!-- Sequences for sale.blanket.order -->
+    <record id="seq_blanket_order" model="ir.sequence">
+        <field name="name">Blanket Order</field>
+        <field name="code">sale.blanket.order</field>
+        <field name="prefix">BO</field>
+        <field name="padding">3</field>
+        <field name="company_id" eval="False"/>
+    </record>
+
+</odoo>

--- a/sale_blanket_order/models/__init__.py
+++ b/sale_blanket_order/models/__init__.py
@@ -1,0 +1,2 @@
+from . import blanket_orders
+from . import sale_orders

--- a/sale_blanket_order/models/__init__.py
+++ b/sale_blanket_order/models/__init__.py
@@ -1,2 +1,3 @@
 from . import blanket_orders
 from . import sale_orders
+from . import sale_config_settings

--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -294,7 +294,7 @@ class BlanketOrderLine(models.Model):
         return max(base_price, final_price)
 
     @api.multi
-    @api.onchange('product_id')
+    @api.onchange('product_id', 'original_qty')
     def onchange_product(self):
         if self.product_id:
             self.product_uom = self.product_id.uom_id.id

--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -31,7 +31,8 @@ class BlanketOrder(models.Model):
         'res.partner', string='Partner', readonly=True,
         states={'draft': [('readonly', False)]})
     lines_ids = fields.One2many(
-        'sale.blanket.order.line', 'order_id', string='Order lines')
+        'sale.blanket.order.line', 'order_id', string='Order lines',
+        copy=True)
     pricelist_id = fields.Many2one(
         'product.pricelist', string='Pricelist', required=True, readonly=True,
         states={'draft': [('readonly', False)]})
@@ -40,7 +41,7 @@ class BlanketOrder(models.Model):
     payment_term_id = fields.Many2one(
         'account.payment.term', string='Payment Terms', readonly=True,
         states={'draft': [('readonly', False)]})
-    confirmed = fields.Boolean()
+    confirmed = fields.Boolean(default=False)
     state = fields.Selection(selection=[
         ('draft', 'Draft'),
         ('opened', 'Opened'),
@@ -129,6 +130,13 @@ class BlanketOrder(models.Model):
         if self.partner_id.team_id:
             values['team_id'] = self.partner_id.team_id.id
         self.update(values)
+
+    @api.multi
+    def copy_data(self, default=None):
+        if default is None:
+            default = {}
+        default.update(self.default_get(['name', 'confirmed']))
+        return super(BlanketOrder, self).copy_data(default)
 
     @api.multi
     def _validate(self):

--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -1,0 +1,321 @@
+# coding: utf-8
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields, models, api, _
+from odoo.exceptions import Warning
+from odoo.tools import float_is_zero
+
+
+class BlanketOrder(models.Model):
+    _name = 'sale.blanket.order'
+    _inherit = ['mail.thread', 'ir.needaction_mixin']
+    _description = 'Blanket Order'
+
+    @api.model
+    def _get_default_team(self):
+        return self.env['crm.team']._get_default_team_id()
+
+    @api.model
+    def _default_currency(self):
+        return self.env.user.company_id.currency_id
+
+    @api.model
+    def _default_company(self):
+        return self.env.user.company_id
+
+    name = fields.Char(
+        default='Draft',
+        readonly=True
+    )
+    partner_id = fields.Many2one(
+        'res.partner', string='Partner', readonly=True,
+        states={'draft': [('readonly', False)]})
+    lines_ids = fields.One2many(
+        'sale.blanket.order.line', 'order_id', string='Order lines')
+    pricelist_id = fields.Many2one(
+        'product.pricelist', string='Pricelist', required=True, readonly=True,
+        states={'draft': [('readonly', False)]})
+    currency_id = fields.Many2one(
+        'res.currency', related='pricelist_id.currency_id', readonly=True)
+    payment_term_id = fields.Many2one(
+        'account.payment.term', string='Payment Terms', readonly=True,
+        states={'draft': [('readonly', False)]})
+    confirmed = fields.Boolean()
+    state = fields.Selection(selection=[
+        ('draft', 'Draft'),
+        ('opened', 'Opened'),
+        ('expired', 'Expired'),
+    ], compute='_compute_state', store=True)
+    validity_date = fields.Date(
+        readonly=True,
+        states={'draft': [('readonly', False)]})
+    client_order_ref = fields.Char(
+        string='Customer Reference', copy=False, readonly=True,
+        states={'draft': [('readonly', False)]})
+    note = fields.Text(
+        readonly=True,
+        states={'draft': [('readonly', False)]})
+    user_id = fields.Many2one(
+        'res.users', string='Salesperson', readonly=True,
+        states={'draft': [('readonly', False)]})
+    team_id = fields.Many2one(
+        'crm.team', string='Sales Team', change_default=True,
+        default=_get_default_team, readonly=True,
+        states={'draft': [('readonly', False)]})
+    company_id = fields.Many2one(
+        'res.company', string='Company', default=_default_company,
+        readonly=True,
+        states={'draft': [('readonly', False)]})
+    sale_count = fields.Integer(compute='_compute_sale_count')
+
+    @api.multi
+    def _get_sale_orders(self):
+        lines = self.mapped('lines_ids')
+        sale_lines = lines.mapped('sale_order_lines_ids')
+        sale_orders = sale_lines.mapped('order_id')
+        sale_orders_ids = list(set(sale_orders.ids))
+        return self.env['sale.order'].browse(sale_orders_ids)
+
+    @api.multi
+    @api.depends('lines_ids.remaining_qty')
+    def _compute_sale_count(self):
+        for blanket_order in self:
+            blanket_order.sale_count = len(blanket_order._get_sale_orders())
+
+    @api.multi
+    @api.depends(
+        'lines_ids.remaining_qty',
+        'validity_date',
+        'confirmed'
+    )
+    def _compute_state(self):
+        today = fields.Date.today()
+        precision = self.env['decimal.precision'].precision_get(
+            'Product Unit of Measure')
+        for order in self:
+            if not order.confirmed:
+                order.state = 'draft'
+            elif order.validity_date <= today:
+                order.state = 'expired'
+            elif float_is_zero(sum(order.lines_ids.mapped('remaining_qty')),
+                               precision_digits=precision):
+                order.state = 'expired'
+            else:
+                order.state = 'opened'
+
+    @api.multi
+    @api.onchange('partner_id')
+    def onchange_partner_id(self):
+        """
+        Update the following fields when the partner is changed:
+        - Pricelist
+        - Payment term
+        """
+        if not self.partner_id:
+            self.payment_term_id = False
+            return
+
+        values = {
+            'pricelist_id': (self.partner_id.property_product_pricelist and
+                             self.partner_id.property_product_pricelist.id or
+                             False),
+            'payment_term_id': (self.partner_id.property_payment_term_id and
+                                self.partner_id.property_payment_term_id.id or
+                                False),
+        }
+
+        if self.partner_id.user_id:
+            values['user_id'] = self.partner_id.user_id.id
+        if self.partner_id.team_id:
+            values['team_id'] = self.partner_id.team_id.id
+        self.update(values)
+
+    @api.multi
+    def _validate(self):
+        try:
+            today = fields.Date.today()
+            for order in self:
+                assert order.validity_date, _("Validity date is mandatory")
+                assert order.validity_date > today, \
+                    _("Validity date must be in the future")
+                assert order.partner_id, _("Partner is mandatory")
+                assert len(order.lines_ids) > 0, _("Must have some lines")
+                order.lines_ids._validate()
+        except AssertionError as e:
+            raise Warning(e.message)
+
+    @api.multi
+    def action_confirm(self):
+        self._validate()
+        for order in self:
+            sequence_obj = self.env['ir.sequence']
+            if order.company_id:
+                sequence_obj = sequence_obj.with_context(
+                    force_company=order.company_id.id)
+            name = sequence_obj.next_by_code('sale.blanket.order')
+            order.write({'confirmed': True, 'name': name})
+        return True
+
+    @api.multi
+    def action_view_sale_orders(self):
+        sale_orders = self._get_sale_orders()
+        action = self.env.ref('sale.action_orders').read()[0]
+        if len(sale_orders) > 0:
+            action['domain'] = [('id', 'in', sale_orders.ids)]
+        else:
+            action = {'type': 'ir.actions.act_window_close'}
+        return action
+
+    @api.model
+    def expire_orders(self):
+        today = fields.Date.today()
+        expired_orders = self.search([
+            ('state', '=', 'opened'),
+            ('validity_date', '<=', today),
+        ])
+        expired_orders.modified(['validity_date'])
+        expired_orders.recompute()
+
+
+class BlanketOrderLine(models.Model):
+    _name = 'sale.blanket.order.line'
+    _description = 'Blanket Order Line'
+
+    sequence = fields.Integer()
+    order_id = fields.Many2one('sale.blanket.order', required=True)
+    product_id = fields.Many2one(
+        'product.product', string='Product', required=True)
+    product_uom = fields.Many2one(
+        'product.uom', string='Unit of Measure', required=True)
+    price_unit = fields.Float(string='Price', required=True)
+    original_qty = fields.Float(
+        string='Original quantity', required=True, default=1)
+    ordered_qty = fields.Float(
+        string='Ordered quantity', compute='_compute_quantities', store=True)
+    invoiced_qty = fields.Float(
+        string='Invoiced quantity', compute='_compute_quantities', store=True)
+    remaining_qty = fields.Float(
+        string='Remaining quantity', compute='_compute_quantities', store=True)
+    delivered_qty = fields.Float(
+        string='Delivered quantity', compute='_compute_quantities', store=True)
+    sale_order_lines_ids = fields.One2many(
+        'sale.order.line', 'blanket_line_id', string='Sale order lines')
+    company_id = fields.Many2one(
+        'res.company', related='order_id.company_id', store=True)
+
+    def _get_real_price_currency(self, product, rule_id, qty, uom,
+                                 pricelist_id):
+        """Retrieve the price before applying the pricelist
+            :param obj product: object of current product record
+            :parem float qty: total quentity of product
+            :param tuple price_and_rule: tuple(price, suitable_rule) coming
+                   from pricelist computation
+            :param obj uom: unit of measure of current order line
+            :param integer pricelist_id: pricelist id of sale order"""
+        # Copied and adapted from the sale module
+        PricelistItem = self.env['product.pricelist.item']
+        field_name = 'lst_price'
+        currency_id = None
+        product_currency = None
+        if rule_id:
+            pricelist_item = PricelistItem.browse(rule_id)
+            if pricelist_item.pricelist_id\
+               .discount_policy == 'without_discount':
+                while pricelist_item.base == 'pricelist'\
+                    and pricelist_item.base_pricelist_id\
+                    and pricelist_item.base_pricelist_id\
+                        .discount_policy == 'without_discount':
+                    price, rule_id = pricelist_item.base_pricelist_id\
+                        .with_context(uom=uom.id).get_product_price_rule(
+                            product, qty, self.order_id.partner_id)
+                    pricelist_item = PricelistItem.browse(rule_id)
+
+            if pricelist_item.base == 'standard_price':
+                field_name = 'standard_price'
+            if pricelist_item.base == 'pricelist'\
+               and pricelist_item.base_pricelist_id:
+                field_name = 'price'
+                product = product.with_context(
+                    pricelist=pricelist_item.base_pricelist_id.id)
+                product_currency = pricelist_item.base_pricelist_id.currency_id
+            currency_id = pricelist_item.pricelist_id.currency_id
+
+        product_currency = (product_currency or
+                            (product.company_id and
+                             product.company_id.currency_id) or
+                            self.env.user.company_id.currency_id)
+        if not currency_id:
+            currency_id = product_currency
+            cur_factor = 1.0
+        else:
+            if currency_id.id == product_currency.id:
+                cur_factor = 1.0
+            else:
+                cur_factor = currency_id._get_conversion_rate(
+                    product_currency, currency_id)
+
+        product_uom = product.uom_id.id
+        if uom and uom.id != product_uom:
+            # the unit price is in a different uom
+            uom_factor = uom._compute_price(1.0, product.uom_id)
+        else:
+            uom_factor = 1.0
+
+        return product[field_name] * uom_factor * cur_factor, currency_id.id
+
+    @api.multi
+    def _get_display_price(self, product):
+        # Copied and adapted from the sale module
+        pricelist = self.order_id.pricelist_id
+        partner = self.order_id.partner_id
+        if self.order_id.pricelist_id.discount_policy == 'with_discount':
+            return product.with_context(pricelist=pricelist.id).price
+        final_price, rule_id = pricelist.get_product_price_rule(
+            self.product_id, self.original_qty or 1.0, partner)
+        context_partner = dict(self.env.context, partner_id=partner.id,
+                               date=fields.Date.today())
+        base_price, currency_id = self.with_context(context_partner)\
+            ._get_real_price_currency(
+                self.product_id, rule_id, self.original_qty, self.product_uom,
+                pricelist.id)
+        if currency_id != pricelist.currency_id.id:
+            currency = self.env['res.currency'].browse(currency_id)
+            base_price = currency.with_context(context_partner).compute(
+                base_price, pricelist.currency_id)
+        # negative discounts (= surcharge) are included in the display price
+        return max(base_price, final_price)
+
+    @api.multi
+    @api.onchange('product_id')
+    def onchange_product(self):
+        if self.product_id:
+            self.product_uom = self.product_id.uom_id.id
+            if self.order_id.pricelist_id and self.order_id.partner_id:
+                self.price_unit = self._get_display_price(self.product_id)
+
+    @api.multi
+    @api.depends(
+        'sale_order_lines_ids.blanket_line_id',
+        'sale_order_lines_ids.product_uom_qty',
+        'sale_order_lines_ids.qty_delivered',
+        'sale_order_lines_ids.qty_invoiced',
+        'original_qty'
+    )
+    def _compute_quantities(self):
+        for line in self:
+            sale_lines = line.sale_order_lines_ids
+            line.ordered_qty = sum(l.product_uom_qty for l in sale_lines)
+            line.invoiced_qty = sum(l.qty_invoiced for l in sale_lines)
+            line.delivered_qty = sum(l.qty_delivered for l in sale_lines)
+            line.remaining_qty = line.original_qty - line.ordered_qty
+
+    @api.multi
+    def _validate(self):
+        try:
+            for line in self:
+                assert line.price_unit > 0.0, \
+                    _("Price must be greater than zero")
+                assert line.original_qty > 0.0, \
+                    _("Quantity must be greater than zero")
+        except AssertionError as e:
+            raise Warning(e.message)

--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -274,6 +274,7 @@ class BlanketOrderLine(models.Model):
     @api.multi
     def _get_display_price(self, product):
         # Copied and adapted from the sale module
+        self.ensure_one()
         pricelist = self.order_id.pricelist_id
         partner = self.order_id.partner_id
         if self.order_id.pricelist_id.discount_policy == 'with_discount':

--- a/sale_blanket_order/models/sale_config_settings.py
+++ b/sale_blanket_order/models/sale_config_settings.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SaleConfigSettings(models.TransientModel):
+
+    _inherit = 'sale.config.settings'
+
+    group_blanket_disable_adding_lines = fields.Boolean(
+        string='Disable adding more lines to SOs',
+        implied_group='sale_blanket_order.blanket_orders_disable_adding_lines')

--- a/sale_blanket_order/models/sale_orders.py
+++ b/sale_blanket_order/models/sale_orders.py
@@ -9,7 +9,8 @@ class SaleOrder(models.Model):
 
     blanket_order_id = fields.Many2one(
         'sale.blanket.order', string='Origin blanket order',
-        related='order_line.blanket_line_id.order_id')
+        related='order_line.blanket_line_id.order_id',
+        readonly=True)
 
 
 class SaleOrderLine(models.Model):

--- a/sale_blanket_order/models/sale_orders.py
+++ b/sale_blanket_order/models/sale_orders.py
@@ -1,0 +1,18 @@
+# coding: utf-8
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    blanket_order_id = fields.Many2one(
+        'sale.blanket.order', string='Origin blanket order',
+        related='order_line.blanket_line_id.order_id')
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    blanket_line_id = fields.Many2one('sale.blanket.order.line')

--- a/sale_blanket_order/report/report.xml
+++ b/sale_blanket_order/report/report.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <report
+        id="report_blanket_order"
+        string="Blanket Order"
+        model="sale.blanket.order"
+        report_type="qweb-pdf"
+        file="sale_blanket_order.report_blanketorder"
+        name="sale_blanket_order.report_blanketorder"
+    />
+</odoo>

--- a/sale_blanket_order/report/templates.xml
+++ b/sale_blanket_order/report/templates.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<template id="report_blanketorder_document">
+    <t t-call="report.external_layout">
+        <t t-set="doc" t-value="doc.with_context({'lang':doc.partner_id.lang})" />
+        <div class="page">
+            <div class="oe_structure"/>
+            <div class="row">
+                <div class="col-xs-6">
+                    <div t-field="doc.partner_id"
+                        t-options='{"widget": "contact", "fields": ["address", "name", "phone", "fax"], "no_marker": True, "phone_icons": True}'/>
+                    <p t-if="doc.partner_id.vat">VAT: <span t-field="doc.partner_id.vat"/></p>
+                </div>
+            </div>
+
+            <h2>
+                <span>Blanket Order # </span>
+                <span t-field="doc.name"/>
+            </h2>
+
+            <div class="row mt32 mb32" id="informations">
+                <div t-if="doc.client_order_ref" class="col-xs-3">
+                    <strong>Your Reference:</strong>
+                    <p t-field="doc.client_order_ref"/>
+                </div>
+                <div class="col-xs-3">
+                    <strong>Validity Date:</strong>
+                    <p t-field="doc.validity_date"/>
+                </div>
+                <div t-if="doc.user_id.name" class="col-xs-3">
+                    <strong>Salesperson:</strong>
+                    <p t-field="doc.user_id"/>
+                </div>
+            </div>
+
+            <table class="table table-condensed">
+                <thead>
+                    <tr>
+                        <th>Product</th>
+                        <th class="text-right">Unit Price</th>
+                        <th class="text-right">Original Qty</th>
+                    </tr>
+               </thead>
+               <tbody class="sale_tbody">
+                    <t t-foreach="doc.lines_ids" t-as="l">
+                        <tr>
+                            <td><span t-field="l.product_id"/></td>
+                            <td class="text-right">
+                                <span t-field="l.price_unit"/>
+                            </td>
+                            <td class="text-right">
+                                <span t-field="l.original_qty"/>
+                                <!-- <span t-field="l.product_uom" groups="product.group_uom"/> -->
+                            </td>
+                        </tr>
+                    </t>
+                </tbody>
+            </table>
+
+            <p t-field="doc.note" />
+            <div class="oe_structure"/>
+        </div>
+    </t>
+</template>
+
+
+<template id="report_blanketorder">
+    <t t-call="report.html_container">
+        <t t-foreach="docs" t-as="doc">
+            <t t-call="sale_blanket_order.report_blanketorder_document" t-lang="doc.partner_id.lang"/>
+        </t>
+    </t>
+</template>
+</odoo>

--- a/sale_blanket_order/security/ir.model.access.csv
+++ b/sale_blanket_order/security/ir.model.access.csv
@@ -1,0 +1,7 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sale_blanket_order,sale.order,model_sale_blanket_order,sales_team.group_sale_salesman,1,1,1,0
+access_sale_blanket_order_line,sale.order.line,model_sale_blanket_order_line,sales_team.group_sale_salesman,1,1,1,1
+access_sale_blanket_order_manager,sale.order.manager,model_sale_blanket_order,sales_team.group_sale_manager,1,1,1,1
+access_sale_blanket_order_line_manager,sale.order.line.manager,model_sale_blanket_order_line,sales_team.group_sale_manager,1,1,1,1
+access_sale_blanket_order_accountant,sale.order.accountant,model_sale_blanket_order,account.group_account_user,1,1,0,0
+access_sale_blanket_order_line_accountant,sale.order.line accountant,model_sale_blanket_order_line,account.group_account_user,1,1,0,0

--- a/sale_blanket_order/security/security.xml
+++ b/sale_blanket_order/security/security.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
+    <record model="res.groups" id="blanket_orders_disable_adding_lines">
+        <field name="name">Disable adding more lines to SOs from Blanket Orders</field>
+    </record>
+
     <!-- Multi - Company Rules -->
 
     <record model="ir.rule" id="blanket_order_comp_rule">

--- a/sale_blanket_order/security/security.xml
+++ b/sale_blanket_order/security/security.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <!-- Multi - Company Rules -->
+
+    <record model="ir.rule" id="blanket_order_comp_rule">
+        <field name="name">Blanket Order multi-company</field>
+        <field name="model_id" ref="model_sale_blanket_order"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+    </record>
+
+    <record model="ir.rule" id="blanket_order_line_comp_rule">
+        <field name="name">Blanket Order Line multi-company</field>
+        <field name="model_id" ref="model_sale_blanket_order_line"/>
+        <field name="global" eval="True"/>
+        <field name="domain_force">['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]</field>
+    </record>
+
+</odoo>

--- a/sale_blanket_order/tests/__init__.py
+++ b/sale_blanket_order/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_blanket_orders

--- a/sale_blanket_order/tests/test_blanket_orders.py
+++ b/sale_blanket_order/tests/test_blanket_orders.py
@@ -5,7 +5,7 @@ from datetime import date, timedelta
 
 from odoo.tests import common
 from odoo import fields
-from odoo.exceptions import Warning
+from odoo.exceptions import UserError
 
 
 class TestBlanketOrders(common.TransactionCase):
@@ -58,7 +58,7 @@ class TestBlanketOrders(common.TransactionCase):
         self.assertEqual(blanket_order.lines_ids[0].price_unit, 56.0)
 
         # date in the past
-        with self.assertRaises(Warning):
+        with self.assertRaises(UserError):
             blanket_order.action_confirm()
 
         blanket_order.validity_date = fields.Date.to_string(tomorrow)

--- a/sale_blanket_order/tests/test_blanket_orders.py
+++ b/sale_blanket_order/tests/test_blanket_orders.py
@@ -1,0 +1,85 @@
+# coding: utf-8
+# Copyright 2018 Acsone
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from datetime import date, timedelta
+
+from odoo.tests import common
+from odoo import fields
+from odoo.exceptions import Warning
+
+
+class TestBlanketOrders(common.TransactionCase):
+
+    def test_create_sale_orders(self):
+        partner = self.env['res.partner'].create({
+            'name': 'TEST',
+            'customer': True,
+        })
+        payment_term = self.env.ref('account.account_payment_term_net')
+        product = self.env['product.product'].create({
+            'name': 'Demo',
+            'categ_id': self.env.ref('product.product_category_1').id,
+            'standard_price': 35.0,
+            'list_price': 40.0,
+            'type': 'consu',
+            'uom_id': self.env.ref('product.product_uom_unit').id,
+            'default_code': 'PROD_DEL02',
+        })
+        sale_pricelist = self.env['product.pricelist'].create({
+            'name': 'Sale pricelist',
+            'discount_policy': 'without_discount',
+            'item_ids': [(0, 0, {
+                'compute_price': 'fixed',
+                'fixed_price': 56.0,
+                'product_id': product.id,
+                'applied_on': '0_product_variant',
+            })]
+        })
+        yesterday = date.today() - timedelta(days=1)
+        tomorrow = date.today() + timedelta(days=1)
+
+        blanket_order = self.env['sale.blanket.order'].create({
+            'partner_id': partner.id,
+            'validity_date': fields.Date.to_string(yesterday),
+            'payment_term_id': payment_term.id,
+            'pricelist_id': sale_pricelist.id,
+            'lines_ids': [(0, 0, {
+                'product_id': product.id,
+                'product_uom': product.uom_id.id,
+                'original_qty': 20.0,
+                'price_unit': 1.0,  # will be updated by pricelist
+            })],
+        })
+        blanket_order.onchange_partner_id()
+        blanket_order.pricelist_id = sale_pricelist
+        blanket_order.lines_ids[0].onchange_product()
+
+        self.assertEqual(blanket_order.state, 'draft')
+        self.assertEqual(blanket_order.lines_ids[0].price_unit, 56.0)
+
+        # date in the past
+        with self.assertRaises(Warning):
+            blanket_order.action_confirm()
+
+        blanket_order.validity_date = fields.Date.to_string(tomorrow)
+        blanket_order.action_confirm()
+
+        self.assertEqual(blanket_order.state, 'opened')
+
+        wizard1 = self.env['sale.blanket.order.wizard'].with_context(
+            active_id=blanket_order.id).create({})
+        wizard1.lines_ids[0].write({'qty': 10.0})
+        wizard1.create_sale_order()
+
+        wizard2 = self.env['sale.blanket.order.wizard'].with_context(
+            active_id=blanket_order.id).create({})
+        wizard2.lines_ids[0].write({'qty': 10.0})
+        wizard2.create_sale_order()
+
+        self.assertEqual(blanket_order.state, 'expired')
+
+        self.assertEqual(blanket_order.sale_count, 2)
+
+        view_action = blanket_order.action_view_sale_orders()
+        domain_ids = view_action['domain'][0][2]
+        self.assertEqual(len(domain_ids), 2)

--- a/sale_blanket_order/views/blanket_orders.xml
+++ b/sale_blanket_order/views/blanket_orders.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_blanket_order_tree" model="ir.ui.view">
+        <field name="name">sale.blanket.order.tree</field>
+        <field name="model">sale.blanket.order</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="partner_id"/>
+                <field name="validity_date"/>
+                <field name="state"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_blanket_order_form" model="ir.ui.view">
+        <field name="name">sale.blanket.order.form</field>
+        <field name="model">sale.blanket.order</field>
+        <field name="arch" type="xml">
+            <form string="Blanket Order" class="o_sale_order">
+                <header>
+                    <button name="%(action_create_sale_order)d" string="Create Sale Order"
+                        type="action" class="btn-primary"
+                        attrs="{'invisible': [('state', '!=', 'opened')]}"/>
+                    <button name="action_confirm" states="draft" string="Confirm" class="btn-primary o_sale_confirm" type="object" />
+                    <field name="state" widget="statusbar" statusbar_visible="draft,opened,expired"/>
+                </header>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button name="action_view_sale_orders"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-pencil-square-o">
+                            <field name="sale_count" widget="statinfo" string="Sale Orders"/>
+                        </button>
+                    </div>
+                    <div class="oe_title">
+                        <h1>
+                            <field name="name" readonly="1"/>
+                        </h1>
+                    </div>
+                    <group>
+                        <group>
+                            <field name="partner_id" domain="[('customer','=',True)]" context="{'search_default_customer':1, 'show_address': 1}" options='{"always_reload": True}'/>
+                        </group>
+                        <group>
+                            <field name="validity_date" attrs="{'required': [('state', '=', 'draft')]}"/>
+                            <field name="payment_term_id"/>
+                        </group>
+                    </group>
+                    <notebook>
+                        <page string="Order Lines">
+                            <field name="lines_ids" mode="tree"
+                                attrs="{'readonly': [('state', 'in', ('opened','expired'))]}">
+                                <tree editable="bottom">
+                                    <field name="sequence" widget="handle"/>
+                                    <field name="product_id"
+                                        context="{'partner_id':parent.partner_id, 'quantity':original_qty, 'company_id': parent.company_id}"
+                                       />
+                                    <field name="product_uom"/>
+                                    <field name="price_unit"/>
+                                    <field name="original_qty"
+                                        string="Original Qty"
+                                        context="{'partner_id':parent.partner_id, 'quantity':original_qty, 'company_id': parent.company_id}"
+                                    />
+                                    <field name="ordered_qty"/>
+                                    <field name="invoiced_qty"/>
+                                    <field name="delivered_qty"/>
+                                    <field name="remaining_qty"/>
+                                </tree>
+                            </field>
+                            <field name="note" class="oe_inline" placeholder="Setup default terms and conditions in your company settings."/>
+                            <div class="oe_clear"/>
+                        </page>
+                        <page string="Other Information">
+                            <group>
+                                <group string="Sales Information" name="sales_person">
+                                    <field name="pricelist_id" attrs="{'required': [('state', '=', 'draft')]}"/>
+                                    <field name="user_id"/>
+                                    <field name="team_id" options="{'no_create': True}"/>
+                                    <field name="client_order_ref"/>
+                                    <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
+                                </group>
+                            </group>
+                        </page>
+                    </notebook>
+                </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" widget="mail_followers"/>
+                    <field name="message_ids" widget="mail_thread"/>
+                </div>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_blanket_order_search" model="ir.ui.view">
+        <field name="name">sale.blanket.order.search</field>
+        <field name="model">sale.blanket.order</field>
+        <field name="arch" type="xml">
+            <search string="Blanket Order">
+                <field name="name" select="True"/>
+            </search>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="act_open_blanket_order_view">
+        <field name="name">Blanket Orders</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">sale.blanket.order</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="view_blanket_order_search"/>
+        <field name="domain">[]</field>
+        <field name="context">{}</field>
+    </record>
+
+    <menuitem id="menu_blanket_order_config"
+        parent="sales_team.menu_sales"
+        groups="sales_team.group_sale_manager"
+        sequence="20"
+        action="act_open_blanket_order_view"/>
+</odoo>

--- a/sale_blanket_order/views/sale_config_settings.xml
+++ b/sale_blanket_order/views/sale_config_settings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2018 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+
+    <record model="ir.ui.view" id="sale_config_settings_form_view">
+        <field name="name">sale.config.settings.form (in sale_blanket_order)</field>
+        <field name="model">sale.config.settings</field>
+        <field name="inherit_id" ref="sale.view_sales_config"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='quotations_sales']" position="after">
+                <group name="blanket_orders" string="Blanket Orders">
+                    <field name="group_blanket_disable_adding_lines"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+
+
+</odoo>

--- a/sale_blanket_order/views/sale_orders.xml
+++ b/sale_blanket_order/views/sale_orders.xml
@@ -27,9 +27,6 @@
             </xpath>
 
             <!-- tree -->
-            <xpath expr="//field[@name='order_line']//tree" position="attributes">
-                <attribute name="create">blanket_order_id==False</attribute>
-            </xpath>
             <xpath expr="//field[@name='order_line']//tree" position="inside">
                 <field name="blanket_line_id" invisible="1"/>
             </xpath>
@@ -44,6 +41,18 @@
             </xpath>
             <xpath expr="//field[@name='order_line']//tree/field[@name='price_unit']" position="attributes">
                 <attribute name="attrs">{'readonly': [('blanket_line_id', '!=', False)]}</attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_order_form_disable_adding_lines" model="ir.ui.view">
+        <field name="name">sale.order.from.blanket.form - disable adding lines</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="groups_id" eval="[(6,0,[ref('sale_blanket_order.blanket_orders_disable_adding_lines')])]" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']//tree" position="attributes">
+                <attribute name="create">blanket_order_id==False</attribute>
             </xpath>
         </field>
     </record>

--- a/sale_blanket_order/views/sale_orders.xml
+++ b/sale_blanket_order/views/sale_orders.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="name">sale.order.from.blanket.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']" position="before">
+                <field name="blanket_order_id" invisible="1"/>
+            </xpath>
+
+            <!-- form -->
+            <xpath expr="//field[@name='order_line']//form" position="inside">
+                <field name="blanket_line_id" invisible="1"/>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//form//field[@name='product_id']" position="attributes">
+                <attribute name="attrs">{'readonly': ['|', '|', ('qty_invoiced', '&gt;', 0), ('procurement_ids', '!=', []), ('blanket_line_id', '!=', False)]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//form//field[@name='product_uom_qty']" position="attributes">
+                <attribute name="attrs">{'readonly': [('blanket_line_id', '!=', False)]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//form//field[@name='product_uom']" position="attributes">
+                <attribute name="attrs">{'readonly': ['|', ('state', 'in', ('sale','done', 'cancel')), ('blanket_line_id', '!=', False)]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//form//field[@name='price_unit']" position="attributes">
+                <attribute name="attrs">{'readonly': [('blanket_line_id', '!=', False)]}</attribute>
+            </xpath>
+
+            <!-- tree -->
+            <xpath expr="//field[@name='order_line']//tree" position="attributes">
+                <attribute name="create">blanket_order_id==False</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//tree" position="inside">
+                <field name="blanket_line_id" invisible="1"/>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//tree/field[@name='product_id']" position="attributes">
+                <attribute name="attrs">{'readonly': ['|', '|', ('qty_invoiced', '&gt;', 0), ('procurement_ids', '!=', []), ('blanket_line_id', '!=', False)]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//tree/field[@name='product_uom_qty']" position="attributes">
+                <attribute name="attrs">{'readonly': [('blanket_line_id', '!=', False)]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//tree/field[@name='product_uom']" position="attributes">
+                <attribute name="attrs">{'readonly': ['|', ('state', 'in', ('sale','done', 'cancel')), ('blanket_line_id', '!=', False)]}</attribute>
+            </xpath>
+            <xpath expr="//field[@name='order_line']//tree/field[@name='price_unit']" position="attributes">
+                <attribute name="attrs">{'readonly': [('blanket_line_id', '!=', False)]}</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_blanket_order/wizard/__init__.py
+++ b/sale_blanket_order/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import create_sale_orders

--- a/sale_blanket_order/wizard/create_sale_orders.py
+++ b/sale_blanket_order/wizard/create_sale_orders.py
@@ -1,0 +1,111 @@
+# coding: utf-8
+# Copyright 2018 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields, models, api, _
+from odoo.exceptions import Warning
+
+
+class BlanketOrderWizard(models.TransientModel):
+    _name = 'sale.blanket.order.wizard'
+    _description = 'Blanket Order Wizard'
+
+    @api.model
+    def _default_order(self):
+        # in case the cron hasn't run
+        self.env['sale.blanket.order'].expire_orders()
+        if not self.env.context.get('active_id'):
+            return False
+        blanket_order = self.env['sale.blanket.order'].browse(
+            self.env.context['active_id'])
+        if blanket_order.state == 'expired':
+            raise Warning(_('You can\'t create a sale order from '
+                            'an expired blanket order!'))
+        return blanket_order
+
+    @api.model
+    def _default_lines(self):
+        blanket_order = self._default_order()
+        lines = [(0, 0, {
+            'blanket_line_id': l.id,
+            'product_id': l.product_id.id,
+            'remaining_qty': l.remaining_qty,
+            'qty': l.remaining_qty,
+        }) for l in blanket_order.lines_ids]
+        return lines
+
+    blanket_order_id = fields.Many2one(
+        'sale.blanket.order', default=_default_order, readonly=True)
+    lines_ids = fields.One2many(
+        'sale.blanket.order.wizard.line', 'wizard_id',
+        string='Lines', default=_default_lines)
+
+    @api.multi
+    def create_sale_order(self):
+        self.ensure_one()
+
+        line_obj = self.env['sale.order.line']
+        order_lines = []
+        for line in self.lines_ids:
+            if line.qty == 0.0:
+                continue
+
+            if line.qty > line.remaining_qty:
+                raise Warning(
+                    _('You can\'t order more than the remaining quantities'))
+
+            vals = {
+                'product_id': line.product_id.id,
+                'product_uom': line.blanket_line_id.product_uom.id,
+                'sequence': line.blanket_line_id.sequence,
+                'price_unit': line.blanket_line_id.price_unit,
+                'blanket_line_id': line.blanket_line_id.id,
+            }
+            vals.update(line_obj.onchange(
+                vals, 'product_id', {'product_id': 'true'})['value'])
+            vals['product_uom_qty'] = line.qty
+            order_lines.append((0, 0, vals))
+
+        if not order_lines:
+            raise Warning(_('An order can\'t be empty'))
+
+        order_vals = {
+            'partner_id': self.blanket_order_id.partner_id.id,
+        }
+        order_vals.update(self.env['sale.order'].onchange(
+            order_vals, 'partner_id', {'partner_id': 'true'})['value'])
+        order_vals.update({
+            'user_id': self.blanket_order_id.user_id.id,
+            'origin': self.blanket_order_id.name,
+            'currency_id': self.blanket_order_id.currency_id.id,
+            'order_line': order_lines,
+            'pricelist_id': (self.blanket_order_id.pricelist_id.id
+                             if self.blanket_order_id.pricelist_id
+                             else False),
+            'payment_term_id': (self.blanket_order_id.payment_term_id.id
+                                if self.blanket_order_id.payment_term_id
+                                else False),
+        })
+
+        sale_order = self.env['sale.order'].create(order_vals)
+        return {
+            'type': 'ir.actions.act_window',
+            'view_type': 'form',
+            'view_mode': 'form',
+            'res_model': 'sale.order',
+            'res_id': sale_order.id,
+        }
+
+
+class BlanketOrderWizardLine(models.TransientModel):
+    _name = 'sale.blanket.order.wizard.line'
+
+    wizard_id = fields.Many2one('sale.blanket.order.wizard')
+    blanket_line_id = fields.Many2one(
+        'sale.blanket.order.line')
+    product_id = fields.Many2one(
+        'product.product',
+        related='blanket_line_id.product_id',
+        string='Product', readonly=True)
+    remaining_qty = fields.Float(
+        related='blanket_line_id.remaining_qty', readonly=True)
+    qty = fields.Float(string='Quantity to Order', required=True)

--- a/sale_blanket_order/wizard/create_sale_orders.py
+++ b/sale_blanket_order/wizard/create_sale_orders.py
@@ -2,7 +2,7 @@
 # Copyright 2018 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import fields, models, api, _
-from odoo.exceptions import Warning
+from odoo.exceptions import UserError
 
 
 class BlanketOrderWizard(models.TransientModel):
@@ -18,8 +18,8 @@ class BlanketOrderWizard(models.TransientModel):
         blanket_order = self.env['sale.blanket.order'].browse(
             self.env.context['active_id'])
         if blanket_order.state == 'expired':
-            raise Warning(_('You can\'t create a sale order from '
-                            'an expired blanket order!'))
+            raise UserError(_('You can\'t create a sale order from '
+                              'an expired blanket order!'))
         return blanket_order
 
     @api.model
@@ -50,7 +50,7 @@ class BlanketOrderWizard(models.TransientModel):
                 continue
 
             if line.qty > line.remaining_qty:
-                raise Warning(
+                raise UserError(
                     _('You can\'t order more than the remaining quantities'))
 
             vals = {
@@ -66,7 +66,7 @@ class BlanketOrderWizard(models.TransientModel):
             order_lines.append((0, 0, vals))
 
         if not order_lines:
-            raise Warning(_('An order can\'t be empty'))
+            raise UserError(_('An order can\'t be empty'))
 
         order_vals = {
             'partner_id': self.blanket_order_id.partner_id.id,

--- a/sale_blanket_order/wizard/create_sale_orders.xml
+++ b/sale_blanket_order/wizard/create_sale_orders.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_create_sale_order" model="ir.ui.view">
+        <field name="name">Create Sale Order</field>
+        <field name="model">sale.blanket.order.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Create Sale Order">
+                <group>
+                    <field name="lines_ids" nolabel="1">
+                        <tree create="false" editable="bottom">
+                            <field name="product_id"/>
+                            <field name="remaining_qty"/>
+                            <field name="qty"/>
+                        </tree>
+                    </field>
+                </group>
+                <footer>
+                    <button name="create_sale_order" string="Create and View Order" type="object"
+                        class="btn-primary"/>
+                    <button string="Cancel" class="btn-default" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_create_sale_order" model="ir.actions.act_window">
+        <field name="name">Create Sale Order</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">sale.blanket.order.wizard</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/setup/sale_blanket_order/odoo/__init__.py
+++ b/setup/sale_blanket_order/odoo/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/sale_blanket_order/odoo/addons/__init__.py
+++ b/setup/sale_blanket_order/odoo/addons/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/sale_blanket_order/odoo/addons/sale_blanket_order
+++ b/setup/sale_blanket_order/odoo/addons/sale_blanket_order
@@ -1,0 +1,1 @@
+../../../../sale_blanket_order

--- a/setup/sale_blanket_order/setup.py
+++ b/setup/sale_blanket_order/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module adds blanket orders, as described in the corresponding issue.

This PR depends on another for the migration of `web_action_conditionable`: https://github.com/OCA/web/pull/845

Fixes #592 