### PR TITLE
[11.0][ADD] New Implement on module sale_disable_inventory_check

### DIFF
--- a/sale_disable_inventory_check/__manifest__.py
+++ b/sale_disable_inventory_check/__manifest__.py
@@ -12,7 +12,12 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": [
-        "sale_stock",
+    "depends": ["sale_stock", ],
+    "data": [
+        # Data
+        'data/product_check_stock_data.xml',
+        # Views
+        'views/product_category_views.xml',
+        'views/product_template_views.xml',
     ],
 }

--- a/sale_disable_inventory_check/data/product_check_stock_data.xml
+++ b/sale_disable_inventory_check/data/product_check_stock_data.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record forcecreate="True" id="default_product_template_check_stock_message" model="ir.property">
+        <field name="name">Check Stock Message Product Template</field>
+        <field name="fields_id" ref="field_product_template_check_stock_on_sale"/>
+        <field name="value">defer</field>
+        <field name="type">selection</field>
+    </record>
+    <record forcecreate="True" id="default_product_category_check_stock_message" model="ir.property">
+        <field name="name">Check Stock Message Product Category</field>
+        <field name="fields_id" ref="field_product_category_check_stock_on_sale"/>
+        <field name="value_integer">1</field>
+        <field name="type">boolean</field>
+    </record>
+
+</odoo>

--- a/sale_disable_inventory_check/models/__init__.py
+++ b/sale_disable_inventory_check/models/__init__.py
@@ -1,3 +1,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import product_category
+from . import product_template
 from . import sale_order_line

--- a/sale_disable_inventory_check/models/product_category.py
+++ b/sale_disable_inventory_check/models/product_category.py
@@ -1,0 +1,16 @@
+# Copyright Komit <http://komit-consulting.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ProductCategory(models.Model):
+    _inherit = 'product.category'
+
+    check_stock_on_sale = fields.Boolean(
+        company_dependent=True,
+        help="Uncheck if you want to disable warning 'Not enough inventory'"
+             " when there isn't enough product in stock",
+        string="Check Stock on Sale",
+        default=True
+    )

--- a/sale_disable_inventory_check/models/product_template.py
+++ b/sale_disable_inventory_check/models/product_template.py
@@ -1,0 +1,33 @@
+# Copyright Komit <http://komit-consulting.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    check_stock_on_sale = fields.Selection(
+        selection=[('skip', 'Skip the check'),
+                   ('not_skip', 'Do not skip the check'),
+                   ('defer', 'Defer to the setting on the category')],
+        company_dependent=True,
+        help="'Skip the check' will disable warning 'Not enough inventory' "
+             "when there isn't enough product in stock!\n"
+             "'Do not skip the check' won't disable warning 'Not enough "
+             "inventory' when there isn't enough product in stock!\n"
+             "'Defer to the setting on the category' will use the "
+             "setting from the Internal Category",
+        string="Check Stock on Sale",
+        default="defer",
+    )
+
+    @api.multi
+    def _check_stock_on_sale(self):
+        self.ensure_one()
+        if self.check_stock_on_sale == 'skip':
+            return False
+        elif self.check_stock_on_sale == 'defer':
+            return self.categ_id.check_stock_on_sale
+        else:
+            return True

--- a/sale_disable_inventory_check/models/sale_order_line.py
+++ b/sale_disable_inventory_check/models/sale_order_line.py
@@ -1,7 +1,7 @@
 # Copyright Komit <http://komit-consulting.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import api, models, _
 
 
 class SaleOrderLine(models.Model):
@@ -9,4 +9,12 @@ class SaleOrderLine(models.Model):
 
     @api.onchange('product_uom_qty', 'product_uom', 'route_id')
     def _onchange_product_id_check_availability(self):
-        return {}
+        res = \
+            super(SaleOrderLine,
+                  self)._onchange_product_id_check_availability()
+        if self.product_id \
+                and not self.product_id.product_tmpl_id._check_stock_on_sale():
+            if res.get('warning', {}).get('title') == _(
+                    'Not enough inventory!'):
+                res.pop('warning')
+        return res

--- a/sale_disable_inventory_check/tests/test_disable_inventory_check.py
+++ b/sale_disable_inventory_check/tests/test_disable_inventory_check.py
@@ -8,11 +8,29 @@ class TestDisableInventoryCheck(common.TransactionCase):
     def setUp(self):
         super(TestDisableInventoryCheck, self).setUp()
 
+        self.category_1 = self.env['product.category'].create({
+            'name': 'Category 1',
+            'check_stock_on_sale': True,
+        })
+        self.category_2 = self.env['product.category'].create({
+            'name': 'Category 2',
+            'check_stock_on_sale': True,
+        })
+
         # Create stockable product
         self.product_1 = self.env['product.product'].create({
             'name': 'Product 1',
             'type': 'product',
-            'uom_id': self.env.ref('product.product_uom_unit').id,
+            'uom_id': self.ref('product.product_uom_unit'),
+            'check_stock_on_sale': 'skip',
+            'categ_id': self.category_1.id,
+        })
+        self.product_2 = self.env['product.product'].create({
+            'name': 'Product 2',
+            'type': 'product',
+            'uom_id': self.ref('product.product_uom_unit'),
+            'check_stock_on_sale': 'defer',
+            'categ_id': self.category_2.id,
         })
 
     def test_disable_inventory_check(self):
@@ -23,12 +41,26 @@ class TestDisableInventoryCheck(common.TransactionCase):
             'state': 'draft',
         })
         # Sale product_1 with quantity is 15
-        order_line = self.env['sale.order.line'].new({
+        order_line1 = self.env['sale.order.line'].new({
             'order_id': order.id,
             'product_id': self.product_1.id,
             'product_uom': self.product_1.uom_id.id,
             'product_uom_qty': 15,
         })
-        res = order_line._onchange_product_id_check_availability()
-        self.assertEqual(res.get('warning', {}), {},
-                         "There should not be a warning!!!")
+        res1 = order_line1._onchange_product_id_check_availability()
+        self.assertNotIn('warning', res1, "There should not be a warning!!!")
+        # Sale product_2 with quantity is 15
+        order_line2 = self.env['sale.order.line'].new({
+            'order_id': order.id,
+            'product_id': self.product_2.id,
+            'product_uom': self.product_2.uom_id.id,
+            'product_uom_qty': 15,
+        })
+        res2 = order_line2._onchange_product_id_check_availability()
+        self.assertIn('warning', res2, "Should have returned a warning")
+        self.assertIsInstance(
+            res2['warning'], dict, "Warning should be a dictionary")
+        self.assertIn('title', res2['warning'], "Warning should have a title")
+        self.assertEqual(
+            res2['warning']['title'], 'Not enough inventory!',
+            "There should be a warning!!!")

--- a/sale_disable_inventory_check/views/product_category_views.xml
+++ b/sale_disable_inventory_check/views/product_category_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_category_form_view_inherit" model="ir.ui.view">
+        <field name="name">product.category.form</field>
+        <field name="model">product.category</field>
+        <field name="inherit_id" ref="product.product_category_form_view" />
+        <field name="arch" type="xml">
+            <group name="first" position="after">
+                <group name="stock_property" string="Inventory Properties">
+                    <field name="check_stock_on_sale"/>
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>

--- a/sale_disable_inventory_check/views/product_template_views.xml
+++ b/sale_disable_inventory_check/views/product_template_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_disable_check_stock_property_form" model="ir.ui.view">
+        <field name="name">view.disable.stock.property.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <group name="packaging" position="after">
+                <group name="disable_check_stock" string="Inventory Property">
+                    <field name="check_stock_on_sale"/>
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
New module sale_disable_inventory_check in PR: https://github.com/OCA/sale-workflow/pull/580 and implement @jcdrubay suggestion 

Something very similar to what is done for "Income Account":
'income': self.property_account_income_id or self.categ_id.property_account_income_categ_id,

We would need:

    A new property field "property_is_check_stock" on Product Template and on Product Category
    A default property like the property with xml record property_account_income_categ_id