### PR TITLE
[10.0][ADD]sale_returned_quantity

### DIFF
--- a/sale_returned_quantity/README.rst
+++ b/sale_returned_quantity/README.rst
@@ -1,0 +1,52 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=======================
+Sale order returned qty
+=======================
+
+Returned quantity in sale order lines. This allow to correct mistakes when
+ validating deliveries without cancelling the order. By returning the wrong
+delivery and making a manual one.
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/167/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/sale-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+* Aaron Henriquez <ahenriquez@eficent.com>
+
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/sale_returned_quantity/__init__.py
+++ b/sale_returned_quantity/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import models
+from . import wizards

--- a/sale_returned_quantity/__manifest__.py
+++ b/sale_returned_quantity/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Sale Order Returned Qty",
+    "version": "10.0.1.0.0",
+    "author": "Eficent,"
+              "Odoo Community Association (OCA)",
+    "website": "https://odoo-community.org/",
+    "category": "Sales Management",
+    "license": "AGPL-3",
+    "depends": [
+        "sale_stock",
+    ],
+    "data": [
+        "views/sale_order_view.xml",
+        "wizards/sale_procurement_wizard_view.xml",
+    ],
+    "installable": True,
+}

--- a/sale_returned_quantity/models/__init__.py
+++ b/sale_returned_quantity/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import sale_order_line

--- a/sale_returned_quantity/models/sale_order_line.py
+++ b/sale_returned_quantity/models/sale_order_line.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+import odoo.addons.decimal_precision as dp
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    returned_qty = fields.Float(
+        string='Returned',
+        digits=dp.get_precision('Product Unit of Measure'),
+        compute='_compute_returned_qty')
+
+    @api.multi
+    def _compute_returned_qty(self):
+        for rec in self:
+            qty = 0.0
+            for move in rec.procurement_ids.mapped('move_ids').filtered(
+                    lambda r: r.state == 'done' and not r.scrapped):
+                if move.location_dest_id.usage == "internal":
+                    if move.origin_returned_move_id:
+                        qty += move.product_uom._compute_quantity(
+                            move.product_uom_qty, rec.product_uom)
+                elif (move.location_dest_id.usage != "customer" and
+                      move.to_refund_so):
+                    qty -= move.product_uom._compute_quantity(
+                        move.product_uom_qty, rec.product_uom)
+            rec.returned_qty = qty
+
+    def _prepare_order_line_procurement(self, group_id=False):
+        res = super(SaleOrderLine, self)._prepare_order_line_procurement(
+            group_id)
+        if self.env.context.get('manual', False):
+            res.update(product_qty=self.env.context.get('qty'))
+            res.update(product_id=self.env.context.get('product'))
+            res.update(product_uom=self.env.context.get('uom'))
+        return res
+
+    @api.multi
+    def _action_procurement_create(self):
+        if self.env.context.get('manual', False):
+            new_procs = self.env['procurement.order']
+            for line in self:
+                vals = line._prepare_order_line_procurement(
+                    group_id=line.procurement_group_id.id)
+                new_proc = self.env["procurement.order"].with_context(
+                    procurement_autorun_defer=True).create(vals)
+                new_proc.message_post_with_view('mail.message_origin_link',
+                    values={'self': new_proc, 'origin': line.order_id},
+                    subtype_id=self.env.ref('mail.mt_note').id)
+                new_procs += new_proc
+            new_procs.run()
+            return new_procs
+        else:
+            return super(SaleOrderLine, self)._action_procurement_create()

--- a/sale_returned_quantity/views/sale_order_view.xml
+++ b/sale_returned_quantity/views/sale_order_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record model="ir.ui.view" id="sale_order_form_view">
+        <field name="name">sale.order.form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <field name="order_line" position="attributes">
+                <attribute name="context">{'default_requested_date':requested_date}</attribute>
+            </field>
+            <xpath expr="//field[@name='order_line']/form//field[@name='qty_delivered']" position="after">
+                <field name="returned_qty" />
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree/field[@name='qty_delivered']" position="after">
+                <field name="returned_qty"/>
+            </xpath>
+        </field>
+    </record>
+    <record id="sale_order_line_ext_tree_view" model="ir.ui.view">
+        <field name="name">sale.order.line.ext.tree</field>
+        <field name="model">sale.order.line</field>
+        <field name="inherit_id" ref="sale.view_order_line_tree" />
+        <field name="arch" type="xml">
+            <field name="qty_delivered" position="after">
+                <field name="returned_qty"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/sale_returned_quantity/wizards/__init__.py
+++ b/sale_returned_quantity/wizards/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from . import sale_procurement_wizard

--- a/sale_returned_quantity/wizards/sale_procurement_wizard.py
+++ b/sale_returned_quantity/wizards/sale_procurement_wizard.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+# © 2017 Eficent Business and IT Consulting Services S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+import time
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError, ValidationError
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT as DT_FORMAT
+import odoo.addons.decimal_precision as dp
+
+
+class SaleProcurementWizard(models.TransientModel):
+    _name = 'sale.procurement.wizard'
+    _description = 'Procure the returned quantity'
+
+    @api.returns('rma.order.line')
+    def _prepare_item(self, line):
+        values = {'product_id': line.product_id.id,
+                  'product_qty': line.product_qty - line.qty_delivered +
+                  line.returned_qty,
+                  'uom_id': line.product_uom.id,
+                  'line_id': line.id,
+                  'order_id': line.order_id and line.order_id.id or False,
+                  'wiz_id': self.env.context['active_id'],
+                  }
+        return values
+
+    @api.model
+    def default_get(self, fields):
+        """Default values for wizard, if there is more than one supplier on
+        lines the supplier field is empty otherwise is the unique line
+        supplier.
+        """
+        context = self._context.copy()
+        res = super(SaleProcurementWizard, self).default_get(fields)
+        sale_obj = self.env['sale.order']
+        sale_ids = self.env.context['active_ids'] or []
+        active_model = self.env.context['active_model']
+
+        if not sale_ids:
+            return res
+        assert active_model == 'sale.order', \
+            'Bad context propagation'
+
+        items = []
+        order = sale_obj.browse(sale_ids)
+        if len(order) > 1:
+            raise ValidationError(
+                _('Only one order at a time'))
+        if order.state not in 'sale':
+            raise UserError(_("The order is not confirmed."))
+        for line in order.order_line:
+            items.append([0, 0, self._prepare_item(line)])
+        res['item_ids'] = items
+        res['order_id'] = order.id
+        context.update({'items_ids': items})
+        return res
+
+    item_ids = fields.One2many(
+        'sale.procurement.wizard.item',
+        'wiz_id', string='Items')
+    order_id = fields.Many2one('sale.order',
+                               readonly=True)
+
+    @api.multi
+    def action_create_picking(self):
+        for item in self.item_ids:
+            item.with_context(
+                manual=True,
+                product=item.product_id.id,
+                qty=item.product_qty,
+                uom=item.uom_id.id).line_id._action_procurement_create()
+
+
+class SaleProcurementWizardItem(models.TransientModel):
+    _name = "sale.procurement.wizard.item"
+    _description = "Lines to procure"
+
+    wiz_id = fields.Many2one(
+        'sale.procurement.wizard',
+        string='Wizard', required=True)
+    line_id = fields.Many2one('sale.order.line',
+                              string='Sale order Line',
+                              readonly=True,
+                              ondelete='cascade')
+    product_id = fields.Many2one('product.product', string='Product')
+    product_qty = fields.Float(
+        string='Pending Qty',
+        digits=dp.get_precision('Product Unit of Measure'))
+    uom_id = fields.Many2one('product.uom', string='Unit of Measure')

--- a/sale_returned_quantity/wizards/sale_procurement_wizard_view.xml
+++ b/sale_returned_quantity/wizards/sale_procurement_wizard_view.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo>
+    <record id="view_sale_procurement" model="ir.ui.view">
+        <field name="name">sale.procure</field>
+        <field name="model">sale.procurement.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Select lines for picking" name="lines">
+                <separator string="Select lines for picking"/>
+                <field name="order_id"/>
+                <field name="item_ids">
+                    <tree string="Sale Lines" editable="bottom" create="false">
+                        <field name="product_id"/>
+                        <field name="product_qty"/>
+                        <field name="uom_id" groups="product.group_uom"/>
+                    </tree>
+                </field>
+                <footer>
+                    <button
+                            string="Confirm"
+                            name="action_create_picking" type="object"
+                            class="oe_highlight"/>
+                    or
+                    <button name="action_cancel"
+                            string="Cancel" class="oe_link" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_sale_procure" model="ir.actions.act_window">
+        <field name="name">Manual Delivery</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">sale.procurement.wizard</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+    </record>
+
+    <record model="ir.values" id="values_action_sale_procure">
+        <field name="model_id" ref="sale.model_sale_order"/>
+        <field name="name">Manual Delivery</field>
+        <field name="key2">client_action_multi</field>
+        <field name="value"
+               eval="'ir.actions.act_window,' + str(ref('action_sale_procure'))" />
+        <field name="key">action</field>
+        <field name="model">sale.order</field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Control the quantity returned in the sale order lines. The purpose is not to use the tool as an RMA but correct mistakes after validating a shipment:

- Show the returning quantity in the sale order lines so the user knows what have been really shipped.
- Allows to manual recreate a procurement in the order. The purpose of this feature is to allow users to correct wrong validated shipments. When that occurs they would be able to return the items and manually procure the products they need.

Pending to include tests
