### PR TITLE
[12.0][IMP][FIX] Update picking note on all SO related Pickings

### DIFF
--- a/sale_stock_picking_note/__manifest__.py
+++ b/sale_stock_picking_note/__manifest__.py
@@ -2,18 +2,21 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     'name': 'Sale Stock Picking Note',
-    'summary': 'Add picking note in sale and purchase order',
+    'summary': 'Add picking note in Sale Order',
     'version': '12.0.1.0.0',
     'category': 'Sales',
     'website': 'https://github.com/OCA/sale-workflow',
     'author': 'Tecnativa, '
+              'Open Source Integrators, '
               'Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'depends': [
         'sale_stock',
     ],
     'data': [
+        'security/sale_order_security.xml',
         'views/sale_order_view.xml',
+        'views/res_config_settings_view.xml',
     ],
     'installable': True,
 }

--- a/sale_stock_picking_note/models/__init__.py
+++ b/sale_stock_picking_note/models/__init__.py
@@ -1,1 +1,2 @@
 from . import sale_stock
+from . import res_config_settings

--- a/sale_stock_picking_note/models/res_config_settings.py
+++ b/sale_stock_picking_note/models/res_config_settings.py
@@ -1,0 +1,12 @@
+# Copyright 2020 Daniel Reis - Open Source Integrators
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    group_sale_picking_note_edit = fields.Boolean(
+        string="Edit picking notes after confirming the Sales Order",
+        implied_group="sale_stock_picking_note.group_sale_picking_note_edit")

--- a/sale_stock_picking_note/readme/CONFIGURATION.rst
+++ b/sale_stock_picking_note/readme/CONFIGURATION.rst
@@ -1,0 +1,6 @@
+By default, the picking not is copied when the Pickings are created,i
+and can't be updated.
+
+To allow the picking note to be updated after the Pickings were created,
+enable the option in General Settings, Shipping section,
+"Edit picking notes after confirming the Sales Order".

--- a/sale_stock_picking_note/readme/CONTRIBUTORS.rst
+++ b/sale_stock_picking_note/readme/CONTRIBUTORS.rst
@@ -4,3 +4,7 @@
   * David Vidal
 
 * Sudhir Arya <sudhir@erpharbor.com>
+
+* Open Source Integrators <https://opensourceintegrators.com>
+
+  * Daniel Reis

--- a/sale_stock_picking_note/security/sale_order_security.xml
+++ b/sale_stock_picking_note/security/sale_order_security.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2020 Daniel Reus- Open Source Integrators
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record id="group_sale_picking_note_edit" model="res.groups">
+        <field name="name">Can edit picking notes after confirming the Sale Order</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
+
+</odoo>

--- a/sale_stock_picking_note/tests/test_sale_stock_picking_note.py
+++ b/sale_stock_picking_note/tests/test_sale_stock_picking_note.py
@@ -1,7 +1,9 @@
 # Copyright 2018 Tecnativa - David Vidal
+# Copyright 2020 Open Source Integrators - Daniel Reis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.tests import common
+from odoo.exceptions import UserError
 
 
 class TestSaleStockPickingNote(common.SavepointCase):
@@ -30,3 +32,9 @@ class TestSaleStockPickingNote(common.SavepointCase):
         self.order.action_confirm()
         self.assertEqual(self.order.picking_ids[:1].note,
                          self.order.picking_note)
+
+    def test_02_cant_update_picking_note(self):
+        """ Can't update picking note after DO is created """
+        self.order.action_confirm()
+        with self.assertRaises(UserError):
+            self.order.picking_note = "This note goes to the picking..."

--- a/sale_stock_picking_note/views/res_config_settings_view.xml
+++ b/sale_stock_picking_note/views/res_config_settings_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="res_config_settings_view_form_sale" model="ir.ui.view">
+        <field name="name">res.config.settings add Edit Picking Note</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="sale.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+
+            <xpath expr="//div[@id='sale_order_dates']" position="after">
+                <div class="col-12 col-lg-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="group_sale_picking_note_edit"/>
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="group_sale_picking_note_edit"/>
+                    </div>
+                </div>
+            </xpath>
+
+        </field>
+    </record>
+
+</odoo>

--- a/sale_stock_picking_note/views/sale_order_view.xml
+++ b/sale_stock_picking_note/views/sale_order_view.xml
@@ -8,8 +8,7 @@
         <field name="inherit_id" ref="sale_stock.view_order_form_inherit_sale_stock"/>
         <field name="arch" type="xml">
             <group name="sale_shipping" position="inside">
-                <field name="picking_note"
-                       attrs="{'readonly': [('state', 'not in', ('draft', 'sent'))]}"/>
+                <field name="picking_note" />
             </group>
         </field>
     </record>


### PR DESCRIPTION
When having multi step rules, such as pick-pack, the picking notes
are now copied to all related Pickings, and not only to the Delivery
Order.

An option was added to allow changing the picking note once the SO is
confirmed, and have the note updates also on the Pickings.
This is useful in case we have additional information for the warehouse
after the customer confirms the order.