### PR TITLE
[10.0][ADD] add module partner_picking_policy

### DIFF
--- a/partner_picking_policy/__init__.py
+++ b/partner_picking_policy/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import models

--- a/partner_picking_policy/__manifest__.py
+++ b/partner_picking_policy/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    'name': "Partner picking policy",
+    'summary': """Set the picking policy on the partner""",
+    'author': 'ACSONE SA/NV,Odoo Community Association (OCA)',
+    'website': "https://github.com/OCA/sale-workflow",
+    'category': 'Sales',
+    'version': '10.0.1.0.0',
+    'license': 'AGPL-3',
+    'depends': [
+        'sale_stock',
+    ],
+    'data': [
+        'views/res_partner.xml',
+    ],
+}

--- a/partner_picking_policy/models/__init__.py
+++ b/partner_picking_policy/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import res_partner
+from . import sale_order

--- a/partner_picking_policy/models/res_partner.py
+++ b/partner_picking_policy/models/res_partner.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, fields, models, _
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    @api.model
+    def _get_selection_picking_policy(self):
+        """
+        Get all possible selection choice for picking_policy
+        (based on the same field on sale.order).
+        :return: list of tuple (str, str)
+        """
+        target_field = "picking_policy"
+        fields_get = self.env['sale.order'].fields_get(
+            allfields=[target_field])
+        return [(v[0], _(v[1])) for v in fields_get[target_field]['selection']]
+
+    picking_policy = fields.Selection(
+        selection="_get_selection_picking_policy",
+        help="Select a specific picking policy for this customer.\n"
+             "You can let the global picking policy by "
+             "letting emtpy this field.",
+        default="",
+    )

--- a/partner_picking_policy/models/sale_order.py
+++ b/partner_picking_policy/models/sale_order.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.onchange('partner_id')
+    def onchange_partner_id(self):
+        """
+        Inherit the onchange on partner_id to update the default value
+        of the picking_policy (who depends on the customer).
+        :return:
+        """
+        result = super(SaleOrder, self).onchange_partner_id()
+        if self.partner_id:
+            if self.partner_id.picking_policy:
+                picking_policy = self.partner_id.picking_policy
+            else:
+                picking_policy = self.env['ir.values'].get_default(
+                    'sale.order', 'picking_policy')
+            self.picking_policy = picking_policy
+        return result

--- a/partner_picking_policy/readme/CONTRIBUTORS.rst
+++ b/partner_picking_policy/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* François Honoré <francois.honore@acsone.eu>

--- a/partner_picking_policy/readme/DESCRIPTION.rst
+++ b/partner_picking_policy/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+In standard Odoo, you can specify a global picking policy on sale settings.
+
+This module allow you to specify a picking policy by customer.
+You can keep the global picking policy if you let blank the picking policy on
+the customer (it's the default value)

--- a/partner_picking_policy/readme/USAGE.rst
+++ b/partner_picking_policy/readme/USAGE.rst
@@ -1,0 +1,7 @@
+To use this module, you need to:
+
+#. Go on a customer
+#. Set a picking policy
+#. Create a new quotation
+#. Select the partner with the specify picking policy
+#. The picking policy on the quotation is updated with the selected partner

--- a/partner_picking_policy/tests/__init__.py
+++ b/partner_picking_policy/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import test_sale_order

--- a/partner_picking_policy/tests/test_sale_order.py
+++ b/partner_picking_policy/tests/test_sale_order.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.tests.common import TransactionCase
+
+
+class TestSaleOrder(TransactionCase):
+    """
+    Tests for sale.order
+    """
+
+    def setUp(self):
+        super(TestSaleOrder, self).setUp()
+        self.sale_obj = self.env['sale.order']
+        self.values_obj = self.env['ir.values']
+        self.partner = self.env.ref("base.res_partner_2")
+        self.product = self.env.ref('product.product_product_4')
+
+    def _create_sale_order(self, partner):
+        """
+        Create a new SO for the given partner
+        :param partner: res.partner recordset
+        :return: sale.order recordset
+        """
+        values = {
+            'partner_id': partner.id,
+            'order_line': [
+                (0, False, {
+                    'product_id': self.product.id,
+                }),
+            ],
+        }
+        return self.sale_obj.create(values)
+
+    def _edit_settings(self, picking_policy):
+        """
+        Edit the default picking policy
+        :param picking_policy: str
+        :return: bool
+        """
+        model_so = self.sale_obj._name
+        pick_policy_field = "picking_policy"
+        self.values_obj.sudo().set_default(
+            model_so, pick_policy_field, picking_policy)
+        default_pick_policy = self.values_obj.get_default(
+            model_so, pick_policy_field)
+        self.assertEqual(picking_policy, default_pick_policy)
+        return True
+
+    def test_picking_policy_on_customer(self):
+        """
+        Scenario to test:
+        - Define a picking policy on the partner
+        - Create a SO
+        - Play the onchange
+        - Check if the picking policy is correct
+
+        Then
+        Do the same without specify a picking policy on the partner
+        and check if the default value is correct.
+
+        Do these 2 again by using another value for picking policy
+        :return:
+        """
+        picking_policies = ["direct", "one"]
+        for picking_policy in picking_policies:
+            # Set another picking policy as default value for SO.
+            other_picking_policy = [
+                p for p in picking_policies if p != picking_policies][0]
+            self._edit_settings(other_picking_policy)
+            self.partner.write({
+                'picking_policy': picking_policy,
+            })
+            # Ensure the write is correctly done
+            self.assertEqual(self.partner.picking_policy, picking_policy)
+            sale_order = self._create_sale_order(partner=self.partner)
+            sale_order.onchange_partner_id()
+            self.assertEqual(sale_order.picking_policy, picking_policy)
+        return
+
+    def test_picking_policy_in_settings(self):
+        """
+        Scenario to test:
+        - Define a picking policy on the partner
+        - Create a SO
+        - Play the onchange
+        - Check if the picking policy is correct
+
+        Then
+        Do the same without specify a picking policy on the partner
+        and check if the default value is correct.
+
+        Do these 2 again by using another value for picking policy
+        :return:
+        """
+        picking_policies = ["direct", "one"]
+        self.partner.write({
+            'picking_policy': False,
+        })
+        for picking_policy in picking_policies:
+            # Set another picking policy as default value for SO.
+            self._edit_settings(picking_policy)
+            # Ensure it still empty
+            self.assertFalse(self.partner.picking_policy)
+            sale_order = self._create_sale_order(partner=self.partner)
+            sale_order.onchange_partner_id()
+            self.assertEqual(sale_order.picking_policy, picking_policy)
+        return

--- a/partner_picking_policy/views/res_partner.xml
+++ b/partner_picking_policy/views/res_partner.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record model="ir.ui.view" id="res_partner_form_view">
+        <field name="name">res.partner.form (in partner_picking_policy)</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="priority" eval="90"/>
+        <field name="arch" type="xml">
+            <field name="user_id" position="after">
+                <field name="picking_policy"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/setup/partner_picking_policy/odoo/__init__.py
+++ b/setup/partner_picking_policy/odoo/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/partner_picking_policy/odoo/addons/__init__.py
+++ b/setup/partner_picking_policy/odoo/addons/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup/partner_picking_policy/odoo/addons/partner_picking_policy
+++ b/setup/partner_picking_policy/odoo/addons/partner_picking_policy
@@ -1,0 +1,1 @@
+../../../../partner_picking_policy

--- a/setup/partner_picking_policy/setup.py
+++ b/setup/partner_picking_policy/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Add a new module `partner_picking_policy`

**Current behavior:**
You can specify a global picking policy into sale settings.

**New behavior:**
You can define a picking policy by partners/customers.
You can let the field empty (on partner) to use the global rule (into sale settings)