### PR TITLE
[10.0][FIX] sale_order_price_recalculation: make it compliant with discount policy "Show public price & discount to the customer"

### DIFF
--- a/sale_order_price_recalculation/models/sale_order.py
+++ b/sale_order_price_recalculation/models/sale_order.py
@@ -21,7 +21,9 @@ class SaleOrder(models.Model):
             line2 = self.env['sale.order.line'].new(dict)
             # we make this to isolate changed values:
             line2.product_uom_change()
+            line2._onchange_discount()
             line.price_unit = line2.price_unit
+            line.discount = line2.discount
         return True
 
     @api.multi


### PR DESCRIPTION
On Odoo standard pricelists, you can wether choose to include the discount on the product price or to show it to the customer:
![image](https://user-images.githubusercontent.com/7813258/71897393-be6d3d00-3156-11ea-9ced-dc38b7b3e560.png)

If you check this option, the recompute method of this addon never takes care of the discount field.
This PR aims to solve that issue.