### PR TITLE
12.0-FIX-installation-product_form_sale_link

### DIFF
--- a/product_form_sale_link/views/product_template.xml
+++ b/product_form_sale_link/views/product_template.xml
@@ -8,7 +8,7 @@
         <field name="name">product.template.form (in product_form_sale_link)</field>
         <field name="model">product.template</field>
         <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
-        <field name="inherit_id" ref="sale.product_template_form_view_sale_order_button"/>
+        <field name="inherit_id" ref="stock.product_template_form_view_procurement_button"/>
         <field name="arch" type="xml">
             <button name="action_view_sales" position="after">
                 <button class="oe_stat_button" name="%(product_form_sale_link.action_product_template_sale_list)d"

--- a/product_form_sale_link/views/product_template.xml
+++ b/product_form_sale_link/views/product_template.xml
@@ -10,12 +10,12 @@
         <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
         <field name="inherit_id" ref="stock.product_template_form_view_procurement_button"/>
         <field name="arch" type="xml">
-            <button name="action_view_sales" position="after">
+            <xpath expr="//form/sheet/div[@class='oe_button_box']" position="inside">
                 <button class="oe_stat_button" name="%(product_form_sale_link.action_product_template_sale_list)d"
                     type="action" icon="fa-list">
                     <field string="Sales" name="sales_count" widget="statinfo" />
                 </button>
-            </button>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Before This PR, if i try to install the module, i have this error:
Element <button name="action_view_sales"> cannot be located in parent view.
I have the error because the Odoo addon sale_stock replace the button in view product_template_view_form_inherit_sale, that i replace the inherited view sale.product_template_form_view_sale_order_button with stock.product_template_form_view_procurement_button