### PR TITLE
[10.0][FIX] sale_triple_discount: Correctly compute taxes with round_globally configuration

### DIFF
--- a/sale_triple_discount/README.rst
+++ b/sale_triple_discount/README.rst
@@ -64,6 +64,7 @@ Contributors
 * Juan José Scarafía <jjs@adhoc.com.ar>
 * Alex Comba <alex.comba@agilebg.com>
 * David Vidal <david.vidal@tecnativa.com>
+* Simone Rubino <simone.rubino@agilebg.com>
 
 Maintainer
 ----------

--- a/sale_triple_discount/__manifest__.py
+++ b/sale_triple_discount/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Sale Triple Discount',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Sales Management',
     'author': 'ADHOC SA, '
               'Agile Business Group, '

--- a/sale_triple_discount/models/__init__.py
+++ b/sale_triple_discount/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
+from . import sale_order
 from . import sale_order_line

--- a/sale_triple_discount/models/sale_order.py
+++ b/sale_triple_discount/models/sale_order.py
@@ -12,21 +12,6 @@ class SaleOrder(models.Model):
     def _amount_all(self):
         prev_values = dict()
         for order in self:
-            for line in order.order_line:
-                prev_values[line] = dict(
-                    discount=line.discount,
-                    discount2=line.discount2,
-                    discount3=line.discount3,
-                )
-                # Update, for some reason, does not work
-                line.write({
-                    'discount': line._get_triple_discount(),
-                    'discount2': 0.0,
-                    'discount3': 0.0
-                })
+            prev_values.update(order.order_line.triple_discount_preprocess())
         super(SaleOrder, self)._amount_all()
-
-        # Restore previous values
-        for line, prev_vals_dict in prev_values.items():
-            # Update, for some reason, does not work
-            line.write(prev_vals_dict)
+        self.env['sale.order.line'].triple_discount_postprocess(prev_values)

--- a/sale_triple_discount/models/sale_order.py
+++ b/sale_triple_discount/models/sale_order.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Simone Rubino - Agile Business Group
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.depends('order_line.price_total')
+    def _amount_all(self):
+        prev_values = dict()
+        for order in self:
+            for line in order.order_line:
+                prev_values[line] = dict(
+                    discount=line.discount,
+                    discount2=line.discount2,
+                    discount3=line.discount3,
+                )
+                # Update, for some reason, does not work
+                line.write({
+                    'discount': line._get_triple_discount(),
+                    'discount2': 0.0,
+                    'discount3': 0.0
+                })
+        super(SaleOrder, self)._amount_all()
+
+        # Restore previous values
+        for line, prev_vals_dict in prev_values.items():
+            # Update, for some reason, does not work
+            line.write(prev_vals_dict)

--- a/sale_triple_discount/tests/test_sale_triple_discount.py
+++ b/sale_triple_discount/tests/test_sale_triple_discount.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Tecnativa - David Vidal
+# Copyright 2018 Simone Rubino - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.tests import common
@@ -111,3 +112,18 @@ class TestSaleOrder(common.SavepointCase):
         self.assertEqual(self.so_line2.discount3,
                          invoice.invoice_line_ids[1].discount3)
         self.assertEqual(self.order.amount_total, invoice.amount_total)
+
+    def test_05_round_globally(self):
+        """ Tests on multiple lines when 'round_globally' is active"""
+        self.env.user.company_id. \
+            tax_calculation_rounding_method = 'round_globally'
+        self.so_line1.discount = 50.0
+        self.so_line1.discount2 = 50.0
+        self.so_line1.discount3 = 50.0
+        self.assertEqual(self.so_line1.price_subtotal, 75.0)
+        self.assertEqual(self.order.amount_untaxed, 675.0)
+        self.assertEqual(self.order.amount_tax, 101.25)
+        self.so_line2.discount3 = 50.0
+        self.assertEqual(self.so_line2.price_subtotal, 300.0)
+        self.assertEqual(self.order.amount_untaxed, 375.0)
+        self.assertEqual(self.order.amount_tax, 56.25)


### PR DESCRIPTION
Steps to reproduce the issue:

0. In debug mode, configure:
    * Tax calculation rounding method* = Round Globally (in Invoicing / Configuration / Settings)
    * Discount = Allow discounts in sales order lines (in Sales / Configuration / Settings)
1. Create a sale order with a product and set:
    * price_unit = 100
    * discount = 50
    * discount2 = 50
    * discount3 = 50
    * any percent tax
2. Save the sale order

Behavior before PR:
The tax is computed on a price of 50 (only discount is applied).
For more proof, try to write something in discount2 and discount3 and check that they are not taken into account at all for taxes computation.

Behavior after PR:
The tax is computed on a price of 12.5 (all discounts are applied).
    