### PR TITLE
[13.0] Create module sale_order_line_packaging_qty

### DIFF
--- a/sale_order_line_packaging_qty/__init__.py
+++ b/sale_order_line_packaging_qty/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_order_line_packaging_qty/__manifest__.py
+++ b/sale_order_line_packaging_qty/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Sale Order Line Packaging Quantity",
+    "summary": "Define quantities according to product packaging on sale order lines",
+    "version": "13.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/sale-workflow",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["sale_stock"],
+    "data": ["views/sale_order.xml"],
+}

--- a/sale_order_line_packaging_qty/models/__init__.py
+++ b/sale_order_line_packaging_qty/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order_line

--- a/sale_order_line_packaging_qty/models/sale_order_line.py
+++ b/sale_order_line_packaging_qty/models/sale_order_line.py
@@ -1,0 +1,85 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class SaleOrderLine(models.Model):
+
+    _inherit = "sale.order.line"
+
+    product_packaging_qty = fields.Float(
+        string="Package quantity",
+        compute="_compute_product_packaging_qty",
+        inverse="_inverse_product_packaging_qty",
+    )
+
+    @api.depends("product_uom_qty", "product_uom", "product_packaging", "product_packaging.qty")
+    def _compute_product_packaging_qty(self):
+        for sol in self:
+            if not sol.product_packaging or sol.product_uom_qty == 0 or sol.product_packaging.qty == 0:
+                sol.product_packaging_qty = 0
+                continue
+            # Consider uom
+            if sol.product_id.uom_id != sol.product_uom:
+                product_qty = sol.product_uom._compute_quantity(
+                    sol.product_uom_qty, sol.product_id.uom_id
+                )
+            else:
+                product_qty = sol.product_uom_qty
+            sol.product_packaging_qty = product_qty / sol.product_packaging.qty
+
+    def _inverse_product_packaging_qty(self):
+        for sol in self:
+            if not sol.product_packaging:
+                raise UserError(
+                    _(
+                        "You must define a package before setting a quantity "
+                        "of said package."
+                    )
+                )
+            if sol.product_packaging.qty == 0:
+                raise UserError(
+                    _("Please select a packaging with a quantity bigger than 0")
+                )
+            sol.write(
+                {
+                    "product_uom_qty": sol.product_packaging.qty * sol.product_packaging_qty,
+                    "product_uom": sol.product_packaging.product_uom_id.id,
+                }
+            )
+
+    @api.onchange('product_packaging')
+    def _onchange_product_packaging(self):
+        if self.product_packaging:
+            self.update(
+                {
+                    "product_packaging_qty": 1,
+                    "product_uom_qty": self.product_packaging.qty,
+                    "product_uom": self.product_id.uom_id,
+                }
+            )
+        else:
+            self.update(
+                {
+                    "product_packaging_qty": 0,
+                }
+            )
+        return super()._onchange_product_packaging()
+
+    @api.onchange('product_packaging_qty')
+    def _onchange_product_packaging_qty(self):
+        if self.product_packaging_qty and not self.product_packaging:
+            raise UserError(
+                _(
+                    "You must define a package before setting a quantity "
+                    "of said package."
+                )
+            )
+        else:
+            self.update(
+                {
+                    "product_uom_qty": self.product_packaging_qty * self.product_packaging.qty,
+                    "product_uom": self.product_id.uom_id,
+                }
+            )

--- a/sale_order_line_packaging_qty/models/sale_order_line.py
+++ b/sale_order_line_packaging_qty/models/sale_order_line.py
@@ -83,3 +83,15 @@ class SaleOrderLine(models.Model):
                     "product_uom": self.product_id.uom_id,
                 }
             )
+
+    @api.onchange('product_uom_qty')
+    def _onchange_product_uom_qty(self):
+        """
+        Ensure a warning is raised when changing the package if the qty
+        is not a multiple of the package qty.
+        """
+        # TODO Drop once https://github.com/odoo/odoo/pull/49150/ is merged
+        res = super()._onchange_product_uom_qty()
+        if not res:
+            res = self._check_package()
+        return res

--- a/sale_order_line_packaging_qty/models/sale_order_line.py
+++ b/sale_order_line_packaging_qty/models/sale_order_line.py
@@ -14,10 +14,16 @@ class SaleOrderLine(models.Model):
         inverse="_inverse_product_packaging_qty",
     )
 
-    @api.depends("product_uom_qty", "product_uom", "product_packaging", "product_packaging.qty")
+    @api.depends(
+        "product_uom_qty", "product_uom", "product_packaging", "product_packaging.qty"
+    )
     def _compute_product_packaging_qty(self):
         for sol in self:
-            if not sol.product_packaging or sol.product_uom_qty == 0 or sol.product_packaging.qty == 0:
+            if (
+                not sol.product_packaging
+                or sol.product_uom_qty == 0
+                or sol.product_packaging.qty == 0
+            ):
                 sol.product_packaging_qty = 0
                 continue
             # Consider uom
@@ -44,12 +50,13 @@ class SaleOrderLine(models.Model):
                 )
             sol.write(
                 {
-                    "product_uom_qty": sol.product_packaging.qty * sol.product_packaging_qty,
+                    "product_uom_qty": sol.product_packaging.qty
+                    * sol.product_packaging_qty,
                     "product_uom": sol.product_packaging.product_uom_id.id,
                 }
             )
 
-    @api.onchange('product_packaging')
+    @api.onchange("product_packaging")
     def _onchange_product_packaging(self):
         if self.product_packaging:
             self.update(
@@ -60,31 +67,10 @@ class SaleOrderLine(models.Model):
                 }
             )
         else:
-            self.update(
-                {
-                    "product_packaging_qty": 0,
-                }
-            )
+            self.update({"product_packaging_qty": 0})
         return super()._onchange_product_packaging()
 
-    @api.onchange('product_packaging_qty')
-    def _onchange_product_packaging_qty(self):
-        if self.product_packaging_qty and not self.product_packaging:
-            raise UserError(
-                _(
-                    "You must define a package before setting a quantity "
-                    "of said package."
-                )
-            )
-        else:
-            self.update(
-                {
-                    "product_uom_qty": self.product_packaging_qty * self.product_packaging.qty,
-                    "product_uom": self.product_id.uom_id,
-                }
-            )
-
-    @api.onchange('product_uom_qty')
+    @api.onchange("product_uom_qty")
     def _onchange_product_uom_qty(self):
         """
         Ensure a warning is raised when changing the package if the qty

--- a/sale_order_line_packaging_qty/models/sale_order_line.py
+++ b/sale_order_line_packaging_qty/models/sale_order_line.py
@@ -44,22 +44,23 @@ class SaleOrderLine(models.Model):
 
     def _inverse_product_packaging_qty(self):
         for sol in self:
-            if not sol.product_packaging:
+            if sol.product_packaging_qty and not sol.product_packaging:
                 raise UserError(
                     _(
                         "You must define a package before setting a quantity "
                         "of said package."
                     )
                 )
-            if sol.product_packaging.qty == 0:
+            if sol.product_packaging and sol.product_packaging.qty == 0:
                 raise UserError(
                     _("Please select a packaging with a quantity bigger than 0")
                 )
-            sol.write(sol._prepare_product_packaging_qty_values())
+            if sol.product_packaging and sol.product_packaging_qty:
+                sol.write(sol._prepare_product_packaging_qty_values())
 
     @api.onchange("product_packaging_qty")
     def _onchange_product_packaging_qty(self):
-        if self.product_packaging and self.product_packaging.qty:
+        if self.product_packaging and self.product_packaging_qty:
             self.update(self._prepare_product_packaging_qty_values())
 
     @api.onchange("product_packaging")

--- a/sale_order_line_packaging_qty/readme/CONTRIBUTORS.rst
+++ b/sale_order_line_packaging_qty/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/sale_order_line_packaging_qty/readme/DESCRIPTION.rst
+++ b/sale_order_line_packaging_qty/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module adds a "Package quantity" field on sale order line in order to
+define a quantity according to the selected "Package".

--- a/sale_order_line_packaging_qty/tests/__init__.py
+++ b/sale_order_line_packaging_qty/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_order_line_packaging_qty

--- a/sale_order_line_packaging_qty/tests/test_sale_order_line_packaging_qty.py
+++ b/sale_order_line_packaging_qty/tests/test_sale_order_line_packaging_qty.py
@@ -11,11 +11,7 @@ class TestSaleOrderLinePackagingQty(SavepointCase):
         cls.partner = cls.env.ref("base.res_partner_12")
         cls.product = cls.env.ref("product.product_product_9")
         cls.packaging = cls.env["product.packaging"].create(
-            {
-                "name": "Test packaging",
-                "product_id": cls.product.id,
-                "qty": 5.0
-            }
+            {"name": "Test packaging", "product_id": cls.product.id, "qty": 5.0}
         )
 
     def test_product_packaging_qty(self):
@@ -25,10 +21,11 @@ class TestSaleOrderLinePackagingQty(SavepointCase):
                 "order_id": order.id,
                 "product_id": self.product.id,
                 "product_uom": self.product.uom_id.id,
-                "product_uom_qty": 3.0
+                "product_uom_qty": 3.0,
             }
         )
         order_line.write({"product_packaging": self.packaging})
+        order_line._onchange_product_packaging()
         self.assertEqual(order_line.product_uom_qty, 5.0)
         self.assertEqual(order_line.product_packaging_qty, 1.0)
         order_line.write({"product_packaging_qty": 3.0})

--- a/sale_order_line_packaging_qty/tests/test_sale_order_line_packaging_qty.py
+++ b/sale_order_line_packaging_qty/tests/test_sale_order_line_packaging_qty.py
@@ -1,0 +1,35 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests import SavepointCase
+
+
+class TestSaleOrderLinePackagingQty(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.partner = cls.env.ref("base.res_partner_12")
+        cls.product = cls.env.ref("product.product_product_9")
+        cls.packaging = cls.env["product.packaging"].create(
+            {
+                "name": "Test packaging",
+                "product_id": cls.product.id,
+                "qty": 5.0
+            }
+        )
+
+    def test_product_packaging_qty(self):
+        order = self.env["sale.order"].create({"partner_id": self.partner.id})
+        order_line = self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.product.id,
+                "product_uom": self.product.uom_id.id,
+                "product_uom_qty": 3.0
+            }
+        )
+        order_line.write({"product_packaging": self.packaging})
+        self.assertEqual(order_line.product_uom_qty, 5.0)
+        self.assertEqual(order_line.product_packaging_qty, 1.0)
+        order_line.write({"product_packaging_qty": 3.0})
+        self.assertEqual(order_line.product_uom_qty, 15.0)

--- a/sale_order_line_packaging_qty/views/sale_order.xml
+++ b/sale_order_line_packaging_qty/views/sale_order.xml
@@ -1,15 +1,52 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <record id="view_order_form_inherit_sale_stock_inherit" model="ir.ui.view">
         <field name="name">sale.order.form.sale.stock.inherit</field>
         <field name="model">sale.order</field>
-        <field name="inherit_id" ref="sale_stock.view_order_form_inherit_sale_stock"/>
+        <field name="inherit_id" ref="sale_stock.view_order_form_inherit_sale_stock" />
+        <field name="priority">100</field>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='product_packaging']" position="after">
-                <field name="product_packaging_qty" groups="product.group_stock_packaging" attrs="{'invisible': [('product_packaging', '=', False)]}"/>
+            <!-- sale.order.line form view -->
+            <xpath
+                expr="//field[@name='order_line']//form//field[@name='product_packaging']"
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'invisible': [('product_id', '=', False)], 'required': [('product_packaging_qty', '!=', 0)]}</attribute>
             </xpath>
-            <xpath expr="//field[@name='product_packaging' and @optional='show']" position="before">
-                <field name="product_packaging_qty" groups="product.group_stock_packaging" attrs="{'invisible': [('product_packaging', '=', False)]}"/>
+            <xpath
+                expr="//field[@name='order_line']//form//field[@name='product_packaging']"
+                position="after"
+            >
+                <field
+                    name="product_packaging_qty"
+                    groups="product.group_stock_packaging"
+                    attrs="{'invisible': [('product_packaging', '=', False)]}"
+                />
+            </xpath>
+            <!-- sale.order.line tree view -->
+            <xpath
+                expr="//field[@name='order_line']//tree//field[@name='product_packaging' and @optional='show']"
+                position="replace"
+            />
+            <xpath
+                expr="//field[@name='order_line']//tree//field[@name='product_uom_qty']"
+                position="before"
+            >
+                <field
+                    name="product_packaging"
+                    attrs="{'invisible': [('product_id', '=', False)]}"
+                    context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}"
+                    domain="[('product_id','=',product_id)]"
+                    groups="product.group_stock_packaging"
+                    optional="show"
+                />
+                <field
+                    name="product_packaging_qty"
+                    groups="product.group_stock_packaging"
+                    attrs="{'invisible': [('product_packaging', '=', False)]}"
+                />
             </xpath>
         </field>
     </record>

--- a/sale_order_line_packaging_qty/views/sale_order.xml
+++ b/sale_order_line_packaging_qty/views/sale_order.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_order_form_inherit_sale_stock_inherit" model="ir.ui.view">
+        <field name="name">sale.order.form.sale.stock.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale_stock.view_order_form_inherit_sale_stock"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_packaging']" position="after">
+                <field name="product_packaging_qty" groups="product.group_stock_packaging" attrs="{'invisible': [('product_packaging', '=', False)]}"/>
+            </xpath>
+            <xpath expr="//field[@name='product_packaging' and @optional='show']" position="before">
+                <field name="product_packaging_qty" groups="product.group_stock_packaging" attrs="{'invisible': [('product_packaging', '=', False)]}"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/sale_order_line_packaging_qty/odoo/addons/sale_order_line_packaging_qty
+++ b/setup/sale_order_line_packaging_qty/odoo/addons/sale_order_line_packaging_qty
@@ -1,0 +1,1 @@
+../../../../sale_order_line_packaging_qty

--- a/setup/sale_order_line_packaging_qty/setup.py
+++ b/setup/sale_order_line_packaging_qty/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module adds a "Package quantity" field on sale order line in order to
define a quantity according to the selected "Package".

Works better with:
 - [x] https://github.com/odoo/odoo/pull/49150
