### PR TITLE
[10.0][FIX] Automatic sale workflow - Register payment multi-currency

### DIFF
--- a/sale_automatic_workflow_payment_mode/__manifest__.py
+++ b/sale_automatic_workflow_payment_mode/__manifest__.py
@@ -1,20 +1,22 @@
 # -*- coding: utf-8 -*-
 # © 2016 Camptocamp SA, Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
-
-{'name': 'Sale Automatic Workflow - Payment Mode',
- 'version': '10.0.1.0.0',
- 'author': 'Camptocamp,Sodexis,Odoo Community Association (OCA)',
- 'license': 'AGPL-3',
- 'category': 'Sales Management',
- 'depends': ['sale_automatic_workflow',
-             'account_payment_sale',  # oca/bank-payment
-             ],
- 'website': 'http://www.camptocamp.com',
- 'data': ['data/automatic_workflow_data.xml',
-          'views/account_payment_mode_views.xml',
-          'views/sale_workflow_process_view.xml',
-          ],
- 'installable': True,
- 'auto_install': True,
- }
+{
+    'name': 'Sale Automatic Workflow - Payment Mode',
+    'version': '10.0.1.0.1',
+    'author': 'Camptocamp,Sodexis,Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
+    'category': 'Sales Management',
+    'depends': [
+        'sale_automatic_workflow',
+        'account_payment_sale',  # oca/bank-payment
+    ],
+    'website': 'http://www.camptocamp.com',
+    'data': [
+        'data/automatic_workflow_data.xml',
+        'views/account_payment_mode_views.xml',
+        'views/sale_workflow_process_view.xml',
+    ],
+    'installable': True,
+    'auto_install': True,
+}

--- a/sale_automatic_workflow_payment_mode/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow_payment_mode/models/automatic_workflow_job.py
@@ -51,6 +51,7 @@ class AutomaticWorkflowJob(models.Model):
                     'payment_type': payment_mode.payment_type,
                     'payment_method_id': payment_mode.payment_method_id.id,
                     'journal_id': payment_mode.fixed_journal_id.id,
+                    'currency_id': invoice.currency_id.id,
                 })
                 payment.post()
         return


### PR DESCRIPTION
**How to reproduce**
- Create an invoice with another currency than your invoice company.
- Use the automatic workflow (with auto-payment)
- Check the invoice payment (it's not full paid, depending on the currency rate).

If you don't use the automatic workflow, you can open the payment wizard and this one ask you the currency to use (by default, Odoo put the currency of the company).

**Patch**
- Use the currency of the invoice into the invoice payment wizard
- Now payment amount match on the invoice