### PR TITLE
[10.0][ADD] Add behavior to auto-fill the automatic workflow with the payment mode (like sale order)

### DIFF
--- a/sale_automatic_workflow_payment_mode/__manifest__.py
+++ b/sale_automatic_workflow_payment_mode/__manifest__.py
@@ -16,6 +16,7 @@
         'data/automatic_workflow_data.xml',
         'views/account_payment_mode_views.xml',
         'views/sale_workflow_process_view.xml',
+        'views/account_invoice.xml',
     ],
     'installable': True,
     'auto_install': True,

--- a/sale_automatic_workflow_payment_mode/models/__init__.py
+++ b/sale_automatic_workflow_payment_mode/models/__init__.py
@@ -2,6 +2,7 @@
 # © 2016 Camptocamp SA, Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+from . import account_invoice
 from . import account_payment_mode
 from . import sale_order
 from . import sale_workflow_process

--- a/sale_automatic_workflow_payment_mode/models/account_invoice.py
+++ b/sale_automatic_workflow_payment_mode/models/account_invoice.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    @api.onchange('payment_mode_id')
+    def onchange_payment_mode_set_workflow(self):
+        if not self.payment_mode_id:
+            return
+        workflow = self.payment_mode_id.workflow_process_id
+        if workflow:
+            self.workflow_process_id = workflow

--- a/sale_automatic_workflow_payment_mode/tests/__init__.py
+++ b/sale_automatic_workflow_payment_mode/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_automatic_workflow_payment_mode
+from . import test_account_invoice
 

--- a/sale_automatic_workflow_payment_mode/tests/test_account_invoice.py
+++ b/sale_automatic_workflow_payment_mode/tests/test_account_invoice.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from uuid import uuid4
+from odoo.addons.sale_automatic_workflow.tests.test_automatic_workflow_base \
+    import TestAutomaticWorkflowBase
+
+
+class TestAutomaticWorkflowPaymentMode(TestAutomaticWorkflowBase):
+
+    def setUp(self):
+        super(TestAutomaticWorkflowPaymentMode, self).setUp()
+        self.invoice_obj = self.env['account.invoice']
+        self.partner_obj = self.env['res.partner']
+        self.product_obj = self.env['product.product']
+        self.product_uom_unit = self.env.ref('product.product_uom_unit')
+        self.workflow = self.create_full_automatic()
+        self._create_payment_mode()
+        self._create_invoice()
+
+    def _create_payment_mode(self):
+        self.journal = self.env['account.journal'].create({
+            'name': 'Test journal',
+            'code': 'TEST',
+            'type': 'general',
+        })
+        self.payment_mode = self.env['account.payment.mode'].create({
+            'name': 'Payment Mode Inbound',
+            'payment_method_id':
+                self.env.ref('account.account_payment_method_manual_in').id,
+            'bank_account_link': 'fixed',
+            'fixed_journal_id': self.journal.id,
+        })
+        method_out = self.env.ref('account.account_payment_method_manual_out')
+        method_out.bank_account_required = True
+        self.mode_out = self.env['account.payment.mode'].create({
+            'name': 'Payment Mode Outbound',
+            'payment_method_id': method_out.id,
+            'bank_account_link': 'fixed',
+            'fixed_journal_id': self.journal.id,
+        })
+
+    def _create_invoice(self):
+        partner_values = {
+            'name': str(uuid4()),
+        }
+        partner = self.partner_obj.create(partner_values)
+        product_values = {
+            'name': 'Bread',
+            'list_price': 5,
+            'type': 'product'
+        }
+        product = self.product_obj.create(product_values)
+        account = product.categ_id.property_account_income_categ_id
+        values = {
+            'partner_id': partner.id,
+            'invoice_line_ids': [(0, 0, {
+                'name': product.name,
+                'product_id': product.id,
+                'price_unit': product.list_price,
+                'account_id': account.id,
+            })],
+        }
+        self.invoice = self.invoice_obj.create(values)
+
+    def test_onchange_workflow(self):
+        """
+        Check if the workflow is automatically set when the payment mode is
+        filled.
+        :return:
+        """
+        self.payment_mode.write({
+            'workflow_process_id': self.workflow.id,
+        })
+        self.invoice.write({
+            'payment_mode_id': self.payment_mode.id
+        })
+        self.assertFalse(self.invoice.workflow_process_id)
+        self.assertTrue(self.payment_mode.workflow_process_id)
+        self.invoice.onchange_payment_mode_set_workflow()
+        self.assertEqual(
+            self.invoice.workflow_process_id,
+            self.invoice.payment_mode_id.workflow_process_id)

--- a/sale_automatic_workflow_payment_mode/views/account_invoice.xml
+++ b/sale_automatic_workflow_payment_mode/views/account_invoice.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record model="ir.ui.view" id="account_invoice_form_view">
+        <field name="name">account.invoice.form (in sale_automatic_workflow_payment_mode)</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.invoice_form"/>
+        <field name="priority" eval="95"/>
+        <field name="arch" type="xml">
+            <field name="payment_mode_id" position="after">
+                <field name="workflow_process_id"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Exactly as the sale order, the automatic workflow of the invoice should be automatically set depending on the payment mode.