### PR TITLE
[FIX] sale_force_invoiced: typo

### DIFF
--- a/sale_force_invoiced/__manifest__.py
+++ b/sale_force_invoiced/__manifest__.py
@@ -5,7 +5,7 @@
     'name': 'Sale Force Invoiced',
     'summary': 'Allows to force the invoice status of the sales order to '
                'Invoiced',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     "author": "Eficent,"
               "Odoo Community Association (OCA)",
     'category': 'sale',

--- a/sale_force_invoiced/tests/test_sale_force_invoiced.py
+++ b/sale_force_invoiced/tests/test_sale_force_invoiced.py
@@ -40,7 +40,6 @@ class TestSaleForceInvoiced(TransactionCase):
             'categ_id': product_ctg.id,
             'type': 'service',
             'invoice_policy': 'order',
-            'track_service': 'manual'
         })
         return product
 


### PR DESCRIPTION
Field `track_service` only is created if `stock` module is installed. And the field in odoo 11.0 is `tracking`.
Remove field as It's not necessary for tests and this changes avoid warnings.

cc @Tecnativa