### PR TITLE
[IMP] sale_elaboration: Reset "is_elaboration" in order line when user changes product

### DIFF
--- a/sale_elaboration/models/sale_order.py
+++ b/sale_elaboration/models/sale_order.py
@@ -70,3 +70,9 @@ class SaleOrderLine(models.Model):
         if self.is_elaboration:
             vals['name'] = '{} - {}'.format(self.order_id.name, self.name)
         return vals
+
+    @api.onchange('product_id')
+    def product_id_change(self):
+        result = super().product_id_change()
+        self.is_elaboration = self.product_id.is_elaboration
+        return result

--- a/sale_elaboration/tests/test_sale_elaboration.py
+++ b/sale_elaboration/tests/test_sale_elaboration.py
@@ -20,12 +20,14 @@ class TestSaleElaboration(SavepointCase):
             'type': 'service',
             'list_price': 50.0,
             'invoice_policy': 'order',
+            'is_elaboration': True,
         })
         cls.product_elaboration_B = cls.env['product.product'].create({
             'name': 'Product Elaboration B',
             'type': 'service',
             'list_price': 25.0,
             'invoice_policy': 'order',
+            'is_elaboration': True,
         })
         cls.pricelist = cls.env['product.pricelist'].create({
             'name': 'Test pricelist',


### PR DESCRIPTION
Prevent lines setted as elaboration after copying a sale order.
cc @Tecnativa