### PR TITLE
[12.0][sale_exception] refactore sale exception to adapt it to base_exception refactore.

### DIFF
--- a/sale_exception/data/sale_exception_data.xml
+++ b/sale_exception/data/sale_exception_data.xml
@@ -19,7 +19,6 @@
     <field name="name">No ZIP code on destination</field>
     <field name="description">No ZIP code on destination</field>
     <field name="sequence">50</field>
-    <field name="rule_group">sale</field>
     <field name="model">sale.order</field>
     <field name="code">if not sale.partner_shipping_id.zip: failed=True</field>
     <field name="active" eval="False"/>
@@ -29,7 +28,6 @@
     <field name="name">Not Enough Virtual Stock</field>
     <field name="description">Not Enough Virtual Stock</field>
     <field name="sequence">50</field>
-    <field name="rule_group">sale</field>
     <field name="model">sale.order.line</field>
     <field name="code">if sale_line.product_id and sale_line.product_id.type == 'product' and sale_line.product_id.with_context(warehouse=sale_line.order_id.warehouse_id.id).virtual_available &lt; sale_line.product_uom_qty: failed=True</field>
     <field name="active" eval="False"/>

--- a/sale_exception/models/__init__.py
+++ b/sale_exception/models/__init__.py
@@ -1,2 +1,3 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 from . import sale
+from . import sale_order_line

--- a/sale_exception/models/sale.py
+++ b/sale_exception/models/sale.py
@@ -9,15 +9,15 @@ from odoo import api, models, fields
 class ExceptionRule(models.Model):
     _inherit = 'exception.rule'
 
-    rule_group = fields.Selection(
-        selection_add=[('sale', 'Sale')],
-    )
     model = fields.Selection(
         selection_add=[
             ('sale.order', 'Sale order'),
             ('sale.order.line', 'Sale order line'),
         ]
     )
+    sale_ids = fields.Many2many(
+        'sale.order',
+        string="Sales")
 
 
 class SaleOrder(models.Model):
@@ -25,15 +25,27 @@ class SaleOrder(models.Model):
     _name = 'sale.order'
     _order = 'main_exception_id asc, date_order desc, name desc'
 
-    rule_group = fields.Selection(
-        selection_add=[('sale', 'Sale')],
-        default='sale',
-    )
+    @api.model
+    def _exception_rule_eval_context(self, rec):
+        res = super(SaleOrder, self)._exception_rule_eval_context(rec)
+        res['sale'] = rec
+        return res
+
+    @api.model
+    def _reverse_field(self):
+        return 'sale_ids'
+
+    @api.multi
+    def detect_exceptions(self):
+        all_exceptions = super(SaleOrder, self).detect_exceptions()
+        lines = self.mapped('order_line')
+        all_exceptions += lines.detect_exceptions()
+        return all_exceptions
 
     @api.model
     def test_all_draft_orders(self):
         order_set = self.search([('state', '=', 'draft')])
-        order_set.test_exceptions()
+        order_set.detect_exceptions()
         return True
 
     @api.constrains('ignore_exception', 'order_line', 'state')

--- a/sale_exception/models/sale_order_line.py
+++ b/sale_exception/models/sale_order_line.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# © 2019 Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = ['sale.order.line', 'base.exception.method']
+    _name = 'sale.order.line'
+
+    ignore_exception = fields.Boolean(
+        related='order_id.ignore_exception',
+        store=True,
+        string="Ignore Exceptions")
+
+    @api.model
+    def _reverse_field(self):
+        return 'sale_ids'
+
+    @api.multi
+    def _detect_exceptions(self, rule):
+        records = super(SaleOrderLine, self)._detect_exceptions(rule)
+        return records.mapped('order_id')
+
+    @api.model
+    def _exception_rule_eval_context(self, rec):
+        # We keep this only for backward compatibility, because some existing
+        # rules may use the variable "sale_line". But we should remove this
+        # code during v13 migration. The record is already available in obj and
+        # object variables and it is more than enough.
+        res = super(SaleOrderLine, self)._exception_rule_eval_context(rec)
+        res['sale_line'] = rec
+        return res

--- a/sale_exception/views/sale_view.xml
+++ b/sale_exception/views/sale_view.xml
@@ -7,8 +7,8 @@
      <field name="view_type">form</field>
      <field name="view_mode">tree,form</field>
      <field name="view_id" ref="base_exception.view_exception_rule_tree"/>
-     <field name="domain">[('rule_group', '=', 'sale')]</field>
-     <field name="context">{'active_test': False, 'default_rule_group' : 'sale'}</field>
+     <field name="domain">[('model', 'in', ['sale.order', 'sale.order.line'])]</field>
+     <field name="context">{'active_test': False, 'default_model' : 'sale.order'}</field>
   </record>
 
   <menuitem


### PR DESCRIPTION
Same refactore thant in version 10.

Depends on https://github.com/OCA/server-tools/pull/1589 and should be merged right after.
On merge, oca_dependencies should be fixed. (remove last commit)