### PR TITLE
[8.0][IMP] sale_procurement_group_by_line add migration scripts

### DIFF
--- a/sale_procurement_group_by_line/migrations/8.0.1.0.0/openupgrade_analysis.txt
+++ b/sale_procurement_group_by_line/migrations/8.0.1.0.0/openupgrade_analysis.txt
@@ -1,0 +1,6 @@
+done: create procurement groups for every sale_order_line_group. Assign procurements to that group
+
+---Fields in module 'sale_procurement_group_by_line'---
+sale_procurement_group_by_line / sale.order.line          / procurement_group_id (many2one): NEW relation: procurement.group
+sale_procurement_group_by_line / sale.order.line          / picking_group_id (many2one): DEL relation: sale.order.line.group
+---XML records in module 'sale_procurement_group_by_line'---

--- a/sale_procurement_group_by_line/migrations/8.0.1.0.0/openupgrade_analysis_work.txt
+++ b/sale_procurement_group_by_line/migrations/8.0.1.0.0/openupgrade_analysis_work.txt
@@ -1,0 +1,4 @@
+---Fields in module 'sale_procurement_group_by_line'---
+sale_procurement_group_by_line / sale.order.line          / procurement_group_id (many2one): NEW relation: procurement.group
+sale_procurement_group_by_line / sale.order.line          / picking_group_id (many2one): DEL relation: sale.order.line.group
+---XML records in module 'sale_procurement_group_by_line'---

--- a/sale_procurement_group_by_line/migrations/8.0.1.0.0/pre-migration.py
+++ b/sale_procurement_group_by_line/migrations/8.0.1.0.0/pre-migration.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+def find_procurements(env):
+    groups = env['sale.order.line.group'].search([])
+    for group in groups:
+        procurements = env['procurement.order'].search(
+            [('sale_line_id', '=', group.sale_line_id)])
+        if procurements:
+            proc_group = env['procurement.group'].create({
+                             'name': group.name
+            })
+            procurements.write({'group_id': proc_group.id})
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    find_procurements(env)

--- a/sale_sourced_by_line/migrations/8.0.1.1.0/openupgrade_analysis.txt
+++ b/sale_sourced_by_line/migrations/8.0.1.1.0/openupgrade_analysis.txt
@@ -1,0 +1,5 @@
+---Fields in module 'sale_sourced_by_line'---
+sale_sourced_by_line / sale.order.line          / warehouse_id (many2one)       : NEW relation: stock.warehouse
+---XML records in module 'sale_sourced_by_line'---
+NEW ir.ui.view: sale_sourced_by_line.view_order_form
+NEW ir.ui.view: sale_sourced_by_line.view_order_form_form

--- a/sale_sourced_by_line/migrations/8.0.1.1.0/openupgrade_analysis_work.txt
+++ b/sale_sourced_by_line/migrations/8.0.1.1.0/openupgrade_analysis_work.txt
@@ -1,0 +1,10 @@
+# done: assign warehouse from sale_order
+
+---Fields in module 'sale_sourced_by_line'---
+sale_sourced_by_line / sale.order.line          / warehouse_id (many2one)       : NEW relation: stock.warehouse
+
+# nothing to do
+
+---XML records in module 'sale_sourced_by_line'---
+NEW ir.ui.view: sale_sourced_by_line.view_order_form
+NEW ir.ui.view: sale_sourced_by_line.view_order_form_form

--- a/sale_sourced_by_line/migrations/8.0.1.1.0/post-migration.py
+++ b/sale_sourced_by_line/migrations/8.0.1.1.0/post-migration.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+def assign_warehouse(env):
+    sales = env['sale.order'].search([])
+    for so in sales:
+        so.order_line.write({'warehouse_id': so.warehouse_id.id})
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    assign_warehouse(env)


### PR DESCRIPTION
Migration scripts. Create procurement groups for every sale_order_line_group. Assign procurements to that group.