### PR TITLE
[10.0] sale_stock_picking_blocking: Do not break recordset (performance)

### DIFF
--- a/sale_stock_picking_blocking/models/sale_order.py
+++ b/sale_stock_picking_blocking/models/sale_order.py
@@ -58,9 +58,7 @@ class SaleOrderLine(models.Model):
 
     @api.multi
     def _action_procurement_create(self):
-        new_procs = self.env['procurement.order']
-        for line in self:
-            if not line.order_id.delivery_block_id:
-                new_procs += super(SaleOrderLine,
-                                   line)._action_procurement_create()
-        return new_procs
+        return super(
+            SaleOrderLine,
+            self.filtered(lambda line: not line.order_id.delivery_block_id)
+        )._action_procurement_create()


### PR DESCRIPTION
Do not break recordset and context in call to _action_procurement_create (performance)

See also https://github.com/odoo/odoo/issues/18714 fixed with https://github.com/OCA/OCB/pull/856