### PR TITLE
12.0 IMP sale_order_lot_selection: allow to confirm sale when lot unavailable

### DIFF
--- a/sale_order_lot_selection/__manifest__.py
+++ b/sale_order_lot_selection/__manifest__.py
@@ -7,5 +7,6 @@
     'license': 'AGPL-3',
     'depends': ['sale_stock'],
     'data': ['view/sale_view.xml'],
+    'demo': ['demo/sale_demo.xml'],
     'installable': True,
 }

--- a/sale_order_lot_selection/demo/sale_demo.xml
+++ b/sale_order_lot_selection/demo/sale_demo.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="lot_cable" model="stock.production.lot">
+        <field name="product_id" ref="stock.product_cable_management_box" />
+        <field name="name">cbl mng</field>
+    </record>
+
+    <record id="sale1" model="sale.order">
+        <field name="partner_id" ref="base.res_partner_1" />
+        <field name="user_id" ref="base.user_admin" />
+    </record>
+
+    <record id="sol1" model="sale.order.line">
+        <field name="order_id" ref="sale_order_lot_selection.sale1" />
+        <field name="product_id" ref="stock.product_cable_management_box" />
+        <field name="product_uom_qty">1</field>
+        <field name="lot_id" ref="sale_order_lot_selection.lot_cable" />
+    </record>
+    <record id="sol2" model="sale.order.line">
+        <field name="order_id" ref="sale_order_lot_selection.sale1" />
+        <field name="product_id" ref="stock.product_cable_management_box" />
+        <field name="product_uom_qty">1</field>
+        <field name="lot_id" ref="sale_order_lot_selection.lot_cable" />
+    </record>
+
+</odoo>

--- a/sale_order_lot_selection/models/sale.py
+++ b/sale_order_lot_selection/models/sale.py
@@ -1,5 +1,4 @@
-from odoo import api, fields, models, _
-from odoo.exceptions import UserError
+from odoo import api, fields, models
 
 
 class SaleOrderLine(models.Model):
@@ -30,27 +29,3 @@ class SaleOrderLine(models.Model):
         return {
             'domain': {'lot_id': [('id', 'in', available_lot_ids)]}
         }
-
-    def assign_move_with_lots(self):
-        for move in self.move_ids:
-            if move.state == 'confirmed':
-                move._action_assign()
-                move.refresh()
-            if (
-                move.state != "assigned"
-            ):
-                raise UserError(
-                    _("Can't reserve products for lot %s") % self.lot_id.name
-                )
-
-
-class SaleOrder(models.Model):
-    _inherit = "sale.order"
-
-    @api.multi
-    def action_confirm(self):
-        res = super().action_confirm()
-        for line in self.order_line:
-            if line.lot_id:
-                line.assign_move_with_lots()
-        return res

--- a/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
+++ b/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
@@ -1,8 +1,7 @@
 # © 2015 Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import openerp.tests.common as test_common
-from odoo.exceptions import UserError
+import odoo.tests.common as test_common
 
 
 class TestSaleOrderLotSelection(test_common.SingleTransactionCase):
@@ -261,8 +260,10 @@ class TestSaleOrderLotSelection(test_common.SingleTransactionCase):
         # lot10 was delivered by order1
         lot10_qty_available = self._stock_quantity(
             self.product_57, lot10, self.stock_location)
-        with self.assertRaisesRegexp(UserError, "Can't reserve products for lot"):
-            self.order3.action_confirm()
+        self.order3.action_confirm()
+        self.assertEqual(self.order3.state, "sale")
+        # products are not available for reservation (lot unavailable)
+        self.assertEqual(self.order3.picking_ids[0].state, "confirmed")
 
         # also test on_change for order2
         onchange_res = self.sol2a._onchange_product_id_set_lot_domain()
@@ -290,5 +291,7 @@ class TestSaleOrderLotSelection(test_common.SingleTransactionCase):
         self.assertEqual(lot12_qty_available, 0)
         # I'll try to confirm it to check lot reservation:
         # lot11 has 1 availability and order4 has quantity 2
-        with self.assertRaisesRegexp(UserError, "Can't reserve products for lot"):
-            self.order4.action_confirm()
+        self.order4.action_confirm()
+        self.assertEqual(self.order4.state, "sale")
+        # products are reserved
+        self.assertEqual(self.order4.picking_ids[0].state, "assigned")

--- a/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
+++ b/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import openerp.tests.common as test_common
-from odoo.exceptions import Warning
+from odoo.exceptions import UserError
 
 
 class TestSaleOrderLotSelection(test_common.SingleTransactionCase):
@@ -23,6 +23,8 @@ class TestSaleOrderLotSelection(test_common.SingleTransactionCase):
         self.product_57.tracking = 'lot'
         self.product_46 = self.env.ref('product.product_product_13')
         self.product_12 = self.env.ref('product.product_product_12')
+        self.prd_cable = self.env.ref("stock.product_cable_management_box")
+        self.lot_cable = self.env.ref("sale_order_lot_selection.lot_cable")
         self.supplier_location = self.env.ref(
             'stock.stock_location_suppliers')
         self.customer_location = self.env.ref(
@@ -36,6 +38,32 @@ class TestSaleOrderLotSelection(test_common.SingleTransactionCase):
             'lot_id': lot.id,
             'location': location.id,
         }).qty_available
+
+    def _inventory_products(self, product, lot, qty):
+        inventory = self.env["stock.inventory"].create({
+            'name': '%s inventory' % product.name,
+            'filter': 'product',
+            'line_ids': [
+                (0, 0, {
+                    'product_id': product.id,
+                    'product_uom_id': product.uom_id.id,
+                    'product_qty': qty,
+                    'location_id': self.stock_location.id,
+                    'prod_lot_id': lot.id
+                }),
+            ],
+        })
+        inventory.action_start()
+        inventory.action_validate()
+
+    def test_several_lines_with_same_lot(self):
+        """ You may want split your order in several lines
+            even if lot/product are the same
+            use cases: price is different or any shipping information
+        """
+        self._inventory_products(self.prd_cable, self.lot_cable, 10)
+        sale = self.env.ref("sale_order_lot_selection.sale1")
+        sale.action_confirm()
 
     def test_sale_order_lot_selection(self):
         # INIT stock of products to 0
@@ -231,7 +259,9 @@ class TestSaleOrderLotSelection(test_common.SingleTransactionCase):
         self.sol3.lot_id = lot10.id
         # I'll try to confirm it to check lot reservation:
         # lot10 was delivered by order1
-        with self.assertRaises(Warning):
+        lot10_qty_available = self._stock_quantity(
+            self.product_57, lot10, self.stock_location)
+        with self.assertRaisesRegexp(UserError, "Can't reserve products for lot"):
             self.order3.action_confirm()
 
         # also test on_change for order2
@@ -260,5 +290,5 @@ class TestSaleOrderLotSelection(test_common.SingleTransactionCase):
         self.assertEqual(lot12_qty_available, 0)
         # I'll try to confirm it to check lot reservation:
         # lot11 has 1 availability and order4 has quantity 2
-        with self.assertRaises(Warning):
+        with self.assertRaisesRegexp(UserError, "Can't reserve products for lot"):
             self.order4.action_confirm()


### PR DESCRIPTION
You may want use unavailable lot (i.e. you sell a product manufactured by a supplier
but with your requirements. Then you provide a lot number before to receive product