### PR TITLE
[10.0] new module sale_delivery_state

### DIFF
--- a/sale_delivery_state/__init__.py
+++ b/sale_delivery_state/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/sale_delivery_state/__manifest__.py
+++ b/sale_delivery_state/__manifest__.py
@@ -8,9 +8,10 @@
     "summary": "Show the delivery state on the sale order",
     "version": "10.0.1.0.0",
     "category": "Product",
-    "website": "www.akretion.com",
-    "author": " Akretion",
+    "website": "https://github.com/OCA/sale-workflow",
+    "author": "Akretion, Odoo Community Association (OCA)",
     "license": "AGPL-3",
+    "installable": True,
     "depends": ["sale"],
     "data": [
         "views/sale_order_views.xml",
@@ -18,5 +19,4 @@
     "demo": [
         "demo/sale_demo.xml",
     ],
-    "installable": True,
 }

--- a/sale_delivery_state/__manifest__.py
+++ b/sale_delivery_state/__manifest__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com).
+# @author Pierrick BRUN <pierrick.brun@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Sale delivery State",
+    "summary": "Show the delivery state on the sale order",
+    "version": "10.0.1.0.0",
+    "category": "Product",
+    "website": "www.akretion.com",
+    "author": " Akretion",
+    "license": "AGPL-3",
+    "depends": ["sale_stock"],
+    "data": [
+        "views/sale_order_views.xml",
+    ],
+    "installable": True,
+}

--- a/sale_delivery_state/__manifest__.py
+++ b/sale_delivery_state/__manifest__.py
@@ -11,9 +11,12 @@
     "website": "www.akretion.com",
     "author": " Akretion",
     "license": "AGPL-3",
-    "depends": ["sale_stock"],
+    "depends": ["sale"],
     "data": [
         "views/sale_order_views.xml",
+    ],
+    "demo": [
+        "demo/sale_demo.xml",
     ],
     "installable": True,
 }

--- a/sale_delivery_state/demo/sale_demo.xml
+++ b/sale_delivery_state/demo/sale_demo.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+        <record id="sale_order_1" model="sale.order">
+            <field name="partner_id" ref="base.res_partner_2"/>
+            <field name="partner_invoice_id" ref="base.res_partner_2"/>
+            <field name="partner_shipping_id" ref="base.res_partner_2"/>
+            <field name="user_id" ref="base.user_demo"/>
+            <field name="pricelist_id" ref="product.list0"/>
+            <field name="team_id" ref="sales_team.team_sales_department"/>
+            <field name="date_order" eval="(DateTime.today() - relativedelta(months=1)).strftime('%Y-%m-%d %H:%M')"/>
+        </record>
+
+        <record id="sale_order_line_1" model="sale.order.line">
+            <field name="order_id" ref="sale_order_1"/>
+            <field name="name">Laptop E5023</field>
+            <field name="product_id" ref="product.product_product_25"/>
+            <field name="product_uom_qty">3</field>
+            <field name="product_uom" ref="product.product_uom_unit"/>
+            <field name="price_unit">2950.00</field>
+        </record>
+
+        <record id="sale_order_line_2" model="sale.order.line">
+            <field name="order_id" ref="sale_order_1"/>
+            <field name="name">Pen drive, 16GB</field>
+            <field name="product_id" ref="product.product_delivery_02"/>
+            <field name="product_uom_qty">5</field>
+            <field name="product_uom" ref="product.product_uom_unit"/>
+            <field name="price_unit">145.00</field>
+        </record>
+
+    </data>
+</odoo>

--- a/sale_delivery_state/models/__init__.py
+++ b/sale_delivery_state/models/__init__.py
@@ -1,4 +1,3 @@
 # -*- coding: utf-8 -*-
 
 from . import sale_order
-from . import stock_picking

--- a/sale_delivery_state/models/__init__.py
+++ b/sale_delivery_state/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import sale_order
+from . import stock_picking

--- a/sale_delivery_state/models/sale_order.py
+++ b/sale_delivery_state/models/sale_order.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2018 Akretion (http://www.akretion.com).
 # @author Pierrick BRUN <pierrick.brun@akretion.com>
+# Copyright 2018 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models, fields, api
@@ -16,19 +17,84 @@ class SaleOrder(models.Model):
         ('partially', 'Partially processed'),
         ('done', 'Done')],
         string='Delivery state',
-        compute='compute_delivery_state',
+        compute='_compute_delivery_state',
         store=True
     )
 
+    def _all_qty_delivered(self):
+        """
+        Returns True if all line have qty_delivered >= to ordered quantities
+
+        If `delivery` module is installed, ignores the lines with delivery costs
+
+        :returns: boolean
+        """
+        self.ensure_one()
+        # Skip delivery costs lines
+        sale_lines = self.order_line
+        Carrier = self.env.get('delivery.carrier')
+        if Carrier:
+            sale_lines = sale_lines.filtered(
+                lambda rec: not rec.is_delivery_cost())
+        precision = self.env['decimal.precision'].precision_get(
+            'Product Unit of Measure'
+        )
+        return all(
+            float_compare(line.qty_delivered, line.product_uom_qty,
+                          precision_digits=precision) >= 0
+            for line in sale_lines
+        )
+
+    def _partially_delivered(self):
+        """
+        Returns True if at least one line is delivered
+
+        :returns: boolean
+        """
+        self.ensure_one()
+        # Skip delivery costs lines
+        sale_lines = self.order_line
+        Carrier = self.env.get('delivery.carrier')
+        if Carrier:
+            sale_lines = sale_lines.filtered(
+                lambda rec: not rec.is_delivery_cost())
+        precision = self.env['decimal.precision'].precision_get(
+            'Product Unit of Measure'
+        )
+        return any(
+            not float_is_zero(line.qty_delivered, precision_digits=precision)
+            for line in self.order_line
+        )
+
     @api.depends('order_line', 'order_line.qty_delivered', 'state')
-    def compute_delivery_state(self):
-        precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+    def _compute_delivery_state(self):
         for order in self:
             if order.state in ('draft', 'cancel'):
                 order.delivery_state = 'no'
-            elif all((float_compare(line.qty_delivered, line.product_uom_qty, precision_digits=precision) >= 0 for line in order.order_line)):
+            elif order._all_qty_delivered():
                 order.delivery_state = 'done'
-            elif any((not float_is_zero(line.qty_delivered, precision_digits=precision) for line in order.order_line)):
+            elif order._partially_delivered():
                 order.delivery_state = 'partially'
             else:
                 order.delivery_state = 'unprocessed'
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    def is_delivery_cost(self):
+        """
+        Returns if a sale line has a delivery products
+        check that a line is a delivery costs
+
+        :returns boolean:
+        """
+        self.ensure_one()
+        Carrier = self.env.get('delivery.carrier')
+        # If you call this without `delivery` module installed
+        # you are probably doing it wrong because it will always
+        # returns False
+        if not Carrier or not self.product_id:
+            return False
+        search_domain = [('product_id', '=', self.product_id.id)]
+        return bool(Carrier.search_count(search_domain))

--- a/sale_delivery_state/models/sale_order.py
+++ b/sale_delivery_state/models/sale_order.py
@@ -3,17 +3,32 @@
 # @author Pierrick BRUN <pierrick.brun@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models, fields
+from odoo import models, fields, api
+from odoo.tools import float_is_zero, float_compare
 
 
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
     delivery_state = fields.Selection([
+        ('no', 'No delivery'),
         ('unprocessed', 'Unprocessed'),
         ('partially', 'Partially processed'),
         ('done', 'Done')],
-        string='Picking state',
-        copy=False,
-        default='unprocessed'
+        string='Delivery state',
+        compute='compute_delivery_state',
+        store=True
     )
+
+    @api.depends('order_line', 'order_line.qty_delivered', 'state')
+    def compute_delivery_state(self):
+        precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+        for order in self:
+            if order.state in ('draft', 'cancel'):
+                order.delivery_state = 'no'
+            elif all((float_compare(line.qty_delivered, line.product_uom_qty, precision_digits=precision) >= 0 for line in order.order_line)):
+                order.delivery_state = 'done'
+            elif any((not float_is_zero(line.qty_delivered, precision_digits=precision) for line in order.order_line)):
+                order.delivery_state = 'partially'
+            else:
+                order.delivery_state = 'unprocessed'

--- a/sale_delivery_state/models/sale_order.py
+++ b/sale_delivery_state/models/sale_order.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com).
+# @author Pierrick BRUN <pierrick.brun@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    delivery_state = fields.Selection([
+        ('unprocessed', 'Unprocessed'),
+        ('partially', 'Partially processed'),
+        ('done', 'Done')],
+        string='Picking state',
+        copy=False,
+        default='unprocessed'
+    )

--- a/sale_delivery_state/readme/CONTRIBUTORS.rst
+++ b/sale_delivery_state/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* Pierrick BRUN <pierrick.brun@akretion.com>
+* Benoît Guillot <benoit.guillot@akretion.com>
+* Yannick Vaucher <yannick.vaucher@camptocamp.com>

--- a/sale_delivery_state/readme/DESCRIPTION.rst
+++ b/sale_delivery_state/readme/DESCRIPTION.rst
@@ -1,0 +1,15 @@
+This odoo module add delivery state on the sale order.
+
+Delivery state is computed based on `qty_delivered` field on sale order lines.
+
+This is usefull for other modules to provide the state of delivery.
+The state of the sale order can be forced to fully delivered in case
+some quantities were cancelled by the customer and you consider you have
+nothing more to deliver.
+
+Sale order lines can have products or services, as long as the field `qty_delivered`
+is set, it will trigger the computation of delivery state.
+
+This module also works with delivery.carrier fees that are added as a
+sale order line. Thoses line are special as they will never be considered delivered.
+Delvery fees lines are ignored in the computation of the delivery state.

--- a/sale_delivery_state/tests/__init__.py
+++ b/sale_delivery_state/tests/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import test_delivery_state

--- a/sale_delivery_state/tests/test_delivery_state.py
+++ b/sale_delivery_state/tests/test_delivery_state.py
@@ -27,6 +27,12 @@ class TestDeliveryState(TransactionCase):
         self.order.order_line[0].qty_delivered = 2
         self.assertEqual(self.order.delivery_state, 'partially')
 
+    def test_forced_delivery_cost(self):
+        self.order.action_confirm()
+        self.order.order_line[0].qty_delivered = 2
+        self.order.force_delivery_state = True
+        self.assertEqual(self.order.delivery_state, 'done')
+
     def test_delivery_done(self):
         self.order.action_confirm()
         for line in self.order.order_line:
@@ -88,6 +94,14 @@ class TestDeliveryState(TransactionCase):
         self.order.action_confirm()
         self.order.order_line[0].qty_delivered = 2
         self.assertEqual(self.order.delivery_state, 'partially')
+
+    def test_forced_delivery_cost(self):
+        self.add_delivery_cost_line()
+        self.mock_delivery()
+        self.order.action_confirm()
+        self.order.order_line[0].qty_delivered = 2
+        self.order.force_delivery_state = True
+        self.assertEqual(self.order.delivery_state, 'done')
 
     def test_delivery_done_delivery_cost(self):
         self.add_delivery_cost_line()

--- a/sale_delivery_state/tests/test_delivery_state.py
+++ b/sale_delivery_state/tests/test_delivery_state.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 # Copyright 2018 Akretion (http://www.akretion.com).
 # @author Benoît GUILLOT <benoit.guillot@akretion.com>
+# Copyright 2018 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from mock import Mock
+from functools import partial
 from odoo.tests.common import TransactionCase
 
 
@@ -27,5 +30,72 @@ class TestDeliveryState(TransactionCase):
     def test_delivery_done(self):
         self.order.action_confirm()
         for line in self.order.order_line:
+            line.qty_delivered = line.product_uom_qty
+        self.assertEqual(self.order.delivery_state, 'done')
+
+    def mock_delivery(self):
+        """
+        Mock `delivery.carrier` model to make tests even if
+        `delivery` module is not installed
+
+        Warning this messes with create, makes sure you
+        don't use create afterwards.
+        """
+        carrier_mock = Mock()
+
+        def search_count(cost_id, domain, *args, **kwargs):
+            """
+            Mock search count for delivery.carrier
+            as we want to make the tests even if `delivery`
+            module is not installed
+            """
+            if domain[0][2] == cost_id:
+                return 1
+            return 0
+
+        cost_id = self.env.ref('product.service_delivery').id
+        carrier_mock._browse.return_value.search_count = partial(
+            search_count, cost_id)
+        self.env.registry['delivery.carrier'] = carrier_mock
+
+    def add_delivery_cost_line(self):
+        # let's assume for this test that service_delivery is assigned
+        # to a carrier
+        delivery_cost = self.env.ref('product.service_delivery')
+        self.env['sale.order.line'].create({
+            'order_id': self.order.id,
+            'name': 'Delivery cost',
+            'product_id': delivery_cost.id,
+            'product_uom_qty': 1,
+            'product_uom': self.env.ref('product.product_uom_unit').id,
+            'price_unit': 10.0,
+        })
+
+    def test_no_delivery_delivery_cost(self):
+        self.add_delivery_cost_line()
+        self.mock_delivery()
+        self.assertEqual(self.order.delivery_state, 'no')
+
+    def test_unprocessed_delivery_delivery_cost(self):
+        self.add_delivery_cost_line()
+        self.mock_delivery()
+        self.order.action_confirm()
+        self.assertEqual(self.order.delivery_state, 'unprocessed')
+
+    def test_partially_delivery_cost(self):
+        self.add_delivery_cost_line()
+        self.mock_delivery()
+        self.order.action_confirm()
+        self.order.order_line[0].qty_delivered = 2
+        self.assertEqual(self.order.delivery_state, 'partially')
+
+    def test_delivery_done_delivery_cost(self):
+        self.add_delivery_cost_line()
+        self.mock_delivery()
+        self.order.action_confirm()
+        delivery_cost = self.env.ref('product.service_delivery')
+        for line in self.order.order_line:
+            if line.product_id == delivery_cost:
+                continue
             line.qty_delivered = line.product_uom_qty
         self.assertEqual(self.order.delivery_state, 'done')

--- a/sale_delivery_state/tests/test_delivery_state.py
+++ b/sale_delivery_state/tests/test_delivery_state.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Akretion (http://www.akretion.com).
+# @author Benoît GUILLOT <benoit.guillot@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestDeliveryState(TransactionCase):
+
+    def setUp(self):
+        super(TestDeliveryState, self).setUp()
+        self.order = self.env.ref('sale_delivery_state.sale_order_1')
+
+    def test_no_delivery(self):
+        self.assertEqual(self.order.delivery_state, 'no')
+
+    def test_unprocessed_delivery(self):
+        self.order.action_confirm()
+        self.assertEqual(self.order.delivery_state, 'unprocessed')
+
+    def test_partially(self):
+        self.order.action_confirm()
+        self.order.order_line[0].qty_delivered = 2
+        self.assertEqual(self.order.delivery_state, 'partially')
+
+    def test_delivery_done(self):
+        self.order.action_confirm()
+        for line in self.order.order_line:
+            line.qty_delivered = line.product_uom_qty
+        self.assertEqual(self.order.delivery_state, 'done')

--- a/sale_delivery_state/views/sale_order_views.xml
+++ b/sale_delivery_state/views/sale_order_views.xml
@@ -1,34 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <data>
-        <record id="view_order_form_inherit_delivery_state" model="ir.ui.view">
-            <field name="name">sale.order.form.sale.stock</field>
-            <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.view_order_form"/>
-            <field name="arch" type="xml">
-                <field name="state" position="before">
-                    <!-- states and attrs[invisible] must be combined with an extra & -->
-                    <button name="action_force_delivery_state" type="object" string="Force delivery done" states="done"
-                            attrs="{'invisible': ['|', '|', ('force_delivery_state', '=', True), ('delivery_state', '=', 'done')]}"/>
-                    <button name="action_unforce_delivery_state" type="object" string="Unforce delivery done" states="done"
-                            attrs="{'invisible': ['|', '|', ('force_delivery_state', '=', False)]}"/>
-		</field>
-                <xpath expr="//field[@name='confirmation_date']" position="before">
-                    <field name="delivery_state" readonly="True"/>
-                    <field name="force_delivery_state" invisible="True"/>
-                </xpath>
-           </field>
-        </record>
-
-        <record id="view_order_tree_inherit_delivery_state" model="ir.ui.view">
-            <field name="name">sale.order.tree</field>
-            <field name="inherit_id" ref="sale.view_order_tree"/>
-            <field name="model">sale.order</field>
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='date_order']" position="after">
-                    <field name="delivery_state"/>
-                </xpath>
+    <record id="view_order_form_inherit_delivery_state" model="ir.ui.view">
+        <field name="name">sale.order.form.sale.stock</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <field name="state" position="before">
+                <!-- states and attrs[invisible] must be combined with an extra & -->
+                <button name="action_force_delivery_state" type="object" string="Force delivery done" states="done"
+                        attrs="{'invisible': ['|', '|', ('force_delivery_state', '=', True), ('delivery_state', '=', 'done')]}"/>
+                <button name="action_unforce_delivery_state" type="object" string="Unforce delivery done" states="done"
+                        attrs="{'invisible': ['|', '|', ('force_delivery_state', '=', False)]}"/>
             </field>
-        </record>
-    </data>
+            <xpath expr="//field[@name='confirmation_date']" position="before">
+                <field name="delivery_state" readonly="True"/>
+                <field name="force_delivery_state" invisible="True"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_order_tree_inherit_delivery_state" model="ir.ui.view">
+        <field name="name">sale.order.tree</field>
+        <field name="inherit_id" ref="sale.view_order_tree"/>
+        <field name="model">sale.order</field>
+        <field name="arch" type="xml">
+            <field name="date_order" position="after">
+                <field name="delivery_state"/>
+            </field>
+        </field>
+    </record>
 </odoo>

--- a/sale_delivery_state/views/sale_order_views.xml
+++ b/sale_delivery_state/views/sale_order_views.xml
@@ -6,8 +6,16 @@
             <field name="model">sale.order</field>
             <field name="inherit_id" ref="sale.view_order_form"/>
             <field name="arch" type="xml">
+                <field name="state" position="before">
+                    <!-- states and attrs[invisible] must be combined with an extra & -->
+                    <button name="action_force_delivery_state" type="object" string="Force delivery done" states="done"
+                            attrs="{'invisible': ['|', '|', ('force_delivery_state', '=', True), ('delivery_state', '=', 'done')]}"/>
+                    <button name="action_unforce_delivery_state" type="object" string="Unforce delivery done" states="done"
+                            attrs="{'invisible': ['|', '|', ('force_delivery_state', '=', False)]}"/>
+		</field>
                 <xpath expr="//field[@name='confirmation_date']" position="before">
                     <field name="delivery_state" readonly="True"/>
+                    <field name="force_delivery_state" invisible="True"/>
                 </xpath>
            </field>
         </record>

--- a/sale_delivery_state/views/sale_order_views.xml
+++ b/sale_delivery_state/views/sale_order_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+        <record id="view_order_form_inherit_delivery_state" model="ir.ui.view">
+            <field name="name">sale.order.form.sale.stock</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='confirmation_date']" position="before">
+                    <field name="picking_state" readonly="True"/>
+                </xpath>
+           </field>
+        </record>
+
+        <record id="view_order_tree_inherit_delivery_state" model="ir.ui.view">
+            <field name="name">sale.order.tree</field>
+            <field name="inherit_id" ref="sale.view_order_tree"/>
+            <field name="model">sale.order</field>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='date_order']" position="after">
+                    <field name="picking_state"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/sale_delivery_state/views/sale_order_views.xml
+++ b/sale_delivery_state/views/sale_order_views.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="sale.view_order_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='confirmation_date']" position="before">
-                    <field name="picking_state" readonly="True"/>
+                    <field name="delivery_state" readonly="True"/>
                 </xpath>
            </field>
         </record>
@@ -18,7 +18,7 @@
             <field name="model">sale.order</field>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='date_order']" position="after">
-                    <field name="picking_state"/>
+                    <field name="delivery_state"/>
                 </xpath>
             </field>
         </record>

--- a/sale_picking_state/i18n/fr.po
+++ b/sale_picking_state/i18n/fr.po
@@ -1,0 +1,47 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_picking_state
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-10-22 09:13+0000\n"
+"PO-Revision-Date: 2018-10-22 09:13+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_picking_state
+#: model:ir.model.fields,field_description:sale_picking_state.field_sale_order_delivery_state
+msgid "Delivery state"
+msgstr "État de livraison"
+
+#. module: sale_picking_state
+#: selection:sale.order,delivery_state:0
+msgid "Done"
+msgstr "Expédié"
+
+#. module: sale_picking_state
+#: selection:sale.order,delivery_state:0
+msgid "No delivery"
+msgstr "Pas de livraison"
+
+#. module: sale_picking_state
+#: selection:sale.order,delivery_state:0
+msgid "Partially processed"
+msgstr "Partiellement expédié"
+
+#. module: sale_picking_state
+#: model:ir.model,name:sale_picking_state.model_sale_order
+msgid "Sales Order"
+msgstr "Commande de vente"
+
+#. module: sale_picking_state
+#: selection:sale.order,delivery_state:0
+msgid "Unprocessed"
+msgstr "À expédier"
+

--- a/sale_picking_state/i18n/sale_picking_state.pot
+++ b/sale_picking_state/i18n/sale_picking_state.pot
@@ -1,0 +1,47 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* sale_picking_state
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-10-22 09:12+0000\n"
+"PO-Revision-Date: 2018-10-22 09:12+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_picking_state
+#: model:ir.model.fields,field_description:sale_picking_state.field_sale_order_delivery_state
+msgid "Delivery state"
+msgstr ""
+
+#. module: sale_picking_state
+#: selection:sale.order,delivery_state:0
+msgid "Done"
+msgstr ""
+
+#. module: sale_picking_state
+#: selection:sale.order,delivery_state:0
+msgid "No delivery"
+msgstr ""
+
+#. module: sale_picking_state
+#: selection:sale.order,delivery_state:0
+msgid "Partially processed"
+msgstr ""
+
+#. module: sale_picking_state
+#: model:ir.model,name:sale_picking_state.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: sale_picking_state
+#: selection:sale.order,delivery_state:0
+msgid "Unprocessed"
+msgstr ""
+


### PR DESCRIPTION
Portage of module `sale_picking_state` renamed to `sale_delivery_state` from: https://github.com/akretion/ak-odoo-incubator/pull/119

This module is there to address the issue when a sale order goes direcly to 'done' state while the delivery is not complete yet. Which in case of synchronisation with other system is lacking accuracy.

Will work well with `delivery` module but doesn't depends on it.

A button to force delivery state appears only in Locked (done) state of the sale order.