### PR TITLE
[FIX] sale_order_secondary_unit: field does not exits in product

### DIFF
--- a/sale_order_secondary_unit/__manifest__.py
+++ b/sale_order_secondary_unit/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Sale Order Secondary Unit',
     'summary': 'Sale product in a secondary unit',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'development_status': 'Beta',
     'category': 'Sale',
     'website': 'https://github.com/OCA/sale-workflow',

--- a/sale_order_secondary_unit/models/sale_order.py
+++ b/sale_order_secondary_unit/models/sale_order.py
@@ -62,4 +62,4 @@ class SaleOrderLine(models.Model):
 
     @api.onchange('product_id')
     def onchange_secondary_unit_product_id(self):
-        self.secondary_uom_id = self.product_id.sale_secondary_uom_id
+        self.secondary_uom_id = self.product_id.secondary_uom_ids[:1]


### PR DESCRIPTION
Tests are failing due to a field that not exists.

cc @Tecnativa