### PR TITLE
[FIX]sale_commercial_partner: Make commercial_partner_id readonly

### DIFF
--- a/sale_commercial_partner/__manifest__.py
+++ b/sale_commercial_partner/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Sale Commercial Partner',
     'summary': "Add stored related field 'Commercial Entity' on sale orders",
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'author': 'Akretion,Odoo Community Association (OCA)',
     'website': 'http://www.akretion.com',
     'category': 'Sales',

--- a/sale_commercial_partner/models/sale.py
+++ b/sale_commercial_partner/models/sale.py
@@ -9,4 +9,4 @@ class SaleOrder(models.Model):
 
     commercial_partner_id = fields.Many2one(
         'res.partner', related='partner_id.commercial_partner_id', store=True,
-        string='Commercial Entity', index=True)
+        string='Commercial Entity', index=True, readonly=True)


### PR DESCRIPTION
Make commercial_partner_id readonly
Based on https://github.com/OCA/sale-workflow/pull/743#discussion_r251329310

@pedrobaeza  For v10 (https://github.com/OCA/sale-workflow/pull/662) It is already there with `compute_sudo` too  (IMO, we dont need `compute_sudo` if it is already `readonly`)