### PR TITLE
[FIX] sale_order_type: Keep sale type on generated invoices

### DIFF
--- a/sale_order_type/models/sale_order.py
+++ b/sale_order_type/models/sale_order.py
@@ -52,3 +52,12 @@ class SaleOrder(models.Model):
         if self.type_id:
             res['sale_type_id'] = self.type_id.id
         return res
+
+    def _finalize_invoices(self, invoices, references):
+        """Make sure sale type is kept when onchanges are called upstream."""
+        sale_types = {x: x.sale_type_id for x in invoices.values()}
+        res = super()._finalize_invoices(invoices, references)
+        for invoice in invoices.values():
+            if invoice.sale_type_id != sale_types[invoice]:
+                invoice.sale_type_id = sale_types[invoice]
+        return res


### PR DESCRIPTION
Steps to reproduce:

* Create a partner with sale type A.
* Create an SO for that partner with sale type B.
* Generate the invoice for that SO.
* Generated invoice will have type A instead of type B.

This is caused by the fact that after creating invoices, there's a process in core called `_finalize_invoices` that calls the onchange of the partner for bringing other missing data, but as there's no filter, it overwrites all fields that are populated through `_onchange_partner_id` successive overwrites.

We fix it saving previous values before calling the method, and comparing afterwards if it has been changed, restoring it if so. It's an ugly code, but there's no better way (mangling with values passed by context for disabling the onchange will populate other environments that will have undesired effects).

cc @Tecnativa TT20555