### PR TITLE
[10.0][FIX] oca_dependencies.txt: Remove unnecessary entry

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -6,4 +6,4 @@ server-tools
 manufacture
 account-invoicing
 product-attribute
-partner-contact https://github.com/akretion/partner-contact 10-partner-history
+partner-contact


### PR DESCRIPTION
This has to be removed as partner_address_version module is merged

@bguillot @pedrobaeza 