### PR TITLE
[10.0][FIX] sale_order_invoicing_finished_task

### DIFF
--- a/sale_order_invoicing_finished_task/models/sale_order.py
+++ b/sale_order_invoicing_finished_task/models/sale_order.py
@@ -6,20 +6,6 @@
 from odoo import api, fields, models
 
 
-class SaleOrder(models.Model):
-    _inherit = 'sale.order'
-
-    @api.depends('state', 'order_line.invoice_status',
-                 'order_line.task_ids.invoiceable')
-    def _get_invoiced(self):
-        super(SaleOrder, self)._get_invoiced()
-        for order in self:
-            if not all(order.tasks_ids.mapped('invoiceable')):
-                order.update({
-                    'invoice_status': 'no',
-                })
-
-
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 


### PR DESCRIPTION
If we have one line "to invoice", we also want that the sale order is "to invoice".

And we don't need to keep the depends added on `order_line.task_ids.invoiceable`,
because the core depends on `order_line.invoice_status` is enought to trigger correctly the computation.