### PR TITLE
[8.0][FIX] sale_delivery_split_date: sale_id not working

### DIFF
--- a/sale_delivery_split_date/__openerp__.py
+++ b/sale_delivery_split_date/__openerp__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Sale Delivery Split Date',
-    'version': '8.0.1.0.0',
+    'version': '8.0.1.2.0',
     'summary': 'Sale Deliveries split by date',
     'category': 'Sales Management',
     'license': 'AGPL-3',

--- a/sale_delivery_split_date/models/stock_picking.py
+++ b/sale_delivery_split_date/models/stock_picking.py
@@ -3,15 +3,37 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import api, fields, models
+from openerp.osv import fields as old_fields
 
 
 class StockPicking(models.Model):
 
     _inherit = 'stock.picking'
 
+    def _get_sale_id(self, cr, uid, ids, name, args, context=None):
+        res = {}
+        line_model = self.pool['sale.order.line']
+        for picking in self.browse(cr, uid, ids, context=context):
+            res[picking.id] = super(StockPicking, self)._get_sale_id(
+                cr, uid, picking.ids, name, args, context=context)[picking.id]
+            if not res[picking.id] and picking.group_id:
+                line_id = line_model.search(
+                    cr, uid,
+                    [('procurement_group_id', '=', picking.group_id.id)],
+                    limit=1, context=context)
+                line = line_model.browse(cr, uid, line_id, context=context)
+                res[picking.id] = line.order_id
+        return res
+
     min_dt = fields.Date(
         string='Scheduled Date (for filter purpose only)',
         compute='_compute_min_dt', store=True)
+
+    _columns = {
+        'sale_id': old_fields.function(
+            _get_sale_id, type="many2one", relation="sale.order",
+            string="Sale Order"),
+    }
 
     @api.multi
     @api.depends('min_date')

--- a/sale_delivery_split_date/tests/test_sale_delivery.py
+++ b/sale_delivery_split_date/tests/test_sale_delivery.py
@@ -45,6 +45,11 @@ class TestSaleDelivery(TransactionCase):
         self.assertEqual(
             len(self.so.picking_ids), 1,
             "There must be 1 picking for the SO when confirmed")
+        for picking in self.so.picking_ids:
+            self.assertEqual(
+                picking.sale_id, self.so,
+                "The sale order related to the picking must be the "
+                "previously confirmed SO")
         self.assertEqual(
             self.so.picking_ids[0].min_date[:10],
             self.so.picking_ids[0].min_dt)
@@ -68,6 +73,11 @@ class TestSaleDelivery(TransactionCase):
         self.assertEqual(
             len(self.so.picking_ids), 2,
             "There must be 2 pickings for the SO when confirmed")
+        for picking in self.so.picking_ids:
+            self.assertEqual(
+                picking.sale_id, self.so,
+                "The sale order related to the picking must be the "
+                "previously confirmed SO")
         sorted_pickings = self.so.picking_ids.sorted(lambda x: x.min_date)
         self.assertEqual(
             self.so.picking_ids[0].min_date[:10],
@@ -101,6 +111,11 @@ class TestSaleDelivery(TransactionCase):
         self.assertEqual(
             len(self.so.picking_ids), 1,
             "There must be only one picking for the SO when confirmed")
+        for picking in self.so.picking_ids:
+            self.assertEqual(
+                picking.sale_id, self.so,
+                "The sale order related to the picking must be the "
+                "previously confirmed SO")
         self.assertEqual(
             self.so.picking_ids[0].min_date[:10],
             self.so.picking_ids[0].min_dt)


### PR DESCRIPTION
When a picking is invoiced it will invoice using the delivery address (partner_id from stock.picking)
This fix avoids that error.

cc @tafaRU 