### PR TITLE
[FIX] Sale Exeption Menu

### DIFF
--- a/sale_exception/__manifest__.py
+++ b/sale_exception/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Sale Exception',
     'summary': 'Custom exceptions on sale order',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     'category': 'Generic Modules/Sale',
     'author': "Akretion, "
               "Sodexis, "

--- a/sale_exception/views/sale_view.xml
+++ b/sale_exception/views/sale_view.xml
@@ -11,19 +11,11 @@
               </record>
 
         <menuitem
-                id="menu_sale_exception_parent"
-                parent="sales_team.menu_sale_config"
-                sequence="20"
-                name="Exceptions"
-        />
-
-
-        <menuitem
                 action="action_sale_test_tree"
                 id="menu_sale_test"
-                parent="menu_sale_exception_parent"
+                sequence="90"
+                parent="sale.menu_sales_config"
         />
-
 
         <record id="view_order_form" model="ir.ui.view">
             <field name="name">sale_exception.view_order_form</field>


### PR DESCRIPTION
Currently, it's located at the root menu because. It's a migration bug because the old menu was removed from 11.0.

**What it looks like before this PR:**
![image](https://user-images.githubusercontent.com/1914185/47471546-200aeb00-d7e1-11e8-976a-7d42137e9cc5.png)
