### PR TITLE
[12.0] [FIX] sale_order_type: Missing warnings on inv onchange method

### DIFF
--- a/sale_order_type/models/account_invoice.py
+++ b/sale_order_type/models/account_invoice.py
@@ -15,11 +15,12 @@ class AccountInvoice(models.Model):
 
     @api.onchange('partner_id', 'company_id')
     def _onchange_partner_id(self):
-        super(AccountInvoice, self)._onchange_partner_id()
+        res = super(AccountInvoice, self)._onchange_partner_id()
         sale_type = (self.partner_id.sale_type or
                      self.partner_id.commercial_partner_id.sale_type)
         if sale_type:
             self.sale_type_id = sale_type
+        return res
 
     @api.onchange('sale_type_id')
     def onchange_sale_type_id(self):


### PR DESCRIPTION
In the original onchange method by odoo, this return an dict with values(warnings and domians), but when inherit this method in this module they not return this dict. Because of this the alert setting in the partner was no working.