### PR TITLE
[8.0][FIX] sale_order_weight: Fix template error

### DIFF
--- a/sale_order_weight/views/sale_report.xml
+++ b/sale_order_weight/views/sale_report.xml
@@ -15,7 +15,7 @@
             <xpath expr="//table[@class='table table-condensed']/tbody/tr/td[3]"
                    position="after">
                 <td class="text-right">
-                    <span t-field="l.product_id and (l.product_id.weight*l.product_uom_qty) or 0.0"/>
+                    <span t-esc="l.product_id and (l.product_id.weight*l.product_uom_qty) or 0.0"/>
                 </td>
             </xpath>
             <xpath expr="//p[@t-field='o.note']"


### PR DESCRIPTION
Hello,

There is a small bug in the template that causes the report printing to fail.

The problem is that _t-field_ directive can only be used for field access, so in this case, where we have a calculated value, _t-esc_ is needed.

Regards