### PR TITLE
[FIX] sale_invoice_group_method: Respect your parents

### DIFF
--- a/sale_invoice_group_method/model/ir_model.py
+++ b/sale_invoice_group_method/model/ir_model.py
@@ -7,12 +7,11 @@ from odoo import api, models
 class IrModelFields(models.Model):
     _inherit = 'ir.model.fields'
 
-    @api.multi
     def name_get(self):
-        res = []
-        context = self._context
-        if context.get('sale_invoice_group_method', True):
+        res = super().name_get()
+        if self.env.context.get('sale_invoice_group_method'):
+            res = dict(res)
             for field in self:
-                res.append((field.id, '%s' % field.field_description))
-            return res
-        return super(IrModelFields, self).name_get()
+                res[field.id] = field.field_description
+            res = list(res.items())
+        return res


### PR DESCRIPTION
Before this patch, unless a context like `sale_invoice_group_method=False` was passed, `super()` would never be called.

Now, it's called always, and only when `sale_invoice_group_method=True` context is passed, it overrides what it needs to.

@Tecnativa TT20969