### PR TITLE
[FIX] 10.0 sale_triple_discount

### DIFF
--- a/sale_triple_discount/README.rst
+++ b/sale_triple_discount/README.rst
@@ -80,6 +80,7 @@ Contributors
 * David Vidal <david.vidal@tecnativa.com>
 * Simone Rubino <simone.rubino@agilebg.com>
 * Jacques-Etienne Baudoux (BCIM sprl) <je@bcim.be>
+* Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
 
 Maintainer
 ----------

--- a/sale_triple_discount/__manifest__.py
+++ b/sale_triple_discount/__manifest__.py
@@ -7,7 +7,7 @@
 
 {
     'name': 'Sale Triple Discount',
-    'version': '10.0.1.0.1',
+    'version': '10.0.1.1.0',
     'category': 'Sales Management',
     'author': 'ADHOC SA, '
               'Agile Business Group, '


### PR DESCRIPTION
there are cases where the cache trick done in triple_discount_preprocess
is lost when sale.order.line _compute_amount is called and processes the
1st line of the sale order => all remaining lines are impacted, and don't
have the discounts 2 and 3 taken into account.

Not updating the sale.order _amount_all method because it is unlikely that
fields on the lines depend on the total amount of the sale.