### PR TITLE
[13.0] Add module sale_cutoff_time_delivery

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,2 +1,3 @@
 product-attribute
 stock-logistics-warehouse
+partner-contact

--- a/sale_cutoff_time_delivery/__init__.py
+++ b/sale_cutoff_time_delivery/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_cutoff_time_delivery/__manifest__.py
+++ b/sale_cutoff_time_delivery/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Sale Cutoff Time Delivery",
+    "summary": "Schedule delivery orders according to cutoff preferences",
+    "version": "13.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/sale-workflow",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["sale_stock"],
+    "data": ["views/res_partner.xml", "views/stock_warehouse.xml"],
+}

--- a/sale_cutoff_time_delivery/__manifest__.py
+++ b/sale_cutoff_time_delivery/__manifest__.py
@@ -11,6 +11,6 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": ["sale_stock"],
+    "depends": ["sale_stock", "partner_tz"],
     "data": ["views/res_partner.xml", "views/stock_warehouse.xml"],
 }

--- a/sale_cutoff_time_delivery/models/__init__.py
+++ b/sale_cutoff_time_delivery/models/__init__.py
@@ -1,0 +1,4 @@
+from . import cutoff_time_mixin
+from . import res_partner
+from . import sale_order
+from . import stock_warehouse

--- a/sale_cutoff_time_delivery/models/cutoff_time_mixin.py
+++ b/sale_cutoff_time_delivery/models/cutoff_time_mixin.py
@@ -1,0 +1,31 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, fields, models
+
+
+class CutoffTimeMixin(models.AbstractModel):
+
+    _name = "cutoff.time.mixin"
+
+    order_delivery_cutoff_hours = fields.Selection(
+        selection="_selection_order_delivery_cutoff_hours", required=True, default="12"
+    )
+    order_delivery_cutoff_minutes = fields.Selection(
+        selection="_selection_order_delivery_cutoff_minutes",
+        required=True,
+        default="00",
+    )
+
+    @api.model
+    def _selection_order_delivery_cutoff_hours(self):
+        return [("{:02}".format(i), "{:02}".format(i)) for i in range(0, 24)]
+
+    @api.model
+    def _selection_order_delivery_cutoff_minutes(self):
+        return [("{:02}".format(i), "{:02}".format(i)) for i in range(0, 60)]
+
+    def get_cutoff_time(self):
+        return {
+            "hour": self.order_delivery_cutoff_hours,
+            "minute": self.order_delivery_cutoff_minutes,
+        }

--- a/sale_cutoff_time_delivery/models/cutoff_time_mixin.py
+++ b/sale_cutoff_time_delivery/models/cutoff_time_mixin.py
@@ -5,7 +5,7 @@ from odoo import api, fields, models
 
 class CutoffTimeMixin(models.AbstractModel):
 
-    _name = "cutoff.time.mixin"
+    _name = "sale.cutoff.time.mixin"
 
     order_delivery_cutoff_hours = fields.Selection(
         selection="_selection_order_delivery_cutoff_hours", required=True, default="12"

--- a/sale_cutoff_time_delivery/models/cutoff_time_mixin.py
+++ b/sale_cutoff_time_delivery/models/cutoff_time_mixin.py
@@ -4,7 +4,6 @@ import math
 from datetime import time
 
 from odoo import api, fields, models
-from odoo.addons.base.models.res_partner import _tz_get
 
 
 class TimeCutoffMixin(models.AbstractModel):
@@ -12,9 +11,6 @@ class TimeCutoffMixin(models.AbstractModel):
     _name = "time.cutoff.mixin"
 
     cutoff_time = fields.Float()
-    tz = fields.Selection(
-        _tz_get, string='Timezone'
-    )
 
     def get_cutoff_time(self):
         hour, minute = self._get_hour_min_from_value(self.cutoff_time)

--- a/sale_cutoff_time_delivery/models/cutoff_time_mixin.py
+++ b/sale_cutoff_time_delivery/models/cutoff_time_mixin.py
@@ -1,31 +1,45 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+import math
+from datetime import time
+
 from odoo import api, fields, models
+from odoo.addons.base.models.res_partner import _tz_get
 
 
-class CutoffTimeMixin(models.AbstractModel):
+class TimeCutoffMixin(models.AbstractModel):
 
-    _name = "sale.cutoff.time.mixin"
+    _name = "time.cutoff.mixin"
 
-    order_delivery_cutoff_hours = fields.Selection(
-        selection="_selection_order_delivery_cutoff_hours", required=True, default="12"
+    cutoff_time = fields.Float()
+    tz = fields.Selection(
+        _tz_get, string='Timezone'
     )
-    order_delivery_cutoff_minutes = fields.Selection(
-        selection="_selection_order_delivery_cutoff_minutes",
-        required=True,
-        default="00",
-    )
-
-    @api.model
-    def _selection_order_delivery_cutoff_hours(self):
-        return [("{:02}".format(i), "{:02}".format(i)) for i in range(0, 24)]
-
-    @api.model
-    def _selection_order_delivery_cutoff_minutes(self):
-        return [("{:02}".format(i), "{:02}".format(i)) for i in range(0, 60)]
 
     def get_cutoff_time(self):
+        hour, minute = self._get_hour_min_from_value(self.cutoff_time)
         return {
-            "hour": self.order_delivery_cutoff_hours,
-            "minute": self.order_delivery_cutoff_minutes,
+            "hour": hour,
+            "minute": minute,
+            "tz": self.tz,
         }
+
+    @api.model
+    def _get_hour_min_from_value(self, value):
+        hour = math.floor(value)
+        minute = round((value % 1) * 60)
+        if minute == 60:
+            minute = 0
+            hour += 1
+        return hour, minute
+
+    @api.model
+    def float_to_time_repr(self, value):
+        pattern = "%02d:%02d"
+        hour, minute = self._get_hour_min_from_value(value)
+        return pattern % (hour, minute)
+
+    @api.model
+    def float_to_time(self, value):
+        hour, minute = self._get_hour_min_from_value(value)
+        return time(hour=hour, minute=minute)

--- a/sale_cutoff_time_delivery/models/cutoff_time_mixin.py
+++ b/sale_cutoff_time_delivery/models/cutoff_time_mixin.py
@@ -9,6 +9,7 @@ from odoo import api, fields, models
 class TimeCutoffMixin(models.AbstractModel):
 
     _name = "time.cutoff.mixin"
+    _description = "Time Cut-off Mixin"
 
     cutoff_time = fields.Float()
 

--- a/sale_cutoff_time_delivery/models/cutoff_time_mixin.py
+++ b/sale_cutoff_time_delivery/models/cutoff_time_mixin.py
@@ -17,7 +17,6 @@ class TimeCutoffMixin(models.AbstractModel):
         return {
             "hour": hour,
             "minute": minute,
-            "tz": self.tz,
         }
 
     @api.model

--- a/sale_cutoff_time_delivery/models/res_partner.py
+++ b/sale_cutoff_time_delivery/models/res_partner.py
@@ -1,0 +1,27 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _name = "res.partner"
+    _inherit = ["res.partner", "cutoff.time.mixin"]
+
+    order_delivery_cutoff_preference = fields.Selection(
+        [
+            ("warehouse_cutoff", "Use global (warehouse) cutoff time"),
+            ("partner_cutoff", "Use partner's cutoff time"),
+        ],
+        string="Delivery orders cutoff preference",
+        default="warehouse_cutoff",
+        required=True,
+        help="Define the cutoff time for delivery orders:\n\n"
+        "* Use global (warehouse) cutoff time: Delivery order for sale orders"
+        " will be postponed to the next warehouse cutoff time\n"
+        "* Use partner's cutoff time: Delivery order for sale orders"
+        " will be postponed to the next partner's cutoff time\n\n"
+        "Example: If cutoff is set to 09:00, any sale order confirmed before "
+        "09:00 will have its delivery order postponed to 09:00, and any sale "
+        "order confirmed after 09:00 will have its delivery order postponed "
+        "to 09:00 on the following day.",
+    )

--- a/sale_cutoff_time_delivery/models/res_partner.py
+++ b/sale_cutoff_time_delivery/models/res_partner.py
@@ -5,7 +5,7 @@ from odoo import fields, models
 
 class ResPartner(models.Model):
     _name = "res.partner"
-    _inherit = ["res.partner", "cutoff.time.mixin"]
+    _inherit = ["res.partner", "sale.cutoff.time.mixin"]
 
     order_delivery_cutoff_preference = fields.Selection(
         [

--- a/sale_cutoff_time_delivery/models/res_partner.py
+++ b/sale_cutoff_time_delivery/models/res_partner.py
@@ -5,7 +5,7 @@ from odoo import fields, models
 
 class ResPartner(models.Model):
     _name = "res.partner"
-    _inherit = ["res.partner", "sale.cutoff.time.mixin"]
+    _inherit = ["res.partner", "time.cutoff.mixin"]
 
     order_delivery_cutoff_preference = fields.Selection(
         [

--- a/sale_cutoff_time_delivery/models/res_partner.py
+++ b/sale_cutoff_time_delivery/models/res_partner.py
@@ -25,3 +25,8 @@ class ResPartner(models.Model):
         "order confirmed after 09:00 will have its delivery order postponed "
         "to 09:00 on the following day.",
     )
+
+    def get_cutoff_time(self):
+        res = super().get_cutoff_time()
+        res['tz'] = self.tz
+        return res

--- a/sale_cutoff_time_delivery/models/res_partner.py
+++ b/sale_cutoff_time_delivery/models/res_partner.py
@@ -28,5 +28,5 @@ class ResPartner(models.Model):
 
     def get_cutoff_time(self):
         res = super().get_cutoff_time()
-        res['tz'] = self.tz
+        res["tz"] = self.tz
         return res

--- a/sale_cutoff_time_delivery/models/sale_order.py
+++ b/sale_cutoff_time_delivery/models/sale_order.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from datetime import timedelta
+import pytz
+from datetime import datetime, time, timedelta
 
 from odoo import _, exceptions, fields, models
 
@@ -27,15 +28,29 @@ class SaleOrderLine(models.Model):
         res = super()._prepare_procurement_values(group_id=group_id)
         if self.order_id.commitment_date:
             return res
+        date_planned = res.get("date_planned")
         cutoff = self.order_id.get_cutoff_time()
-        # Postpone delivery for order confirmed before cutoff to cutoff time
-        new_date_planned = res.get("date_planned").replace(
-            hour=int(cutoff.get("hour")), minute=int(cutoff.get("minute"))
-        )
+        tz = cutoff.get('tz')
+        if tz and tz != 'UTC':
+            cutoff_time = time(hour=cutoff.get('hour'), minute=cutoff.get('minute'))
+            # Convert here to naive datetime in UTC
+            tz_loc = pytz.timezone(self.tz)
+            utc_loc = pytz.timezone('UTC')
+            tz_date_planned = date_planned.astimezone(tz_loc)
+            tz_cutoff_datetime = datetime.combine(tz_date_planned, cutoff_time)
+            utc_cutoff_datetime = tz_loc.localize(tz_cutoff_datetime).astimezone(utc_loc).replace(
+                tzinfo=None)
+        else:
+            utc_cutoff_datetime = date_planned.replace(hour=cutoff.get('hour'), minute=cutoff.get('minute'))
+        if date_planned <= utc_cutoff_datetime:
+            # Postpone delivery for date planned before cutoff to cutoff time
+            new_date_planned = date_planned.replace(
+                hour=utc_cutoff_datetime.hour, minute=utc_cutoff_datetime.minute
+            )
         # Postpone delivery for order confirmed after cutoff to day after
-        if self.order_id.date_order > fields.Datetime.now().replace(
-            hour=int(cutoff.get("hour")), minute=int(cutoff.get("minute"))
-        ):
-            new_date_planned += timedelta(days=1)
+        elif date_planned > utc_cutoff_datetime:
+            new_date_planned = date_planned.replace(
+                hour=utc_cutoff_datetime.hour, minute=utc_cutoff_datetime.minute
+            ) + timedelta(days=1)
         res["date_planned"] = new_date_planned
         return res

--- a/sale_cutoff_time_delivery/models/sale_order.py
+++ b/sale_cutoff_time_delivery/models/sale_order.py
@@ -80,6 +80,6 @@ class SaleOrderLine(models.Model):
             time(hour=cutoff.get('hour'), minute=cutoff.get('minute')),
             base_date=expected_date
         )
-        if expected_date <= utc_cutoff_time:
+        if expected_date.time() <= utc_cutoff_time:
             return expected_date
         return expected_date + timedelta(days=1)

--- a/sale_cutoff_time_delivery/models/sale_order.py
+++ b/sale_cutoff_time_delivery/models/sale_order.py
@@ -75,11 +75,16 @@ class SaleOrderLine(models.Model):
         cutoff = self.order_id.get_cutoff_time()
         if not cutoff:
             return expected_date
-        utc_cutoff_time = tz_utils.tz_to_utc_time(
-            cutoff.get('tz'),
-            time(hour=cutoff.get('hour'), minute=cutoff.get('minute')),
-            base_date=expected_date
-        )
+        cutoff_tz = cutoff.get('tz')
+        cutoff_time = time(hour=cutoff.get('hour'), minute=cutoff.get('minute'))
+        if cutoff_tz:
+            utc_cutoff_time = tz_utils.tz_to_utc_time(
+                cutoff_tz,
+                cutoff_time,
+                base_date=expected_date
+            )
+        else:
+            utc_cutoff_time = cutoff_time
         if expected_date.time() <= utc_cutoff_time:
             return expected_date
         return expected_date + timedelta(days=1)

--- a/sale_cutoff_time_delivery/models/sale_order.py
+++ b/sale_cutoff_time_delivery/models/sale_order.py
@@ -44,9 +44,12 @@ class SaleOrderLine(models.Model):
             tz_date_planned = date_planned.astimezone(tz_loc)
             tz_cutoff_datetime = datetime.combine(tz_date_planned, cutoff_time)
             utc_cutoff_datetime = tz_loc.localize(tz_cutoff_datetime).astimezone(utc_loc).replace(
-                tzinfo=None)
+                tzinfo=None
+            )
         else:
-            utc_cutoff_datetime = date_planned.replace(hour=cutoff.get('hour'), minute=cutoff.get('minute'))
+            utc_cutoff_datetime = date_planned.replace(
+                hour=cutoff.get('hour'), minute=cutoff.get('minute')
+            )
         if date_planned <= utc_cutoff_datetime:
             # Postpone delivery for date planned before cutoff to cutoff time
             new_date_planned = date_planned.replace(

--- a/sale_cutoff_time_delivery/models/sale_order.py
+++ b/sale_cutoff_time_delivery/models/sale_order.py
@@ -1,0 +1,41 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from datetime import timedelta
+
+from odoo import _, exceptions, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def get_cutoff_time(self):
+        self.ensure_one()
+        partner = self.partner_shipping_id
+        if partner.order_delivery_cutoff_preference == "warehouse_cutoff":
+            return self.warehouse_id.get_cutoff_time()
+        elif partner.order_delivery_cutoff_preference == "partner_cutoff":
+            return self.partner_shipping_id.get_cutoff_time()
+        else:
+            raise exceptions.UserError(_("Invalid cutoff settings"))
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _prepare_procurement_values(self, group_id=False):
+        """Postpone delivery according to cutoff time"""
+        res = super()._prepare_procurement_values(group_id=group_id)
+        if self.order_id.commitment_date:
+            return res
+        cutoff = self.order_id.get_cutoff_time()
+        # Postpone delivery for order confirmed before cutoff to cutoff time
+        new_date_planned = res.get("date_planned").replace(
+            hour=int(cutoff.get("hour")), minute=int(cutoff.get("minute"))
+        )
+        # Postpone delivery for order confirmed after cutoff to day after
+        if self.order_id.date_order > fields.Datetime.now().replace(
+            hour=int(cutoff.get("hour")), minute=int(cutoff.get("minute"))
+        ):
+            new_date_planned += timedelta(days=1)
+        res["date_planned"] = new_date_planned
+        return res

--- a/sale_cutoff_time_delivery/models/sale_order.py
+++ b/sale_cutoff_time_delivery/models/sale_order.py
@@ -73,10 +73,13 @@ class SaleOrderLine(models.Model):
         """Postpone expected_date to next cut-off"""
         expected_date = super()._expected_date()
         cutoff = self.order_id.get_cutoff_time()
+        if not cutoff:
+            return expected_date
         utc_cutoff_time = tz_utils.tz_to_utc_time(
             cutoff.get('tz'),
-            time(hour=cutoff.get('hour'), minute=cutoff.get('minute'))
+            time(hour=cutoff.get('hour'), minute=cutoff.get('minute')),
+            base_date=expected_date
         )
-        if datetime.now().time() <= utc_cutoff_time:
+        if expected_date <= utc_cutoff_time:
             return expected_date
         return expected_date + timedelta(days=1)

--- a/sale_cutoff_time_delivery/models/sale_order.py
+++ b/sale_cutoff_time_delivery/models/sale_order.py
@@ -1,14 +1,15 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 import logging
-import pytz
 from datetime import datetime, time, timedelta
 
-from odoo import _, api, exceptions, fields, models
+import pytz
+
+from odoo import api, models
+
 from odoo.addons.partner_tz.tools import tz_utils
 
 _logger = logging.getLogger(__name__)
-
 
 
 class SaleOrder(models.Model):
@@ -54,49 +55,59 @@ class SaleOrderLine(models.Model):
             if not self.order_id.warehouse_id.apply_cutoff:
                 _logger.debug(
                     "No cutoff applied on order %s as partner %s is set to use "
-                    "%s and warehouse %s doesn't apply cutoff." % (
+                    "%s and warehouse %s doesn't apply cutoff."
+                    % (
                         self.order_id,
                         partner,
                         partner.order_delivery_cutoff_preference,
-                        self.order_id.warehouse_id
+                        self.order_id.warehouse_id,
                     )
                 )
             else:
                 _logger.warning(
                     "No cutoff applied on order %s. %s time not applied"
-                    "on line %s." % (
-                        self.order_id, partner.order_delivery_cutoff_preference, self
-                    )
+                    "on line %s."
+                    % (self.order_id, partner.order_delivery_cutoff_preference, self)
                 )
             return res
-        tz = cutoff.get('tz')
+        tz = cutoff.get("tz")
         date_planned = res.get("date_planned")
-        if tz and tz != 'UTC':
-            cutoff_time = time(hour=cutoff.get('hour'), minute=cutoff.get('minute'))
+        if tz and tz != "UTC":
+            cutoff_time = time(hour=cutoff.get("hour"), minute=cutoff.get("minute"))
             # Convert here to naive datetime in UTC
             tz_loc = pytz.timezone(tz)
             tz_date_planned = date_planned.astimezone(tz_loc)
             tz_cutoff_datetime = datetime.combine(tz_date_planned, cutoff_time)
-            utc_cutoff_datetime = tz_utils.tz_to_utc_naive_datetime(tz_loc, tz_cutoff_datetime)
+            utc_cutoff_datetime = tz_utils.tz_to_utc_naive_datetime(
+                tz_loc, tz_cutoff_datetime
+            )
         else:
             utc_cutoff_datetime = date_planned.replace(
-                hour=cutoff.get('hour'), minute=cutoff.get('minute'), second=0
+                hour=cutoff.get("hour"), minute=cutoff.get("minute"), second=0
             )
         if date_planned <= utc_cutoff_datetime:
             # Postpone delivery for date planned before cutoff to cutoff time
             new_date_planned = date_planned.replace(
-                hour=utc_cutoff_datetime.hour, minute=utc_cutoff_datetime.minute, second=0
+                hour=utc_cutoff_datetime.hour,
+                minute=utc_cutoff_datetime.minute,
+                second=0,
             )
         # Postpone delivery for order confirmed after cutoff to day after
         else:
             new_date_planned = date_planned.replace(
-                hour=utc_cutoff_datetime.hour, minute=utc_cutoff_datetime.minute, second=0
+                hour=utc_cutoff_datetime.hour,
+                minute=utc_cutoff_datetime.minute,
+                second=0,
             ) + timedelta(days=1)
         _logger.debug(
             "%s applied on order %s. Date planned for line %s"
-            " rescheduled from %s to %s" % (
-                partner.order_delivery_cutoff_preference, self.order_id,
-                self, date_planned, new_date_planned
+            " rescheduled from %s to %s"
+            % (
+                partner.order_delivery_cutoff_preference,
+                self.order_id,
+                self,
+                date_planned,
+                new_date_planned,
             )
         )
         res["date_planned"] = new_date_planned
@@ -108,13 +119,11 @@ class SaleOrderLine(models.Model):
         cutoff = self.order_id.get_cutoff_time()
         if not cutoff:
             return expected_date
-        cutoff_tz = cutoff.get('tz')
-        cutoff_time = time(hour=cutoff.get('hour'), minute=cutoff.get('minute'))
+        cutoff_tz = cutoff.get("tz")
+        cutoff_time = time(hour=cutoff.get("hour"), minute=cutoff.get("minute"))
         if cutoff_tz:
             utc_cutoff_time = tz_utils.tz_to_utc_time(
-                cutoff_tz,
-                cutoff_time,
-                base_date=expected_date
+                cutoff_tz, cutoff_time, base_date=expected_date
             )
         else:
             utc_cutoff_time = cutoff_time

--- a/sale_cutoff_time_delivery/models/sale_order.py
+++ b/sale_cutoff_time_delivery/models/sale_order.py
@@ -48,17 +48,17 @@ class SaleOrderLine(models.Model):
             )
         else:
             utc_cutoff_datetime = date_planned.replace(
-                hour=cutoff.get('hour'), minute=cutoff.get('minute')
+                hour=cutoff.get('hour'), minute=cutoff.get('minute'), second=0
             )
         if date_planned <= utc_cutoff_datetime:
             # Postpone delivery for date planned before cutoff to cutoff time
             new_date_planned = date_planned.replace(
-                hour=utc_cutoff_datetime.hour, minute=utc_cutoff_datetime.minute
+                hour=utc_cutoff_datetime.hour, minute=utc_cutoff_datetime.minute, second=0
             )
         # Postpone delivery for order confirmed after cutoff to day after
         elif date_planned > utc_cutoff_datetime:
             new_date_planned = date_planned.replace(
-                hour=utc_cutoff_datetime.hour, minute=utc_cutoff_datetime.minute
+                hour=utc_cutoff_datetime.hour, minute=utc_cutoff_datetime.minute, second=0
             ) + timedelta(days=1)
         res["date_planned"] = new_date_planned
         return res

--- a/sale_cutoff_time_delivery/models/sale_order.py
+++ b/sale_cutoff_time_delivery/models/sale_order.py
@@ -67,7 +67,7 @@ class SaleOrderLine(models.Model):
 
         By default, if the planned date is the same day but after the cut-off,
         the new planned date is delayed one day later. The argument
-        keep_same_ay force keeping the same day.
+        keep_same_day forces keeping the same day.
         """
         cutoff = self.order_id.get_cutoff_time()
         partner = self.order_id.partner_shipping_id

--- a/sale_cutoff_time_delivery/models/stock_warehouse.py
+++ b/sale_cutoff_time_delivery/models/stock_warehouse.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import fields, models
+
 from odoo.addons.base.models.res_partner import _tz_get
 
 
@@ -9,11 +10,9 @@ class StockWarehouse(models.Model):
     _inherit = ["stock.warehouse", "time.cutoff.mixin"]
 
     apply_cutoff = fields.Boolean()
-    tz = fields.Selection(
-        _tz_get, string='Timezone'
-    )
+    tz = fields.Selection(_tz_get, string="Timezone")
 
     def get_cutoff_time(self):
         res = super().get_cutoff_time()
-        res['tz'] = self.tz
+        res["tz"] = self.tz
         return res

--- a/sale_cutoff_time_delivery/models/stock_warehouse.py
+++ b/sale_cutoff_time_delivery/models/stock_warehouse.py
@@ -12,3 +12,8 @@ class StockWarehouse(models.Model):
     tz = fields.Selection(
         _tz_get, string='Timezone'
     )
+
+    def get_cutoff_time(self):
+        res = super().get_cutoff_time()
+        res['tz'] = self.tz
+        return res

--- a/sale_cutoff_time_delivery/models/stock_warehouse.py
+++ b/sale_cutoff_time_delivery/models/stock_warehouse.py
@@ -5,4 +5,4 @@ from odoo import fields, models
 
 class StockWarehouse(models.Model):
     _name = "stock.warehouse"
-    _inherit = ["stock.warehouse", "sale.cutoff.time.mixin"]
+    _inherit = ["stock.warehouse", "time.cutoff.mixin"]

--- a/sale_cutoff_time_delivery/models/stock_warehouse.py
+++ b/sale_cutoff_time_delivery/models/stock_warehouse.py
@@ -5,4 +5,4 @@ from odoo import fields, models
 
 class StockWarehouse(models.Model):
     _name = "stock.warehouse"
-    _inherit = ["stock.warehouse", "cutoff.time.mixin"]
+    _inherit = ["stock.warehouse", "sale.cutoff.time.mixin"]

--- a/sale_cutoff_time_delivery/models/stock_warehouse.py
+++ b/sale_cutoff_time_delivery/models/stock_warehouse.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import fields, models
+from odoo.addons.base.models.res_partner import _tz_get
 
 
 class StockWarehouse(models.Model):
@@ -8,3 +9,6 @@ class StockWarehouse(models.Model):
     _inherit = ["stock.warehouse", "time.cutoff.mixin"]
 
     apply_cutoff = fields.Boolean()
+    tz = fields.Selection(
+        _tz_get, string='Timezone'
+    )

--- a/sale_cutoff_time_delivery/models/stock_warehouse.py
+++ b/sale_cutoff_time_delivery/models/stock_warehouse.py
@@ -6,3 +6,5 @@ from odoo import fields, models
 class StockWarehouse(models.Model):
     _name = "stock.warehouse"
     _inherit = ["stock.warehouse", "time.cutoff.mixin"]
+
+    apply_cutoff = fields.Boolean()

--- a/sale_cutoff_time_delivery/models/stock_warehouse.py
+++ b/sale_cutoff_time_delivery/models/stock_warehouse.py
@@ -1,0 +1,8 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class StockWarehouse(models.Model):
+    _name = "stock.warehouse"
+    _inherit = ["stock.warehouse", "cutoff.time.mixin"]

--- a/sale_cutoff_time_delivery/readme/CONFIGURE.rst
+++ b/sale_cutoff_time_delivery/readme/CONFIGURE.rst
@@ -1,0 +1,6 @@
+Application of cutoff is defined by partner, with default value being the
+cutoff time of the sale order's warehouse.
+
+Therefore, the cutoff time must be configured on the warehouse before confirming
+any sale order, otherwise a cutoff time of 12:00 (default value) will be applied
+anyway.

--- a/sale_cutoff_time_delivery/readme/CONFIGURE.rst
+++ b/sale_cutoff_time_delivery/readme/CONFIGURE.rst
@@ -1,6 +1,5 @@
 Application of cutoff is defined by partner, with default value being the
 cutoff time of the sale order's warehouse.
 
-Therefore, the cutoff time must be configured on the warehouse before confirming
-any sale order, otherwise a cutoff time of 12:00 (default value) will be applied
-anyway.
+Cut-off must however be applied on the warehouse by marking the checkbox
+"Apply cutoff" so that the computation happens.

--- a/sale_cutoff_time_delivery/readme/CONTRIBUTORS.rst
+++ b/sale_cutoff_time_delivery/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/sale_cutoff_time_delivery/readme/DESCRIPTION.rst
+++ b/sale_cutoff_time_delivery/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+This module allows to define Cutoff times for delivery orders.
+
+If no commitment date is set, any sale order confirmed after the applicable
+cutoff time will have its delivery order postponed by one day at the time of
+the applicable cutoff, and any sale order confirmed before the applicable
+cutoff time will have its delivery order postponed to the time of the applicable
+cutoff.

--- a/sale_cutoff_time_delivery/readme/ROADMAP.rst
+++ b/sale_cutoff_time_delivery/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+* Consider timezones
+* Improve cutoff mixin and view by using a dedicated field and widget for time

--- a/sale_cutoff_time_delivery/readme/ROADMAP.rst
+++ b/sale_cutoff_time_delivery/readme/ROADMAP.rst
@@ -1,2 +1,11 @@
-* Consider timezones
-* Improve cutoff mixin and view by using a dedicated field and widget for time
+* Storing times using `float_time` widget requires extra processing to ensure
+  computations are done in the right timezone, because the value is not stored
+  as UTC in the database, and must therefore be related to a `tz` field.
+
+  `float_time` in this sense should only be used for durations and not for a
+  "point in time" as this is always needs a Date for a timezone conversion to
+  be done properly. (Because a conversion from UTC to e.g. Europe/Brussels won't
+  give the same result in winter or summer because of Daylight Saving Time).
+
+  Therefore the right move would be to use a `resource.calendar` to define
+  cutoff time using Datetime with recurrences.

--- a/sale_cutoff_time_delivery/tests/__init__.py
+++ b/sale_cutoff_time_delivery/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_cutoff_time_delivery

--- a/sale_cutoff_time_delivery/tests/test_sale_cutoff_time_delivery.py
+++ b/sale_cutoff_time_delivery/tests/test_sale_cutoff_time_delivery.py
@@ -14,23 +14,20 @@ class TestSaleWeekdayDelivery(SavepointCase):
             {
                 "name": "Partner cutoff",
                 "order_delivery_cutoff_preference": "partner_cutoff",
-                "order_delivery_cutoff_hours": "09",
-                "order_delivery_cutoff_minutes": "00",
+                "cutoff_time": 9.0
             }
         )
         cls.customer_warehouse = cls.env["res.partner"].create(
             {
                 "name": "Partner warehouse cutoff",
                 "order_delivery_cutoff_preference": "warehouse_cutoff",
-                "order_delivery_cutoff_hours": "09",
-                "order_delivery_cutoff_minutes": "00",
+                "cutoff_time": 9.0
             }
         )
         cls.warehouse = cls.env.ref("stock.warehouse0")
         cls.warehouse.write(
             {
-                "order_delivery_cutoff_hours": "10",
-                "order_delivery_cutoff_minutes": "00",
+                "cutoff_time": 10.0
             }
         )
         cls.product = cls.env.ref("product.product_product_9")

--- a/sale_cutoff_time_delivery/tests/test_sale_cutoff_time_delivery.py
+++ b/sale_cutoff_time_delivery/tests/test_sale_cutoff_time_delivery.py
@@ -1,0 +1,88 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from freezegun import freeze_time
+
+from odoo import fields
+from odoo.tests import SavepointCase
+
+
+class TestSaleWeekdayDelivery(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.customer_partner = cls.env["res.partner"].create(
+            {
+                "name": "Partner cutoff",
+                "order_delivery_cutoff_preference": "partner_cutoff",
+                "order_delivery_cutoff_hours": "09",
+                "order_delivery_cutoff_minutes": "00",
+            }
+        )
+        cls.customer_warehouse = cls.env["res.partner"].create(
+            {
+                "name": "Partner warehouse cutoff",
+                "order_delivery_cutoff_preference": "warehouse_cutoff",
+                "order_delivery_cutoff_hours": "09",
+                "order_delivery_cutoff_minutes": "00",
+            }
+        )
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.warehouse.write(
+            {
+                "order_delivery_cutoff_hours": "10",
+                "order_delivery_cutoff_minutes": "00",
+            }
+        )
+        cls.product = cls.env.ref("product.product_product_9")
+
+    def _create_order(self, partner=None):
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": partner.id,
+                "partner_shipping_id": partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product.name,
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1,
+                            "product_uom": self.product.uom_id.id,
+                            "price_unit": self.product.list_price,
+                        },
+                    )
+                ],
+            }
+        )
+        return order
+
+    @freeze_time("2020-03-25 08:00:00")
+    def test_before_cutoff_time_delivery(self):
+        order = self._create_order(partner=self.customer_partner)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-25 09:00:00")
+        )
+        order = self._create_order(partner=self.customer_warehouse)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-25 10:00:00")
+        )
+
+    @freeze_time("2020-03-25 18:00:00")
+    def test_after_cutoff_time_delivery(self):
+        order = self._create_order(partner=self.customer_partner)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-26 09:00:00")
+        )
+        order = self._create_order(partner=self.customer_warehouse)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-26 10:00:00")
+        )

--- a/sale_cutoff_time_delivery/tests/test_sale_cutoff_time_delivery.py
+++ b/sale_cutoff_time_delivery/tests/test_sale_cutoff_time_delivery.py
@@ -14,22 +14,18 @@ class TestSaleWeekdayDelivery(SavepointCase):
             {
                 "name": "Partner cutoff",
                 "order_delivery_cutoff_preference": "partner_cutoff",
-                "cutoff_time": 9.0
+                "cutoff_time": 9.0,
             }
         )
         cls.customer_warehouse = cls.env["res.partner"].create(
             {
                 "name": "Partner warehouse cutoff",
                 "order_delivery_cutoff_preference": "warehouse_cutoff",
-                "cutoff_time": 9.0
+                "cutoff_time": 9.0,
             }
         )
         cls.warehouse = cls.env.ref("stock.warehouse0")
-        cls.warehouse.write(
-            {
-                "cutoff_time": 10.0
-            }
-        )
+        cls.warehouse.write({"cutoff_time": 10.0})
         cls.product = cls.env.ref("product.product_product_9")
 
     def _create_order(self, partner=None):

--- a/sale_cutoff_time_delivery/views/res_partner.xml
+++ b/sale_cutoff_time_delivery/views/res_partner.xml
@@ -10,7 +10,11 @@
                 position="inside"
             >
                 <field name="order_delivery_cutoff_preference" />
-                <field name="cutoff_time" attrs="{'invisible': [('order_delivery_cutoff_preference', '!=', 'partner_cutoff')]}" widget="float_time" />
+                <field
+                    name="cutoff_time"
+                    attrs="{'invisible': [('order_delivery_cutoff_preference', '!=', 'partner_cutoff')]}"
+                    widget="float_time"
+                />
             </xpath>
         </field>
     </record>

--- a/sale_cutoff_time_delivery/views/res_partner.xml
+++ b/sale_cutoff_time_delivery/views/res_partner.xml
@@ -10,8 +10,7 @@
                 position="inside"
             >
                 <field name="order_delivery_cutoff_preference" />
-                <field name="cutoff_time" attrs="{'invisible': [('order_delivery_cutoff_preference', '!=', 'partner_cutoff')]}" />
-                <field name="tz" attrs="{'invisible': [('order_delivery_cutoff_preference', '!=', 'partner_cutoff')]}" />
+                <field name="cutoff_time" attrs="{'invisible': [('order_delivery_cutoff_preference', '!=', 'partner_cutoff')]}" widget="float_time" />
             </xpath>
         </field>
     </record>

--- a/sale_cutoff_time_delivery/views/res_partner.xml
+++ b/sale_cutoff_time_delivery/views/res_partner.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_partner_form_inherit" model="ir.ui.view">
+        <field name="name">res.partner.form.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//page[@name='sales_purchases']//group[@name='sale']"
+                position="inside"
+            >
+                <field name="order_delivery_cutoff_preference" />
+                <div
+                    attrs="{'invisible': [('order_delivery_cutoff_preference', '!=', 'partner_cutoff')]}"
+                >
+                    <label
+                        string="Cut-off time for delivery orders"
+                        for="order_delivery_cutoff_hours"
+                    />
+                    <div class="o_row">
+                        <field
+                            class="oe_inline"
+                            name="order_delivery_cutoff_hours"
+                        />:<field
+                            class="oe_inline"
+                            name="order_delivery_cutoff_minutes"
+                        />
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_cutoff_time_delivery/views/res_partner.xml
+++ b/sale_cutoff_time_delivery/views/res_partner.xml
@@ -10,23 +10,8 @@
                 position="inside"
             >
                 <field name="order_delivery_cutoff_preference" />
-                <div
-                    attrs="{'invisible': [('order_delivery_cutoff_preference', '!=', 'partner_cutoff')]}"
-                >
-                    <label
-                        string="Cut-off time for delivery orders"
-                        for="order_delivery_cutoff_hours"
-                    />
-                    <div class="o_row">
-                        <field
-                            class="oe_inline"
-                            name="order_delivery_cutoff_hours"
-                        />:<field
-                            class="oe_inline"
-                            name="order_delivery_cutoff_minutes"
-                        />
-                    </div>
-                </div>
+                <field name="cutoff_time" attrs="{'invisible': [('order_delivery_cutoff_preference', '!=', 'partner_cutoff')]}" />
+                <field name="tz" attrs="{'invisible': [('order_delivery_cutoff_preference', '!=', 'partner_cutoff')]}" />
             </xpath>
         </field>
     </record>

--- a/sale_cutoff_time_delivery/views/stock_warehouse.xml
+++ b/sale_cutoff_time_delivery/views/stock_warehouse.xml
@@ -7,8 +7,15 @@
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
                 <field name="apply_cutoff" />
-                <field name="cutoff_time" attrs="{'invisible': [('apply_cutoff', '!=', True)]}" widget="float_time" />
-                <field name="tz" attrs="{'invisible': [('apply_cutoff', '!=', True)]}" />
+                <field
+                    name="cutoff_time"
+                    attrs="{'invisible': [('apply_cutoff', '!=', True)]}"
+                    widget="float_time"
+                />
+                <field
+                    name="tz"
+                    attrs="{'invisible': [('apply_cutoff', '!=', True)]}"
+                />
             </field>
         </field>
     </record>

--- a/sale_cutoff_time_delivery/views/stock_warehouse.xml
+++ b/sale_cutoff_time_delivery/views/stock_warehouse.xml
@@ -6,8 +6,9 @@
         <field name="inherit_id" ref="stock.view_warehouse" />
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
-                <field name="cutoff_time" />
-                <field name="tz" />
+                <field name="apply_cutoff" />
+                <field name="cutoff_time" attrs="{'invisible': [('apply_cutoff', '!=', True)]}" />
+                <field name="tz" attrs="{'invisible': [('apply_cutoff', '!=', True)]}" />
             </field>
         </field>
     </record>

--- a/sale_cutoff_time_delivery/views/stock_warehouse.xml
+++ b/sale_cutoff_time_delivery/views/stock_warehouse.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_warehouse_inherit" model="ir.ui.view">
+        <field name="name">stock.warehouse.inherit</field>
+        <field name="model">stock.warehouse</field>
+        <field name="inherit_id" ref="stock.view_warehouse" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <label
+                    string="Cut-off time for delivery orders"
+                    for="order_delivery_cutoff_hours"
+                />
+                <div class="o_row">
+                    <field
+                        class="oe_inline"
+                        name="order_delivery_cutoff_hours"
+                    />:<field class="oe_inline" name="order_delivery_cutoff_minutes" />
+                </div>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/sale_cutoff_time_delivery/views/stock_warehouse.xml
+++ b/sale_cutoff_time_delivery/views/stock_warehouse.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
                 <field name="apply_cutoff" />
-                <field name="cutoff_time" attrs="{'invisible': [('apply_cutoff', '!=', True)]}" />
+                <field name="cutoff_time" attrs="{'invisible': [('apply_cutoff', '!=', True)]}" widget="float_time" />
                 <field name="tz" attrs="{'invisible': [('apply_cutoff', '!=', True)]}" />
             </field>
         </field>

--- a/sale_cutoff_time_delivery/views/stock_warehouse.xml
+++ b/sale_cutoff_time_delivery/views/stock_warehouse.xml
@@ -6,16 +6,8 @@
         <field name="inherit_id" ref="stock.view_warehouse" />
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
-                <label
-                    string="Cut-off time for delivery orders"
-                    for="order_delivery_cutoff_hours"
-                />
-                <div class="o_row">
-                    <field
-                        class="oe_inline"
-                        name="order_delivery_cutoff_hours"
-                    />:<field class="oe_inline" name="order_delivery_cutoff_minutes" />
-                </div>
+                <field name="cutoff_time" />
+                <field name="tz" />
             </field>
         </field>
     </record>

--- a/setup/sale_cutoff_time_delivery/odoo/addons/sale_cutoff_time_delivery
+++ b/setup/sale_cutoff_time_delivery/odoo/addons/sale_cutoff_time_delivery
@@ -1,0 +1,1 @@
+../../../../sale_cutoff_time_delivery

--- a/setup/sale_cutoff_time_delivery/setup.py
+++ b/setup/sale_cutoff_time_delivery/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Depends on:
 - [x] https://github.com/OCA/partner-contact/pull/876

This module allows to define Cutoff times for delivery orders.

If no commitment date is set, any sale order confirmed after the applicable
cutoff time will have its delivery order postponed by one day at the time of
the applicable cutoff, and any sale order confirmed before the applicable
cutoff time will have its delivery order postponed to the time of the applicable
cutoff.

Application of cutoff is defined by partner, with default value being the
cutoff time of the sale order's warehouse.

Cut-off must however be applied on the warehouse by marking the checkbox
"Apply cutoff" so that the computation happens.
