### PR TITLE
remove obsolete base_sale_multi_channel reference

### DIFF
--- a/sale_exception/README.rst
+++ b/sale_exception/README.rst
@@ -28,9 +28,10 @@ Sale Exception
 This module allows you attach several customizable exceptions to your
 sale order in a way that you can filter orders by exceptions type and fix them.
 
-This is especially useful in an scenario for mass sales order import, because 
-it's likely some orders have errors when you import them (like product not found 
-in Odoo, wrong line format etc.)
+This is especially useful in an scenario for mass sales order import such as
+with the base_sale_multi_channels module, because it's likely some orders have
+errors when you import them (like product not found in Odoo, wrong line
+format etc.)
 
 **Table of contents**
 

--- a/sale_exception/README.rst
+++ b/sale_exception/README.rst
@@ -28,10 +28,9 @@ Sale Exception
 This module allows you attach several customizable exceptions to your
 sale order in a way that you can filter orders by exceptions type and fix them.
 
-This is especially useful in an scenario for mass sales order import such as
-with the base_sale_multi_channels module, because it's likely some orders have
-errors when you import them (like product not found in Odoo, wrong line
-format etc.)
+This is especially useful in an scenario for mass sales order import, because 
+it's likely some orders have errors when you import them (like product not found 
+in Odoo, wrong line format etc.)
 
 **Table of contents**
 

--- a/sale_exception/readme/DESCRIPTION.rst
+++ b/sale_exception/readme/DESCRIPTION.rst
@@ -1,7 +1,6 @@
 This module allows you attach several customizable exceptions to your
 sale order in a way that you can filter orders by exceptions type and fix them.
 
-This is especially useful in an scenario for mass sales order import such as
-with the base_sale_multi_channels module, because it's likely some orders have
-errors when you import them (like product not found in Odoo, wrong line
-format etc.)
+This is especially useful in an scenario for mass sales order import because 
+it's likely some orders have errors when you import them (like product not 
+found in Odoo, wrong line format etc.)


### PR DESCRIPTION
The base_sale_multi_channel module doesn't exist for a long time but is still indicated in README. Remove it.