### PR TITLE
12.0-fix-installation-product_form_sale_link

### DIFF
--- a/product_form_sale_link/views/product_template.xml
+++ b/product_form_sale_link/views/product_template.xml
@@ -10,12 +10,12 @@
         <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
         <field name="inherit_id" ref="sale.product_template_form_view_sale_order_button"/>
         <field name="arch" type="xml">
-            <button name="action_view_sales" position="after">
+            <xpath expr="//form/sheet/div[@hasclass='oe_button_box']" position="inside">
                 <button class="oe_stat_button" name="%(product_form_sale_link.action_product_template_sale_list)d"
                     type="action" icon="fa-list">
                     <field string="Sales" name="sales_count" widget="statinfo" />
                 </button>
-            </button>
+            </xpath>
         </field>
     </record>
 

--- a/product_form_sale_link/views/product_template.xml
+++ b/product_form_sale_link/views/product_template.xml
@@ -10,7 +10,7 @@
         <field name="groups_id" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
         <field name="inherit_id" ref="sale.product_template_form_view_sale_order_button"/>
         <field name="arch" type="xml">
-            <xpath expr="//form/sheet/div[@hasclass='oe_button_box']" position="inside">
+            <xpath expr="//form/sheet/div[hasclass('oe_button_box')]" position="inside">
                 <button class="oe_stat_button" name="%(product_form_sale_link.action_product_template_sale_list)d"
                     type="action" icon="fa-list">
                     <field string="Sales" name="sales_count" widget="statinfo" />


### PR DESCRIPTION
Before This PR, if i try to install the module, i have this error:
Element cannot be located in parent view.
I have the error because the Odoo addon sale_stock replace the button in view product_template_view_form_inherit_sale, now i insert button inside div of button.