### PR TITLE
[12.0] sale_automatic_workflow_split

### DIFF
--- a/sale_automatic_workflow_split/__init__.py
+++ b/sale_automatic_workflow_split/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_automatic_workflow_split/__manifest__.py
+++ b/sale_automatic_workflow_split/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2017-2019 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+{
+    "name": "Sale Automatic Workflow Split",
+    "version": "12.0.1.0.0",
+    "category": "Sales Management",
+    "summary": "Add separete crons to perform workflow partially",
+    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/sale_workflow",
+    "depends": ["sale_automatic_workflow"],
+    "data": ["data/ir_cron.xml"],
+    "installable": True,
+}

--- a/sale_automatic_workflow_split/data/ir_cron.xml
+++ b/sale_automatic_workflow_split/data/ir_cron.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<odoo noupdate="1">
+
+    <record forcecreate="True" id="ir_cron_automatic_workflow_job_validate_order" model="ir.cron">
+        <field name="name">Automatic Workflow Job - Validate Orders</field>
+        <field ref="model_automatic_workflow_job" name="model_id"/>
+        <field eval="True" name="active"/>
+        <field name="user_id" ref="base.user_root"/>
+        <field name="interval_number">1</field>
+        <field name="interval_type">minutes</field>
+        <field name="numbercall">-1</field>
+        <field eval="False" name="doall"/>
+        <field name="state">code</field>
+        <field name="code">model.run_validate_order()</field>
+    </record>
+
+    <record forcecreate="True" id="ir_cron_automatic_workflow_job_validate_picking" model="ir.cron">
+        <field name="name">Automatic Workflow Job - Validate Pickings</field>
+        <field ref="model_automatic_workflow_job" name="model_id"/>
+        <field eval="True" name="active"/>
+        <field name="user_id" ref="base.user_root"/>
+        <field name="interval_number">1</field>
+        <field name="interval_type">minutes</field>
+        <field name="numbercall">-1</field>
+        <field eval="False" name="doall"/>
+        <field name="state">code</field>
+        <field name="code">model.run_validate_picking()</field>
+    </record>
+
+    <record forcecreate="True" id="ir_cron_automatic_workflow_job_create_invoice" model="ir.cron">
+        <field name="name">Automatic Workflow Job - Create Invoices</field>
+        <field ref="model_automatic_workflow_job" name="model_id"/>
+        <field eval="True" name="active"/>
+        <field name="user_id" ref="base.user_root"/>
+        <field name="interval_number">30</field>
+        <field name="interval_type">minutes</field>
+        <field name="numbercall">-1</field>
+        <field eval="False" name="doall"/>
+        <field name="state">code</field>
+        <field name="code">model.run_create_invoice()</field>
+    </record>
+
+    <record forcecreate="True" id="ir_cron_automatic_workflow_job_validate_invoice" model="ir.cron">
+        <field name="name">Automatic Workflow Job - Validate Invoices</field>
+        <field ref="model_automatic_workflow_job" name="model_id"/>
+        <field eval="True" name="active"/>
+        <field name="user_id" ref="base.user_root"/>
+        <field name="interval_number">30</field>
+        <field name="interval_type">minutes</field>
+        <field name="numbercall">-1</field>
+        <field eval="False" name="doall"/>
+        <field name="state">code</field>
+        <field name="code">model.run_validate_invoice()</field>
+    </record>
+
+    <record forcecreate="True" id="ir_cron_automatic_workflow_job_sale_done" model="ir.cron">
+        <field name="name">Automatic Workflow Job - Set Sales as Done</field>
+        <field ref="model_automatic_workflow_job" name="model_id"/>
+        <field eval="True" name="active"/>
+        <field name="user_id" ref="base.user_root"/>
+        <field name="interval_number">10</field>
+        <field name="interval_type">minutes</field>
+        <field name="numbercall">-1</field>
+        <field eval="False" name="doall"/>
+        <field name="state">code</field>
+        <field name="code">model.run_sale_done()</field>
+    </record>
+
+</odoo>

--- a/sale_automatic_workflow_split/models/__init__.py
+++ b/sale_automatic_workflow_split/models/__init__.py
@@ -1,0 +1,1 @@
+from . import automatic_workflow_job

--- a/sale_automatic_workflow_split/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow_split/models/automatic_workflow_job.py
@@ -1,0 +1,55 @@
+# Copyright 2017-2019 Camptocamp SA
+
+from odoo import api, models
+from odoo.tools.safe_eval import safe_eval
+
+
+class AutomaticWorkflowJob(models.Model):
+    _inherit = 'automatic.workflow.job'
+
+    def _each_workflow(self):
+        for workflow in self.env['sale.workflow.process'].search([]):
+            domain = [('workflow_process_id', '=', workflow.id)]
+            yield workflow, domain
+
+    @api.model
+    def run_validate_order(self):
+        for workflow, domain in self._each_workflow():
+            if workflow.validate_order:
+                self._validate_sale_orders(
+                    safe_eval(workflow.order_filter_id.domain) + domain
+                )
+
+    @api.model
+    def run_validate_picking(self):
+        for workflow, domain in self._each_workflow():
+            if workflow.validate_pickings:
+                self._validate_pickings(
+                    safe_eval(workflow.picking_filter_id.domain) + domain
+                )
+
+    @api.model
+    def run_create_invoice(self):
+        for workflow, domain in self._each_workflow():
+            if workflow.create_invoice:
+                self._create_invoices(
+                    safe_eval(workflow.create_invoice_filter_id.domain)
+                    + domain
+                )
+
+    @api.model
+    def run_validate_invoice(self):
+        for workflow, domain in self._each_workflow():
+            if workflow.validate_invoice:
+                self._validate_invoices(
+                    safe_eval(workflow.validate_invoice_filter_id.domain)
+                    + domain
+                )
+
+    @api.model
+    def run_sale_done(self):
+        for workflow, domain in self._each_workflow():
+            if workflow.sale_done:
+                self._sale_done(
+                    safe_eval(workflow.sale_done_filter_id.domain) + domain
+                )

--- a/sale_automatic_workflow_split/readme/CONTRIBUTORS.rst
+++ b/sale_automatic_workflow_split/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>

--- a/sale_automatic_workflow_split/readme/DESCRIPTION.rst
+++ b/sale_automatic_workflow_split/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+Split the automatic workflows in several independent crons.
+Allow different intervals. Validating invoices takes a lot of time for instance 
+but does not need to be done very fast. Confirming sales orders has to wait on 
+validation on invoices, but we want this operation to be fast.


### PR DESCRIPTION
this addon allows avoiding performance issues by splitting workflow cron on smaller, it works in tune with  cron from sale_automatic_workflow, no need to disable it