### PR TITLE
[12.0][IMP] sale exception

### DIFF
--- a/sale_exception/README.rst
+++ b/sale_exception/README.rst
@@ -71,6 +71,7 @@ Contributors
 * Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Florian da Costa <florian.dacosta@akretion.com>
+* Iván Todorovich <ivan.todorovich@druidoo.io>
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_exception/__manifest__.py
+++ b/sale_exception/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Sale Exception',
     'summary': 'Custom exceptions on sale order',
-    'version': '12.0.1.1.1',
+    'version': '12.0.1.1.0',
     'category': 'Generic Modules/Sale',
     'author': "Akretion, "
               "Sodexis, "

--- a/sale_exception/__manifest__.py
+++ b/sale_exception/__manifest__.py
@@ -10,7 +10,6 @@
     'author': "Akretion, "
               "Sodexis, "
               "Camptocamp, "
-              "Druidoo, "
               "Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/sale-workflow',
     'depends': ['sale', 'base_exception'],

--- a/sale_exception/__manifest__.py
+++ b/sale_exception/__manifest__.py
@@ -5,11 +5,12 @@
 {
     'name': 'Sale Exception',
     'summary': 'Custom exceptions on sale order',
-    'version': '12.0.1.0.1',
+    'version': '12.0.1.1.1',
     'category': 'Generic Modules/Sale',
     'author': "Akretion, "
               "Sodexis, "
               "Camptocamp, "
+              "Druidoo, "
               "Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/sale-workflow',
     'depends': ['sale', 'base_exception'],

--- a/sale_exception/readme/CONTRIBUTORS.rst
+++ b/sale_exception/readme/CONTRIBUTORS.rst
@@ -8,3 +8,4 @@
 * Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Florian da Costa <florian.dacosta@akretion.com>
+* Iván Todorovich <ivan.todorovich@druidoo.io>

--- a/sale_exception/views/sale_view.xml
+++ b/sale_exception/views/sale_view.xml
@@ -39,17 +39,8 @@
                     </p>
                 </div>
             </sheet>
-
             <xpath expr="//field[@name='date_order']/.." position="inside">
                 <field name="ignore_exception" states="sale" />
-            </xpath>
-
-            <xpath expr="//group[@name='sales_person']/.." position="inside">
-                <newline />
-                <group name="exception" colspan="2" col="2">
-                    <separator string="Exception" colspan="2"/>
-                    <field name="exception_ids" colspan="2" nolabel="1"/>
-                </group>
             </xpath>
         </field>
     </record>

--- a/sale_exception/views/sale_view.xml
+++ b/sale_exception/views/sale_view.xml
@@ -27,16 +27,12 @@
         <field name="arch" type="xml">
             <sheet position="before">
                 <div class="alert alert-danger" role="alert" style="margin-bottom:0px;"
-                     attrs="{'invisible': [('exception_ids_formatted','=',False)]}">
-                    <p>
-                        <strong>There are exceptions blocking the confirmation of this Sale Order:</strong><br/>
-                        <field name="exception_ids_formatted"/>
-                    </p>
-                    <p>
-                        <button name="action_ignore_exceptions" type="object" class="btn-danger"
+                     attrs="{'invisible': [('exceptions_summary','=',False)]}">
+                    <p><strong>There are exceptions blocking the confirmation of this Sale Order:</strong></p>
+                    <field name="exceptions_summary"/>
+                    <button name="action_ignore_exceptions" type="object" class="btn-danger"
                             string="Ignore Exceptions" help="Click here to be able to confirm this Sale Orders regardless of the exceptions."
                             groups="base_exception.group_exception_rule_manager"/>
-                    </p>
                 </div>
             </sheet>
             <xpath expr="//field[@name='date_order']/.." position="inside">

--- a/sale_exception/views/sale_view.xml
+++ b/sale_exception/views/sale_view.xml
@@ -1,82 +1,83 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
-   <record id="action_sale_test_tree" model="ir.actions.act_window">
-     <field name="name">Sale Exception Rules</field>
-     <field name="res_model">exception.rule</field>
-     <field name="view_type">form</field>
-     <field name="view_mode">tree,form</field>
-     <field name="view_id" ref="base_exception.view_exception_rule_tree"/>
-     <field name="domain">[('model', 'in', ['sale.order', 'sale.order.line'])]</field>
-     <field name="context">{'active_test': False, 'default_model' : 'sale.order'}</field>
-  </record>
 
-  <menuitem
-    action="action_sale_test_tree"
-    id="menu_sale_test"
-    sequence="90"
-    parent="sale.menu_sales_config"
-    groups="base_exception.group_exception_rule_manager"
-  />
+    <record id="action_sale_test_tree" model="ir.actions.act_window">
+        <field name="name">Sale Exception Rules</field>
+        <field name="res_model">exception.rule</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_id" ref="base_exception.view_exception_rule_tree"/>
+        <field name="domain">[('model', 'in', ['sale.order', 'sale.order.line'])]</field>
+        <field name="context">{'active_test': False, 'default_model' : 'sale.order'}</field>
+    </record>
 
-  <record id="view_order_form" model="ir.ui.view">
-    <field name="name">sale_exception.view_order_form</field>
-    <field name="model">sale.order</field>
-    <field name="inherit_id" ref="sale.view_order_form"/>
-    <field name="arch" type="xml">
-      <field name="name" position="after">
-        <group name="main_exception">
-        <field name="main_exception_id" options='{"no_open": True}'
-               class="oe_inline" string="Error:"
-               attrs="{'invisible':[('main_exception_id','=', False)]}"/>
-        </group>
-      </field>
-      <xpath expr="//field[@name='date_order']/.." position="inside">
-        <field name="ignore_exception" states="sale" />
-      </xpath>
-      <xpath expr="//group[@name='sales_person']/.."
-             position="inside">
-        <newline />
-        <group name="exception" colspan="2" col="2">
-          <separator string="Exception" colspan="2"/>
-          <field name="exception_ids" colspan="2" nolabel="1"/>
-        </group>
-      </xpath>
-    </field>
-  </record>
+    <menuitem
+        action="action_sale_test_tree"
+        id="menu_sale_test"
+        sequence="90"
+        parent="sale.menu_sales_config"
+        groups="base_exception.group_exception_rule_manager"
+    />
 
-  <record id="view_order_tree" model="ir.ui.view">
-    <field name="name">sale_exception.view_order_tree</field>
-    <field name="model">sale.order</field>
-    <field name="inherit_id" ref="sale.view_order_tree"/>
-    <field name="arch" type="xml">
-      <field name="state" position="after">
-        <field name="main_exception_id"/>
-      </field>
-    </field>
-  </record>
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="name">sale_exception.view_order_form</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form"/>
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <group name="main_exception">
+                    <field name="main_exception_id" options='{"no_open": True}'
+                     class="oe_inline" string="Error:"
+                     attrs="{'invisible':[('main_exception_id','=', False)]}"/>
+                 </group>
+             </field>
+             <xpath expr="//field[@name='date_order']/.." position="inside">
+                <field name="ignore_exception" states="sale" />
+            </xpath>
+            <xpath expr="//group[@name='sales_person']/.."
+                position="inside">
+                <newline />
+                <group name="exception" colspan="2" col="2">
+                    <separator string="Exception" colspan="2"/>
+                    <field name="exception_ids" colspan="2" nolabel="1"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
 
-  <record id="view_quotation_tree" model="ir.ui.view">
-    <field name="name">sale_exception.view_order_tree</field>
-    <field name="model">sale.order</field>
-    <field name="inherit_id" ref="sale.view_quotation_tree"/>
-    <field name="arch" type="xml">
-      <field name="state" position="after">
-        <field name="main_exception_id"/>
-      </field>
-    </field>
-  </record>
+    <record id="view_order_tree" model="ir.ui.view">
+        <field name="name">sale_exception.view_order_tree</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_tree"/>
+        <field name="arch" type="xml">
+            <field name="state" position="after">
+                <field name="main_exception_id"/>
+            </field>
+        </field>
+    </record>
 
-  <record id="view_sales_order_filter" model="ir.ui.view">
-    <field name="name">sale_exception.view_sales_order_filter</field>
-    <field name="model">sale.order</field>
-    <field name="inherit_id" ref="sale.view_sales_order_filter" />
-    <field name="arch" type="xml">
-      <filter name="my_sale_orders_filter" position="after">
-        <separator orientation="vertical"/>
-        <filter icon="terp-emblem-important" name="tofix" string="Blocked in draft" domain="[('main_exception_id','!=',False)]"/>
-      </filter>
-    </field>
-  </record>
+    <record id="view_quotation_tree" model="ir.ui.view">
+        <field name="name">sale_exception.view_order_tree</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_quotation_tree"/>
+        <field name="arch" type="xml">
+            <field name="state" position="after">
+                <field name="main_exception_id"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="view_sales_order_filter" model="ir.ui.view">
+        <field name="name">sale_exception.view_sales_order_filter</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_sales_order_filter" />
+        <field name="arch" type="xml">
+            <filter name="my_sale_orders_filter" position="after">
+                <separator orientation="vertical"/>
+                <filter icon="terp-emblem-important" name="tofix" string="Blocked in draft" domain="[('main_exception_id','!=',False)]"/>
+            </filter>
+        </field>
+    </record>
 
 </odoo>

--- a/sale_exception/views/sale_view.xml
+++ b/sale_exception/views/sale_view.xml
@@ -15,7 +15,9 @@
     action="action_sale_test_tree"
     id="menu_sale_test"
     sequence="90"
-    parent="sale.menu_sales_config"/>
+    parent="sale.menu_sales_config"
+    groups="base_exception.group_exception_rule_manager"
+  />
 
   <record id="view_order_form" model="ir.ui.view">
     <field name="name">sale_exception.view_order_form</field>

--- a/sale_exception/views/sale_view.xml
+++ b/sale_exception/views/sale_view.xml
@@ -25,18 +25,26 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
-            <field name="name" position="after">
-                <group name="main_exception">
-                    <field name="main_exception_id" options='{"no_open": True}'
-                     class="oe_inline" string="Error:"
-                     attrs="{'invisible':[('main_exception_id','=', False)]}"/>
-                 </group>
-             </field>
-             <xpath expr="//field[@name='date_order']/.." position="inside">
+            <sheet position="before">
+                <div class="alert alert-danger" role="alert" style="margin-bottom:0px;"
+                     attrs="{'invisible': [('exception_ids_formatted','=',False)]}">
+                    <p>
+                        <strong>There are exceptions blocking the confirmation of this Sale Order:</strong><br/>
+                        <field name="exception_ids_formatted"/>
+                    </p>
+                    <p>
+                        <button name="action_ignore_exceptions" type="object" class="btn-danger"
+                            string="Ignore Exceptions" help="Click here to be able to confirm this Sale Orders regardless of the exceptions."
+                            groups="base_exception.group_exception_rule_manager"/>
+                    </p>
+                </div>
+            </sheet>
+
+            <xpath expr="//field[@name='date_order']/.." position="inside">
                 <field name="ignore_exception" states="sale" />
             </xpath>
-            <xpath expr="//group[@name='sales_person']/.."
-                position="inside">
+
+            <xpath expr="//group[@name='sales_person']/.." position="inside">
                 <newline />
                 <group name="exception" colspan="2" col="2">
                     <separator string="Exception" colspan="2"/>


### PR DESCRIPTION
Improve information messages when the order has exceptions:

![image](https://user-images.githubusercontent.com/1914185/59680571-f2403f80-91d1-11e9-8d1c-3af3feb2fef5.png)



---

This PR also contains this change: https://github.com/OCA/sale-workflow/pull/722 ([IMP] sale_exception: show menu only to Exception Rule Managers)


- [x] Depends on https://github.com/OCA/server-tools/pull/1609

@florian-dacosta @hparfr @mourad-ehm @sebastienbeau @bealdav