### PR TITLE
[11.0] sale_blanket_order: fix the following use case scenario.

### DIFF
--- a/sale_blanket_order/README.rst
+++ b/sale_blanket_order/README.rst
@@ -42,7 +42,7 @@ A new menu in the Sales area is created, allowing users to create new blanket or
 
 To create a new Sale Blanket Order go to the sale menu in the Sales section:
 
-.. image:: https://raw.githubusercontent.com/sale_blanket_order/static/description/BO_menu.png
+.. figure:: https://raw.githubusercontent.com/OCA/sale-workflow/12.0/sale_blanket_order/static/description/BO_menu.png
     :alt: Blanket Orders menu
 
 Hitting the button create will open the form view in which we can introduce the following
@@ -58,27 +58,27 @@ information:
     * Original, Ordered, Invoiced, Received and Remaining quantities
 * Terms and Conditions of the Blanket Order
 
-.. image:: https://raw.githubusercontent.com/sale_blanket_order/static/description/BO_form.png
+.. figure:: https://raw.githubusercontent.com/OCA/sale-workflow/12.0/sale_blanket_order/static/description/BO_form.png
     :alt: Blanket Orders form
 
 From the form, once the Blanket Order has been confirmed and its state is open, the user can
 create a Sale Order, check the Sale Orders associated to the Blanket Order and/or
 see the Blanket Order lines associated to the BO.
 
-.. image:: https://raw.githubusercontent.com/sale_blanket_order/static/description/BO_actions.png
+.. figure:: https://raw.githubusercontent.com/OCA/sale-workflow/12.0/sale_blanket_order/static/description/BO_actions.png
     :alt: Actions that can be done from Blanket Order
 
 Hitting the button Create Sale Order will open a wizard that will ask for the amount of each
 product in the BO lines for which the Sale Order will be created.
 
-.. image:: https://raw.githubusercontent.com/sale_blanket_order/static/description/PO_from_BO.png
+.. figure:: https://raw.githubusercontent.com/OCA/sale-workflow/12.0/sale_blanket_order/static/description/PO_from_BO.png
     :alt: Create Sale Order from Blanket Order
 
 Installing this module will add an additional menu which will show all the blanket order lines
 currently defined in the system. From this list the user can create customized Sale Orders
 selecting the lines for which the PO (or POs if the customers are different) is (are) created.
 
-.. image:: https://raw.githubusercontent.com/sale_blanket_order/static/description/BO_lines.png
+.. figure:: https://raw.githubusercontent.com/OCA/sale-workflow/12.0/sale_blanket_order/static/description/BO_lines.png
     :alt: Blanket Order lines and actions
 
 In the Sale Order form one field is added in the PO lines, the Blanket Order line field. This
@@ -89,7 +89,7 @@ factors:
 * Closer Validity date
 * Remaining quantity > Quantity introduced in the Sale Order line
 
-.. image:: https://raw.githubusercontent.com/sale_blanket_order/static/description/PO_BOLine.png
+.. figure:: https://raw.githubusercontent.com/OCA/sale-workflow/12.0/sale_blanket_order/static/description/PO_BOLine.png
     :alt: New field added in Sale Order Line
 
 Bug Tracker

--- a/sale_blanket_order/README.rst
+++ b/sale_blanket_order/README.rst
@@ -116,6 +116,8 @@ Contributors
 * André Pereira <github@andreparames.com> (https://www.acsone.eu/)
 * Adrià Gil Sorribes <adria.gil@eficent.com> (https://www.eficent.com/)
 * Jordi Ballester Alomar <jordi.ballester@eficent.com>
+* Alex Comba <alex.comba@agilebg.com>
+
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_blanket_order/__manifest__.py
+++ b/sale_blanket_order/__manifest__.py
@@ -5,7 +5,7 @@
     'category': 'Sale',
     'license': 'AGPL-3',
     'author': 'Acsone SA/NV, Odoo Community Association (OCA)',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'website': 'https://github.com/OCA/sale-workflow',
     'summary': "Blanket Orders",
     'depends': [

--- a/sale_blanket_order/readme/CONTRIBUTORS.rst
+++ b/sale_blanket_order/readme/CONTRIBUTORS.rst
@@ -1,3 +1,5 @@
 * André Pereira <github@andreparames.com> (https://www.acsone.eu/)
 * Adrià Gil Sorribes <adria.gil@eficent.com> (https://www.eficent.com/)
 * Jordi Ballester Alomar <jordi.ballester@eficent.com>
+* Alex Comba <alex.comba@agilebg.com>
+

--- a/sale_blanket_order/readme/USAGE.rst
+++ b/sale_blanket_order/readme/USAGE.rst
@@ -2,7 +2,7 @@ A new menu in the Sales area is created, allowing users to create new blanket or
 
 To create a new Sale Blanket Order go to the sale menu in the Sales section:
 
-.. image:: /sale_blanket_order/static/description/BO_menu.png
+.. figure:: ../static/description/BO_menu.png
     :alt: Blanket Orders menu
 
 Hitting the button create will open the form view in which we can introduce the following
@@ -18,27 +18,27 @@ information:
     * Original, Ordered, Invoiced, Received and Remaining quantities
 * Terms and Conditions of the Blanket Order
 
-.. image:: /sale_blanket_order/static/description/BO_form.png
+.. figure:: ../static/description/BO_form.png
     :alt: Blanket Orders form
 
 From the form, once the Blanket Order has been confirmed and its state is open, the user can
 create a Sale Order, check the Sale Orders associated to the Blanket Order and/or
 see the Blanket Order lines associated to the BO.
 
-.. image:: /sale_blanket_order/static/description/BO_actions.png
+.. figure:: ../static/description/BO_actions.png
     :alt: Actions that can be done from Blanket Order
 
 Hitting the button Create Sale Order will open a wizard that will ask for the amount of each
 product in the BO lines for which the Sale Order will be created.
 
-.. image:: /sale_blanket_order/static/description/PO_from_BO.png
+.. figure:: ../static/description/PO_from_BO.png
     :alt: Create Sale Order from Blanket Order
 
 Installing this module will add an additional menu which will show all the blanket order lines
 currently defined in the system. From this list the user can create customized Sale Orders
 selecting the lines for which the PO (or POs if the customers are different) is (are) created.
 
-.. image:: /sale_blanket_order/static/description/BO_lines.png
+.. figure:: ../static/description/BO_lines.png
     :alt: Blanket Order lines and actions
 
 In the Sale Order form one field is added in the PO lines, the Blanket Order line field. This
@@ -49,5 +49,5 @@ factors:
 * Closer Validity date
 * Remaining quantity > Quantity introduced in the Sale Order line
 
-.. image:: /sale_blanket_order/static/description/PO_BOLine.png
+.. figure:: ../static/description/PO_BOLine.png
     :alt: New field added in Sale Order Line

--- a/sale_blanket_order/static/description/index.html
+++ b/sale_blanket_order/static/description/index.html
@@ -389,7 +389,9 @@ due to reaching the validity date or exhausting all the quantities of products.<
 <h1><a class="toc-backref" href="#id1">Usage</a></h1>
 <p>A new menu in the Sales area is created, allowing users to create new blanket orders.</p>
 <p>To create a new Sale Blanket Order go to the sale menu in the Sales section:</p>
-<img alt="Blanket Orders menu" src="https://raw.githubusercontent.com/sale_blanket_order/static/description/BO_menu.png" />
+<div class="figure">
+<img alt="Blanket Orders menu" src="https://raw.githubusercontent.com/OCA/sale-workflow/12.0/sale_blanket_order/static/description/BO_menu.png" />
+</div>
 <p>Hitting the button create will open the form view in which we can introduce the following
 information:</p>
 <ul class="simple">
@@ -409,18 +411,26 @@ information:</p>
 </li>
 <li>Terms and Conditions of the Blanket Order</li>
 </ul>
-<img alt="Blanket Orders form" src="https://raw.githubusercontent.com/sale_blanket_order/static/description/BO_form.png" />
+<div class="figure">
+<img alt="Blanket Orders form" src="https://raw.githubusercontent.com/OCA/sale-workflow/12.0/sale_blanket_order/static/description/BO_form.png" />
+</div>
 <p>From the form, once the Blanket Order has been confirmed and its state is open, the user can
 create a Sale Order, check the Sale Orders associated to the Blanket Order and/or
 see the Blanket Order lines associated to the BO.</p>
-<img alt="Actions that can be done from Blanket Order" src="https://raw.githubusercontent.com/sale_blanket_order/static/description/BO_actions.png" />
+<div class="figure">
+<img alt="Actions that can be done from Blanket Order" src="https://raw.githubusercontent.com/OCA/sale-workflow/12.0/sale_blanket_order/static/description/BO_actions.png" />
+</div>
 <p>Hitting the button Create Sale Order will open a wizard that will ask for the amount of each
 product in the BO lines for which the Sale Order will be created.</p>
-<img alt="Create Sale Order from Blanket Order" src="https://raw.githubusercontent.com/sale_blanket_order/static/description/PO_from_BO.png" />
+<div class="figure">
+<img alt="Create Sale Order from Blanket Order" src="https://raw.githubusercontent.com/OCA/sale-workflow/12.0/sale_blanket_order/static/description/PO_from_BO.png" />
+</div>
 <p>Installing this module will add an additional menu which will show all the blanket order lines
 currently defined in the system. From this list the user can create customized Sale Orders
 selecting the lines for which the PO (or POs if the customers are different) is (are) created.</p>
-<img alt="Blanket Order lines and actions" src="https://raw.githubusercontent.com/sale_blanket_order/static/description/BO_lines.png" />
+<div class="figure">
+<img alt="Blanket Order lines and actions" src="https://raw.githubusercontent.com/OCA/sale-workflow/12.0/sale_blanket_order/static/description/BO_lines.png" />
+</div>
 <p>In the Sale Order form one field is added in the PO lines, the Blanket Order line field. This
 field keeps track to which Blanket Order line the PO line is associated. Upon adding a new product
 in a newly created Sale Order a blanket order line will be suggested depending on the following
@@ -429,7 +439,9 @@ factors:</p>
 <li>Closer Validity date</li>
 <li>Remaining quantity &gt; Quantity introduced in the Sale Order line</li>
 </ul>
-<img alt="New field added in Sale Order Line" src="https://raw.githubusercontent.com/sale_blanket_order/static/description/PO_BOLine.png" />
+<div class="figure">
+<img alt="New field added in Sale Order Line" src="https://raw.githubusercontent.com/OCA/sale-workflow/12.0/sale_blanket_order/static/description/PO_BOLine.png" />
+</div>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>

--- a/sale_blanket_order/static/description/index.html
+++ b/sale_blanket_order/static/description/index.html
@@ -453,6 +453,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>André Pereira &lt;<a class="reference external" href="mailto:github&#64;andreparames.com">github&#64;andreparames.com</a>&gt; (<a class="reference external" href="https://www.acsone.eu/">https://www.acsone.eu/</a>)</li>
 <li>Adrià Gil Sorribes &lt;<a class="reference external" href="mailto:adria.gil&#64;eficent.com">adria.gil&#64;eficent.com</a>&gt; (<a class="reference external" href="https://www.eficent.com/">https://www.eficent.com/</a>)</li>
 <li>Jordi Ballester Alomar &lt;<a class="reference external" href="mailto:jordi.ballester&#64;eficent.com">jordi.ballester&#64;eficent.com</a>&gt;</li>
+<li>Alex Comba &lt;<a class="reference external" href="mailto:alex.comba&#64;agilebg.com">alex.comba&#64;agilebg.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/sale_blanket_order/tests/test_blanket_orders.py
+++ b/sale_blanket_order/tests/test_blanket_orders.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2018 Eficent Business and IT Consulting Services S.L.
+# Copyright 2018 Eficent Business and IT Consulting Services S.L.
+# Copyright 2019 Alex Comba - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from datetime import date, timedelta
 
@@ -258,3 +259,62 @@ class TestSaleBlanketOrders(common.TransactionCase):
         sale_order.order_line[0].onchange_blanket_order_line()
         self.assertEqual(blanket_order.line_ids[0].remaining_qty, 12.0)
         self.assertEqual(sale_order.order_line[0].price_unit, 20.0)
+
+    def test_06_create_sale_orders_from_blanket_order(self):
+        """ We create a blanket order and create three sale orders
+            where the first two consume the first blanket order line
+        """
+        blanket_order = self.blanket_order_obj.create({
+            'partner_id': self.partner.id,
+            'validity_date': fields.Date.to_string(self.tomorrow),
+            'payment_term_id': self.payment_term.id,
+            'pricelist_id': self.sale_pricelist.id,
+            'line_ids': [
+                (0, 0, {
+                    'product_id': self.product.id,
+                    'product_uom': self.product.uom_id.id,
+                    'original_uom_qty': 30.0,
+                    'price_unit': 30.0,
+                }), (0, 0, {
+                    'product_id': self.product2.id,
+                    'product_uom': self.product2.uom_id.id,
+                    'original_uom_qty': 20.0,
+                    'price_unit': 60.0,
+                })
+            ],
+        })
+        blanket_order.sudo().onchange_partner_id()
+        blanket_order.sudo().action_confirm()
+
+        wizard1 = self.blanket_order_wiz_obj.with_context(
+            active_id=blanket_order.id,
+            active_model='sale.blanket.order').create({})
+        wizard1.line_ids.filtered(
+            lambda l:  l.product_id == self.product).write({'qty': 10.0})
+        wizard1.line_ids.filtered(
+            lambda l:  l.product_id == self.product2).write({'qty': 10.0})
+        wizard1.sudo().create_sale_order()
+
+        wizard2 = self.blanket_order_wiz_obj.with_context(
+            active_id=blanket_order.id,
+            active_model='sale.blanket.order').create({})
+        wizard2.line_ids.filtered(
+            lambda l:  l.product_id == self.product).write({'qty': 20.0})
+        wizard2.line_ids.filtered(
+            lambda l:  l.product_id == self.product2).write({'qty': 0})
+        wizard2.sudo().create_sale_order()
+
+        wizard3 = self.blanket_order_wiz_obj.with_context(
+            active_id=blanket_order.id,
+            active_model='sale.blanket.order').create({})
+        wizard3.line_ids.filtered(
+            lambda l:  l.product_id == self.product2).write({'qty': 10.0})
+        wizard3.sudo().create_sale_order()
+
+        self.assertEqual(blanket_order.state, 'done')
+
+        self.assertEqual(blanket_order.sale_count, 3)
+
+        view_action = blanket_order.action_view_sale_orders()
+        domain_ids = view_action['domain'][0][2]
+        self.assertEqual(len(domain_ids), 3)


### PR DESCRIPTION
Steps to reproduce:

* create and confirm a blanket order (BO) with (product A, qty 30) and (product B, qty 20)
* from the BO create a SO with (product A, qty 10) and (product B, qty 10)
* from the BO create a SO with (product A, qty 20) and (product B, qty 0)
* from the BO create another SO with (product B, qty 10)

Current behavior:

It raises the exception "The sale has already been completed.".

Expected behavior:

No exception is raised.