### PR TITLE
[11.0][FIX] product_supplierinfo_for_customer_sale: Search supplierinfo by product variant first

### DIFF
--- a/product_supplierinfo_for_customer_sale/README.rst
+++ b/product_supplierinfo_for_customer_sale/README.rst
@@ -30,6 +30,14 @@ customer code defined in the product and allows
 use the product codes and product name configured in each products in sale
 orders.
 
+**Table of contents**
+
+.. contents::
+   :local:
+
+Usage
+=====
+
 To use this module, you need:
 
 - Go to product and configure *Partner product name* and *Partner product code*
@@ -61,11 +69,6 @@ To use this module, you need:
 .. figure:: https://raw.githubusercontent.com/OCA/sale-workflow/11.0/product_supplierinfo_for_customer_sale/static/description/description_code_2.png
     :alt: Search by exist customer code
     :width: 600 px
-
-**Table of contents**
-
-.. contents::
-   :local:
 
 Known issues / Roadmap
 ======================
@@ -101,6 +104,7 @@ Contributors
 * Moisés López <moylop260@vauxoo.com>
 * Yennifer Santiago <yennifer@vauxoo.com>
 * Julio Serna Hernández <julio@vauxoo.com>
+* Sergio Teruel <sergio.teruel@tecnativa.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/product_supplierinfo_for_customer_sale/__manifest__.py
+++ b/product_supplierinfo_for_customer_sale/__manifest__.py
@@ -7,7 +7,7 @@
     "summary": "Loads in every sale order line the customer code defined "
                "in the product",
     "author": "Agile Business Group,Vauxoo,Odoo Community Association (OCA)",
-    "website": "https://github.com/OCA/sale-workflow/tree/11.0/product_supplierinfo_for_customer_sale", # noqa
+    "website": "https://github.com/OCA/sale-workflow",
     "category": "Sales Management",
     "license": "AGPL-3",
     "depends": [

--- a/product_supplierinfo_for_customer_sale/readme/CONTRIBUTORS.rst
+++ b/product_supplierinfo_for_customer_sale/readme/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@
 * Moisés López <moylop260@vauxoo.com>
 * Yennifer Santiago <yennifer@vauxoo.com>
 * Julio Serna Hernández <julio@vauxoo.com>
+* Sergio Teruel <sergio.teruel@tecnativa.com>

--- a/product_supplierinfo_for_customer_sale/readme/DESCRIPTION.rst
+++ b/product_supplierinfo_for_customer_sale/readme/DESCRIPTION.rst
@@ -2,35 +2,3 @@ Based on product_supplierinfo_for_customer, this module loads in every sale orde
 customer code defined in the product and allows
 use the product codes and product name configured in each products in sale
 orders.
-
-To use this module, you need:
-
-- Go to product and configure *Partner product name* and *Partner product code*
-  for each selected customer.
-
-.. figure:: static/description/configuration_customer.png
-    :alt: Configure customer codes
-    :width: 600 px
-
-- When add order lines in sale quotation for a customer that has an specific
-  name and code in the product, you can search that product with that customer
-  name or code. Then, this values will be displayed in product description.
-
-.. figure:: static/description/search_code.png
-    :alt: Search by exist customer code
-    :width: 600 px
-
-.. figure:: static/description/description_code.png
-    :alt: Search by exist customer code
-    :width: 600 px
-
-- If product does not have a configuration for customer selected, product will
-  be search by its default code.
-
-.. figure:: static/description/search_code_2.png
-    :alt: Search by exist customer code
-    :width: 600 px
-
-.. figure:: static/description/description_code_2.png
-    :alt: Search by exist customer code
-    :width: 600 px

--- a/product_supplierinfo_for_customer_sale/readme/USAGE.rst
+++ b/product_supplierinfo_for_customer_sale/readme/USAGE.rst
@@ -1,0 +1,31 @@
+To use this module, you need:
+
+- Go to product and configure *Partner product name* and *Partner product code*
+  for each selected customer.
+
+.. figure:: ../static/description/configuration_customer.png
+    :alt: Configure customer codes
+    :width: 600 px
+
+- When add order lines in sale quotation for a customer that has an specific
+  name and code in the product, you can search that product with that customer
+  name or code. Then, this values will be displayed in product description.
+
+.. figure:: ../static/description/search_code.png
+    :alt: Search by exist customer code
+    :width: 600 px
+
+.. figure:: ../static/description/description_code.png
+    :alt: Search by exist customer code
+    :width: 600 px
+
+- If product does not have a configuration for customer selected, product will
+  be search by its default code.
+
+.. figure:: ../static/description/search_code_2.png
+    :alt: Search by exist customer code
+    :width: 600 px
+
+.. figure:: ../static/description/description_code_2.png
+    :alt: Search by exist customer code
+    :width: 600 px

--- a/product_supplierinfo_for_customer_sale/static/description/index.html
+++ b/product_supplierinfo_for_customer_sale/static/description/index.html
@@ -372,6 +372,22 @@ ul.auto-toc {
 customer code defined in the product and allows
 use the product codes and product name configured in each products in sale
 orders.</p>
+<p><strong>Table of contents</strong></p>
+<div class="contents local topic" id="contents">
+<ul class="simple">
+<li><a class="reference internal" href="#usage" id="id1">Usage</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id2">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
+</ul>
+</li>
+</ul>
+</div>
+<div class="section" id="usage">
+<h1><a class="toc-backref" href="#id1">Usage</a></h1>
 <p>To use this module, you need:</p>
 <ul class="simple">
 <li>Go to product and configure <em>Partner product name</em> and <em>Partner product code</em>
@@ -401,28 +417,16 @@ be search by its default code.</li>
 <div class="figure">
 <img alt="Search by exist customer code" src="https://raw.githubusercontent.com/OCA/sale-workflow/11.0/product_supplierinfo_for_customer_sale/static/description/description_code_2.png" style="width: 600px;" />
 </div>
-<p><strong>Table of contents</strong></p>
-<div class="contents local topic" id="contents">
-<ul class="simple">
-<li><a class="reference internal" href="#known-issues-roadmap" id="id1">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
-</ul>
-</li>
-</ul>
 </div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#id1">Known issues / Roadmap</a></h1>
+<h1><a class="toc-backref" href="#id2">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>Putting a minimum qty in a pricelist rule means the system will use the
 option ‘list price’ instead of any option you chose.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/sale-workflow/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -430,16 +434,16 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id3">Credits</a></h1>
+<h1><a class="toc-backref" href="#id4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id4">Authors</a></h2>
+<h2><a class="toc-backref" href="#id5">Authors</a></h2>
 <ul class="simple">
 <li>Agile Business Group</li>
 <li>Vauxoo</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
 <ul class="simple">
 <li>Xavier Jimenez &lt;<a class="reference external" href="mailto:xavier.jimenez&#64;qubiq.es">xavier.jimenez&#64;qubiq.es</a>&gt;</li>
 <li>Nicola Malcontenti &lt;<a class="reference external" href="mailto:nicola.malcontenti&#64;agilebg.com">nicola.malcontenti&#64;agilebg.com</a>&gt;</li>
@@ -447,10 +451,11 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Moisés López &lt;<a class="reference external" href="mailto:moylop260&#64;vauxoo.com">moylop260&#64;vauxoo.com</a>&gt;</li>
 <li>Yennifer Santiago &lt;<a class="reference external" href="mailto:yennifer&#64;vauxoo.com">yennifer&#64;vauxoo.com</a>&gt;</li>
 <li>Julio Serna Hernández &lt;<a class="reference external" href="mailto:julio&#64;vauxoo.com">julio&#64;vauxoo.com</a>&gt;</li>
+<li>Sergio Teruel &lt;<a class="reference external" href="mailto:sergio.teruel&#64;tecnativa.com">sergio.teruel&#64;tecnativa.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/product_supplierinfo_for_customer_sale/tests/test_product_supplierinfo_for_customer_sale.py
+++ b/product_supplierinfo_for_customer_sale/tests/test_product_supplierinfo_for_customer_sale.py
@@ -13,11 +13,28 @@ class TestProductSupplierinfoForCustomerSale(common.TransactionCase):
         self.pricelist_model = self.env['product.pricelist']
         self.customer = self._create_customer('customer1')
         self.product = self.env.ref('product.product_product_4')
+        self.product_variant_1 = self.env.ref('product.product_product_4b')
+        self.product_variant_2 = self.env.ref('product.product_product_4c')
         self.supplierinfo = self._create_supplierinfo(
             'customer', self.customer, self.product)
         self.pricelist = self._create_pricelist(
             'Test Pricelist', self.product)
         self.company = self.env.ref('base.main_company')
+        self._create_supplierinfo(
+            'customer', self.customer, self.product_variant_1)
+        self._create_supplierinfo(
+            'customer', self.customer, self.product_variant_2,
+            empty_variant=True)
+        self.product_template = self.env['product.template'].create({
+            'name': 'product wo variants'
+        })
+        self._create_supplierinfo(
+            'customer', self.customer,
+            self.product_template.product_variant_ids[:1],
+            empty_variant=True)
+        self.pricelist_template = self._create_pricelist(
+            'Test Pricelist Template',
+            self.product_template.product_variant_ids[:1])
 
     def _create_customer(self, name):
         """Create a Partner."""
@@ -28,8 +45,9 @@ class TestProductSupplierinfoForCustomerSale(common.TransactionCase):
             'phone': 123456,
         })
 
-    def _create_supplierinfo(self, supplierinfo_type, partner, product):
-        return self.supplierinfo_model.create({
+    def _create_supplierinfo(self, supplierinfo_type, partner, product,
+                             empty_variant=False):
+        vals = {
             'name': partner.id,
             'product_id': product.id,
             'product_name': 'product4',
@@ -37,7 +55,11 @@ class TestProductSupplierinfoForCustomerSale(common.TransactionCase):
             'supplierinfo_type': supplierinfo_type,
             'price': 100.0,
             'min_qty': 15.0,
-        })
+        }
+        if empty_variant:
+            vals.pop('product_id', None)
+            vals['product_tmpl_id'] = product.product_tmpl_id.id
+        return self.supplierinfo_model.create(vals)
 
     def _create_pricelist(self, name, product):
         return self.pricelist_model.create({
@@ -68,3 +90,63 @@ class TestProductSupplierinfoForCustomerSale(common.TransactionCase):
         self.assertEqual(
             line.product_uom_qty, self.supplierinfo.min_qty,
             "Error: Min qty was not passed to the sale order line")
+
+    def test_product_supplierinfo_for_customer_sale_variant(self):
+        so = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'pricelist_id': self.pricelist.id,
+        })
+        line = self.env['sale.order.line'].create({
+            'product_id': self.product_variant_1.id,
+            'order_id': so.id,
+        })
+        line.product_id_change()
+        self.assertEqual(
+            line.product_customer_code, self.supplierinfo.product_code,
+            "Error: Customer product code was not passed to sale order line")
+
+    def test_product_supplierinfo_for_customer_sale_template(self):
+        supplierinfo = self._create_supplierinfo('customer', self.customer,
+                                                 self.product_variant_2)
+        so = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'pricelist_id': self.pricelist.id,
+        })
+        line = self.env['sale.order.line'].create({
+            'product_id': self.product_variant_2.id,
+            'order_id': so.id,
+        })
+        line.product_id_change()
+        self.assertEqual(
+            line.product_customer_code, supplierinfo.product_code,
+            "Error: Customer product code was not passed to sale order line")
+        # Test with product without variants
+        so2 = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'pricelist_id': self.pricelist_template.id,
+        })
+        line2 = self.env['sale.order.line'].create({
+            'product_id': self.product_template.product_variant_ids.id,
+            'order_id': so2.id,
+        })
+        line2.product_id_change()
+        self.assertEqual(
+            line2.product_customer_code, supplierinfo.product_code,
+            "Error: Customer product code was not passed to sale order line")
+
+    def test_product_supplierinfo_for_customer_sale_variant_wo_template(self):
+        supplierinfo = self._create_supplierinfo(
+            'customer', self.customer, self.product_variant_2,
+            empty_variant=True)
+        so = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'pricelist_id': self.pricelist.id,
+        })
+        line = self.env['sale.order.line'].create({
+            'product_id': self.product_variant_2.id,
+            'order_id': so.id,
+        })
+        line.product_id_change()
+        self.assertEqual(
+            line.product_customer_code, supplierinfo.product_code,
+            "Error: Customer product code was not passed to sale order line")


### PR DESCRIPTION
When you have a product with several variants and supplierinfo for every variant, always set product code from template due to incorrect domain search.
