### PR TITLE
[10.0][ADD] new module to version partner from sale orders

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -6,3 +6,4 @@ server-tools
 manufacture
 account-invoicing
 product-attribute
+partner-contact

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -6,4 +6,4 @@ server-tools
 manufacture
 account-invoicing
 product-attribute
-partner-contact
+partner-contact https://github.com/akretion/partner-contact 10-partner-history

--- a/sale_partner_version/README.rst
+++ b/sale_partner_version/README.rst
@@ -1,0 +1,49 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+====================
+Sale Partner Vesrion
+====================
+
+This module use the partner versionning module to set version from validated sale order.
+
+Usage
+=====
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/partner-contact/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Benoît Guillot <benoit.guillot@akretion.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/sale_partner_version/__init__.py
+++ b/sale_partner_version/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion - Benoît Guillot
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/sale_partner_version/__manifest__.py
+++ b/sale_partner_version/__manifest__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion - Benoît Guillot
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    'name': 'Sale Partner Version',
+    'version': '10.0.1.0.0',
+    'author': "Akretion, "
+              "Odoo Community Association (OCA)",
+    'website': 'http://www.akretion.com',
+    'category': 'Sale',
+    'license': 'AGPL-3',
+    'installable': True,
+    'depends': [
+        'sale',
+        'partner_address_version',
+    ],
+    'data': [
+    ],
+}

--- a/sale_partner_version/models/__init__.py
+++ b/sale_partner_version/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion - Benoît Guillot
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import sale

--- a/sale_partner_version/models/sale.py
+++ b/sale_partner_version/models/sale.py
@@ -12,6 +12,6 @@ class SaleOrder(models.Model):
     def action_confirm(self):
         address_fields = ['partner_shipping_id', 'partner_invoice_id']
         for order in self:
-            for address_field in address_fields:
-                order[address_field] = order[address_field].get_address_version()
+            for field in address_fields:
+                order[field] = order[field].get_address_version()
         return super(SaleOrder, self).action_confirm()

--- a/sale_partner_version/models/sale.py
+++ b/sale_partner_version/models/sale.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion - Benoît Guillot
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, api
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.multi
+    def action_confirm(self):
+        address_fields = ['partner_shipping_id', 'partner_invoice_id']
+        for order in self:
+            for address_field in address_fields:
+                order[address_field] = order[address_field].get_address_version()
+        return super(SaleOrder, self).action_confirm()

--- a/sale_partner_version/tests/__init__.py
+++ b/sale_partner_version/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion - Benoît Guillot
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_sale_partner_version

--- a/sale_partner_version/tests/test_sale_partner_version.py
+++ b/sale_partner_version/tests/test_sale_partner_version.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion - Benoît Guillot
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestSalePartnerVersion(TransactionCase):
+
+    def setUp(self):
+        super(TestSalePartnerVersion, self).setUp()
+        self.sale = self.env.ref('sale.sale_order_1')
+
+    def test_sale_version_partner(self):
+        self.assertFalse(self.sale.partner_invoice_id.version_hash)
+        self.assertFalse(self.sale.partner_shipping_id.version_hash)
+        self.sale.action_confirm()
+        self.assertTrue(self.sale.partner_invoice_id.version_hash)
+        self.assertTrue(self.sale.partner_shipping_id.version_hash)


### PR DESCRIPTION
Hi

This module depends on the module of this PR : https://github.com/OCA/partner-contact/pull/669

It sets a version on addresses of the sale order when the sale order is validated.