### PR TITLE
[10] sale_triple_discount: Fix tax total on report

### DIFF
--- a/sale_triple_discount/README.rst
+++ b/sale_triple_discount/README.rst
@@ -65,6 +65,7 @@ Contributors
 * Alex Comba <alex.comba@agilebg.com>
 * David Vidal <david.vidal@tecnativa.com>
 * Simone Rubino <simone.rubino@agilebg.com>
+* Jacques-Etienne Baudoux (BCIM sprl) <je@bcim.be>
 
 Maintainer
 ----------

--- a/sale_triple_discount/__manifest__.py
+++ b/sale_triple_discount/__manifest__.py
@@ -2,6 +2,7 @@
 # Copyright 2015 ADHOC SA  (http://www.adhoc.com.ar)
 # Copyright 2017 Alex Comba - Agile Business Group
 # Copyright 2017 Tecnativa - David Vidal
+# Copyright 2018 Jacques-Etienne Baudoux (BCIM sprl) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {

--- a/sale_triple_discount/models/sale_order.py
+++ b/sale_triple_discount/models/sale_order.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2018 Simone Rubino - Agile Business Group
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# Copyright 2018 Jacques-Etienne Baudoux (BCIM sprl) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, models
 
@@ -15,3 +16,25 @@ class SaleOrder(models.Model):
             prev_values.update(order.order_line.triple_discount_preprocess())
         super(SaleOrder, self)._amount_all()
         self.env['sale.order.line'].triple_discount_postprocess(prev_values)
+
+    @api.multi
+    def _get_tax_amount_by_group(self):
+        # Copy/paste from standard method in sale
+        self.ensure_one()
+        res = {}
+        for line in self.order_line:
+            price_reduce = line.price_reduce  # changed
+            taxes = line.tax_id.compute_all(
+                price_reduce, quantity=line.product_uom_qty,
+                product=line.product_id,
+                partner=self.partner_shipping_id)['taxes']
+            for tax in line.tax_id:
+                group = tax.tax_group_id
+                res.setdefault(group, 0.0)
+                for t in taxes:
+                    if (t['id'] == tax.id or
+                            t['id'] in tax.children_tax_ids.ids):
+                        res[group] += t['amount']
+        res = sorted(res.items(), key=lambda l: l[0].sequence)
+        res = map(lambda l: (l[0].name, l[1]), res)
+        return res


### PR DESCRIPTION
Include the discount2/3 in the computation
Ideally, the standard odoo sale code should be fixed to take the reduced price properly.