### PR TITLE
[10.0][FIX] sale_promotion_rule: Enable sequence order

### DIFF
--- a/sale_promotion_rule/models/sale_promotion_rule.py
+++ b/sale_promotion_rule/models/sale_promotion_rule.py
@@ -17,6 +17,7 @@ _logger = logging.getLogger(__name__)
 class SalePromotionRule(models.Model):
     _name = 'sale.promotion.rule'
     _description = 'Sale Promotion Rule'
+    _order = "sequence, id"
 
     sequence = fields.Integer(default=10)
     rule_type = fields.Selection(

--- a/sale_promotion_rule/tests/test_promotion.py
+++ b/sale_promotion_rule/tests/test_promotion.py
@@ -434,3 +434,25 @@ class PromotionCase(TransactionCase, AbstractCommonPromotionCase):
             self.sale.amount_total
         )
         self.assertFalse(so_line.coupon_promotion_rule_id)
+
+    def test_multi_promotion_rules_exclusive_sequence(self):
+        """
+        Ensure it's working in case of multi available promotions.
+        So the first promotion rule > 100 should not be applied
+        :return:
+        """
+        promo_copy = self.promotion_rule_auto.copy({
+            'name': '> 100',
+            'minimal_amount': 199,
+            'multi_rule_strategy': 'exclusive',
+            'sequence': 10,
+        })
+        self.promotion_rule_auto.write({
+            'minimal_amount': 100,
+            'multi_rule_strategy': 'exclusive',
+            'sequence': 20,
+        })
+        self.sale.apply_promotions()
+        for line in self.sale.order_line:
+            self.check_discount_rule_set(line, promo_copy)
+        return


### PR DESCRIPTION
Sequence order was never applied du of missing _order.

The only one used was 'id'