### PR TITLE
[12.0][FIX] To approve quotation display & Confirm on creation

### DIFF
--- a/sale_double_validation/__manifest__.py
+++ b/sale_double_validation/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Double validation for Sales',
     'summary': "",
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'author': 'Camptocamp,Odoo Community Association (OCA)',
     'maintainer': 'Camptocamp',
     'license': 'AGPL-3',

--- a/sale_double_validation/models/company.py
+++ b/sale_double_validation/models/company.py
@@ -22,3 +22,8 @@ class Company(models.Model):
         default=5000,
         help="Minimum amount for which a double validation is required"
     )
+
+    so_double_validation_manager_skip = fields.Boolean(
+        string='Allow skip of validation by managers.',
+        default=False,
+    )

--- a/sale_double_validation/models/sale.py
+++ b/sale_double_validation/models/sale.py
@@ -45,8 +45,8 @@ class SaleOrder(models.Model):
     @api.model
     def create(self, vals):
         obj = super().create(vals)
-        if obj.is_to_approve():
-            obj.state = 'to_approve'
+        if not obj.is_to_approve():
+            obj.state = 'draft'
         return obj
 
     @api.multi

--- a/sale_double_validation/models/sale.py
+++ b/sale_double_validation/models/sale.py
@@ -19,10 +19,11 @@ class SaleOrder(models.Model):
                 exists = True
         if not exists:
             selection.insert(0, ('to_approve', _('To Approve')))
-        for field in self._fields:
-            act_field = self._fields.get(field)
+        for act_field in self._fields.values():
 
-            if act_field.states and all(x in act_field.states.keys() for x in ['draft', 'sent']):
+            if act_field.states and all(
+                x in act_field.states.keys() for x in ['draft', 'sent']
+            ):
                 act_field.states = {'to_approve': [('readonly', False)]}
 
     @api.multi
@@ -57,4 +58,9 @@ class SaleOrder(models.Model):
     @api.depends('state')
     def _compute_type_name(self):
         for record in self:
-            record.type_name = _('Quotation') if record.state in ('to_approve', 'draft', 'sent', 'cancel') else _('Sales Order')
+            record.type_name = _('Quotation') if record.state in (
+                'to_approve',
+                'draft',
+                'sent',
+                'cancel'
+            ) else _('Sales Order')

--- a/sale_double_validation/models/sale.py
+++ b/sale_double_validation/models/sale.py
@@ -37,11 +37,18 @@ class SaleOrder(models.Model):
             precision_rounding=self.currency_id.rounding) <= 0
 
     @api.multi
+    def can_skip(self):
+        self.ensure_one()
+        if self.company_id.so_double_validation_manager_skip:
+            if self.user_has_groups('sales_team.group_sale_manager'):
+                return True
+        return False
+
+    @api.multi
     def is_to_approve(self):
         self.ensure_one()
         return (self.company_id.so_double_validation == 'two_step' and
-                self.is_amount_to_approve() and
-                not self.user_has_groups('sales_team.group_sale_manager'))
+                self.is_amount_to_approve() and not self.can_skip())
 
     @api.model
     def create(self, vals):

--- a/sale_double_validation/views/sale.xml
+++ b/sale_double_validation/views/sale.xml
@@ -5,12 +5,29 @@
     <field name="model">sale.order</field>
     <field name="inherit_id" ref="sale.view_order_form"/>
     <field name="arch" type="xml">
-
       <button name="action_cancel" position="before">
         <button name="action_approve" type="object" states='to_approve' string="Approve Order" class="oe_highlight" groups="sales_team.group_sale_manager"/>
       </button>
-
+      <button name="action_cancel" position="attributes">
+        <attribute name="states">to_approve,draft,sent,sale</attribute>
+      </button>
     </field>
   </record>
+
+  <record id="sale_order_view_search_inherit_quotation" model="ir.ui.view">
+      <field name="name">sale.order.search.inherit.quotation</field>
+      <field name="model">sale.order</field>
+      <field name="inherit_id" ref="sale.sale_order_view_search_inherit_quotation"/>
+      <field name="mode">extension</field>
+      <field name="arch" type="xml">
+        <xpath expr="//filter[@name='draft']" position="attributes">
+          <attribute name="domain">[('state','in',('to_approve', 'draft', 'sent'))]</attribute>
+        </xpath>
+      </field>
+  </record>
+  <record id="sale.action_orders" model="ir.actions.act_window">
+      <field name="domain">[('state', 'not in', ('to_approve', 'draft', 'sent', 'cancel'))]</field>
+  </record>
+
 </odoo>
 


### PR DESCRIPTION
- Add the state to_apporve to quotations instead of sales
- dont allow managers to confirm directly when creating
- allow cancelation in to_approve state