### PR TITLE
[IMP] sale_order_line_input: Use existing view to include fields added by

### DIFF
--- a/sale_order_line_input/__manifest__.py
+++ b/sale_order_line_input/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Sale Order Line Input',
     'summary': 'Search, create or modify directly sale order lines',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     'development_status': 'Beta',
     'category': 'Sales',
     'website': 'https://github.com/OCA/sale-workflow',

--- a/sale_order_line_input/views/sale_order_line_view.xml
+++ b/sale_order_line_input/views/sale_order_line_view.xml
@@ -5,8 +5,10 @@
     <record id="view_sales_order_line_input_tree" model="ir.ui.view">
         <field name="name">sale.order.line.input.tree.</field>
         <field name="model">sale.order.line</field>
-        <field name="priority">20</field>
+        <field name="inherit_id" ref="sale.view_order_line_tree"/>
+        <field name="priority">1</field>
         <field name="arch" type="xml">
+          <tree position="replace">
             <tree string="Sales Orders Lines"
                   decoration-info="invoice_status=='to invoice'" decoration-warning="state=='draft'" decoration-muted="state=='cancel'" decoration-success="state=='done'"
                   editable="top" create="true">
@@ -22,6 +24,7 @@
                        options='{"always_reload": True}'
                        required="1"
                        attrs="{'readonly': [('order_partner_id', '!=', False), ('order_id', '!=', False)]}"/>
+                <field name="salesman_id" invisible="1"/>
                 <field name="product_id"
                        attrs="{'readonly': [('product_updatable', '=', False)]}"
                        force_save="1"
@@ -64,6 +67,7 @@
                 <field name="pricelist_id" invisible="1"/>
                 <field name="company_id" invisible="1"/>
             </tree>
+          </tree>
         </field>
     </record>
 


### PR DESCRIPTION
other modules.

For example:
https://github.com/odoo/odoo/blob/704bdba6b44ee13cddd9c25c2ee0d9314f3f4de5/addons/sale_stock/views/sale_order_views.xml#L44
https://github.com/OCA/sale-workflow/blob/d648633462bdd17e74932cb637df98c35f458dd4/sale_order_line_date/views/sale_order_view.xml#L27

@Tecnativa