### PR TITLE
[IMP][12.0][sale_order_price_recalculation] Adding information about the order to recalculate_names line2 add 'order_id': self

### DIFF
--- a/sale_order_price_recalculation/models/sale_order.py
+++ b/sale_order_price_recalculation/models/sale_order.py
@@ -32,6 +32,7 @@ class SaleOrder(models.Model):
             # we make this to isolate changed values:
             line2 = self.env['sale.order.line'].new({
                 'product_id': line.product_id,
+                'order_id': self
             })
             line2.product_id_change()
             line.name = line2.name


### PR DESCRIPTION
Adding information about the order to recalculate_names line2 dummy order line will allow for using the correct language. Without this fix, the recalculate_names function was useless in multi-language environments.