### PR TITLE
[10.0][FIX] Fix sale_promotion_rule in case of multi rules

### DIFF
--- a/sale_promotion_rule/models/sale_promotion_rule.py
+++ b/sale_promotion_rule/models/sale_promotion_rule.py
@@ -335,13 +335,15 @@ according to the strategy
     @api.multi
     def _apply(self, orders):
         for rule in self:
-            orders = orders.filtered(
+            orders_valid = orders.filtered(
                 lambda o, r=rule: r._is_promotion_valid(o))
-            rule._apply_rule_to_order_lines(orders.mapped('order_line'))
+            if not orders_valid:
+                continue
+            rule._apply_rule_to_order_lines(orders_valid.mapped('order_line'))
             if rule.rule_type == 'coupon':
-                orders.write({'coupon_promotion_rule_id': rule.id})
+                orders_valid.write({'coupon_promotion_rule_id': rule.id})
             else:
-                orders.write({'promotion_rule_ids': [(4, rule.id)]})
+                orders_valid.write({'promotion_rule_ids': [(4, rule.id)]})
 
     @api.multi
     def _apply_rule_to_order_lines(self, lines):

--- a/sale_promotion_rule/tests/test_promotion.py
+++ b/sale_promotion_rule/tests/test_promotion.py
@@ -388,3 +388,22 @@ class PromotionCase(TransactionCase, AbstractCommonPromotionCase):
                 "%s != %s" % (new_amount, discount_amount)
             )
             self.sale.clear_promotions()
+
+    def test_multi_promotion_rules(self):
+        """
+        Ensure it's working in case of multi available promotions.
+        So the first promotion rule (promotion_rule_auto) should be check
+        (and not available due to minimal amount), then the promo_copy should
+        be check and applied.
+        :return:
+        """
+        promo_copy = self.promotion_rule_auto.copy({
+            'name': 'Almost free',
+        })
+        self.promotion_rule_auto.write({
+            'minimal_amount': 999999,
+        })
+        self.sale.apply_promotions()
+        for line in self.sale.order_line:
+            self.check_discount_rule_set(line, promo_copy)
+        return


### PR DESCRIPTION
Currently, if you have multi-promotion rules, new ones (based on the order) has not applied.
Due to a little mistake with `orders` variable, these orders are ignored during the loop execution.

MR is red because the 10.0 branch is red too.