### PR TITLE
[FIX] sale_order_invoicing_finished_task: Add missing dependency

### DIFF
--- a/sale_order_invoicing_finished_task/models/sale_order.py
+++ b/sale_order_invoicing_finished_task/models/sale_order.py
@@ -13,8 +13,7 @@ class SaleOrder(models.Model):
                  'order_line.task_ids.invoiceable')
     def _get_invoiced(self):
         super(SaleOrder, self)._get_invoiced()
-        for order in self.filtered(lambda o: (
-                o.invoice_status != 'no' and o.picking_policy == 'one')):
+        for order in self.filtered(lambda o: o.invoice_status != 'no'):
             if not all(t.invoiceable for t in order.mapped(
                     'order_line.task_ids') if t.invoicing_finished_task):
                 order.update({


### PR DESCRIPTION
Currently, this addon uses `sale.order`'s `picking_policy` field, but that field is defined in `sale_stock`, which isn't included in the dependency tree.

Testing the addon, thus, can produce this error:

    ERROR: test_check_qty_to_invoice (odoo.addons.sale_order_invoicing_finished_task.tests.test_sale_order_invoicing_finished_task.TestInvoicefinishedTask)
    Traceback (most recent call last):
    `   File "/opt/odoo/auto/addons/sale_order_invoicing_finished_task/tests/test_sale_order_invoicing_finished_task.py", line 140, in test_check_qty_to_invoice
    `     self.sale_order.action_confirm()
    `   File "/opt/odoo/auto/addons/sale_timesheet/models/sale_order.py", line 60, in action_confirm
    `     result = super(SaleOrder, self).action_confirm()
    `   File "/opt/odoo/auto/addons/portal_sale/models/sale_order.py", line 16, in action_confirm
    `     return super(SaleOrder, self).action_confirm()
    `   File "/opt/odoo/auto/addons/sale/models/sale.py", line 462, in action_confirm
    `     order.state = 'sale'
    `   File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 954, in __set__
    `     record.write({self.name: write_value})
    `   File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 274, in write
    `     result = super(MailThread, self).write(values)
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3567, in write
    `     self._write(old_vals)
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3793, in _write
    `     self.recompute()
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5340, in recompute
    `     vals = rec._convert_to_write({n: rec[n] for n in ns})
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5340, in <dictcomp>
    `     vals = rec._convert_to_write({n: rec[n] for n in ns})
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5236, in __getitem__
    `     return self._fields[key].__get__(self, type(self))
    `   File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 915, in __get__
    `     self.determine_value(record)
    `   File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1001, in determine_value
    `     self.compute_value(recs)
    `   File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 981, in compute_value
    `     self._compute_value(records)
    `   File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 972, in _compute_value
    `     getattr(records, self.compute)()
    `   File "/opt/odoo/auto/addons/sale_order_invoicing_finished_task/models/sale_order.py", line 16, in _get_invoiced
    `     for order in self.filtered(lambda o: (
    `   File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5019, in filtered
    `     return self.browse([rec.id for rec in self if func(rec)])
    `   File "/opt/odoo/auto/addons/sale_order_invoicing_finished_task/models/sale_order.py", line 17, in <lambda>
    `     o.invoice_status != 'no' and o.picking_policy == 'one')):
    ` AttributeError: 'sale.order' object has no attribute 'picking_policy'

I simply added the dependency.