### PR TITLE
[10.0] Add sale_quotation_product_sync

### DIFF
--- a/sale_quotation_product_sync/__init__.py
+++ b/sale_quotation_product_sync/__init__.py
@@ -1,0 +1,1 @@
+from . import wizards

--- a/sale_quotation_product_sync/__manifest__.py
+++ b/sale_quotation_product_sync/__manifest__.py
@@ -14,7 +14,6 @@
         "website_quote",
     ],
     "data": [
-        # "security/ir.model.access.csv",
         "wizards/sale_quotation_synchronizer.xml",
     ],
 }

--- a/sale_quotation_product_sync/__manifest__.py
+++ b/sale_quotation_product_sync/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Sale Quotation Synchronizer",
+    "summary": "Synchronize quotations and quotation templates from products",
+    "version": "10.0.1.0.0",
+    "category": "Sales",
+    "website": "https://github.com/OCA/sale-workflow",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": [
+        "website_quote",
+    ],
+    "data": [
+        # "security/ir.model.access.csv",
+        "wizards/sale_quotation_synchronizer.xml",
+    ],
+}

--- a/sale_quotation_product_sync/readme/CONTRIBUTORS.rst
+++ b/sale_quotation_product_sync/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>
+* Patrick Tombez <patrick.tombez@camptocamp.com>

--- a/sale_quotation_product_sync/readme/DESCRIPTION.rst
+++ b/sale_quotation_product_sync/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module adds a sale quotation synchronization wizard. The wizard aims to
+ease the update of existing quotations and templates according to changes (e.g.
+unit price) in the product definition.

--- a/sale_quotation_product_sync/readme/ROADMAP.rst
+++ b/sale_quotation_product_sync/readme/ROADMAP.rst
@@ -1,2 +1,2 @@
 * Add more fields to synchronize (e.g. descriptions, taxes)
-* Add a report (computed fields?) of models to update/updated
+* Add a report of models to update (computed fields?)/record updated (wiz state)

--- a/sale_quotation_product_sync/readme/ROADMAP.rst
+++ b/sale_quotation_product_sync/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+* Add more fields to synchronize (e.g. descriptions, taxes)
+* Add a report (computed fields?) of models to update/updated

--- a/sale_quotation_product_sync/readme/USAGE.rst
+++ b/sale_quotation_product_sync/readme/USAGE.rst
@@ -1,0 +1,4 @@
+1. Open the wizard under Sales > Configuration > Sales > Quotations synchronization
+2. Select the models to synchronize
+3. Select the fields to synchronize
+4. Select the products to be synchronized

--- a/sale_quotation_product_sync/tests/__init__.py
+++ b/sale_quotation_product_sync/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_quotation_synchronizer

--- a/sale_quotation_product_sync/tests/test_quotation_synchronizer.py
+++ b/sale_quotation_product_sync/tests/test_quotation_synchronizer.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+from odoo.tests import common
+
+
+class TestQuotationSynchronizer(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestQuotationSynchronizer, cls).setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.any_customer = cls.env['res.partner'].search([
+            ('customer', '=', True),
+        ], limit=1)
+        cls.template_default = cls.env.ref(
+            'website_quote.website_quote_template_default')
+        cls.product_2 = cls.env.ref('product.product_product_2')
+        cls.product_3 = cls.env.ref('product.product_product_3')
+        cls.template_default.write({
+            'quote_line': [
+                (0, 0, {
+                    'product_id': cls.product_3.id,
+                    'name': 'Sample Text',
+                    'product_uom_qty': 2.,
+                    'price_unit': 450.,
+                    'product_uom_id': cls.product_3.uom_id.id,
+                    'tested_sample': 'Sample3',
+                }),
+            ],
+            'options': [
+                (0, 0, {
+                    'product_id': cls.product_2.id,
+                    'name': cls.product_2.name,
+                    'quantity': 1,
+                    'price_unit': 38.25,
+                    'uom_id': cls.product_2.uom_id.id,
+                }),
+            ],
+        })
+
+    def test_price_propagation(self):
+        order = self.env['sale.order'].create({
+            'partner_id': self.any_customer.id,
+            'template_id': self.template_default.id,
+        })
+        order.onchange_template_id()
+        order_line_p3 = order.order_line.filtered(
+            lambda ol: ol.product_id == self.product_3)
+
+        order_copy = order.copy()
+        order_copy_line_p3 = order_copy.order_line.filtered(
+            lambda ol: ol.product_id == self.product_3)
+        order_copy.action_confirm()
+
+        self.assertEqual(order_line_p3.price_unit, 450.0)
+        self.assertEqual(order.amount_total, 900.0)
+        self.assertEqual(order_copy_line_p3.price_unit, 450.0)
+        self.assertEqual(order_copy.amount_total, 900.0)
+
+        self.product_3.list_price = 500
+        self.product_2.list_price = 50
+        wizard = self.env['sale.quotation.synchronizer'].create({
+            'product_ids': [(4, self.product_2.id), (4, self.product_3.id)]
+        })
+        wizard.execute()
+        # The price change should propagate to quotation template line
+        self.assertEqual(self.template_default.quote_line.price_unit, 500.0)
+        # The price change should propagate to quotation template option
+        self.assertEqual(self.template_default.options.price_unit, 50.0)
+        # The price change should propagate to 'draft' order
+        self.assertEqual(order_line_p3.price_unit, 500.0)
+        self.assertEqual(order.amount_total, 1000.0)
+        # but not to the confirmed one
+        self.assertEqual(order_copy_line_p3.price_unit, 450.0)
+        self.assertEqual(order_copy.amount_total, 900.0)

--- a/sale_quotation_product_sync/wizards/__init__.py
+++ b/sale_quotation_product_sync/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_quotation_synchronizer

--- a/sale_quotation_product_sync/wizards/sale_quotation_synchronizer.py
+++ b/sale_quotation_product_sync/wizards/sale_quotation_synchronizer.py
@@ -1,0 +1,79 @@
+# Copyright 2019 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, fields, models
+
+
+class SaleQuotationSynchronizer(models.TransientModel):
+
+    _name = 'sale.quotation.synchronizer'
+    _description = 'Synchronize quotations from product'
+
+    product_ids = fields.Many2many('product.product')
+
+    sync_sale_order_line = fields.Boolean(
+        string='Sync draft order lines', default=True,
+    )
+    sync_sale_quote_line = fields.Boolean(
+        string='Sync quotation template lines', default=True,
+    )
+    sync_sale_quote_option = fields.Boolean(
+        string='Sync quotation template options', default=True,
+    )
+
+    sync_price_unit = fields.Boolean(
+        string='Sync unit price', default=True, readonly=True,
+    )
+
+    def _sync_sale_order_lines(self, product):
+        sale_order_lines = self.env['sale.order.line'].search(
+            [
+                ('product_id', '=', product.id),
+                ('order_id.state', '=', 'draft')
+            ]
+        )
+        for order_line in sale_order_lines:
+            new_price = product.lst_price
+            if order_line.product_uom != product.uom_id:
+                new_price = product.uom_id._compute_quantity(
+                    1, order_line.product_uom
+                )
+            order_line.write({'price_unit': new_price})
+
+    def _sync_sale_quote_lines(self, product):
+        sale_quote_lines = self.env['sale.quote.line'].search(
+            [
+                ('product_id', '=', product.id),
+            ]
+        )
+        for quote_line in sale_quote_lines:
+            new_price = product.lst_price
+            if quote_line.product_uom_id != product.uom_id:
+                new_price = product.uom_id._compute_quantity(
+                    1, quote_line.product_uom_id
+                )
+            quote_line.write({'price_unit': new_price})
+
+    def _sync_sale_quote_options(self, product):
+        sale_quote_options = self.env['sale.quote.option'].search(
+            [
+                ('product_id', '=', product.id),
+            ]
+        )
+        for quote_option in sale_quote_options:
+            new_price = product.lst_price
+            if quote_option.uom_id != product.uom_id:
+                new_price = product.uom_id._compute_quantity(
+                    1, quote_option.uom_id
+                )
+            quote_option.write({'price_unit': new_price})
+
+    @api.multi
+    def execute(self):
+        self.ensure_one()
+        for product in self.product_ids:
+            if self.sync_sale_order_line:
+                self._sync_sale_order_lines(product=product)
+            if self.sync_sale_quote_line:
+                self._sync_sale_quote_lines(product=product)
+            if self.sync_sale_quote_option:
+                self._sync_sale_quote_options(product=product)

--- a/sale_quotation_product_sync/wizards/sale_quotation_synchronizer.xml
+++ b/sale_quotation_product_sync/wizards/sale_quotation_synchronizer.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="sale_quotation_synchronizer_form_view" model="ir.ui.view">
+        <field name="name">sale quotation synchronizer</field>
+        <field name="model">sale.quotation.synchronizer</field>
+        <field name="arch" type="xml">
+            <form string="Sale quotation Synchronization">
+                <group name="config">
+                    <group name="target_models" string="Target">
+                        <field name="sync_sale_order_line" />
+                        <field name="sync_sale_quote_line" />
+                        <field name="sync_sale_quote_option" />
+                    </group>
+                    <group name="operations" string="Operations">
+                        <field name="sync_price_unit" />
+                    </group>
+                    <field name="product_ids">
+                        <tree>
+                            <field name="name" />
+                            <field name="lst_price" />
+                        </tree>
+                    </field>
+                </group>
+                <footer>
+                    <button string="Update" type="object" name="execute" class="btn-primary" />
+                    <button string="Cancel" special="cancel" class="btn-default"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <act_window id="sale_quotation_synchronizer_action"
+                name="Quotations synchronization"
+                target="new"
+                res_model="sale.quotation.synchronizer"
+                view_type="form"
+                view_mode="form"
+                view_id="sale_quotation_synchronizer_form_view" />
+
+    <menuitem id="sale_quotation_synchronizer_menu" action="sale_quotation_synchronizer_action" parent="sale.menu_sales_config" name="Quotations synchronization" groups="sales_team.group_sale_salesman,sales_team.group_sale_manager"/>
+</odoo>


### PR DESCRIPTION
This module adds a sale quotation synchronization wizard. The wizard aims to
ease the update of existing quotations and templates according to changes (e.g.
unit price) in the product definition.
