### PR TITLE
[12.0][sale_exception] Fix error when checking sale order sans sale order line exception rules

### DIFF
--- a/sale_exception/__manifest__.py
+++ b/sale_exception/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Sale Exception',
     'summary': 'Custom exceptions on sale order',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'category': 'Generic Modules/Sale',
     'author': "Akretion, "
               "Sodexis, "
@@ -19,4 +19,7 @@
         'wizard/sale_exception_confirm_view.xml',
         'views/sale_view.xml',
     ],
+    'demo': [
+        'demo/sale_exception_demo.xml',
+    ]
 }

--- a/sale_exception/demo/sale_exception_demo.xml
+++ b/sale_exception/demo/sale_exception_demo.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id ="excep_no_sol" model="exception.rule">
+        <field name="name">No order lines</field>
+        <field name="description">At least one order line should be present in the sale</field>
+        <field name="sequence">50</field>
+        <field name="model">sale.order</field>
+        <field name="exception_type">by_domain</field>
+        <field name="domain">[('order_line', '=', False)]</field>
+        <field name="active" eval="False"/>
+    </record>
+
+    <record id ="excep_no_free" model="exception.rule">
+        <field name="name">No free order</field>
+        <field name="description">The total can't be 0</field>
+        <field name="sequence">50</field>
+        <field name="model">sale.order</field>
+        <field name="exception_type">by_domain</field>
+        <field name="domain">[('amount_total', '=', 0)]</field>
+        <field name="active" eval="False"/>
+    </record>
+    <record id ="excep_no_dumping" model="exception.rule">
+        <field name="name">No dumping</field>
+        <field name="description">A product is sold cheaper than his cost.</field>
+        <field name="sequence">50</field>
+        <field name="model">sale.order.line</field>
+        <field name="code">failed = obj.product_id.standard_price != 0 and obj.product_id.standard_price &gt; obj.price_unit</field>
+        <field name="active" eval="False"/>
+    </record>
+
+</odoo>

--- a/sale_exception/models/sale_order_line.py
+++ b/sale_exception/models/sale_order_line.py
@@ -14,6 +14,10 @@ class SaleOrderLine(models.Model):
         store=True,
         string="Ignore Exceptions")
 
+    @api.multi
+    def _get_main_records(self):
+        return self.mapped('order_id')
+
     @api.model
     def _reverse_field(self):
         return 'sale_ids'

--- a/sale_exception/readme/CONTRIBUTORS.rst
+++ b/sale_exception/readme/CONTRIBUTORS.rst
@@ -6,3 +6,5 @@
 * Simone Orsi <simone.orsi@camptocamp.com>
 * SodexisTeam <dev@sodexis.com>
 * Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
+* Raphaël Reverdy <raphael.reverdy@akretion.com>
+* Florian da Costa <florian.dacosta@akretion.com>

--- a/sale_exception/tests/__init__.py
+++ b/sale_exception/tests/__init__.py
@@ -1,2 +1,3 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 from . import test_sale_exception
+from . import test_multi_records

--- a/sale_exception/tests/test_multi_records.py
+++ b/sale_exception/tests/test_multi_records.py
@@ -1,0 +1,102 @@
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo.addons.sale.tests.test_sale_order import TestSaleOrder
+
+
+class TestSaleExceptionMultiRecord(TestSaleOrder):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+
+    def test_sale_order_exception(self):
+        exception_no_sol = self.env.ref('sale_exception.excep_no_sol')
+        exception_no_free = self.env.ref('sale_exception.excep_no_free')
+        exception_no_dumping = self.env.ref('sale_exception.excep_no_dumping')
+        exceptions = (
+            exception_no_sol +
+            exception_no_free +
+            exception_no_dumping)
+        exceptions.write({'active': True})
+
+        partner = self.env.ref('base.res_partner_1')
+        p = self.env.ref('product.product_product_7')
+        so1 = self.env['sale.order'].create({
+            'partner_id': partner.id,
+            'partner_invoice_id': partner.id,
+            'partner_shipping_id': partner.id,
+            'order_line': [(0, 0, {'name': p.name,
+                                   'product_id': p.id,
+                                   'product_uom_qty': 2,
+                                   'product_uom': p.uom_id.id,
+                                   'price_unit': p.list_price})],
+            'pricelist_id': self.env.ref('product.list0').id,
+        })
+
+        so2 = self.env['sale.order'].create({
+            'partner_id': partner.id,
+            'partner_invoice_id': partner.id,
+            'partner_shipping_id': partner.id,
+            'pricelist_id': self.env.ref('product.list0').id,
+        })
+
+        so3 = self.env['sale.order'].create({
+            'partner_id': partner.id,
+            'partner_invoice_id': partner.id,
+            'partner_shipping_id': partner.id,
+            'order_line': [(0, 0, {'name': p.name,
+                                   'product_id': p.id,
+                                   'product_uom_qty': 2,
+                                   'product_uom': p.uom_id.id,
+                                   'price_unit': p.list_price / 2})],
+            'pricelist_id': self.env.ref('product.list0').id,
+        })
+
+        orders = so1 + so2 + so3
+        for order in orders:
+            # ensure init state
+            self.assertTrue(order.state == 'draft')
+            self.assertTrue(len(order.exception_ids) == 0)
+
+        self.env['sale.order'].test_all_draft_orders()
+
+        # basic tests
+
+        self.assertTrue(so1.state == 'draft')
+        self.assertTrue(len(so1.exception_ids) == 0)
+
+        self.assertTrue(so2.state == 'draft')
+        self.assertTrue(exception_no_sol in so2.exception_ids)
+        self.assertTrue(exception_no_free in so2.exception_ids)
+
+        self.assertTrue(so3.state == 'draft')
+        self.assertTrue(exception_no_dumping in so3.exception_ids)
+
+        # test return value of detect_exception()
+
+        all_detected = orders.detect_exceptions()
+        self.assertTrue(exception_no_sol.id in all_detected)
+        self.assertTrue(exception_no_dumping.id in all_detected)
+        self.assertTrue(exception_no_free.id in all_detected)
+
+        one_two_detected = (so1 + so2).detect_exceptions()
+        self.assertTrue(exception_no_sol.id in one_two_detected)
+        self.assertFalse(exception_no_dumping.id in one_two_detected)
+        self.assertTrue(exception_no_free.id in one_two_detected)
+
+        # test subset of rules
+        def new_rule_domain(self=False):
+            return [
+                ('model', '=', 'sale.order'),
+                ('id', '!=', exception_no_sol.id)
+            ]
+
+        orders._rule_domain = new_rule_domain
+        # even if the rule is excluded from the search
+        # it should still be present on the sale order
+        orders.detect_exceptions()
+        all_detected = orders.mapped('exception_ids').ids
+        self.assertTrue(exception_no_sol.id in all_detected)
+        self.assertTrue(exception_no_dumping.id in all_detected)
+        self.assertTrue(exception_no_free.id in all_detected)


### PR DESCRIPTION
Same as https://github.com/OCA/sale-workflow/pull/780
Fix the bug and add a test accordingly.

Depends on https://github.com/OCA/server-tools/pull/1602

@hparfr @mourad-ehm @sebastienbeau @bealdav 