### PR TITLE
[10] sale_triple_discount: Fix tax total if the rouding is globally

### DIFF
--- a/sale_triple_discount/README.rst
+++ b/sale_triple_discount/README.rst
@@ -64,6 +64,7 @@ Contributors
 * Juan José Scarafía <jjs@adhoc.com.ar>
 * Alex Comba <alex.comba@agilebg.com>
 * David Vidal <david.vidal@tecnativa.com>
+* Sylvain Van Hoof <sylvain@okia.be>
 
 Maintainer
 ----------

--- a/sale_triple_discount/models/__init__.py
+++ b/sale_triple_discount/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import sale_order_line
+from . import sale_order

--- a/sale_triple_discount/models/sale_order.py
+++ b/sale_triple_discount/models/sale_order.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Sylvain Van Hoof (Okia SPRL) <sylvain@okia.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.depends('order_line.price_total')
+    def _amount_all(self):
+        """
+        Compute the total amounts of the SO with discounts.
+        Copy/paste from standard method in sale
+        """
+        for order in self:
+            amount_untaxed = amount_tax = 0.0
+            for line in order.order_line:
+                amount_untaxed += line.price_subtotal
+                # FORWARDPORT UP TO 10.0
+                if order.company_id.tax_calculation_rounding_method == \
+                        'round_globally':
+                    price_reduce = line.price_reduce  # Use the price reduced
+                    taxes = line.tax_id.compute_all(
+                        price_reduce,
+                        currency=line.order_id.currency_id,
+                        quantity=line.product_uom_qty,
+                        product=line.product_id,
+                        partner=order.partner_shipping_id
+                    )
+                    amount_tax += sum(
+                        t.get('amount', 0.0) for t in taxes.get('taxes', []))
+                else:
+                    amount_tax += line.price_tax
+            order.update({
+                'amount_untaxed':
+                    order.pricelist_id.currency_id.round(amount_untaxed),
+                'amount_tax': order.pricelist_id.currency_id.round(amount_tax),
+                'amount_total': amount_untaxed + amount_tax,
+            })


### PR DESCRIPTION
The module sale_triple_discount will add three discount on the sale order.
If the rounding method (on the company) is "round globally", the tax total is wrong.

![selection_006](https://user-images.githubusercontent.com/5175164/52267791-3d9c3480-293a-11e9-9c0a-0f58bf67fcb5.png)

![selection_007](https://user-images.githubusercontent.com/5175164/52267799-3ffe8e80-293a-11e9-81c8-ba17883d98e0.png)

**How I fix it ?**
I inherited the method _amount_all to use the field price_reduce on the sale.order.line