### PR TITLE
[12.0][FIX] sale_commitment_lead_time, unit test error

### DIFF
--- a/sale_commitment_lead_time/tests/test_sale_order_preparation_time.py
+++ b/sale_commitment_lead_time/tests/test_sale_order_preparation_time.py
@@ -48,7 +48,8 @@ class TestSaleOrderPreparationTime(SavepointCase):
 
     def test_late_delivery(self):
         self.sale5.action_confirm()
-        self.sale5.confirmation_date -= timedelta(days=3)
+        self.sale5.confirmation_date = (self.sale5.confirmation_date -
+                                        timedelta(days=3))
         self.sale5.picking_ids.move_line_ids.write({'qty_done': 1})
         self.sale5.picking_ids.action_done()
         self.assertNotEquals(self.sale5.on_time_delivery, True)


### PR DESCRIPTION
Fixed following error, if the test is run on date = 1st or 2nd
<pre>
2020-05-02 06:23:09,548 15552 ERROR 12_account_spreaad_cost_revenue odoo.addons.sale_commitment_lead_time.tests.test_sale_order_preparation_time: `     day=(datetime.now().day - 3)) 
2020-05-02 06:23:09,548 15552 ERROR 12_account_spreaad_cost_revenue odoo.addons.sale_commitment_lead_time.tests.test_sale_order_preparation_time: ` ValueError: day is out of range for month
</pre>
