### PR TITLE
[FIX] sale_blanket_order

### DIFF
--- a/sale_blanket_order/models/__init__.py
+++ b/sale_blanket_order/models/__init__.py
@@ -1,3 +1,6 @@
-from . import blanket_orders
-from . import sale_orders
-from . import sale_config_settings
+from . import (
+    blanket_orders,
+    sale_order,
+    sale_order_line,
+    sale_config_settings,
+)

--- a/sale_blanket_order/models/sale_order.py
+++ b/sale_blanket_order/models/sale_order.py
@@ -1,0 +1,39 @@
+# Copyright 2018 ACSONE SA/NV
+# Copyright 2019 Eficent and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models, _
+from odoo.exceptions import ValidationError
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    blanket_order_id = fields.Many2one(
+        'sale.blanket.order', string='Origin blanket order',
+        related='order_line.blanket_order_line.order_id')
+
+    @api.model
+    def _check_exchausted_blanket_order_line(self):
+        return any(line.blanket_order_line.remaining_qty < 0.0 for
+                   line in self.order_line)
+
+    @api.multi
+    def button_confirm(self):
+        res = super().button_confirm()
+        for order in self:
+            if order._check_exchausted_blanket_order_line():
+                raise ValidationError(_(
+                    "Cannot confirm order %s as one of the lines refers to a"
+                    " blanket order that has no remaining quantity.")
+                    % order.name)
+        return res
+
+    @api.constrains('partner_id')
+    def check_partner_id(self):
+        for line in self.order_line:
+            if line.blanket_order_line:
+                if line.blanket_order_line.partner_id != \
+                        self.partner_id:
+                    raise ValidationError(_(
+                        'The customer must be equal to the '
+                        'blanket order lines customer'))

--- a/sale_blanket_order/models/sale_order_line.py
+++ b/sale_blanket_order/models/sale_order_line.py
@@ -6,40 +6,6 @@ from datetime import date, timedelta
 from odoo.exceptions import ValidationError
 
 
-class SaleOrder(models.Model):
-    _inherit = 'sale.order'
-
-    blanket_order_id = fields.Many2one(
-        'sale.blanket.order', string='Origin blanket order',
-        related='order_line.blanket_order_line.order_id')
-
-    @api.model
-    def _check_exchausted_blanket_order_line(self):
-        return any(line.blanket_order_line.remaining_qty < 0.0 for
-                   line in self.order_line)
-
-    @api.multi
-    def button_confirm(self):
-        res = super().button_confirm()
-        for order in self:
-            if order._check_exchausted_blanket_order_line():
-                raise ValidationError(
-                    _('Cannot confirm order %s as one of the lines refers '
-                      'to a blanket order that has no remaining quantity.')
-                    % order.name)
-        return res
-
-    @api.constrains('partner_id')
-    def check_partner_id(self):
-        for line in self.order_line:
-            if line.blanket_order_line:
-                if line.blanket_order_line.partner_id != \
-                        self.partner_id:
-                    raise ValidationError(_(
-                        'The customer must be equal to the '
-                        'blanket order lines customer'))
-
-
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
@@ -108,8 +74,8 @@ class SaleOrderLine(models.Model):
     @api.onchange('product_uom_qty', 'product_uom')
     def product_uom_change(self):
         res = super().product_uom_change()
-        if self.product_id and not self.env.context.get(
-                'skip_blanket_find', False):
+        if self.product_id and not \
+                self.env.context.get('skip_blanket_find', False):
             return self.get_assigned_bo_line()
         return res
 

--- a/sale_blanket_order/models/sale_order_line.py
+++ b/sale_blanket_order/models/sale_order_line.py
@@ -60,7 +60,6 @@ class SaleOrderLine(models.Model):
                     self._get_assigned_bo_line(eligible_bo_lines)
         else:
             self.blanket_order_line = False
-        self.onchange_blanket_order_line()
         return {'domain': {'blanket_order_line': [
             ('id', 'in', eligible_bo_lines.ids)]}}
 
@@ -74,8 +73,7 @@ class SaleOrderLine(models.Model):
     @api.onchange('product_uom_qty', 'product_uom')
     def product_uom_change(self):
         res = super().product_uom_change()
-        if self.product_id and not \
-                self.env.context.get('skip_blanket_find', False):
+        if self.product_id and self.env.context.get('find_blanket', False):
             return self.get_assigned_bo_line()
         return res
 
@@ -94,7 +92,7 @@ class SaleOrderLine(models.Model):
                 self.tax_id = bol.taxes_id
         else:
             self._compute_tax_id()
-            self.with_context(skip_blanket_find=True).product_uom_change()
+            self.with_context(find_blanket=True).product_uom_change()
 
     @api.constrains('product_id')
     def check_product_id(self):


### PR DESCRIPTION
# Steps to reproduce

* Create a product with a 19% tax included in the price
* Set the sale price to 2,000$
* Create a pricelist with a fixed price for the previous product: 4,000$
* Create a sales order and use the previous pricelist
* Create a sales order line and select the previous product

# Result

* Unit price is set to 3,361$

# Expected Result

* Unit price is set to 4,000$

Note: If you change the product and re-select it (to force the execution of the onchange), the unit price is correct.

This pull request fixes the bug described above.