### PR TITLE
[10.0][FIX] sale_promotion_rule: Apply coupon to lines if percentage

### DIFF
--- a/sale_promotion_rule/models/sale_promotion_rule.py
+++ b/sale_promotion_rule/models/sale_promotion_rule.py
@@ -394,7 +394,8 @@ according to the strategy
                 if self.multi_rule_strategy != 'cumulate':
                     discount = 0.0
                 discount += percent_discount
-                if self.rule_type == 'coupon':
+                if self.rule_type == 'coupon' and \
+                        self.discount_type == 'percentage':
                     v = {
                         'discount': discount,
                         'coupon_promotion_rule_id': self.id

--- a/sale_promotion_rule/tests/test_promotion.py
+++ b/sale_promotion_rule/tests/test_promotion.py
@@ -407,3 +407,30 @@ class PromotionCase(TransactionCase, AbstractCommonPromotionCase):
         for line in self.sale.order_line:
             self.check_discount_rule_set(line, promo_copy)
         return
+
+    def test_promotion_fixed_plus_discount(self):
+        """
+        Apply a manual discount on a line and apply a coupon code with
+        fixed amount and combine strategy. Both should apply.
+        """
+        self.promotion_rule_auto.minimal_amount = 999999999  # disable
+        self.promotion_rule_fixed_amount.discount_type = "amount_tax_included"
+        self.promotion_rule_fixed_amount.multi_rule_strategy = "cumulate"
+        so_line = self.sale.order_line[0]
+        so_line.discount = 20.0
+        so_line.price_unit = 80.0
+        self.assertEquals(
+            710.0,
+            self.sale.amount_total
+        )
+        self.add_coupon_code(FIXED_AMOUNT_CODE)
+        self.sale.apply_promotions()
+        self.assertEquals(
+            20.0,
+            so_line.discount,
+        )
+        self.assertEquals(
+            690.0,
+            self.sale.amount_total
+        )
+        self.assertFalse(so_line.coupon_promotion_rule_id)


### PR DESCRIPTION
If the coupon rule apply a discount in fixed price, the rule should
not be applied on each sale order line