### PR TITLE
[ADD] Add sequence field to sale.order.line form

### DIFF
--- a/sale_order_line_sequence/views/sale_view.xml
+++ b/sale_order_line_sequence/views/sale_view.xml
@@ -15,6 +15,9 @@
                 <xpath expr="//field[@name='order_line']/tree/field[@name='product_id']" position="before">
                     <field name="sequence2"/>
                 </xpath>
+                <xpath expr="//field[@name='order_line']/form//field[@name='product_id']" position="before">
+                    <field name="sequence" invisible="1"/>
+                </xpath>
             </field>
         </record>
 


### PR DESCRIPTION
when using the sale.order.line form instead of the editable tree - then the generated default sequence will get lost without that