### PR TITLE
[12.0][FIX] Sale Order Cancel Reasons menu configuration

### DIFF
--- a/sale_cancel_reason/readme/CONTRIBUTORS.rst
+++ b/sale_cancel_reason/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Guewen Baconnier, Camptocamp SA
 * Kitti U. <kittiu@ecosoft.co.th>
 * Victor M.M Torres <victor.martin@tecnativa.com>
+* Bhavesh Odedra <bodedra@opensourceintegrators.com>

--- a/sale_cancel_reason/view/sale_view.xml
+++ b/sale_cancel_reason/view/sale_view.xml
@@ -49,7 +49,7 @@
     </record>
 
     <menuitem id="menu_sale_order_cancel_reason"
-      parent="sales_team.menu_sale_config"
+      parent="sale.menu_sale_config"
       name="Sale Order Cancel Reasons"
       action="action_sale_order_cancel_reason"
       sequence="150" groups="sales_team.group_sale_manager"/>


### PR DESCRIPTION
Before PR:
--------------

![Firefox_Screenshot_2019-11-11T05-40-23 482Z](https://user-images.githubusercontent.com/14229503/68564116-b4d89900-0475-11ea-88a9-e35804e224ad.png)

![Screenshot from 2019-11-11 11-10-28](https://user-images.githubusercontent.com/14229503/68564189-e2bddd80-0475-11ea-93b2-489621d7769b.png)

After PR:
------------

- Sale Order Cancel Reasons menu position will be `Sales > Configuration`

![Firefox_Screenshot_2019-11-11T06-14-57 542Z](https://user-images.githubusercontent.com/14229503/68565185-bbb4db00-0478-11ea-9b5c-db2dc17d7277.png)
