### PR TITLE
[10.0][FIX] sale_triple_discount: Cache management during onchange

### DIFF
--- a/sale_triple_discount/__manifest__.py
+++ b/sale_triple_discount/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Sale Triple Discount',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.0.2',
     'category': 'Sales Management',
     'author': 'ADHOC SA, '
               'Agile Business Group, '

--- a/sale_triple_discount/models/sale_order_line.py
+++ b/sale_triple_discount/models/sale_order_line.py
@@ -66,9 +66,10 @@ class SaleOrderLine(models.Model):
         this method is called multiple times.
         Updating the cache provides consistency through recomputations."""
         prev_values = dict()
-        self.invalidate_cache(
-            fnames=['discount', 'discount2', 'discount3'],
-            ids=self.ids)
+        if not self.env.in_onchange:
+            self.invalidate_cache(
+                fnames=['discount', 'discount2', 'discount3'],
+                ids=self.ids)
         for line in self:
             prev_values[line] = dict(
                 discount=line.discount,


### PR DESCRIPTION
Behavior before this commit:
1. Create an invoice with one line: qty 1, unit price 100, discount 0, tax 22% -> tax amount is 22 OK
2. Edit discount to 50 -> tax amount is still 22 KO
3. Edit the discount back to 0 -> tax amount becomes 11 KO

Behavior after this commit:
1. Create an invoice with one line: qty 1, unit price 100, discount 0, tax 22% -> tax amount is 22 OK
2. Edit discount to 50 -> tax amount is 11 OK
3. Edit the discount back to 0 -> tax amount becomes 22 OK