### PR TITLE
[11.0] [ADD] sale_forecast

### DIFF
--- a/sale_forecast/README.rst
+++ b/sale_forecast/README.rst
@@ -1,0 +1,32 @@
+==============
+Sale Forecast
+==============
+
+Based on `procurement_sale_forecast <https://github.com/odoomrp/odoomrp-wip/tree/8.0/procurement_sale_forecast>`_.
+
+This module allows you to create a sale forecast.
+
+* Possibility to load sale order lines or a sale forecast previously created.
+* Allows you to group forecast lines by product, partner, date, category and forecast.
+* There's a pivot view where you can see the real quantity and the forecasted quantity.
+
+Usage
+=====
+
+Sales -> Sale Forecast
+
+Contributors
+============
+* Carlos Martínez <carlos@domatix.com>
+* Nacho Serra <nacho.serra@domatix.com>
+* Nacho HM <nacho@domatix.com>
+* Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
+* Ainara Galdona <ainaragaldona@avanzosc.es>
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Daniel Campos <danielcampos@avanzosc.es>
+
+
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3

--- a/sale_forecast/README.rst
+++ b/sale_forecast/README.rst
@@ -1,0 +1,32 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: https://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==============
+Sale Forecast
+==============
+
+Based on `procurement_sale_forecast <https://github.com/odoomrp/odoomrp-wip/tree/8.0/procurement_sale_forecast>`_.
+
+This module allows you to create a sale forecast.
+
+* Possibility to load sale order lines or a sale forecast previously created.
+* Allows you to group forecast lines by product, partner, date, category and forecast.
+* There's a pivot view where you can see the real quantity and the forecasted quantity.
+
+Usage
+=====
+
+Sales -> Sale Forecast
+
+Contributors
+------------
+
+* Carlos Martínez <carlos@domatix.com>
+* Nacho Serra <nacho.serra@domatix.com>
+* Nacho HM <nacho@domatix.com>
+* Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
+* Ainara Galdona <ainaragaldona@avanzosc.es>
+* Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>
+* Ana Juaristi <anajuaristi@avanzosc.es>
+* Daniel Campos <danielcampos@avanzosc.es>

--- a/sale_forecast/__init__.py
+++ b/sale_forecast/__init__.py
@@ -1,0 +1,4 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models
+from . import wizard

--- a/sale_forecast/__manifest__.py
+++ b/sale_forecast/__manifest__.py
@@ -11,17 +11,17 @@
     "contributors": [
         "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
         "Ainara Galdona <ainaragaldona@avanzosc.es>",
-        "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
+        "Pedro M. Baeza <pedro.baeza@tecnativa.com>",
         "Ana Juaristi <anajuaristi@avanzosc.es>",
         "Daniel Campos <danielcampos@avanzosc.es>",
     ],
     "depends": [
-        "product",
-        "sale_stock",
+        "base",
     ],
-    "data": ["security/ir.model.access.csv",
-             "wizard/sale_forecast_load_view.xml",
-             "views/sale_view.xml",
-             ],
+    "data": [
+        "security/ir.model.access.csv",
+        "wizard/sale_forecast_load_view.xml",
+        "views/sale_view.xml",
+    ],
     "installable": True,
 }

--- a/sale_forecast/__manifest__.py
+++ b/sale_forecast/__manifest__.py
@@ -1,0 +1,30 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Sale Forecast",
+    "summary": "Sale forecast, based on procurement_sale_forecast",
+    "version": "11.0.1.0.0",
+    "author": "Domatix",
+    "license": "AGPL-3",
+    "category": "Sales",
+    "website": "http://www.domatix.com",
+    "contributors": [
+        "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
+        "Ainara Galdona <ainaragaldona@avanzosc.es>",
+        "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Daniel Campos <danielcampos@avanzosc.es>",
+    ],
+    "depends": [
+        "base",
+        "product",
+        "sale",
+        "stock",
+        "sale_stock",
+    ],
+    "data": ["security/ir.model.access.csv",
+             "wizard/sale_forecast_load_view.xml",
+             "views/sale_view.xml",
+             ],
+    "installable": True,
+}

--- a/sale_forecast/__manifest__.py
+++ b/sale_forecast/__manifest__.py
@@ -1,0 +1,27 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Sale Forecast",
+    "summary": "Sale forecast, based on procurement_sale_forecast",
+    "version": "11.0.1.0.0",
+    "author": "Domatix,Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "category": "Sales",
+    "website": "https://github.com/OCA/sale-workflow",
+    "contributors": [
+        "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
+        "Ainara Galdona <ainaragaldona@avanzosc.es>",
+        "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+        "Daniel Campos <danielcampos@avanzosc.es>",
+    ],
+    "depends": [
+        "product",
+        "sale_stock",
+    ],
+    "data": ["security/ir.model.access.csv",
+             "wizard/sale_forecast_load_view.xml",
+             "views/sale_view.xml",
+             ],
+    "installable": True,
+}

--- a/sale_forecast/i18n/es.po
+++ b/sale_forecast/i18n/es.po
@@ -1,0 +1,351 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_forecast
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-09-05 10:58+0000\n"
+"PO-Revision-Date: 2018-09-05 10:58+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_actual_qty
+msgid "Actual Qty"
+msgstr "Cantidad real"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.load_self_sale_forecast_wizard
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_load_form_view
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load_product_categ_id
+msgid "Category"
+msgstr "Categoría"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_commercial_id
+msgid "Commercial"
+msgstr "Comercial"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.load_self_sale_forecast_wizard
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_create_uid
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_create_uid
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load_create_uid
+#: model:ir.model.fields,field_description:sale_forecast.field_self_sale_forecast_load_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_create_date
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_create_date
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load_create_date
+#: model:ir.model.fields,field_description:sale_forecast.field_self_sale_forecast_load_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_currency_id
+msgid "Currency"
+msgstr "Moneda"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_date
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_search_view
+msgid "Date"
+msgstr "Fecha"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_date_from
+msgid "Date From"
+msgstr "Fecha desde"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_date_to
+msgid "Date To"
+msgstr "Fecha hasta"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_date_from
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load_date_from
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_search_view
+msgid "Date from"
+msgstr "Fecha desde"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_date_to
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load_date_to
+msgid "Date to"
+msgstr "Fecha hasta"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_display_name
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_display_name
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load_display_name
+#: model:ir.model.fields,field_description:sale_forecast.field_self_sale_forecast_load_display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load_factor
+msgid "Factor"
+msgstr "Factor"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_forecast_id
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load_forecast_id
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_search_view
+msgid "Forecast"
+msgstr "Previsión"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_forecast_lines
+msgid "Forecast Lines"
+msgstr "Líneas de Previsión"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_search_view
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_search_view
+msgid "Group By"
+msgstr "Agrupar por"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_id
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_id
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load_id
+#: model:ir.model.fields,field_description:sale_forecast.field_self_sale_forecast_load_id
+msgid "ID"
+msgstr "ID"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast___last_update
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line___last_update
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load___last_update
+#: model:ir.model.fields,field_description:sale_forecast.field_self_sale_forecast_load___last_update
+msgid "Last Modified on"
+msgstr "Última Modificación en"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_write_uid
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load_write_uid
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_write_uid
+#: model:ir.model.fields,field_description:sale_forecast.field_self_sale_forecast_load_write_uid
+msgid "Last Updated by"
+msgstr "Última Actualización por"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_write_date
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load_write_date
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_write_date
+#: model:ir.model.fields,field_description:sale_forecast.field_self_sale_forecast_load_write_date
+msgid "Last Updated on"
+msgstr "Última Actualización el"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_form_view
+msgid "Lines"
+msgstr "Ventas"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_load_form_view
+msgid "Load"
+msgstr "Cargar"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_form_view
+msgid "Load Sale Forecast"
+msgstr "Cargar previsión de venta"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_form_view
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_load_form_view
+msgid "Load Sales"
+msgstr "Cargar Ventas"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.load_self_sale_forecast_wizard
+msgid "Load from sale forecast"
+msgstr "Cargar previsión de venta"
+
+#. module: sale_forecast
+#: model:ir.actions.act_window,name:sale_forecast.action_load_sale_forecast_act_window
+msgid "Load sale forecast"
+msgstr "Cargar previsión de venta"
+
+#. module: sale_forecast
+#: model:ir.model,name:sale_forecast.model_self_sale_forecast_load
+msgid "Load sale forecast from existing sale forecast"
+msgstr "Cargar previsión de venta"
+
+#. module: sale_forecast
+#: model:ir.actions.act_window,name:sale_forecast.action_sale_forecast_load_view
+msgid "Load sales"
+msgstr "Cargar ventas"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_name
+msgid "Name"
+msgstr "Nombre"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_form_view
+msgid "Nombre"
+msgstr "Nombre"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_partner_id
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load_partner_id
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_search_view
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_search_view
+msgid "Partner"
+msgstr "Cliente"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.view_sale_forecast_line_pivot
+msgid "Pivot view"
+msgstr "Pivot view"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_product_id
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load_product_id
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_search_view
+msgid "Product"
+msgstr "Producto"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_product_category_id
+msgid "Product Category"
+msgstr "Categoría de producto"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_search_view
+msgid "Product category"
+msgstr "Categoría de producto"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_qty
+msgid "Quantity"
+msgstr "Cantidad Prevista"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_form_view
+msgid "Recalculate actual qty"
+msgstr "Recalcular cantidad real"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load_sale_id
+msgid "Sale"
+msgstr "Venta"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_self_sale_forecast_load_forecast_id
+#: model:ir.model.fields,field_description:sale_forecast.field_self_sale_forecast_load_forecast_sales
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_form_view
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_tree_view
+msgid "Sale Forecast"
+msgstr "Previsión de venta"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_form_view
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_tree_editable_view
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_tree_view
+msgid "Sale Forecast Line"
+msgstr "Línea de previsión de venta"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_search_view
+msgid "Sale Forecast Line Search"
+msgstr "Búsqueda de línea de previsión de venta"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_search_view
+msgid "Sale Forecast Search"
+msgstr "Búsqueda de previsión"
+
+#. module: sale_forecast
+#: model:ir.actions.act_window,name:sale_forecast.action_view_stock_sale_forecast_form
+msgid "Sales Forecast"
+msgstr "Previsión de ventas"
+
+#. module: sale_forecast
+#: model:ir.actions.act_window,name:sale_forecast.action_view_stock_sale_forecast_line_form
+#: model:ir.ui.menu,name:sale_forecast.menu_stock_sale_forecast_lines
+msgid "Sales Forecast Lines"
+msgstr "Líneas de previsión de ventas"
+
+#. module: sale_forecast
+#: model:ir.ui.menu,name:sale_forecast.menu_stock_sale_forecast
+#: model:ir.ui.menu,name:sale_forecast.menu_stock_sale_forecast_all
+msgid "Sales Forecasts"
+msgstr "Previsiones de ventas"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_subtotal
+msgid "Subtotal"
+msgstr "Subtotal"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_load_product_tmpl_id
+msgid "Template"
+msgstr "Plantilla"
+
+#. module: sale_forecast
+#: model:ir.model.fields,help:sale_forecast.field_sale_forecast_line_commercial_id
+msgid "The internal user that is in charge of communicating with this contact if any."
+msgstr "El usuario interno encargado de comunicarse con este contacto si lo hubiese."
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_tree_editable_view
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_tree_view
+msgid "Total"
+msgstr "Total"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_tree_editable_view
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_tree_view
+msgid "Total Actual Qty"
+msgstr "Cantidad total real"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_tree_editable_view
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_line_tree_view
+msgid "Total Qty"
+msgstr "Cantidad total"
+
+#. module: sale_forecast
+#: model:ir.model.fields,field_description:sale_forecast.field_sale_forecast_line_unit_price
+msgid "Unit Price"
+msgstr "Precio unitario"
+
+#. module: sale_forecast
+#: model:ir.ui.view,arch_db:sale_forecast.sale_forecast_load_form_view
+msgid "or"
+msgstr "o"
+
+#. module: sale_forecast
+#: model:ir.model,name:sale_forecast.model_sale_forecast
+msgid "sale.forecast"
+msgstr "sale.forecast"
+
+#. module: sale_forecast
+#: model:ir.model,name:sale_forecast.model_sale_forecast_line
+msgid "sale.forecast.line"
+msgstr "sale.forecast.line"
+
+#. module: sale_forecast
+#: model:ir.model,name:sale_forecast.model_sale_forecast_load
+msgid "sale.forecast.load"
+msgstr "Carga de ventas en prevision"

--- a/sale_forecast/models/__init__.py
+++ b/sale_forecast/models/__init__.py
@@ -1,0 +1,3 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import sale

--- a/sale_forecast/models/sale.py
+++ b/sale_forecast/models/sale.py
@@ -1,0 +1,144 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, exceptions, fields, models, _
+import odoo.addons.decimal_precision as dp
+
+
+class SaleForecast(models.Model):
+    _name = 'sale.forecast'
+
+    name = fields.Char(string='Name', required=True)
+    date_from = fields.Date(string='Date From', required=True)
+    date_to = fields.Date(string='Date To', required=True)
+    forecast_lines = fields.One2many('sale.forecast.line',
+                                     'forecast_id', string="Forecast Lines")
+
+    @api.constrains('date_from', 'date_to')
+    def check_dates(self):
+        if self.date_from >= self.date_to:
+            raise exceptions.ValidationError(_('Error! Date to must be lower '
+                                             'than date from.'))
+
+    @api.multi
+    def recalculate_actual_qty(self):
+        sale_obj = self.env['sale.order.line']
+        prod_obj = self.env['product.product']
+        for record in self.forecast_lines:
+            if record.product_id:
+                if record.partner_id:
+                    sale_ids = sale_obj.search([
+                        ('product_id', '=', record.product_id.id),
+                        ('order_id.partner_id', '=', record.partner_id.id),
+                        ('invoice_status', '=', 'invoiced'),
+                        ('order_id.confirmation_date', '>=', record.date_from),
+                        ('order_id.confirmation_date', '<=', record.date_to)])
+                else:
+                    sale_ids = sale_obj.search([
+                        ('product_id', '=', record.product_id.id),
+                        ('invoice_status', '=', 'invoiced'),
+                        ('order_id.confirmation_date', '>=', record.date_from),
+                        ('order_id.confirmation_date', '<=', record.date_to)])
+                record.actual_qty = sum(sale_ids.mapped('product_uom_qty'))
+
+            elif record.product_category_id:
+                product_ids = prod_obj.search([
+                    ('categ_id', '=', record.product_category_id.id)])
+                if record.partner_id:
+                    sale_ids = sale_obj.search([
+                        ('product_id', 'in', product_ids.ids),
+                        ('order_id.partner_id', '=', record.partner_id.id),
+                        ('invoice_status', '=', 'invoiced'),
+                        ('order_id.confirmation_date', '>=', record.date_from),
+                        ('order_id.confirmation_date', '<=', record.date_to)])
+                else:
+                    sale_ids = sale_obj.search([
+                        ('product_id', 'in', product_ids.ids),
+                        ('invoice_status', '=', 'invoiced'),
+                        ('order_id.confirmation_date', '>=', record.date_from),
+                        ('order_id.confirmation_date', '<=', record.date_to)])
+                record.actual_qty = sum(sale_ids.mapped('product_uom_qty'))
+
+
+class SaleForecastLine(models.Model):
+
+    _name = 'sale.forecast.line'
+    _order = 'forecast_id,product_id,qty,partner_id'
+
+    @api.depends('unit_price', 'qty')
+    def _get_subtotal(self):
+        for record in self:
+            record.subtotal = record.unit_price * record.qty
+
+    @api.onchange('product_id')
+    def onchange_product(self):
+        if self.product_id:
+            self.unit_price = self.product_id.list_price
+
+    product_id = fields.Many2one('product.product', string='Product')
+    product_category_id = fields.Many2one('product.category',
+                                          string='Product Category')
+    qty = fields.Float('Quantity', default=1,
+                       digits=dp.get_precision('Product Unit of Measure'))
+    unit_price = fields.Float('Unit Price',
+                              digits=dp.get_precision('Product Price'))
+    subtotal = fields.Float('Subtotal', compute=_get_subtotal, store=True,
+                            digits=dp.get_precision('Product Price'))
+    partner_id = fields.Many2one("res.partner", string="Partner")
+    commercial_id = fields.Many2one(comodel_name="res.users",
+                                    related="partner_id.user_id",
+                                    string="Commercial")
+    currency_id = fields.Many2one(
+        comodel_name="res.currency", string="Currency",
+        related="partner_id.property_product_pricelist.currency_id")
+    date_from = fields.Date(string="Date from", store=True,
+                            related="forecast_id.date_from")
+    date_to = fields.Date(string="Date to", related="forecast_id.date_to",
+                          store=True)
+    forecast_id = fields.Many2one('sale.forecast',
+                                  string='Forecast',
+                                  ondelete='cascade')
+    date = fields.Date("Date")
+
+    actual_qty = fields.Float(
+        string='Actual Qty',
+        compute='_compute_actual_qty',
+        store=True)
+
+    @api.depends('forecast_id.forecast_lines')
+    def _compute_actual_qty(self):
+        sale_obj = self.env['sale.order.line']
+        prod_obj = self.env['product.product']
+        for record in self:
+            if record.product_id:
+                if record.partner_id:
+                    sale_ids = sale_obj.search([
+                        ('product_id', '=', record.product_id.id),
+                        ('order_id.partner_id', '=', record.partner_id.id),
+                        ('invoice_status', '=', 'invoiced'),
+                        ('order_id.confirmation_date', '>=', record.date_from),
+                        ('order_id.confirmation_date', '<=', record.date_to)])
+                else:
+                    sale_ids = sale_obj.search([
+                        ('product_id', '=', record.product_id.id),
+                        ('invoice_status', '=', 'invoiced'),
+                        ('order_id.confirmation_date', '>=', record.date_from),
+                        ('order_id.confirmation_date', '<=', record.date_to)])
+                record.actual_qty = sum(sale_ids.mapped('product_uom_qty'))
+
+            elif record.product_category_id:
+                product_ids = prod_obj.search([
+                    ('categ_id', '=', record.product_category_id.id)])
+                if record.partner_id:
+                    sale_ids = sale_obj.search([
+                        ('product_id', 'in', product_ids.ids),
+                        ('order_id.partner_id', '=', record.partner_id.id),
+                        ('invoice_status', '=', 'invoiced'),
+                        ('order_id.confirmation_date', '>=', record.date_from),
+                        ('order_id.confirmation_date', '<=', record.date_to)])
+                else:
+                    sale_ids = sale_obj.search([
+                        ('product_id', 'in', product_ids.ids),
+                        ('invoice_status', '=', 'invoiced'),
+                        ('order_id.confirmation_date', '>=', record.date_from),
+                        ('order_id.confirmation_date', '<=', record.date_to)])
+                record.actual_qty = sum(sale_ids.mapped('product_uom_qty'))

--- a/sale_forecast/models/sale.py
+++ b/sale_forecast/models/sale.py
@@ -1,0 +1,101 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, exceptions, fields, models, _
+import odoo.addons.decimal_precision as dp
+
+
+class SaleForecast(models.Model):
+    _name = 'sale.forecast'
+
+    name = fields.Char(string='Name', required=True)
+    date_from = fields.Date(string='Date From', required=True)
+    date_to = fields.Date(string='Date To', required=True)
+    forecast_lines = fields.One2many('sale.forecast.line',
+                                     'forecast_id', string="Forecast Lines")
+
+    @api.constrains('date_from', 'date_to')
+    def check_dates(self):
+        if self.date_from >= self.date_to:
+            raise exceptions.ValidationError(_('Error! Date to must be lower '
+                                             'than date from.'))
+
+    @api.multi
+    def recalculate_actual_qty(self):
+        for record in self.forecast_lines:
+            record._compute_actual_qty()
+
+
+class SaleForecastLine(models.Model):
+
+    _name = 'sale.forecast.line'
+    _order = 'forecast_id,product_id,qty,partner_id'
+
+    @api.multi
+    @api.depends('unit_price', 'qty')
+    def _get_subtotal(self):
+        for record in self:
+            record.subtotal = record.unit_price * record.qty
+
+    @api.onchange('product_id')
+    def onchange_product(self):
+        if self.product_id:
+            self.unit_price = self.product_id.list_price
+
+    product_id = fields.Many2one('product.product', string='Product')
+    product_category_id = fields.Many2one('product.category',
+                                          string='Product Category')
+    qty = fields.Float('Quantity', default=1,
+                       digits=dp.get_precision('Product Unit of Measure'))
+    unit_price = fields.Float('Unit Price',
+                              digits=dp.get_precision('Product Price'))
+    subtotal = fields.Float('Subtotal', compute=_get_subtotal, store=True,
+                            digits=dp.get_precision('Product Price'))
+    partner_id = fields.Many2one("res.partner", string="Partner")
+    commercial_id = fields.Many2one(comodel_name="res.users",
+                                    related="partner_id.user_id",
+                                    string="Commercial")
+    currency_id = fields.Many2one(
+        comodel_name="res.currency", string="Currency",
+        related="partner_id.property_product_pricelist.currency_id")
+    date_from = fields.Date(string="Date from", store=True,
+                            related="forecast_id.date_from")
+    date_to = fields.Date(string="Date to", related="forecast_id.date_to",
+                          store=True)
+    forecast_id = fields.Many2one('sale.forecast',
+                                  string='Forecast',
+                                  ondelete='cascade')
+    date = fields.Date("Date")
+
+    actual_qty = fields.Float(
+        string='Actual Qty',
+        compute='_compute_actual_qty',
+        store=True)
+
+    @api.multi
+    @api.depends('forecast_id.forecast_lines')
+    def _compute_actual_qty(self):
+        sale_obj = self.env['sale.order.line']
+        prod_obj = self.env['product.product']
+        for record in self:
+            domain = [
+                ('invoice_status', '=', 'invoiced'),
+                ('order_id.confirmation_date', '>=', record.date_from),
+                ('order_id.confirmation_date', '<=', record.date_to)
+            ]
+            if record.product_id:
+                domain += [('product_id', '=', record.product_id.id)]
+                if record.partner_id:
+                    domain += [
+                        ('order_id.partner_id', '=', record.partner_id.id)]
+                sale_ids = sale_obj.search(domain)
+                record.actual_qty = sum(sale_ids.mapped('product_uom_qty'))
+
+            elif record.product_category_id:
+                product_ids = prod_obj.search([
+                    ('categ_id', '=', record.product_category_id.id)])
+                domain += [('product_id', 'in', product_ids.ids)]
+                if record.partner_id:
+                    domain += [
+                        ('order_id.partner_id', '=', record.partner_id.id)]
+                sale_ids = sale_obj.search(domain)
+                record.actual_qty = sum(sale_ids.mapped('product_uom_qty'))

--- a/sale_forecast/models/sale.py
+++ b/sale_forecast/models/sale.py
@@ -32,7 +32,7 @@ class SaleForecastLine(models.Model):
 
     @api.multi
     @api.depends('unit_price', 'qty')
-    def _get_subtotal(self):
+    def _compute_subtotal(self):
         for record in self:
             record.subtotal = record.unit_price * record.qty
 
@@ -48,7 +48,7 @@ class SaleForecastLine(models.Model):
                        digits=dp.get_precision('Product Unit of Measure'))
     unit_price = fields.Float('Unit Price',
                               digits=dp.get_precision('Product Price'))
-    subtotal = fields.Float('Subtotal', compute=_get_subtotal, store=True,
+    subtotal = fields.Float('Subtotal', compute=_compute_subtotal, store=True,
                             digits=dp.get_precision('Product Price'))
     partner_id = fields.Many2one("res.partner", string="Partner")
     commercial_id = fields.Many2one(comodel_name="res.users",

--- a/sale_forecast/security/ir.model.access.csv
+++ b/sale_forecast/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sale_forecast,sale.forecast.user,model_sale_forecast,base.group_user,1,0,0,0
+access_sale_forecast_sale_manager,sale.forecast.manager,model_sale_forecast,sales_team.group_sale_manager,1,1,1,1
+access_sale_forecast_line,sale.forecast.line.user,model_sale_forecast_line,base.group_user,1,0,0,0
+access_sale_forecast_sale_line_manager,sale.forecast.line.manager,model_sale_forecast_line,sales_team.group_sale_manager,1,1,1,1

--- a/sale_forecast/tests/__init__.py
+++ b/sale_forecast/tests/__init__.py
@@ -1,0 +1,3 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import test_sale_forecast

--- a/sale_forecast/tests/test_sale_forecast.py
+++ b/sale_forecast/tests/test_sale_forecast.py
@@ -15,6 +15,7 @@ class TestSaleForecastFlow(common.TransactionCase):
         self.so_model = self.env['sale.order']
         self.sf_model = self.env['sale.forecast']
         self.sf_line_model = self.env['sale.forecast.line']
+        self.sf_load_model = self.env['sale.forecast.load']
         self.po_line_model = self.env['sale.order.line']
         self.res_partner_model = self.env['res.partner']
         self.product_tmpl_model = self.env['product.template']
@@ -55,9 +56,10 @@ class TestSaleForecastFlow(common.TransactionCase):
 
     def test_sale_forecast_load_sales(self):
         """ Test sale forecast flow."""
-        uom_id = self.product_uom_model.search([('name', '=', 'Unit(s)')])[0]
+        uom_id = self.product_uom_model.search([
+            ('name', '=', 'Unit(s)')], limit=1)
         pricelist = self.pricelist_model.search([
-            ('name', '=', 'Public Pricelist')])[0]
+            ('name', '=', 'Public Pricelist')], limit=1)
 
         so_vals = {
             'partner_id': self.partner_agrolite.id,
@@ -140,7 +142,7 @@ class TestSaleForecastFlow(common.TransactionCase):
             "active_id": sf.id
             }
 
-        load_sales_wizard = self.env['sale.forecast.load'].with_context(
+        load_sales_wizard = self.sf_load_model.with_context(
             context).create(
             {
                 'factor': 3,
@@ -158,7 +160,7 @@ class TestSaleForecastFlow(common.TransactionCase):
             30,
             'Lines are not grouped proper.')
 
-        load_sales_wizard_partner = self.env['sale.forecast.load'].\
+        load_sales_wizard_partner = self.sf_load_model.\
             with_context(context).create(
                 {
                     'factor': 3,

--- a/sale_forecast/tests/test_sale_forecast.py
+++ b/sale_forecast/tests/test_sale_forecast.py
@@ -28,12 +28,12 @@ class TestSaleForecastFlow(common.TransactionCase):
         self.categ_id = self.categ_model.create({
             'name': 'Sale Forecast'
         })
-        self.productsf = self.env['product.product'].create({
+        self.productsf = self.product_model.create({
             'name': 'Product Sale Forecast',
             'type': 'product',
             'categ_id': self.categ_id.id,
         })
-        self.productsf2 = self.env['product.product'].create({
+        self.productsf2 = self.product_model.create({
             'name': 'Product Sale Forecast2',
             'type': 'product',
             'categ_id': self.categ_id.id,
@@ -42,12 +42,12 @@ class TestSaleForecastFlow(common.TransactionCase):
         self.categ_id2 = self.categ_model.create({
             'name': 'Sale Forecast 2'
         })
-        self.productsf3 = self.env['product.product'].create({
+        self.productsf3 = self.product_model.create({
             'name': 'Product Sale Forecast',
             'type': 'product',
             'categ_id': self.categ_id2.id,
         })
-        self.productsf4 = self.env['product.product'].create({
+        self.productsf4 = self.product_model.create({
             'name': 'Product Sale Forecast2',
             'type': 'product',
             'categ_id': self.categ_id2.id,
@@ -115,7 +115,6 @@ class TestSaleForecastFlow(common.TransactionCase):
             'name': 'Test 1',
             'date_from': date.today() + relativedelta(years=2),
             'date_to': date.today() + relativedelta(years=1),
-
         }
         with self.assertRaises(ValidationError):
             self.sf_model.create(sf_vals)
@@ -123,7 +122,6 @@ class TestSaleForecastFlow(common.TransactionCase):
             'name': 'Test 1',
             'date_from': date.today() + relativedelta(years=1),
             'date_to': date.today() + relativedelta(years=2),
-
         }
         self.sf_model.create(sf_vals)
 

--- a/sale_forecast/tests/test_sale_forecast.py
+++ b/sale_forecast/tests/test_sale_forecast.py
@@ -1,0 +1,318 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from datetime import date
+from dateutil.relativedelta import relativedelta
+from odoo.exceptions import ValidationError
+from odoo.tests import common
+
+
+class TestSaleForecastFlow(common.TransactionCase):
+
+    def setUp(self):
+        super(TestSaleForecastFlow, self).setUp()
+        # Useful models
+
+        self.so_model = self.env['sale.order']
+        self.sf_model = self.env['sale.forecast']
+        self.sf_line_model = self.env['sale.forecast.line']
+        self.po_line_model = self.env['sale.order.line']
+        self.res_partner_model = self.env['res.partner']
+        self.product_tmpl_model = self.env['product.template']
+        self.product_model = self.env['product.product']
+        self.product_uom_model = self.env['product.uom']
+        self.categ_model = self.env['product.category']
+        self.supplierinfo_model = self.env["product.supplierinfo"]
+        self.pricelist_model = self.env['product.pricelist']
+        self.partner = self.env.ref('base.res_partner_1')
+        self.partner_agrolite = self.env.ref('base.res_partner_2')
+        self.categ_id = self.categ_model.create({
+            'name': 'Sale Forecast'
+        })
+        self.productsf = self.env['product.product'].create({
+            'name': 'Product Sale Forecast',
+            'type': 'product',
+            'categ_id': self.categ_id.id,
+        })
+        self.productsf2 = self.env['product.product'].create({
+            'name': 'Product Sale Forecast2',
+            'type': 'product',
+            'categ_id': self.categ_id.id,
+        })
+
+        self.categ_id2 = self.categ_model.create({
+            'name': 'Sale Forecast 2'
+        })
+        self.productsf3 = self.env['product.product'].create({
+            'name': 'Product Sale Forecast',
+            'type': 'product',
+            'categ_id': self.categ_id2.id,
+        })
+        self.productsf4 = self.env['product.product'].create({
+            'name': 'Product Sale Forecast2',
+            'type': 'product',
+            'categ_id': self.categ_id2.id,
+        })
+
+    def test_sale_forecast_load_sales(self):
+        """ Test sale forecast flow."""
+        uom_id = self.product_uom_model.search([('name', '=', 'Unit(s)')])[0]
+        pricelist = self.pricelist_model.search([
+            ('name', '=', 'Public Pricelist')])[0]
+
+        so_vals = {
+            'partner_id': self.partner_agrolite.id,
+            'pricelist_id': pricelist.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.productsf.name,
+                    'product_id': self.productsf.id,
+                    'product_uom_qty': 1.0,
+                    'product_uom': uom_id.id,
+                    'price_unit': 121.0
+                })
+            ]
+        }
+        so_vals2 = {
+            'partner_id': self.partner.id,
+            'pricelist_id': pricelist.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.productsf.name,
+                    'product_id': self.productsf.id,
+                    'product_uom_qty': 1.0,
+                    'product_uom': uom_id.id,
+                    'price_unit': 121.0
+                })
+            ]
+        }
+        so_vals3 = {
+            'partner_id': self.partner.id,
+            'pricelist_id': pricelist.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.productsf.name,
+                    'product_id': self.productsf.id,
+                    'product_uom_qty': 2.0,
+                    'product_uom': uom_id.id,
+                    'price_unit': 121.0
+                })
+            ]
+        }
+        so_vals4 = {
+            'partner_id': self.partner_agrolite.id,
+            'pricelist_id': pricelist.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.productsf.name,
+                    'product_id': self.productsf.id,
+                    'product_uom_qty': 2.0,
+                    'product_uom': uom_id.id,
+                    'price_unit': 121.0
+                })
+            ]
+        }
+        sf_vals = {
+            'name': 'Test 1',
+            'date_from': date.today() + relativedelta(years=2),
+            'date_to': date.today() + relativedelta(years=1),
+
+        }
+        with self.assertRaises(ValidationError):
+            self.sf_model.create(sf_vals)
+        sf_vals = {
+            'name': 'Test 1',
+            'date_from': date.today() + relativedelta(years=1),
+            'date_to': date.today() + relativedelta(years=2),
+
+        }
+        self.sf_model.create(sf_vals)
+
+        self.so_model.create(so_vals)
+        confirmed_so = self.so_model.create(so_vals2)
+        confirmed_so.action_confirm()
+        confirmed_so2 = self.so_model.create(so_vals3)
+        confirmed_so2.action_confirm()
+        confirmed_so3 = self.so_model.create(so_vals4)
+        confirmed_so3.action_confirm()
+
+        sf = self.sf_model.create(sf_vals)
+        context = {
+            "active_model": 'sale.forecast',
+            "active_ids": [sf.id],
+            "active_id": sf.id
+            }
+
+        load_sales_wizard = self.env['sale.forecast.load'].with_context(
+            context).create(
+            {
+                'factor': 3,
+                'product_id': self.productsf.id
+            })
+        load_sales_wizard.load_sales()
+        self.assertEqual(
+            sum(sf.forecast_lines.mapped('qty')),
+            15,
+            'Sales are not loaded proper.')
+
+        load_sales_wizard.load_sales()
+        self.assertEqual(
+            sum(sf.forecast_lines.mapped('qty')),
+            30,
+            'Lines are not grouped proper.')
+
+        load_sales_wizard_partner = self.env['sale.forecast.load'].\
+            with_context(context).create(
+                {
+                    'factor': 3,
+                    'product_categ_id': self.categ_id.id,
+                    'partner_id': self.partner.id
+                })
+        load_sales_wizard_partner.load_sales()
+        self.assertEqual(
+            sum(sf.forecast_lines.mapped('qty')),
+            39,
+            'Sales are not loaded proper.')
+
+    def test_sale_forecast_load_sale_forecast(self):
+        """ Test sale forecast flow."""
+
+        sf_vals = {
+            'name': 'Test 2',
+            'date_from': date.today() + relativedelta(years=1),
+            'date_to': date.today() + relativedelta(years=2),
+            'forecast_lines': [
+                (0, 0, {
+                    'product_id': self.productsf.id,
+                    'qty': 1,
+                })
+            ]
+        }
+        sf = self.sf_model.create(sf_vals)
+
+        empty_sf_vals = {
+            'name': 'Test 3',
+            'date_from': date.today() + relativedelta(years=1),
+            'date_to': date.today() + relativedelta(years=2),
+        }
+        empty_sf = self.sf_model.create(empty_sf_vals)
+        context = {
+            "active_model": 'sale.forecast',
+            "active_ids": [empty_sf.id],
+            "active_id": empty_sf.id
+            }
+
+        load_sale_forecast_wizard_dict = \
+            self.env['self.sale.forecast.load'].with_context(context).create(
+                {
+                    'forecast_sales': sf.id
+                })
+        load_sale_forecast_wizard_dict.button_confirm()
+        self.assertEqual(
+            sum(empty_sf.forecast_lines.mapped('qty')),
+            1,
+            'Sales forecasts are not loaded proper.')
+
+        load_sale_forecast_wizard_dict.button_confirm()
+        self.assertEqual(
+            len(empty_sf.forecast_lines),
+            1,
+            'Lines are not grouped proper.')
+
+    def test_sale_forecast_recalculate_actual_qty(self):
+        """ Test sale forecast flow."""
+        uom_id = self.product_uom_model.search([('name', '=', 'Unit(s)')])[0]
+        pricelist = self.pricelist_model.search([
+            ('name', '=', 'Public Pricelist')])[0]
+
+        so_vals = {
+            'partner_id': self.partner_agrolite.id,
+            'pricelist_id': pricelist.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.productsf3.name,
+                    'product_id': self.productsf3.id,
+                    'product_uom_qty': 1.0,
+                    'product_uom': uom_id.id,
+                    'price_unit': 121.0
+                })
+            ]
+        }
+        so_vals2 = {
+            'partner_id': self.partner.id,
+            'pricelist_id': pricelist.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.productsf3.name,
+                    'product_id': self.productsf3.id,
+                    'product_uom_qty': 1.0,
+                    'product_uom': uom_id.id,
+                    'price_unit': 121.0
+                })
+            ]
+        }
+        so_vals3 = {
+            'partner_id': self.partner.id,
+            'pricelist_id': pricelist.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.productsf4.name,
+                    'product_id': self.productsf4.id,
+                    'product_uom_qty': 1.0,
+                    'product_uom': uom_id.id,
+                    'price_unit': 121.0
+                })
+            ]
+        }
+
+        sf_vals = {
+            'name': 'Test 4',
+            'date_from': date.today() + relativedelta(months=-1),
+            'date_to': date.today() + relativedelta(months=1),
+            'forecast_lines': [
+                (0, 0, {
+                    'product_id': self.productsf3.id,
+                    'qty': 1,
+                }),
+
+
+            ]
+        }
+        self.so_model.create(so_vals)
+        invoiced_so = self.so_model.create(so_vals2)
+        invoiced_so.action_confirm()
+        invoiced_so.action_invoice_create()
+
+        sf = self.sf_model.create(sf_vals)
+        self.sf_line_model.create({
+            'forecast_id': sf.id,
+            'product_category_id': self.categ_id2.id,
+            'qty': 1,
+        })
+        line = self.sf_line_model.create({
+            'forecast_id': sf.id,
+            'product_id': self.productsf4.id,
+            'partner_id': self.partner_agrolite.id,
+            'qty': 1,
+        })
+        line.product_id = self.productsf3.id,
+        line.onchange_product()
+
+        self.sf_line_model.create({
+            'forecast_id': sf.id,
+            'product_category_id': self.categ_id2.id,
+            'partner_id': self.partner_agrolite.id,
+            'qty': 1,
+        })
+        self.assertEqual(
+            sum(sf.forecast_lines.mapped('actual_qty')),
+            2,
+            'Actual quantities are not computed proper.')
+
+        invoiced_so2 = self.so_model.create(so_vals3)
+        invoiced_so2.action_confirm()
+        invoiced_so2.action_invoice_create()
+        sf.recalculate_actual_qty()
+        self.assertEqual(
+            sum(sf.forecast_lines.mapped('actual_qty')),
+            3,
+            'Actual quantities are not computed proper.')

--- a/sale_forecast/views/sale_view.xml
+++ b/sale_forecast/views/sale_view.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+-->
+<odoo>
+        <menuitem id="menu_stock_sale_forecast" name="Sales Forecasts"
+            parent="sale.sale_menu_root" sequence="2" groups="base.group_user"/>
+
+        <record model="ir.ui.view" id="sale_forecast_line_form_view">
+            <field name="name">sale.forecast.line.form</field>
+            <field name="model">sale.forecast.line</field>
+            <field name="priority" eval="50"/>
+            <field name="arch" type="xml">
+                <form string="Sale Forecast Line">
+                    <sheet>
+                        <group>
+                            <group colspan="4" col="4">
+                                <field name="forecast_id" colspan="4"/>
+                                <field name="partner_id" colspan="4"/>
+                                <field name="commercial_id" invisible="1" readonly="1"/>
+                                <field name="date" invisible="1"/>
+                            </group>
+                            <group colspan="4" col="6">
+                                <field name="product_id" colspan="3"/>
+                                <field name="product_category_id" colspan="3"/>
+                                <field name="qty"  colspan="2"/>
+                                <field name="actual_qty" colspan="2" />
+                                <field name="unit_price"  colspan="2"/>
+                                <field name="subtotal" colspan="2"/>
+                                <field name="currency_id" invisible="1" readonly="1"/>
+                            </group>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="sale_forecast_line_tree_view">
+            <field name="name">sale.forecast.line.tree</field>
+            <field name="model">sale.forecast.line</field>
+            <field name="priority" eval="50"/>
+            <field name="arch" type="xml">
+                <tree string="Sale Forecast Line" editable="bottom">
+                    <field name="forecast_id"/>
+                    <field name="product_id"/>
+                    <field name="product_category_id"/>
+                    <field name="partner_id"/>
+                    <field name="date_from" />
+                    <field name="date_to"/>
+                    <field name="unit_price"/>
+                    <field name="qty" sum="Total Qty"/>
+                    <field name="actual_qty" sum="Total Actual Qty" />
+                    <field name="subtotal" sum="Total"/>
+                    <field name="commercial_id" invisible="1"/>
+                    <field name="currency_id" invisible="1"/>
+                </tree>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="sale_forecast_line_tree_editable_view">
+            <field name="name">sale.forecast.line.editable.tree</field>
+            <field name="model">sale.forecast.line</field>
+            <field name="arch" type="xml">
+                <tree string="Sale Forecast Line" editable="bottom">
+                    <field name="date" invisible="1"/>
+                    <field name="partner_id"/>
+                    <field name="commercial_id" invisible="1" readonly="1"/>
+                    <field name="product_id" attrs="{'readonly':[('product_category_id', '!=', False)], 'required':[('product_category_id', '=', False)]}"/>
+                    <field name="product_category_id" attrs="{'readonly':[('product_id', '!=', False)], 'required':[('product_id', '=', False)]}"/>
+                    <field name="qty" sum="Total Qty"/>
+                    <field name="actual_qty" sum="Total Actual Qty" />
+                    <field name="unit_price"/>
+                    <field name="subtotal" sum="Total"/>
+                    <field name="currency_id" invisible="1" readonly="1"/>
+                </tree>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="sale_forecast_line_search_view">
+            <field name="name">sale.forecast.line.search</field>
+            <field name="model">sale.forecast.line</field>
+            <field name="arch" type="xml">
+                <search string="Sale Forecast Line Search">
+                    <field name="forecast_id" />
+                    <field name="partner_id" />
+                    <field name="date" invisible="1" />
+                    <field name="product_id" />
+                    <field name="product_category_id" />
+                    <group expand="0" string="Group By">
+                        <filter string="Forecast" name="forecast_id" context="{'group_by':'forecast_id'}" />
+                        <filter string="Partner" name="partner_id" context="{'group_by':'partner_id'}" />
+                        <filter string="Date" name= "date" context="{'group_by':'date'}" />
+                        <filter string="Product" name="product_id" context="{'group_by':'product_id'}" />
+                        <filter string="Product category" name="product_category_id" context="{'group_by':'product_category_id'}" />
+                    </group>
+                </search>
+            </field>
+        </record>
+
+        <record id="action_view_stock_sale_forecast_line_form" model="ir.actions.act_window">
+            <field name="name">Sales Forecast Lines</field>
+            <field name="res_model">sale.forecast.line</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,pivot</field>
+        </record>
+        <record id="view_stock_sale_forecast_line_tree" model="ir.actions.act_window.view">
+            <field eval="1" name="sequence"/>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="sale_forecast_line_tree_view"/>
+            <field name="act_window_id" ref="action_view_stock_sale_forecast_line_form"/>
+        </record>
+        <record id="view_stock_sale_forecast_line_form" model="ir.actions.act_window.view">
+            <field eval="2" name="sequence"/>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="sale_forecast_line_form_view"/>
+            <field name="act_window_id" ref="action_view_stock_sale_forecast_line_form"/>
+        </record>
+        <record id="view_sale_forecast_line_pivot" model="ir.ui.view">
+        <field name="name">view.sale_forecast_line_pivot</field>
+        <field name="model">sale.forecast.line</field>
+        <field name="arch" type="xml">
+        <pivot string="Pivot view">
+          <field name="product_id" type="row" />
+          <field name="date_to" type="col" />
+          <field name="qty" type="measure" />
+          <field name="actual_qty" type="measure" />
+        </pivot>
+        </field>
+        </record>
+        <record model="ir.ui.view" id="sale_forecast_form_view">
+            <field name="name">sale.forecast.form</field>
+            <field name="model">sale.forecast</field>
+            <field name="arch" type="xml">
+                <form string="Sale Forecast">
+                    <header>
+                        <button name="%(action_sale_forecast_load_view)d" type="action" string="Load Sales"  groups="sales_team.group_sale_manager"/>
+                        <button name="%(action_load_sale_forecast_act_window)d" type="action" string="Load Sale Forecast"  groups="sales_team.group_sale_manager"/>
+
+                    </header>
+                    <sheet>
+                      <div class="oe_button_box" name="button_box">
+                      </div>
+                      <div class="oe_title">
+                        <h1>
+                          <field name="name" placeholder="Nombre"/>
+                        </h1>
+                      </div>
+
+                        <group>
+                            <group colspan="4" col="4">
+                                <field name="date_from" />
+                                <field name="date_to"/>
+                            </group>
+                            <group colspan="4" col="4" string="Lines">
+                                <field name="forecast_lines" colspan="4" nolabel="1"/>
+                                <button name="recalculate_actual_qty" string="Recalculate actual qty" type="object"/>
+                            </group>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="sale_forecast_tree_view">
+            <field name="name">sale.forecast.tree</field>
+            <field name="model">sale.forecast</field>
+            <field name="priority" eval="50"/>
+            <field name="arch" type="xml">
+                <tree string="Sale Forecast">
+                    <field name="name"/>
+                    <field name="date_from" />
+                    <field name="date_to"/>
+                </tree>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="sale_forecast_search_view">
+            <field name="name">sale.forecast.search</field>
+            <field name="model">sale.forecast</field>
+            <field name="arch" type="xml">
+                <search string="Sale Forecast Search">
+                    <field name="name"/>
+                    <field name="date_from" />
+                    <field name="date_to" />
+                    <group expand="0" string="Group By">
+                        <filter string="Partner" domain="[]"
+                            name="partner_id"
+                            context="{'group_by':'partner_id'}" />
+                        <filter string="Date from "
+                            name="date_from"
+                            domain="[]" context="{'group_by':'date_from'}" />
+                    </group>
+                </search>
+            </field>
+        </record>
+
+        <record id="action_view_stock_sale_forecast_form" model="ir.actions.act_window">
+            <field name="name">Sales Forecast</field>
+            <field name="res_model">sale.forecast</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+
+
+        <menuitem id="menu_stock_sale_forecast_all" name="Sales Forecasts"
+            parent="menu_stock_sale_forecast" action="action_view_stock_sale_forecast_form"
+            groups="base.group_user"/>
+        <menuitem id="menu_stock_sale_forecast_lines" name="Sales Forecast Lines"
+            parent="menu_stock_sale_forecast" action="action_view_stock_sale_forecast_line_form"
+            groups="base.group_user"/>
+
+</odoo>

--- a/sale_forecast/wizard/__init__.py
+++ b/sale_forecast/wizard/__init__.py
@@ -1,0 +1,3 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import sale_forecast_load

--- a/sale_forecast/wizard/sale_forecast_load.py
+++ b/sale_forecast/wizard/sale_forecast_load.py
@@ -1,0 +1,171 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
+
+
+class SaleForecastLoad(models.TransientModel):
+
+    _name = 'sale.forecast.load'
+
+    def _get_default_forecast(self):
+        model = self.env.context.get('active_model', False)
+        record = self.env[model].browse(self.env.context.get('active_id'))
+        forecast = False
+        if model == 'sale.forecast':
+            forecast = record.id
+        return forecast
+
+    def _get_default_date_from(self):
+        model = self.env.context.get('active_model', False)
+        record = self.env[model].browse(self.env.context.get('active_id'))
+        date_from = False
+        if model == 'sale.forecast':
+            reg_date = record.date_from
+            cur_year = fields.Date.from_string(reg_date).year
+            date_from = fields.Date.from_string(reg_date).replace(
+                year=cur_year-1)
+        return date_from
+
+    def _get_default_date_to(self):
+        model = self.env.context.get('active_model', False)
+        record = self.env[model].browse(self.env.context.get('active_id'))
+        date_to = False
+        if model == 'sale.forecast':
+            reg_date = record.date_to
+            cur_year = fields.Date.from_string(reg_date).year
+            date_to = fields.Date.from_string(reg_date).replace(
+                year=cur_year-1)
+        return date_to
+
+    partner_id = fields.Many2one("res.partner", string="Partner")
+    date_from = fields.Date(string="Date from", default=_get_default_date_from)
+    date_to = fields.Date(string="Date to", default=_get_default_date_to)
+    forecast_id = fields.Many2one("sale.forecast", "Forecast",
+                                  default=_get_default_forecast)
+    product_categ_id = fields.Many2one("product.category", string="Category")
+    product_tmpl_id = fields.Many2one("product.template", string="Template")
+    product_id = fields.Many2one("product.product", string="Product")
+    factor = fields.Float(string="Factor", default=1)
+
+    @api.multi
+    def match_sales_forecast(self, sales, factor):
+        self.ensure_one()
+        res = {}
+        for sale in sales:
+            product = sale.product_id.id
+            partner = sale.order_id.partner_id.id
+            # cumulative
+            if partner not in res:
+                res[partner] = {}
+            if product not in res[partner]:
+                res[partner][product] = {'qty': 0.0, 'amount': 0.0}
+            product_dict = res[partner][product]
+            sum_qty = product_dict['qty'] + sale.product_uom_qty * factor
+            sum_subtotal = (product_dict['amount'] +
+                            sale.price_subtotal)
+            product_dict['qty'] = sum_qty
+            product_dict['amount'] = sum_subtotal
+        return res
+
+    @api.multi
+    def get_sale_forecast_lists(self, forecast):
+        sale_line_obj = self.env['sale.order.line']
+        sale_obj = self.env['sale.order']
+        product_obj = self.env['product.product']
+        self.ensure_one()
+        sale_domain = [('date_order', '>=', self.date_from),
+                       ('date_order', '<=', self.date_to),
+                       ('state', 'in', ['sale', 'done'])]
+        if self.partner_id:
+            sale_domain += [('partner_id', '=', self.partner_id.id)]
+        sales = sale_obj.search(sale_domain)
+        sale_line_domain = [('order_id', 'in', sales.ids)]
+        if self.product_id:
+            sale_line_domain += [('product_id', '=', self.product_id.id)]
+        elif self.product_categ_id:
+            products = product_obj.search([('categ_id', '=',
+                                            self.product_categ_id.id)])
+            sale_line_domain += [('product_id', 'in', products.ids)]
+        sale_lines = sale_line_obj.search(sale_line_domain)
+        return sale_lines
+
+    @api.multi
+    def load_sales(self):
+        self.ensure_one()
+        forecast_line_obj = self.env['sale.forecast.line']
+        forecast = self.forecast_id
+        sale_lines = self.get_sale_forecast_lists(forecast)
+        result = self.match_sales_forecast(sale_lines, self.factor)
+        for partner in result.keys():
+            for product in result[partner].keys():
+                prod_vals = result[partner][product]
+                line = forecast_line_obj.search(
+                    [
+                        ('forecast_id', '=', self.forecast_id.id),
+                        ('partner_id', '=', partner),
+                        ('product_id', '=', product)
+                    ])
+                unit_price = prod_vals['amount'] / prod_vals['qty']
+                if line:
+                    line.unit_price = (line.unit_price * line.qty + unit_price
+                                       * prod_vals['qty']) / (line.qty +
+                                                              prod_vals['qty'])
+
+                    line.qty += prod_vals['qty']
+                else:
+                    forecast_line_vals = {'product_id': product,
+                                          'forecast_id': self.forecast_id.id,
+                                          'partner_id': partner,
+                                          'qty': prod_vals['qty'],
+                                          'unit_price': unit_price
+                                          }
+                    forecast_line_obj.create(forecast_line_vals)
+        return True
+
+
+class SelfSaleForecastLoad(models.TransientModel):
+    _name = 'self.sale.forecast.load'
+    _description = 'Load sale forecast from existing sale forecast'
+
+    def _get_default_forecast(self):
+        model = self.env.context.get('active_model', False)
+        record = self.env[model].browse(self.env.context.get('active_id'))
+        forecast = False
+        if model == 'sale.forecast':
+            forecast = record.id
+        return forecast
+
+    forecast_id = fields.Many2one(
+        comodel_name='sale.forecast',
+        string='Sale Forecast',
+        default=_get_default_forecast)
+
+    forecast_sales = fields.Many2one(
+        comodel_name='sale.forecast',
+        string='Sale Forecast')
+
+    @api.multi
+    def button_confirm(self):
+        for line in self.forecast_sales.forecast_lines:
+            forecast_line_obj = self.env['sale.forecast.line']
+            line_dest = forecast_line_obj.search(
+                [
+                    ('forecast_id', '=', self.forecast_id.id),
+                    ('partner_id', '=', line.partner_id.id),
+                    ('product_id', '=', line.product_id.id)
+                ])
+            if line_dest:
+                line_dest.unit_price = (line_dest.unit_price * line_dest.qty
+                                        + line.unit_price * line.qty) / (
+                                            line_dest.qty + line.qty)
+
+                line_dest.qty += line.qty
+            else:
+                self.forecast_id.write({'forecast_lines': [(0, 0, {
+                    'product_id': line.product_id.id,
+                    'product_category_id': line.product_category_id.id,
+                    'unit_price': line.unit_price,
+                    'qty': line.qty,
+                    'subtotal': line.subtotal,
+                    'partner_id': line.partner_id.id,
+                    })],
+                })

--- a/sale_forecast/wizard/sale_forecast_load.py
+++ b/sale_forecast/wizard/sale_forecast_load.py
@@ -1,0 +1,171 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models, fields, api
+
+
+class SaleForecastLoad(models.TransientModel):
+
+    _name = 'sale.forecast.load'
+
+    def _get_default_forecast(self):
+        model = self.env.context.get('active_model', False)
+        record = self.env[model].browse(self.env.context.get('active_id'))
+        forecast = False
+        if model == 'sale.forecast':
+            forecast = record.id
+        return forecast
+
+    def _get_default_date_from(self):
+        model = self.env.context.get('active_model', False)
+        record = self.env[model].browse(self.env.context.get('active_id'))
+        date_from = False
+        if model == 'sale.forecast':
+            reg_date = record.date_from
+            cur_year = fields.Date.from_string(reg_date).year
+            date_from = fields.Date.from_string(reg_date).replace(
+                year=cur_year-1)
+        return date_from
+
+    def _get_default_date_to(self):
+        model = self.env.context.get('active_model', False)
+        record = self.env[model].browse(self.env.context.get('active_id'))
+        date_to = False
+        if model == 'sale.forecast':
+            reg_date = record.date_to
+            cur_year = fields.Date.from_string(reg_date).year
+            date_to = fields.Date.from_string(reg_date).replace(
+                year=cur_year-1)
+        return date_to
+
+    partner_id = fields.Many2one("res.partner", string="Partner")
+    date_from = fields.Date(string="Date from", default=_get_default_date_from)
+    date_to = fields.Date(string="Date to", default=_get_default_date_to)
+    forecast_id = fields.Many2one("sale.forecast", "Forecast",
+                                  default=_get_default_forecast)
+    product_categ_id = fields.Many2one("product.category", string="Category")
+    product_tmpl_id = fields.Many2one("product.template", string="Template")
+    product_id = fields.Many2one("product.product", string="Product")
+    factor = fields.Float(string="Factor", default=1)
+
+    @api.multi
+    def match_sales_forecast(self, sales, factor):
+        self.ensure_one()
+        res = {}
+        for sale in sales:
+            product = sale.product_id.id
+            partner = sale.order_id.partner_id.id
+            # cumulative
+            if partner not in res:
+                res[partner] = {}
+            if product not in res[partner]:
+                res[partner][product] = {'qty': 0.0, 'amount': 0.0}
+            product_dict = res[partner][product]
+            sum_qty = product_dict['qty'] + sale.product_uom_qty * factor
+            sum_subtotal = (product_dict['amount'] +
+                            sale.price_subtotal)
+            product_dict['qty'] = sum_qty
+            product_dict['amount'] = sum_subtotal
+        return res
+
+    @api.multi
+    def get_sale_forecast_lists(self, forecast):
+        sale_line_obj = self.env['sale.order.line']
+        sale_obj = self.env['sale.order']
+        product_obj = self.env['product.product']
+        self.ensure_one()
+        sale_domain = [('date_order', '>=', self.date_from),
+                       ('date_order', '<=', self.date_to),
+                       ('state', 'in', ['sale', 'done'])]
+        if self.partner_id:
+            sale_domain += [('partner_id', '=', self.partner_id.id)]
+        sales = sale_obj.search(sale_domain)
+        sale_line_domain = [('order_id', 'in', sales.ids)]
+        if self.product_id:
+            sale_line_domain += [('product_id', '=', self.product_id.id)]
+        elif self.product_categ_id:
+            products = product_obj.search([('categ_id', '=',
+                                            self.product_categ_id.id)])
+            sale_line_domain += [('product_id', 'in', products.ids)]
+        sale_lines = sale_line_obj.search(sale_line_domain)
+        return sale_lines
+
+    @api.multi
+    def load_sales(self):
+        self.ensure_one()
+        forecast_line_obj = self.env['sale.forecast.line']
+        forecast = self.forecast_id
+        sale_lines = self.get_sale_forecast_lists(forecast)
+        result = self.match_sales_forecast(sale_lines, self.factor)
+        for partner in result.keys():
+            for product in result[partner].keys():
+                prod_vals = result[partner][product]
+                line = forecast_line_obj.search(
+                    [
+                        ('forecast_id', '=', self.forecast_id.id),
+                        ('partner_id', '=', partner),
+                        ('product_id', '=', product)
+                    ])
+                unit_price = prod_vals['amount'] / prod_vals['qty']
+                if line:
+                    line.unit_price = (line.unit_price * line.qty + unit_price
+                                       * prod_vals['qty']) / (line.qty +
+                                                              prod_vals['qty'])
+
+                    line.qty += prod_vals['qty']
+                else:
+                    forecast_line_vals = {'product_id': product,
+                                          'forecast_id': self.forecast_id.id,
+                                          'partner_id': partner,
+                                          'qty': prod_vals['qty'],
+                                          'unit_price': unit_price
+                                          }
+                    forecast_line_obj.create(forecast_line_vals)
+        return True
+
+
+class SelfSaleForecastLoad(models.TransientModel):
+    _name = 'self.sale.forecast.load'
+    _description = 'Load sale forecast from existing sale forecast'
+
+    def _get_default_forecast(self):
+        model = self.env.context.get('active_model', False)
+        record = self.env[model].browse(self.env.context.get('active_id'))
+        forecast = False
+        if model == 'sale.forecast':
+            forecast = record.id
+        return forecast
+
+    forecast_id = fields.Many2one(
+        comodel_name='sale.forecast',
+        string='Sale Forecast',
+        default=_get_default_forecast)
+
+    forecast_sales = fields.Many2one(
+        comodel_name='sale.forecast',
+        string='Sale Forecast')
+
+    @api.multi
+    def button_confirm(self):
+        for line in self.forecast_sales.forecast_lines:
+            forecast_line_obj = self.env['sale.forecast.line']
+            line_dest = forecast_line_obj.search(
+                [
+                    ('forecast_id', '=', self.forecast_id.id),
+                    ('partner_id', '=', line.partner_id.id),
+                    ('product_id', '=', line.product_id.id)
+                ])
+            if line_dest:
+                line_dest.unit_price = (line_dest.unit_price * line_dest.qty
+                                        + line.unit_price * line.qty) / (
+                                            line_dest.qty + line.qty)
+
+                line_dest.qty += line.qty
+            else:
+                self.forecast_id.write({'forecast_lines': [(0, 0, {
+                    'product_id': line.product_id.id,
+                    'product_category_id': line.product_category_id.id,
+                    'unit_price': line.unit_price,
+                    'qty': line.qty,
+                    'subtotal': line.subtotal,
+                    'partner_id': line.partner_id.id,
+                    })],
+                })

--- a/sale_forecast/wizard/sale_forecast_load_view.xml
+++ b/sale_forecast/wizard/sale_forecast_load_view.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+-->
+<odoo>
+        <record model="ir.ui.view" id="sale_forecast_load_form_view">
+            <field name="name">sale.forecast.load.sale.form</field>
+            <field name="model">sale.forecast.load</field>
+            <field name="arch" type="xml">
+                <form string="Load Sales">
+                    <group colspan="4" col="4">
+                        <field name="partner_id" select="1" colspan="4"
+                        domain="[('customer','=',True)]"
+                        context="{'search_default_customer':1, 'show_address': 1}"/>
+                        <field name="date_from" select="1" required="1"/>
+                        <field name="date_to" select="1" required="1"/>
+                        <field name="factor"/>
+                        <field name="product_categ_id" select="1"/>
+                        <newline/>
+                        <field name="product_id" select="1" colspan="4"/>
+                    </group>
+                    <footer>
+                        <button name="load_sales" type="object"
+                        string="Load" class="oe_highlight"/>
+                        or
+                        <button string="Cancel" class="oe_link"
+                        special="cancel" />
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record model="ir.actions.act_window" id="action_sale_forecast_load_view">
+            <field name="name">Load sales</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">sale.forecast.load</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+            <field name="view_id" ref="sale_forecast_load_form_view"/>
+        </record>
+
+        <record id="load_self_sale_forecast_wizard" model="ir.ui.view">
+            <field name="name">load_self_sale_forecast.wizard</field>
+            <field name="model">self.sale.forecast.load</field>
+            <field name="arch"  type="xml">
+                <form string="Load from sale forecast">
+                  <group name="load_sale_forecast">
+                    <field name="forecast_id" invisible="1" />
+
+                    <field name="forecast_sales" required="1" />
+
+                  </group>
+                    <footer>
+                        <button name="button_confirm" type="object"
+                            class="oe_highlight" string="Confirm"/>
+                        <button special="cancel" string="Cancel" class="oe_link"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record id="action_load_sale_forecast_act_window" model="ir.actions.act_window">
+            <field name="name">Load sale forecast</field>
+            <field name="res_model">self.sale.forecast.load</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+        </record>
+</odoo>


### PR DESCRIPTION
Based on procurement_sale_forecast.

This module allows you to create a sale forecast.

* Possibility to load sale order lines or a sale forecast previously created.
* Allows you to group forecast lines by product, partner, date, category and forecast.
* There's a pivot view where you can see the real quantity and the forecasted quantity.