### PR TITLE
[FIX] sale_order_invoicing_finished_task: missed picking_policy condition

### DIFF
--- a/sale_order_invoicing_finished_task/__manifest__.py
+++ b/sale_order_invoicing_finished_task/__manifest__.py
@@ -7,7 +7,7 @@
 {
     "name": "Sale Order Invoicing Finished Task",
     "summary": "Control invoice order lines if his task has been finished",
-    "version": "10.0.1.0.2",
+    "version": "10.0.1.0.3",
     "category": "Sales",
     "website": "https://github.com/OCA/sale-workflow",
     "author": "Tecnativa, "

--- a/sale_order_invoicing_finished_task/models/sale_order.py
+++ b/sale_order_invoicing_finished_task/models/sale_order.py
@@ -13,8 +13,10 @@ class SaleOrder(models.Model):
                  'order_line.task_ids.invoiceable')
     def _get_invoiced(self):
         super(SaleOrder, self)._get_invoiced()
-        for order in self:
-            if not all(order.tasks_ids.mapped('invoiceable')):
+        for order in self.filtered(lambda o: (
+                o.invoice_status != 'no' and o.picking_policy == 'one')):
+            if not all(t.invoiceable for t in order.mapped(
+                    'order_line.task_ids') if t.invoicing_finished_task):
                 order.update({
                     'invoice_status': 'no',
                 })

--- a/sale_order_invoicing_finished_task/views/project_view.xml
+++ b/sale_order_invoicing_finished_task/views/project_view.xml
@@ -24,6 +24,7 @@
 
         <div name="button_box" position="inside">
             <button name="toggle_invoiceable" type="object"
+                    attrs="{'invisible': [('invoicing_finished_task','=', False)]}"
                     class="oe_stat_button" icon="fa-file">
                 <field name="invoiceable" widget="boolean_button"
                     options='{"terminology": {


### PR DESCRIPTION
Before this PR:
sale order invoice_status allways 'no'

After this PR:
Evaluate condition to set invoice_status = 'no'
Invoiceable button only visible if invoicing_finished_task product

@Tecnativa