### PR TITLE
11.0 fix sale order product recommendation

### DIFF
--- a/sale_order_product_recommendation/__manifest__.py
+++ b/sale_order_product_recommendation/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Sale Order Product Recommendation",
     "summary": "Recommend products to sell to customer based on history",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "category": "Sales",
     "website": "https://github.com/OCA/sale-workflow",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/sale_order_product_recommendation/views/sale_order_view.xml
+++ b/sale_order_product_recommendation/views/sale_order_view.xml
@@ -12,7 +12,7 @@
             <header>
                 <button
                     name="%(sale_order_recommendation_action)d"
-                    states="draft,sent"
+                    states="draft,sent,sale"
                     string="Recommended Products"
                     type="action"/>
             </header>

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -163,7 +163,6 @@ class SaleOrderRecommendationLine(models.TransientModel):
     product_id = fields.Many2one(
         "product.product",
         string="Product",
-        readonly=True,
     )
     price_unit = fields.Monetary(
         compute="_compute_price_unit",

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
@@ -22,7 +22,7 @@
                                 <field name="currency_id" invisible="1"/>
                                 <field name="sale_line_id" invisible="1"/>
                                 <field name="is_modified" invisible="1"/>
-                                <field name="product_id"/>
+                                <field name="product_id" readonly="1"/>
                                 <field name="price_unit"/>
                                 <field name="times_delivered"/>
                                 <field name="units_delivered"/>


### PR DESCRIPTION
This PR includes two commits:

- A fix for the wizard that was failing to load lines from the recommendations that weren't loaded from the SO itself.
- An improvement to be able to use the wizard even if the SO is confirmed (the same restrictions that
exist editing the order manually apply)

cc @Tecnativa