### PR TITLE
[11.0][FIX] Fix access rights error with sale_order_invoicing_finished_task

### DIFF
--- a/sale_order_invoicing_finished_task/__manifest__.py
+++ b/sale_order_invoicing_finished_task/__manifest__.py
@@ -7,7 +7,7 @@
     "name": "Sale Order Invoicing Finished Task",
     "summary": "Control invoice order lines if their related task has been "
                "set to invoiceable",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.2",
     "category": "Sales",
     "website": "https://github.com/OCA/sale-workflow",
     "author": "Tecnativa, "

--- a/sale_order_invoicing_finished_task/views/project_view.xml
+++ b/sale_order_invoicing_finished_task/views/project_view.xml
@@ -18,7 +18,7 @@
     <field name="model">project.task</field>
     <field name="inherit_id" ref="project.view_task_form2"/>
     <field name="arch" type="xml">
-        <xpath expr="//field[@name='planned_hours']" position="after">
+        <xpath expr="/form" position="inside">
             <field name="invoicing_finished_task" invisible="1"/>
         </xpath>
 


### PR DESCRIPTION
Before this PR, users that are not in group `hr_timesheet.group_hr_timesheet_user` cannot see project tasks. On attempt to open task in project, error is raised with message that, `field[@name='planned_hours']` could not be located on parent view. This happens, because this field is visible only for users that have group `hr_timesheet.group_hr_timesheet_user` (see [odoo code](https://github.com/odoo/odoo/blob/11.0/addons/hr_timesheet/views/project_views.xml#L58)).



In this PR, we make this view applicable only to users that are in group `hr_timesheet.group_hr_timesheet_user`, thus users that are not in this group will see normal project task view.