### PR TITLE
[9.0] sale_automatic_workflow: avoid domain confusion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "2.7"
 
 addons:
+  postgresql: "9.6"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility

--- a/sale_automatic_workflow/models/sale_workflow_process.py
+++ b/sale_automatic_workflow/models/sale_workflow_process.py
@@ -35,25 +35,28 @@ class SaleWorkflowProcess(models.Model):
         default='direct',
     )
     validate_order = fields.Boolean(string='Validate Order')
-    order_filter_domain = fields.Char(
+    order_filter_domain = fields.Text(
         string='Order Filter Domain',
-        default="[('state', '=', 'draft')]"
+        related='order_filter_id.domain',
+        readonly=True,
     )
     create_invoice = fields.Boolean(string='Create Invoice')
-    create_invoice_filter_domain = fields.Char(
+    create_invoice_filter_domain = fields.Text(
         string='Create Invoice Filter Domain',
-        default="[('state','in',['sale','done']),"
-        "('invoice_status','=','to invoice')]"
+        related='create_invoice_filter_id.domain',
+        readonly=True,
     )
     validate_invoice = fields.Boolean(string='Validate Invoice')
-    validate_invoice_filter_domain = fields.Char(
+    validate_invoice_filter_domain = fields.Text(
         string='Validate Invoice Filter Domain',
-        default="[('state', '=', 'draft')]"
+        related='validate_invoice_filter_id.domain',
+        readonly=True,
     )
     validate_picking = fields.Boolean(string='Confirm and Transfer Picking')
-    picking_filter_domain = fields.Char(
+    picking_filter_domain = fields.Text(
         string='Picking Filter Domain',
-        default="[('state', 'in', ['draft', 'confirmed', 'assigned'])]"
+        related='picking_filter_id.domain',
+        readonly=True,
     )
     invoice_date_is_order_date = fields.Boolean(
         string='Force Invoice Date',
@@ -68,10 +71,10 @@ class SaleWorkflowProcess(models.Model):
              "marked as delivered"
     )
     sale_done = fields.Boolean(string='Sale Done')
-    sale_done_filter_domain = fields.Char(
+    sale_done_filter_domain = fields.Text(
         string='Sale Done Filter Domain',
-        default="[('state', '=', 'sale'),('invoice_status','=','invoiced'),"
-                "('all_qty_delivered', '=', True)]"
+        related='sale_done_filter_id.domain',
+        readonly=True,
     )
     warning = fields.Text(
         'Warning Message', translate=True,
@@ -123,30 +126,3 @@ class SaleWorkflowProcess(models.Model):
             'sale_automatic_workflow.automatic_workflow_sale_done_filter'
         )
     )
-
-    @api.onchange('order_filter_id')
-    def onchange_order_filter_id(self):
-        if self.order_filter_id:
-            self.order_filter_domain = self.order_filter_id.domain
-
-    @api.onchange('picking_filter_id')
-    def onchange_picking_filter_id(self):
-        if self.picking_filter_id:
-            self.picking_filter_domain = self.picking_filter_id.domain
-
-    @api.onchange('create_invoice_filter_id')
-    def onchange_create_invoice_filter_id(self):
-        domain = self.create_invoice_filter_id.domain
-        if self.create_invoice_filter_id:
-            self.create_invoice_filter_domain = domain
-
-    @api.onchange('validate_invoice_filter_id')
-    def onchange_validate_invoice_filter_id(self):
-        domain = self.validate_invoice_filter_id.domain
-        if self.validate_invoice_filter_id:
-            self.validate_invoice_filter_domain = domain
-
-    @api.onchange('sale_done_filter_id')
-    def onchange_sale_done_filter_id(self):
-        if self.sale_done_filter_id:
-            self.sale_done_filter_domain = self.sale_done_filter_id.domain

--- a/sale_automatic_workflow/views/sale_workflow_process_view.xml
+++ b/sale_automatic_workflow/views/sale_workflow_process_view.xml
@@ -25,7 +25,7 @@
                         <field name="validate_order" />
                         <label for="order_filter_id" attrs="{'required':[('validate_order','=',True)], 'invisible':[('validate_order','!=',True)]}"/>
                         <div attrs="{'required':[('validate_order','=',True)], 'invisible':[('validate_order','!=',True)]}">
-                            <field name="order_filter_domain" />
+                            <field name="order_filter_domain" widget="char"/>
                             <div class="oe_edit_only oe_inline">
                                 Set selection based on a search filter:
                                                 
@@ -36,7 +36,7 @@
                         <field name="validate_picking" />
                         <label for="picking_filter_id" attrs="{'required':[('validate_picking','=',True)], 'invisible':[('validate_picking','!=',True)]}"/>
                         <div attrs="{'required':[('validate_picking','=',True)], 'invisible':[('validate_picking','!=',True)]}">
-                            <field name="picking_filter_domain" />
+                            <field name="picking_filter_domain" widget="char"/>
                             <div class="oe_edit_only oe_inline">
                                 Set selection based on a search filter:
                                                 
@@ -47,7 +47,7 @@
                         <field name="create_invoice" />
                         <label for="create_invoice_filter_id" attrs="{'required':[('create_invoice','=',True)], 'invisible':[('create_invoice','!=',True)]}"/>
                         <div attrs="{'required':[('create_invoice','=',True)], 'invisible':[('create_invoice','!=',True)]}">
-                            <field name="create_invoice_filter_domain" />
+                            <field name="create_invoice_filter_domain" widget="char"/>
                             <div class="oe_edit_only oe_inline">
                                 Set selection based on a search filter:
                                                 
@@ -58,7 +58,7 @@
                         <field name="validate_invoice" />
                         <label for="validate_invoice_filter_id" attrs="{'required':[('validate_invoice','=',True)], 'invisible':[('validate_invoice','!=',True)]}"/>
                         <div attrs="{'required':[('validate_invoice','=',True)], 'invisible':[('validate_invoice','!=',True)]}">
-                            <field name="validate_invoice_filter_domain" />
+                            <field name="validate_invoice_filter_domain" widget="char"/>
                             <div class="oe_edit_only oe_inline">
                                 Set selection based on a search filter:
                                                 
@@ -68,7 +68,7 @@
                         <field name="sale_done" />
                         <label for="sale_done_filter_id" attrs="{'required':[('sale_done','=',True)], 'invisible':[('sale_done','!=',True)]}"/>
                         <div attrs="{'required':[('sale_done','=',True)], 'invisible':[('sale_done','!=',True)]}">
-                            <field name="sale_done_filter_domain" />
+                            <field name="sale_done_filter_domain" widget="char"/>
                             <div class="oe_edit_only oe_inline">
                                 Set selection based on a search filter:
                                                 


### PR DESCRIPTION
Domain fields are for display only.
Make them related readonly to avoid confusion.
Partial backport of 921bdc9e3d962c4066be22529dbf6caf00c6eafd