### PR TITLE
[11.0] [ADD] website_quote_substitute_product: New module

### DIFF
--- a/website_quote_substitute_product/README.rst
+++ b/website_quote_substitute_product/README.rst
@@ -1,0 +1,24 @@
+======================================
+Website Quote Subsitute Product
+======================================
+
+This module allows you to add substitute products on the order and link them to a specific sale order line.
+Afterwards, you can change the products via Odoo or the online quotation.
+
+
+Usage
+=====
+
+* Sales -> Quotation/Sale Order -> Subsitute products
+* Sales -> Quotation/Sale Order -> Online link through 'Send email'
+
+Contributors
+============
+* Carlos Martínez <carlos@domatix.com>
+* Nacho Serra <nacho.serra@domatix.com>
+* Nacho HM <nacho@domatix.com>
+
+
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: https://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3

--- a/website_quote_substitute_product/__init__.py
+++ b/website_quote_substitute_product/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import controllers

--- a/website_quote_substitute_product/__manifest__.py
+++ b/website_quote_substitute_product/__manifest__.py
@@ -9,8 +9,8 @@
     'category': 'Sale',
     'depends': ['website_quote'],
     'data': [
-        'views/sale_order_view.xml',
         'security/ir.model.access.csv',
+        'views/sale_order_view.xml',
         'views/website_quote_templates.xml'
         ],
     'installable': True,

--- a/website_quote_substitute_product/__manifest__.py
+++ b/website_quote_substitute_product/__manifest__.py
@@ -1,0 +1,17 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+{
+    'name': 'Substitute Product for Online Proposals',
+    'summary': 'Allows to change products by others recommended via web.',
+    'version': '11.0.1.0.0',
+    'license': 'AGPL-3',
+    'author': 'Domatix, Odoo Community Association (OCA)',
+    'website': 'https://github.com/OCA/sale-workflow',
+    'category': 'Sale',
+    'depends': ['website_quote'],
+    'data': [
+        'views/sale_order_view.xml',
+        'security/ir.model.access.csv',
+        'views/website_quote_templates.xml'
+        ],
+    'installable': True,
+}

--- a/website_quote_substitute_product/controllers/__init__.py
+++ b/website_quote_substitute_product/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/website_quote_substitute_product/controllers/main.py
+++ b/website_quote_substitute_product/controllers/main.py
@@ -1,0 +1,24 @@
+import werkzeug
+from odoo import http
+from odoo.http import request
+
+
+class SaleQuote(http.Controller):
+
+    @http.route(
+        ["/quote/substitute_line/<int:line_id>/<int:order_id>/<token>"],
+        type='http',
+        auth="public",
+        website=True
+        )
+    def substitute_line(self, line_id, order_id, token, **post):
+        Order = request.env['sale.order'].sudo().browse(int(order_id))
+        if token != Order.access_token:
+            return request.render('website.404')
+        if Order.state not in ('draft', 'sent'):
+            return False
+        LineSub = request.env['sale.order.substitute'].sudo().browse(
+            int(line_id))
+        LineSub.button_substitute_product()
+        return werkzeug.utils.redirect(
+            "/quote/%s/%s#quote_header_2" % (Order.id, token))

--- a/website_quote_substitute_product/i18n/es.po
+++ b/website_quote_substitute_product/i18n/es.po
@@ -1,0 +1,204 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* website_quote_substitute_product
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-08-06 08:46+0000\n"
+"PO-Revision-Date: 2018-08-06 08:46+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: website_quote_substitute_product
+#: model:ir.ui.view,arch_db:website_quote_substitute_product.substitute_pricing
+msgid "% discount"
+msgstr "% descuento"
+
+#. module: website_quote_substitute_product
+#: model:ir.ui.view,arch_db:website_quote_substitute_product.substitute_pricing
+msgid "&amp;bull;"
+msgstr "&amp;bull;"
+
+#. module: website_quote_substitute_product
+#: model:ir.ui.view,arch_db:website_quote_substitute_product.substitute_pricing
+msgid "<span>Change</span>"
+msgstr "<span>Cambiar</span>"
+
+#. module: website_quote_substitute_product
+#: model:ir.ui.view,arch_db:website_quote_substitute_product.substitute_pricing
+msgid "<strong>Subtotal:</strong>"
+msgstr "<strong>Subtotal:</strong>"
+
+#. module: website_quote_substitute_product
+#: model:ir.ui.view,arch_db:website_quote_substitute_product.substitute_pricing
+msgid "<strong>Total:</strong>"
+msgstr "<strong>Total:</strong>"
+
+#. module: website_quote_substitute_product
+#: model:ir.ui.view,arch_db:website_quote_substitute_product.view_sale_order_substitute_product_form
+msgid "Add to change the product"
+msgstr "Cambiar producto"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_price_subtotal
+msgid "Amount"
+msgstr "Importe"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_create_date
+msgid "Created on"
+msgstr "Creado en"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,help:website_quote_substitute_product.field_sale_order_substitute_product_uom
+msgid "Default Unit of Measure used for all stock operation."
+msgstr "Unidad de medida predeterminada utilizada para todas las operaciones de stock."
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_description
+msgid "Description"
+msgstr "Descripción"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_discount
+msgid "Discount"
+msgstr "Descuento"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_id
+msgid "ID"
+msgstr "ID"
+
+#. module: website_quote_substitute_product
+#: code:addons/website_quote_substitute_product/controllers/main.py:110
+#: code:addons/website_quote_substitute_product/controllers/main.py:202
+#, python-format
+msgid "If we store your payment information on our server, subscription payments will be made automatically."
+msgstr "Si almacenamos su información de pago en nuestro servidor, las suscripciones de pago se harán automáticamente"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute___last_update
+msgid "Last Modified on"
+msgstr "Última Modificación en"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_write_uid
+msgid "Last Updated by"
+msgstr "Última Actualización por"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_write_date
+msgid "Last Updated on"
+msgstr "Última Actualización el"
+
+#. module: website_quote_substitute_product
+#: code:addons/website_quote_substitute_product/controllers/main.py:200
+#, python-format
+msgid "Pay & Confirm"
+msgstr "Pagar y confirmar"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_price_difference
+msgid "Price Difference"
+msgstr "Diferencia de precio"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_price_unit
+msgid "Price Unit"
+msgstr "Precio unitario"
+
+#. module: website_quote_substitute_product
+#: model:ir.model,name:website_quote_substitute_product.model_product_product
+msgid "Product"
+msgstr "Producto"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_quantity
+msgid "Quantity"
+msgstr "Cantidad"
+
+#. module: website_quote_substitute_product
+#: model:ir.model,name:website_quote_substitute_product.model_sale_order
+msgid "Quotation"
+msgstr "Presupuesto"
+
+#. module: website_quote_substitute_product
+#: code:addons/website_quote_substitute_product/controllers/main.py:52
+#, python-format
+msgid "Quotation viewed by customer"
+msgstr "Presupuesto visto por cliente"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_sale_order_line_id
+msgid "Sale Order Line"
+msgstr "Producto de la línea"
+
+#. module: website_quote_substitute_product
+#: model:ir.model,name:website_quote_substitute_product.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Línea de pedido de ventas"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_order_id
+msgid "Substitute"
+msgstr "Sustitutivo"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_line_substitute_line_ids
+msgid "Substitute Line ids"
+msgstr "Substitute Line ids"
+
+#. module: website_quote_substitute_product
+#: model:ir.model,name:website_quote_substitute_product.model_sale_order_substitute
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_product_substitute_id
+msgid "Substitute Product"
+msgstr "Producto sustitutivo"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_product_substitute_ids
+#: model:ir.ui.view,arch_db:website_quote_substitute_product.view_sale_order_substitute_product_form
+msgid "Substitute Products"
+msgstr "Productos sustitutivos"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_tax_id
+msgid "Tax"
+msgstr "Impuesto"
+
+#. module: website_quote_substitute_product
+#: model:ir.ui.view,arch_db:website_quote_substitute_product.substitute_pricing
+msgid "Taxes:"
+msgstr "Impuestos:"
+
+#. module: website_quote_substitute_product
+#: code:addons/website_quote_substitute_product/models/sale_order.py:49
+#, python-format
+msgid "Uncategorized"
+msgstr "Sin categoría"
+
+#. module: website_quote_substitute_product
+#: model:ir.model.fields,field_description:website_quote_substitute_product.field_sale_order_substitute_product_uom
+msgid "UoM"
+msgstr "UdM"
+
+#. module: website_quote_substitute_product
+#: code:addons/website_quote_substitute_product/controllers/main.py:157
+#, python-format
+msgid "You cannot add options to a confirmed order."
+msgstr "No puedes añadir opciones en un pedido confirmado."

--- a/website_quote_substitute_product/models/__init__.py
+++ b/website_quote_substitute_product/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/website_quote_substitute_product/models/sale_order.py
+++ b/website_quote_substitute_product/models/sale_order.py
@@ -1,0 +1,158 @@
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, fields, models
+import odoo.addons.decimal_precision as dp
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    product_substitute_ids = fields.One2many(
+        comodel_name='sale.order.substitute',
+        inverse_name='order_id',
+        string='Substitute Products')
+
+
+class SaleOrderSubstitute(models.Model):
+    _name = 'sale.order.substitute'
+    _description = 'Substitute Product'
+
+    @api.model
+    def default_get(self, fields):
+        res = super(SaleOrderSubstitute, self).default_get(fields)
+        res['order_id'] = self.env.context.get('kit')
+        return res
+
+    @api.depends('product_uom_qty', 'discount', 'price_unit', 'tax_id')
+    def _compute_amount(self):
+        """
+        Compute the amounts of the SO substitute line.
+        """
+        for line in self:
+            price = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
+            taxes = line.tax_id.compute_all(
+                price, line.order_id.currency_id, line.product_uom_qty,
+                product=line.product_substitute_id,
+                partner=line.order_id.partner_shipping_id)
+            line.update({
+                'price_tax': sum(t.get('amount', 0.0) for t in taxes.get(
+                    'taxes', [])),
+                'price_total': taxes['total_included'],
+                'price_subtotal': taxes['total_excluded'],
+            })
+
+    sale_order_line_id = fields.Many2one(
+        comodel_name='sale.order.line',
+        required=True,
+        string='Sale Order Line')
+
+    order_id = fields.Many2one(
+        comodel_name='sale.order',
+        string='Substitute')
+
+    product_substitute_id = fields.Many2one(
+        comodel_name='product.product',
+        required=True,
+        string='Substitute Product')
+
+    description = fields.Char(
+        string='Description')
+
+    product_uom_qty = fields.Float(
+        string='Quantity',
+        digits=dp.get_precision('Product Unit of Measure'),
+        required=True,
+        default=1.0)
+
+    product_uom = fields.Many2one(
+        comodel_name='product.uom',
+        string='Unit of Measure',
+        related='product_substitute_id.uom_id')
+
+    price_unit = fields.Float(
+        string='Price Unit',
+        digits=dp.get_precision('Product Price'))
+
+    price_difference = fields.Float(
+        string='Price Difference',
+        digits=dp.get_precision('Product Price'),
+        compute='_compute_price_difference')
+
+    tax_id = fields.Many2many(
+        comodel_name='account.tax',
+        string='Tax')
+
+    discount = fields.Float(
+        string='Discount')
+
+    currency_id = fields.Many2one(
+        related='order_id.currency_id',
+        store=True,
+        string='Currency',
+        readonly=True)
+    price_subtotal = fields.Float(
+        string='Amount',
+        compute='_compute_amount',
+        store=True)
+    price_tax = fields.Float(
+        compute='_compute_amount',
+        string='Taxes',
+        readonly=True,
+        store=True)
+    price_total = fields.Monetary(
+        compute='_compute_amount',
+        string='Total',
+        readonly=True,
+        store=True)
+
+    @api.onchange('sale_order_line_id')
+    def _onchange_product_id(self):
+        line = self.sale_order_line_id
+        if line.product_id:
+            self.product_uom_qty = line.product_uom_qty
+            self.description = line.product_id.description_sale or\
+                line.product_id.name
+            self.price_unit = line.product_id.lst_price
+            self.product_uom_qty = line.product_uom_qty
+            self.update({'tax_id': line.tax_id.ids})
+
+    @api.onchange('product_substitute_id')
+    def _onchange_substitute_product(self):
+        self.description = self.product_substitute_id.description_sale or\
+            self.product_substitute_id.name
+        self.price_unit = self.product_substitute_id.lst_price
+
+    def _compute_price_difference(self):
+        for record in self:
+            record.price_difference = record.sale_order_line_id.price_unit -\
+                record.price_unit
+
+    @api.multi
+    def button_substitute_product(self):
+        for record in self:
+            line = record.sale_order_line_id
+            product_old_id = line.product_id
+            price_unit_old = line.price_unit
+            quantity_old = line.product_uom_qty
+            description_old = line.product_id.description_sale or\
+                line.product_id.name
+            line.write({
+                'product_id': record.product_substitute_id.id,
+                'name': record.description,
+                'price_unit': record.price_unit,
+                'product_uom_qty': record.product_uom_qty})
+
+            record.write({'product_substitute_id': product_old_id.id,
+                          'price_unit': price_unit_old,
+                          'product_uom_qty': quantity_old,
+                          'description': description_old})
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    substitute_line_ids = fields.One2many(
+        comodel_name='sale.order.substitute',
+        inverse_name='sale_order_line_id',
+        string='Substitute Line ids',
+        ondelete='cascade')

--- a/website_quote_substitute_product/security/ir.model.access.csv
+++ b/website_quote_substitute_product/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sale_order_substitute,access_sale_order_substitute,model_sale_order_substitute,,1,1,1,1

--- a/website_quote_substitute_product/tests/__init__.py
+++ b/website_quote_substitute_product/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_substitute

--- a/website_quote_substitute_product/tests/test_product_substitute.py
+++ b/website_quote_substitute_product/tests/test_product_substitute.py
@@ -1,0 +1,101 @@
+from odoo.tests import common
+
+
+class TestProductSubstitute(common.TransactionCase):
+
+    def setUp(self):
+        super(TestProductSubstitute, self).setUp()
+
+        self.so_model = self.env['sale.order']
+        self.po_line_model = self.env['sale.order.line']
+        self.res_partner_model = self.env['res.partner']
+        self.product_model = self.env['product.product']
+        self.product_uom_model = self.env['product.uom']
+        self.pricelist_model = self.env['product.pricelist']
+        self.partner = self.env.ref('base.res_partner_1')
+        self.product1 = self.product_model.create({
+            'name': 'Product A',
+            'type': 'product',
+            'lst_price': 1,
+            'categ_id': self.env.ref('product.product_category_all').id,
+        })
+        self.product2 = self.product_model.create({
+            'name': 'Product B',
+            'type': 'product',
+            'lst_price': 2,
+            'categ_id': self.env.ref('product.product_category_all').id,
+        })
+        self.product3 = self.product_model.create({
+            'name': 'Product C',
+            'type': 'product',
+            'lst_price': 3,
+            'categ_id': self.env.ref('product.product_category_all').id,
+        })
+        self.product4 = self.product_model.create({
+            'name': 'Product D',
+            'type': 'product',
+            'lst_price': 4,
+            'categ_id': self.env.ref('product.product_category_all').id,
+        })
+
+    def test_subsitute_product(self):
+        """ Test substitute product button."""
+        uom_id = self.product_uom_model.search([('name', '=', 'Unit(s)')])[0]
+        pricelist = self.pricelist_model.search([
+            ('name', '=', 'Public Pricelist')])[0]
+
+        so_vals = {
+            'partner_id': self.partner.id,
+            'pricelist_id': pricelist.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.product2.name,
+                    'product_id': self.product2.id,
+                    'product_uom_qty': 1.0,
+                    'product_uom': uom_id.id,
+                    'price_unit': 121.0
+                })
+            ],
+
+        }
+
+        so = self.so_model.create(so_vals)
+        so.write({
+            'order_line': [
+                (0, 0, {
+                    'name': self.product4.name,
+                    'product_id': self.product4.id,
+                    'product_uom_qty': 1.0,
+                    'product_uom': uom_id.id,
+                    'price_unit': 4
+                })
+            ]
+        })
+        so.write({
+            'product_substitute_ids': [
+                (0, 0, {
+                    'sale_order_line_id': so.order_line[0].id,
+                    'product_substitute_id': self.product2.id,
+                })
+            ]
+        })
+        so.write({
+            'product_substitute_ids': [
+                (0, 0, {
+                    'sale_order_line_id': so.order_line[0].id,
+                    'product_substitute_id': self.product3.id,
+                })
+            ]
+        })
+        so.product_substitute_ids[0]._onchange_substitute_product()
+        so.product_substitute_ids[1]._onchange_substitute_product()
+        so.product_substitute_ids[0].sale_order_line_id = so.order_line[1].id
+        so.product_substitute_ids[0]._onchange_product_id()
+        so.product_substitute_ids[0].sale_order_line_id = so.order_line[0].id
+        so.product_substitute_ids[0]._onchange_product_id()
+        so.product_substitute_ids[0].button_substitute_product()
+
+        self.assertEqual(
+            so.order_line[0].product_id.id,
+            self.product2.id,
+            'Products are not changed proper.')

--- a/website_quote_substitute_product/views/sale_order_view.xml
+++ b/website_quote_substitute_product/views/sale_order_view.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <record id="view_order_form" model="ir.ui.view">
+  <field name="name">view.sale_order_substitute_product.form</field>
+  <field name="model">sale.order</field>
+  <field name='inherit_id' ref='sale.view_order_form'/>
+  <field name="arch" type="xml">
+  <xpath expr="//form/sheet/notebook/page[1]" position="after">
+    <page string="Substitute Products">
+        <field name="product_substitute_ids" context="{'kit': id}">
+          <tree string="Substitute Products" editable="bottom">
+            <field name="order_id" invisible="1" />
+            <field name="sale_order_line_id" force_save="1" domain="[('order_id','=',order_id)]" />
+            <field name="product_substitute_id" />
+            <field name="description" />
+            <field name="product_uom_qty" />
+            <field name="price_unit" />
+            <field name="price_subtotal" />
+            <field name="tax_id" widget="many2many_tags" />
+            <field name="price_total" />
+            <field name="price_difference" readonly="1" />
+            <button name="button_substitute_product" class="oe_link" icon="fa-shopping-cart" string="Add to change the product" type="object"/>
+          </tree>
+        </field>
+    </page>
+  </xpath>
+  </field>
+  </record>
+</odoo>

--- a/website_quote_substitute_product/views/website_quote_templates.xml
+++ b/website_quote_substitute_product/views/website_quote_templates.xml
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <template id="substitute_pricing" inherit_id="website_quote.pricing">
+
+    <xpath expr="//section/t/table/tbody" position="replace">
+      <tbody>
+          <t t-foreach="page" t-as="layout_category">
+
+              <t t-if="layout_category_size > 1 or page_size > 1" groups="sale.group_sale_layout">
+                  <tr class="active">
+                      <td colspan="7" style="font-weight: bold; border-bottom: 1px solid black;">&amp;bull;
+                          <t t-esc="layout_category['name']"/>
+                      </td>
+                  </tr>
+              </t>
+
+              <!-- Lines associated -->
+              <t t-set="color" t-value="2"/>
+              <t t-foreach="layout_category['lines']" t-as="line">
+                <t t-set="color" t-value="color+1"/>
+
+                  <t t-if="color%2!=0">
+                  <tr style="background-color:#F9FAFC; font-weight: bold;">
+                    <td>
+                        <span t-field="line.name"/>
+                    </td>
+                    <td>
+                        <div id="quote_qty">
+                            <span t-field="line.product_uom_qty"/>
+                            <span t-field="line.product_uom"/>
+                        </div>
+                    </td>
+                    <td>
+                        <div t-foreach="line.tax_id" t-as="tax">
+                            <t t-esc="tax.name"/>
+                        </div>
+                    </td>
+                    <td>
+                        <strong t-if="line.discount" class="text-info">
+                            <t t-esc="((line.discount % 1) and '%s' or '%d') % line.discount"/>% discount
+                        </strong>
+                    </td>
+                    <td class="text-right">
+                          <div t-field="line.price_unit"
+                              t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'
+                              t-att-style="line.discount and 'text-decoration: line-through' or None"
+                              t-att-class="(line.discount and 'text-danger' or '') + ' text-right'"/>
+                          <div t-if="line.discount">
+                              <t t-esc="(1-line.discount / 100.0) * line.price_unit" t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'/>
+                          </div>
+                    </td>
+                    <td class="text-right" groups="sale.group_show_price_subtotal">
+                        <span t-field="line.price_subtotal"
+                              t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'/>
+                    </td>
+                    <td class="text-right" groups="sale.group_show_price_total">
+                        <span t-field="line.price_total"
+                              t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'/>
+                    </td>
+                    <td class="text-center">
+                        <a t-attf-href="./update_line/#{ line.id }/?order_id=#{ quotation.id }&amp;unlink=True&amp;token=#{ quotation.access_token }" class="mb8 js_update_line_json hidden-print" t-if="line.option_line_id">
+                            <span class="fa fa-trash-o"></span>
+                        </a>
+                    </td>
+                </tr>
+              </t>
+                <t t-if="color%2==0">
+                <tr  style="font-weight: bold;">
+                  <td>
+                      <span t-field="line.name"/>
+                  </td>
+                  <td>
+                      <div id="quote_qty">
+                          <span t-field="line.product_uom_qty"/>
+                          <span t-field="line.product_uom"/>
+                      </div>
+                  </td>
+                  <td>
+                      <div t-foreach="line.tax_id" t-as="tax">
+                          <t t-esc="tax.name"/>
+                      </div>
+                  </td>
+                  <td>
+                      <strong t-if="line.discount" class="text-info">
+                          <t t-esc="((line.discount % 1) and '%s' or '%d') % line.discount"/>% discount
+                      </strong>
+                  </td>
+                  <td class="text-right">
+                        <div t-field="line.price_unit"
+                            t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'
+                            t-att-style="line.discount and 'text-decoration: line-through' or None"
+                            t-att-class="(line.discount and 'text-danger' or '') + ' text-right'"/>
+                        <div t-if="line.discount">
+                            <t t-esc="(1-line.discount / 100.0) * line.price_unit" t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'/>
+                        </div>
+                  </td>
+                  <td class="text-right" groups="sale.group_show_price_subtotal">
+                      <span t-field="line.price_subtotal"
+                            t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'/>
+                  </td>
+                  <td class="text-right" groups="sale.group_show_price_total">
+                      <span t-field="line.price_total"
+                            t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'/>
+                  </td>
+                  <td class="text-center">
+                      <a t-attf-href="./update_line/#{ line.id }/?order_id=#{ quotation.id }&amp;unlink=True&amp;token=#{ quotation.access_token }" class="mb8 js_update_line_json hidden-print" t-if="line.option_line_id">
+                          <span class="fa fa-trash-o"></span>
+                      </a>
+                  </td>
+              </tr>
+            </t>
+
+                <!-- Lines substitutives -->
+
+                <t t-foreach="line.substitute_line_ids" t-as="line_sub">
+                  <t t-if="color%2!=0">
+                  <tr style="background-color:#F9FAFC;">
+                    <td>
+                        <span t-field="line_sub.product_substitute_id.name"/>
+                    </td>
+                    <td>
+                        <div id="quote_qty">
+                            <span t-field="line_sub.product_uom_qty"/>
+                            <span t-field="line_sub.product_uom"/>
+                        </div>
+                    </td>
+                    <td>
+                        <div t-foreach="line_sub.tax_id" t-as="tax">
+                            <t t-esc="tax.name"/>
+                        </div>
+                    </td>
+                    <td>
+                        <strong t-if="line_sub.discount" class="text-info">
+                            <t t-esc="((line_sub.discount % 1) and '%s' or '%d') % line_sub.discount"/>% discount
+                        </strong>
+                    </td>
+                    <td class="text-right">
+                          <div t-field="line_sub.price_unit"
+                              t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'
+                              t-att-style="line_sub.discount and 'text-decoration: line_sub-through' or None"
+                              t-att-class="(line_sub.discount and 'text-danger' or '') + ' text-right'"/>
+                          <div t-if="line_sub.discount">
+                              <t t-esc="(1-line_sub.discount / 100.0) * line_sub.price_unit" t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'/>
+                          </div>
+                    </td>
+                    <td class="text-right" groups="sale.group_show_price_subtotal">
+                        <span t-field="line_sub.price_subtotal"
+                              t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'/>
+                    </td>
+                    <td class="text-right" groups="sale.group_show_price_total">
+                        <span t-field="line_sub.price_total"
+                              t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'/>
+                    </td>
+                    <td class="text-center">
+                      <a t-attf-href="/quote/substitute_line/#{ line_sub.id }/#{ quotation.id }/#{ quotation.access_token }"
+                      class="btn btn-info">
+                          <span>Change</span>
+                      </a>
+                    </td>
+                </tr>
+              </t>
+
+              <t t-if="color%2==0">
+              <tr>
+                <td>
+                    <span t-field="line_sub.product_substitute_id.name"/>
+                </td>
+                <td>
+                    <div id="quote_qty">
+                        <span t-field="line_sub.product_uom_qty"/>
+                        <span t-field="line_sub.product_uom"/>
+                    </div>
+                </td>
+                <td>
+                    <div t-foreach="line_sub.tax_id" t-as="tax">
+                        <t t-esc="tax.name"/>
+                    </div>
+                </td>
+                <td>
+                    <strong t-if="line_sub.discount" class="text-info">
+                        <t t-esc="((line_sub.discount % 1) and '%s' or '%d') % line_sub.discount"/>% discount
+                    </strong>
+                </td>
+                <td class="text-right">
+                      <div t-field="line_sub.price_unit"
+                          t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'
+                          t-att-style="line_sub.discount and 'text-decoration: line_sub-through' or None"
+                          t-att-class="(line_sub.discount and 'text-danger' or '') + ' text-right'"/>
+                      <div t-if="line_sub.discount">
+                          <t t-esc="(1-line_sub.discount / 100.0) * line_sub.price_unit" t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'/>
+                      </div>
+                </td>
+                <td class="text-right" groups="sale.group_show_price_subtotal">
+                    <span t-field="line_sub.price_subtotal"
+                          t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'/>
+                </td>
+                <td class="text-right" groups="sale.group_show_price_total">
+                    <span t-field="line_sub.price_total"
+                          t-options='{"widget": "monetary", "display_currency": quotation.pricelist_id.currency_id}'/>
+                </td>
+                <td class="text-center">
+                  <a t-attf-href="/quote/substitute_line/#{ line_sub.id }/#{ quotation.id }/#{ quotation.access_token }"
+                  class="btn btn-info">
+                      <span>Change</span>
+                  </a>
+                </td>
+            </tr>
+          </t>
+
+
+                </t>
+              </t>
+
+              <t t-if="(layout_category_size > 1  or page_size > 1) and layout_category['subtotal']" groups="sale.group_sale_layout">
+                  <tr>
+                      <td></td><td></td><td></td><td></td>
+                      <td class="text-right" style="padding-bottom: 32px"><strong>Subtotal:</strong></td>
+                      <td class="text-right" style="padding-bottom: 32px">
+                          <t t-set="subtotal" t-value="sum(line.price_subtotal for line in layout_category['lines'])"/>
+                          <strong data-id="total_amount" t-esc="subtotal" t-options="{'widget': 'monetary', 'display_currency': quotation.pricelist_id.currency_id}"/>
+                      </td>
+                      <td></td>
+                  </tr>
+              </t>
+          </t>
+          <t t-if="page_index == page_size - 1">
+              <t t-if="any([line.tax_id for line in quotation.order_line])">
+                  <tr>
+                      <td></td><td></td><td></td><td></td>
+                      <td class="text-right"><strong>Subtotal:</strong></td>
+                      <td class="text-right">
+                          <strong data-id="total_amount" t-field="quotation.amount_untaxed" t-options='{"widget": "monetary","display_currency": quotation.pricelist_id.currency_id}'/>
+                      </td>
+                      <td></td>
+                  </tr>
+
+                  <tr>
+                      <td></td><td></td><td></td><td></td>
+                      <td class="text-right">Taxes:</td>
+                      <td class="text-right">
+                          <span data-id="total_amount" t-field="quotation.amount_tax" t-options='{"widget": "monetary","display_currency": quotation.pricelist_id.currency_id}'/>
+                      </td>
+                      <td></td>
+                  </tr>
+              </t>
+              <tr>
+                  <td></td><td></td><td></td><td></td>
+                  <td class="text-right"><strong>Total:</strong></td>
+                  <td class="text-right">
+                      <strong data-id="total_amount" t-field="quotation.amount_total" t-options='{"widget": "monetary","display_currency": quotation.pricelist_id.currency_id}'/>
+                  </td>
+                  <td></td>
+              </tr>
+          </t>
+      </tbody>
+    </xpath>
+  </template>
+</odoo>


### PR DESCRIPTION
This module allows you to add substitute products on the sale order and link them to a specific sale order line. Afterwards, you can change the products via Odoo or the online quotation.