### PR TITLE
[13.0] sale_order_product_recommendation: Forward port of #1100

### DIFF
--- a/sale_order_product_recommendation/README.rst
+++ b/sale_order_product_recommendation/README.rst
@@ -73,6 +73,7 @@ Contributors
   * Jairo Llopis
   * David Vidal
   * Alexandre Díaz
+  * Pedro M. Baeza
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_order_product_recommendation/__manifest__.py
+++ b/sale_order_product_recommendation/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2017 Jairo Llopis <jairo.llopis@tecnativa.com>
+# Copyright 2020 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Sale Order Product Recommendation",

--- a/sale_order_product_recommendation/readme/CONTRIBUTORS.rst
+++ b/sale_order_product_recommendation/readme/CONTRIBUTORS.rst
@@ -3,3 +3,4 @@
   * Jairo Llopis
   * David Vidal
   * Alexandre Díaz
+  * Pedro M. Baeza

--- a/sale_order_product_recommendation/static/description/index.html
+++ b/sale_order_product_recommendation/static/description/index.html
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
-<title>Sale Order Product Recommendation</title>
-<style type="text/css">
-
-/*
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta
+      name="generator"
+      content="Docutils 0.15.1: http://docutils.sourceforge.net/"
+    />
+    <title>Sale Order Product Recommendation</title>
+    <style type="text/css">
+      /*
 :Author: David Goodger (goodger@python.org)
 :Id: $Id: html4css1.css 7952 2016-07-26 18:15:59Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
@@ -18,79 +20,112 @@ See http://docutils.sf.net/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
 */
 
-/* used to remove borders from tables and images */
-.borderless, table.borderless td, table.borderless th {
-  border: 0 }
+      /* used to remove borders from tables and images */
+      .borderless,
+      table.borderless td,
+      table.borderless th {
+        border: 0;
+      }
 
-table.borderless td, table.borderless th {
-  /* Override padding for "table.docutils td" with "! important".
+      table.borderless td,
+      table.borderless th {
+        /* Override padding for "table.docutils td" with "! important".
      The right padding separates the table cells. */
-  padding: 0 0.5em 0 0 ! important }
+        padding: 0 0.5em 0 0 !important;
+      }
 
-.first {
-  /* Override more specific margin styles with "! important". */
-  margin-top: 0 ! important }
+      .first {
+        /* Override more specific margin styles with "! important". */
+        margin-top: 0 !important;
+      }
 
-.last, .with-subtitle {
-  margin-bottom: 0 ! important }
+      .last,
+      .with-subtitle {
+        margin-bottom: 0 !important;
+      }
 
-.hidden {
-  display: none }
+      .hidden {
+        display: none;
+      }
 
-.subscript {
-  vertical-align: sub;
-  font-size: smaller }
+      .subscript {
+        vertical-align: sub;
+        font-size: smaller;
+      }
 
-.superscript {
-  vertical-align: super;
-  font-size: smaller }
+      .superscript {
+        vertical-align: super;
+        font-size: smaller;
+      }
 
-a.toc-backref {
-  text-decoration: none ;
-  color: black }
+      a.toc-backref {
+        text-decoration: none;
+        color: black;
+      }
 
-blockquote.epigraph {
-  margin: 2em 5em ; }
+      blockquote.epigraph {
+        margin: 2em 5em;
+      }
 
-dl.docutils dd {
-  margin-bottom: 0.5em }
+      dl.docutils dd {
+        margin-bottom: 0.5em;
+      }
 
-object[type="image/svg+xml"], object[type="application/x-shockwave-flash"] {
-  overflow: hidden;
-}
+      object[type="image/svg+xml"],
+      object[type="application/x-shockwave-flash"] {
+        overflow: hidden;
+      }
 
-/* Uncomment (and remove this text!) to get bold-faced definition list terms
+      /* Uncomment (and remove this text!) to get bold-faced definition list terms
 dl.docutils dt {
   font-weight: bold }
 */
 
-div.abstract {
-  margin: 2em 5em }
+      div.abstract {
+        margin: 2em 5em;
+      }
 
-div.abstract p.topic-title {
-  font-weight: bold ;
-  text-align: center }
+      div.abstract p.topic-title {
+        font-weight: bold;
+        text-align: center;
+      }
 
-div.admonition, div.attention, div.caution, div.danger, div.error,
-div.hint, div.important, div.note, div.tip, div.warning {
-  margin: 2em ;
-  border: medium outset ;
-  padding: 1em }
+      div.admonition,
+      div.attention,
+      div.caution,
+      div.danger,
+      div.error,
+      div.hint,
+      div.important,
+      div.note,
+      div.tip,
+      div.warning {
+        margin: 2em;
+        border: medium outset;
+        padding: 1em;
+      }
 
-div.admonition p.admonition-title, div.hint p.admonition-title,
-div.important p.admonition-title, div.note p.admonition-title,
-div.tip p.admonition-title {
-  font-weight: bold ;
-  font-family: sans-serif }
+      div.admonition p.admonition-title,
+      div.hint p.admonition-title,
+      div.important p.admonition-title,
+      div.note p.admonition-title,
+      div.tip p.admonition-title {
+        font-weight: bold;
+        font-family: sans-serif;
+      }
 
-div.attention p.admonition-title, div.caution p.admonition-title,
-div.danger p.admonition-title, div.error p.admonition-title,
-div.warning p.admonition-title, .code .error {
-  color: red ;
-  font-weight: bold ;
-  font-family: sans-serif }
+      div.attention p.admonition-title,
+      div.caution p.admonition-title,
+      div.danger p.admonition-title,
+      div.error p.admonition-title,
+      div.warning p.admonition-title,
+      .code .error {
+        color: red;
+        font-weight: bold;
+        font-family: sans-serif;
+      }
 
-/* Uncomment (and remove this text!) to get reduced vertical space in
+      /* Uncomment (and remove this text!) to get reduced vertical space in
    compound paragraphs.
 div.compound .compound-first, div.compound .compound-middle {
   margin-bottom: 0.5em }
@@ -99,341 +134,537 @@ div.compound .compound-last, div.compound .compound-middle {
   margin-top: 0.5em }
 */
 
-div.dedication {
-  margin: 2em 5em ;
-  text-align: center ;
-  font-style: italic }
+      div.dedication {
+        margin: 2em 5em;
+        text-align: center;
+        font-style: italic;
+      }
 
-div.dedication p.topic-title {
-  font-weight: bold ;
-  font-style: normal }
+      div.dedication p.topic-title {
+        font-weight: bold;
+        font-style: normal;
+      }
 
-div.figure {
-  margin-left: 2em ;
-  margin-right: 2em }
+      div.figure {
+        margin-left: 2em;
+        margin-right: 2em;
+      }
 
-div.footer, div.header {
-  clear: both;
-  font-size: smaller }
+      div.footer,
+      div.header {
+        clear: both;
+        font-size: smaller;
+      }
 
-div.line-block {
-  display: block ;
-  margin-top: 1em ;
-  margin-bottom: 1em }
+      div.line-block {
+        display: block;
+        margin-top: 1em;
+        margin-bottom: 1em;
+      }
 
-div.line-block div.line-block {
-  margin-top: 0 ;
-  margin-bottom: 0 ;
-  margin-left: 1.5em }
+      div.line-block div.line-block {
+        margin-top: 0;
+        margin-bottom: 0;
+        margin-left: 1.5em;
+      }
 
-div.sidebar {
-  margin: 0 0 0.5em 1em ;
-  border: medium outset ;
-  padding: 1em ;
-  background-color: #ffffee ;
-  width: 40% ;
-  float: right ;
-  clear: right }
+      div.sidebar {
+        margin: 0 0 0.5em 1em;
+        border: medium outset;
+        padding: 1em;
+        background-color: #ffffee;
+        width: 40%;
+        float: right;
+        clear: right;
+      }
 
-div.sidebar p.rubric {
-  font-family: sans-serif ;
-  font-size: medium }
+      div.sidebar p.rubric {
+        font-family: sans-serif;
+        font-size: medium;
+      }
 
-div.system-messages {
-  margin: 5em }
+      div.system-messages {
+        margin: 5em;
+      }
 
-div.system-messages h1 {
-  color: red }
+      div.system-messages h1 {
+        color: red;
+      }
 
-div.system-message {
-  border: medium outset ;
-  padding: 1em }
+      div.system-message {
+        border: medium outset;
+        padding: 1em;
+      }
 
-div.system-message p.system-message-title {
-  color: red ;
-  font-weight: bold }
+      div.system-message p.system-message-title {
+        color: red;
+        font-weight: bold;
+      }
 
-div.topic {
-  margin: 2em }
+      div.topic {
+        margin: 2em;
+      }
 
-h1.section-subtitle, h2.section-subtitle, h3.section-subtitle,
-h4.section-subtitle, h5.section-subtitle, h6.section-subtitle {
-  margin-top: 0.4em }
+      h1.section-subtitle,
+      h2.section-subtitle,
+      h3.section-subtitle,
+      h4.section-subtitle,
+      h5.section-subtitle,
+      h6.section-subtitle {
+        margin-top: 0.4em;
+      }
 
-h1.title {
-  text-align: center }
+      h1.title {
+        text-align: center;
+      }
 
-h2.subtitle {
-  text-align: center }
+      h2.subtitle {
+        text-align: center;
+      }
 
-hr.docutils {
-  width: 75% }
+      hr.docutils {
+        width: 75%;
+      }
 
-img.align-left, .figure.align-left, object.align-left, table.align-left {
-  clear: left ;
-  float: left ;
-  margin-right: 1em }
+      img.align-left,
+      .figure.align-left,
+      object.align-left,
+      table.align-left {
+        clear: left;
+        float: left;
+        margin-right: 1em;
+      }
 
-img.align-right, .figure.align-right, object.align-right, table.align-right {
-  clear: right ;
-  float: right ;
-  margin-left: 1em }
+      img.align-right,
+      .figure.align-right,
+      object.align-right,
+      table.align-right {
+        clear: right;
+        float: right;
+        margin-left: 1em;
+      }
 
-img.align-center, .figure.align-center, object.align-center {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-}
+      img.align-center,
+      .figure.align-center,
+      object.align-center {
+        display: block;
+        margin-left: auto;
+        margin-right: auto;
+      }
 
-table.align-center {
-  margin-left: auto;
-  margin-right: auto;
-}
+      table.align-center {
+        margin-left: auto;
+        margin-right: auto;
+      }
 
-.align-left {
-  text-align: left }
+      .align-left {
+        text-align: left;
+      }
 
-.align-center {
-  clear: both ;
-  text-align: center }
+      .align-center {
+        clear: both;
+        text-align: center;
+      }
 
-.align-right {
-  text-align: right }
+      .align-right {
+        text-align: right;
+      }
 
-/* reset inner alignment in figures */
-div.align-right {
-  text-align: inherit }
+      /* reset inner alignment in figures */
+      div.align-right {
+        text-align: inherit;
+      }
 
-/* div.align-center * { */
-/*   text-align: left } */
+      /* div.align-center * { */
+      /*   text-align: left } */
 
-.align-top    {
-  vertical-align: top }
+      .align-top {
+        vertical-align: top;
+      }
 
-.align-middle {
-  vertical-align: middle }
+      .align-middle {
+        vertical-align: middle;
+      }
 
-.align-bottom {
-  vertical-align: bottom }
+      .align-bottom {
+        vertical-align: bottom;
+      }
 
-ol.simple, ul.simple {
-  margin-bottom: 1em }
+      ol.simple,
+      ul.simple {
+        margin-bottom: 1em;
+      }
 
-ol.arabic {
-  list-style: decimal }
+      ol.arabic {
+        list-style: decimal;
+      }
 
-ol.loweralpha {
-  list-style: lower-alpha }
+      ol.loweralpha {
+        list-style: lower-alpha;
+      }
 
-ol.upperalpha {
-  list-style: upper-alpha }
+      ol.upperalpha {
+        list-style: upper-alpha;
+      }
 
-ol.lowerroman {
-  list-style: lower-roman }
+      ol.lowerroman {
+        list-style: lower-roman;
+      }
 
-ol.upperroman {
-  list-style: upper-roman }
+      ol.upperroman {
+        list-style: upper-roman;
+      }
 
-p.attribution {
-  text-align: right ;
-  margin-left: 50% }
+      p.attribution {
+        text-align: right;
+        margin-left: 50%;
+      }
 
-p.caption {
-  font-style: italic }
+      p.caption {
+        font-style: italic;
+      }
 
-p.credits {
-  font-style: italic ;
-  font-size: smaller }
+      p.credits {
+        font-style: italic;
+        font-size: smaller;
+      }
 
-p.label {
-  white-space: nowrap }
+      p.label {
+        white-space: nowrap;
+      }
 
-p.rubric {
-  font-weight: bold ;
-  font-size: larger ;
-  color: maroon ;
-  text-align: center }
+      p.rubric {
+        font-weight: bold;
+        font-size: larger;
+        color: maroon;
+        text-align: center;
+      }
 
-p.sidebar-title {
-  font-family: sans-serif ;
-  font-weight: bold ;
-  font-size: larger }
+      p.sidebar-title {
+        font-family: sans-serif;
+        font-weight: bold;
+        font-size: larger;
+      }
 
-p.sidebar-subtitle {
-  font-family: sans-serif ;
-  font-weight: bold }
+      p.sidebar-subtitle {
+        font-family: sans-serif;
+        font-weight: bold;
+      }
 
-p.topic-title {
-  font-weight: bold }
+      p.topic-title {
+        font-weight: bold;
+      }
 
-pre.address {
-  margin-bottom: 0 ;
-  margin-top: 0 ;
-  font: inherit }
+      pre.address {
+        margin-bottom: 0;
+        margin-top: 0;
+        font: inherit;
+      }
 
-pre.literal-block, pre.doctest-block, pre.math, pre.code {
-  margin-left: 2em ;
-  margin-right: 2em }
+      pre.literal-block,
+      pre.doctest-block,
+      pre.math,
+      pre.code {
+        margin-left: 2em;
+        margin-right: 2em;
+      }
 
-pre.code .ln { color: grey; } /* line numbers */
-pre.code, code { background-color: #eeeeee }
-pre.code .comment, code .comment { color: #5C6576 }
-pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
-pre.code .literal.string, code .literal.string { color: #0C5404 }
-pre.code .name.builtin, code .name.builtin { color: #352B84 }
-pre.code .deleted, code .deleted { background-color: #DEB0A1}
-pre.code .inserted, code .inserted { background-color: #A3D289}
+      pre.code .ln {
+        color: grey;
+      } /* line numbers */
+      pre.code,
+      code {
+        background-color: #eeeeee;
+      }
+      pre.code .comment,
+      code .comment {
+        color: #5c6576;
+      }
+      pre.code .keyword,
+      code .keyword {
+        color: #3b0d06;
+        font-weight: bold;
+      }
+      pre.code .literal.string,
+      code .literal.string {
+        color: #0c5404;
+      }
+      pre.code .name.builtin,
+      code .name.builtin {
+        color: #352b84;
+      }
+      pre.code .deleted,
+      code .deleted {
+        background-color: #deb0a1;
+      }
+      pre.code .inserted,
+      code .inserted {
+        background-color: #a3d289;
+      }
 
-span.classifier {
-  font-family: sans-serif ;
-  font-style: oblique }
+      span.classifier {
+        font-family: sans-serif;
+        font-style: oblique;
+      }
 
-span.classifier-delimiter {
-  font-family: sans-serif ;
-  font-weight: bold }
+      span.classifier-delimiter {
+        font-family: sans-serif;
+        font-weight: bold;
+      }
 
-span.interpreted {
-  font-family: sans-serif }
+      span.interpreted {
+        font-family: sans-serif;
+      }
 
-span.option {
-  white-space: nowrap }
+      span.option {
+        white-space: nowrap;
+      }
 
-span.pre {
-  white-space: pre }
+      span.pre {
+        white-space: pre;
+      }
 
-span.problematic {
-  color: red }
+      span.problematic {
+        color: red;
+      }
 
-span.section-subtitle {
-  /* font-size relative to parent (h1..h6 element) */
-  font-size: 80% }
+      span.section-subtitle {
+        /* font-size relative to parent (h1..h6 element) */
+        font-size: 80%;
+      }
 
-table.citation {
-  border-left: solid 1px gray;
-  margin-left: 1px }
+      table.citation {
+        border-left: solid 1px gray;
+        margin-left: 1px;
+      }
 
-table.docinfo {
-  margin: 2em 4em }
+      table.docinfo {
+        margin: 2em 4em;
+      }
 
-table.docutils {
-  margin-top: 0.5em ;
-  margin-bottom: 0.5em }
+      table.docutils {
+        margin-top: 0.5em;
+        margin-bottom: 0.5em;
+      }
 
-table.footnote {
-  border-left: solid 1px black;
-  margin-left: 1px }
+      table.footnote {
+        border-left: solid 1px black;
+        margin-left: 1px;
+      }
 
-table.docutils td, table.docutils th,
-table.docinfo td, table.docinfo th {
-  padding-left: 0.5em ;
-  padding-right: 0.5em ;
-  vertical-align: top }
+      table.docutils td,
+      table.docutils th,
+      table.docinfo td,
+      table.docinfo th {
+        padding-left: 0.5em;
+        padding-right: 0.5em;
+        vertical-align: top;
+      }
 
-table.docutils th.field-name, table.docinfo th.docinfo-name {
-  font-weight: bold ;
-  text-align: left ;
-  white-space: nowrap ;
-  padding-left: 0 }
+      table.docutils th.field-name,
+      table.docinfo th.docinfo-name {
+        font-weight: bold;
+        text-align: left;
+        white-space: nowrap;
+        padding-left: 0;
+      }
 
-/* "booktabs" style (no vertical lines) */
-table.docutils.booktabs {
-  border: 0px;
-  border-top: 2px solid;
-  border-bottom: 2px solid;
-  border-collapse: collapse;
-}
-table.docutils.booktabs * {
-  border: 0px;
-}
-table.docutils.booktabs th {
-  border-bottom: thin solid;
-  text-align: left;
-}
+      /* "booktabs" style (no vertical lines) */
+      table.docutils.booktabs {
+        border: 0px;
+        border-top: 2px solid;
+        border-bottom: 2px solid;
+        border-collapse: collapse;
+      }
+      table.docutils.booktabs * {
+        border: 0px;
+      }
+      table.docutils.booktabs th {
+        border-bottom: thin solid;
+        text-align: left;
+      }
 
-h1 tt.docutils, h2 tt.docutils, h3 tt.docutils,
-h4 tt.docutils, h5 tt.docutils, h6 tt.docutils {
-  font-size: 100% }
+      h1 tt.docutils,
+      h2 tt.docutils,
+      h3 tt.docutils,
+      h4 tt.docutils,
+      h5 tt.docutils,
+      h6 tt.docutils {
+        font-size: 100%;
+      }
 
-ul.auto-toc {
-  list-style-type: none }
+      ul.auto-toc {
+        list-style-type: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="document" id="sale-order-product-recommendation">
+      <h1 class="title">Sale Order Product Recommendation</h1>
 
-</style>
-</head>
-<body>
-<div class="document" id="sale-order-product-recommendation">
-<h1 class="title">Sale Order Product Recommendation</h1>
-
-<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! This file is generated by oca-gen-addon-readme !!
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/OCA/sale-workflow/tree/13.0/sale_order_product_recommendation"><img alt="OCA/sale-workflow" src="https://img.shields.io/badge/github-OCA%2Fsale--workflow-lightgray.png?logo=github" /></a> <a class="reference external" href="https://translation.odoo-community.org/projects/sale-workflow-13-0/sale-workflow-13-0-sale_order_product_recommendation"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external" href="https://runbot.odoo-community.org/runbot/167/13.0"><img alt="Try me on Runbot" src="https://img.shields.io/badge/runbot-Try%20me-875A7B.png" /></a></p>
-<p>This module adds a recommended products wizard to current sale order.</p>
-<p>It is based on recent delivered products, and allows the salesman to quickly
-know the most sold products for current customer, which results in an easy to
-use hint to improve sale.</p>
-<p><strong>Table of contents</strong></p>
-<div class="contents local topic" id="contents">
-<ul class="simple">
-<li><a class="reference internal" href="#usage" id="id1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
-</ul>
-</li>
-</ul>
-</div>
-<div class="section" id="usage">
-<h1><a class="toc-backref" href="#id1">Usage</a></h1>
-<p>To use this module, you need to:</p>
-<ol class="arabic simple">
-<li>Create a new sale order.</li>
-<li>Assign its customer.</li>
-<li>Press <em>Recommended Products</em> button.</li>
-<li>Add products into the opened wizard.</li>
-<li>Press <em>Accept</em>.</li>
-</ol>
-</div>
-<div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
-<p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/sale-workflow/issues">GitHub Issues</a>.
-In case of trouble, please check there if your issue has already been reported.
-If you spotted it first, help us smashing it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/OCA/sale-workflow/issues/new?body=module:%20sale_order_product_recommendation%0Aversion:%2013.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
-<p>Do not contact contributors directly about support or help with technical issues.</p>
-</div>
-<div class="section" id="credits">
-<h1><a class="toc-backref" href="#id3">Credits</a></h1>
-<div class="section" id="authors">
-<h2><a class="toc-backref" href="#id4">Authors</a></h2>
-<ul class="simple">
-<li>Tecnativa</li>
-</ul>
-</div>
-<div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
-<ul class="simple">
-<li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
-<li>Jairo Llopis</li>
-<li>David Vidal</li>
-<li>Alexandre Díaz</li>
-</ul>
-</li>
-</ul>
-</div>
-<div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
-<p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
-<p>OCA, or the Odoo Community Association, is a nonprofit organization whose
-mission is to support the collaborative development of Odoo features and
-promote its widespread use.</p>
-<p>This module is part of the <a class="reference external" href="https://github.com/OCA/sale-workflow/tree/13.0/sale_order_product_recommendation">OCA/sale-workflow</a> project on GitHub.</p>
-<p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
-</div>
-</div>
-</div>
-</body>
+      <p>
+        <a
+          class="reference external"
+          href="https://odoo-community.org/page/development-status"
+          ><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png"
+        /></a>
+        <a
+          class="reference external"
+          href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"
+          ><img
+            alt="License: AGPL-3"
+            src="https://img.shields.io/badge/licence-AGPL--3-blue.png"
+        /></a>
+        <a
+          class="reference external"
+          href="https://github.com/OCA/sale-workflow/tree/13.0/sale_order_product_recommendation"
+          ><img
+            alt="OCA/sale-workflow"
+            src="https://img.shields.io/badge/github-OCA%2Fsale--workflow-lightgray.png?logo=github"
+        /></a>
+        <a
+          class="reference external"
+          href="https://translation.odoo-community.org/projects/sale-workflow-13-0/sale-workflow-13-0-sale_order_product_recommendation"
+          ><img
+            alt="Translate me on Weblate"
+            src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png"
+        /></a>
+        <a
+          class="reference external"
+          href="https://runbot.odoo-community.org/runbot/167/13.0"
+          ><img
+            alt="Try me on Runbot"
+            src="https://img.shields.io/badge/runbot-Try%20me-875A7B.png"
+        /></a>
+      </p>
+      <p>This module adds a recommended products wizard to current sale order.</p>
+      <p>
+        It is based on recent delivered products, and allows the salesman to quickly
+        know the most sold products for current customer, which results in an easy to
+        use hint to improve sale.
+      </p>
+      <p><strong>Table of contents</strong></p>
+      <div class="contents local topic" id="contents">
+        <ul class="simple">
+          <li><a class="reference internal" href="#usage" id="id1">Usage</a></li>
+          <li>
+            <a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a>
+          </li>
+          <li>
+            <a class="reference internal" href="#credits" id="id3">Credits</a>
+            <ul>
+              <li>
+                <a class="reference internal" href="#authors" id="id4">Authors</a>
+              </li>
+              <li>
+                <a class="reference internal" href="#contributors" id="id5"
+                  >Contributors</a
+                >
+              </li>
+              <li>
+                <a class="reference internal" href="#maintainers" id="id6"
+                  >Maintainers</a
+                >
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+      <div class="section" id="usage">
+        <h1><a class="toc-backref" href="#id1">Usage</a></h1>
+        <p>To use this module, you need to:</p>
+        <ol class="arabic simple">
+          <li>Create a new sale order.</li>
+          <li>Assign its customer.</li>
+          <li>Press <em>Recommended Products</em> button.</li>
+          <li>Add products into the opened wizard.</li>
+          <li>Press <em>Accept</em>.</li>
+        </ol>
+      </div>
+      <div class="section" id="bug-tracker">
+        <h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
+        <p>
+          Bugs are tracked on
+          <a
+            class="reference external"
+            href="https://github.com/OCA/sale-workflow/issues"
+            >GitHub Issues</a
+          >. In case of trouble, please check there if your issue has already been
+          reported. If you spotted it first, help us smashing it by providing a detailed
+          and welcomed
+          <a
+            class="reference external"
+            href="https://github.com/OCA/sale-workflow/issues/new?body=module:%20sale_order_product_recommendation%0Aversion:%2013.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**"
+            >feedback</a
+          >.
+        </p>
+        <p>
+          Do not contact contributors directly about support or help with technical
+          issues.
+        </p>
+      </div>
+      <div class="section" id="credits">
+        <h1><a class="toc-backref" href="#id3">Credits</a></h1>
+        <div class="section" id="authors">
+          <h2><a class="toc-backref" href="#id4">Authors</a></h2>
+          <ul class="simple">
+            <li>Tecnativa</li>
+          </ul>
+        </div>
+        <div class="section" id="contributors">
+          <h2><a class="toc-backref" href="#id5">Contributors</a></h2>
+          <ul class="simple">
+            <li>
+              <a class="reference external" href="https://www.tecnativa.com"
+                >Tecnativa</a
+              >:
+              <ul>
+                <li>Jairo Llopis</li>
+                <li>David Vidal</li>
+                <li>Alexandre Díaz</li>
+                <li>Pedro M. Baeza</li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+        <div class="section" id="maintainers">
+          <h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
+          <p>This module is maintained by the OCA.</p>
+          <a
+            class="reference external image-reference"
+            href="https://odoo-community.org"
+            ><img
+              alt="Odoo Community Association"
+              src="https://odoo-community.org/logo.png"
+          /></a>
+          <p>
+            OCA, or the Odoo Community Association, is a nonprofit organization whose
+            mission is to support the collaborative development of Odoo features and
+            promote its widespread use.
+          </p>
+          <p>
+            This module is part of the
+            <a
+              class="reference external"
+              href="https://github.com/OCA/sale-workflow/tree/13.0/sale_order_product_recommendation"
+              >OCA/sale-workflow</a
+            >
+            project on GitHub.
+          </p>
+          <p>
+            You are welcome to contribute. To learn how please visit
+            <a
+              class="reference external"
+              href="https://odoo-community.org/page/Contribute"
+              >https://odoo-community.org/page/Contribute</a
+            >.
+          </p>
+        </div>
+      </div>
+    </div>
+  </body>
 </html>

--- a/sale_order_product_recommendation/tests/test_recommendation.py
+++ b/sale_order_product_recommendation/tests/test_recommendation.py
@@ -1,4 +1,5 @@
 # Copyright 2017 Tecnativa - Jairo Llopis
+# Copyright 2020 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo.exceptions import UserError
 
@@ -59,7 +60,6 @@ class RecommendationCaseTests(RecommendationCase):
         wizard = self.wizard()
         wiz_line_prod1 = wizard.line_ids.filtered(lambda x: x.product_id == self.prod_1)
         wiz_line_prod1.units_included = qty
-        wiz_line_prod1._onchange_units_included()
         wizard.action_accept()
         self.assertEqual(len(self.new_so.order_line), 1)
         self.assertEqual(self.new_so.order_line.product_id, self.prod_1)
@@ -69,7 +69,6 @@ class RecommendationCaseTests(RecommendationCase):
         wizard = self.wizard()
         wiz_line = wizard.line_ids.filtered(lambda x: x.product_id == self.prod_1)
         wiz_line.units_included = 0
-        wiz_line._onchange_units_included()
         # The confirmed line can't be deleted
         with self.assertRaises(UserError):
             wizard.action_accept()
@@ -86,7 +85,6 @@ class RecommendationCaseTests(RecommendationCase):
         wizard = self.wizard()
         wiz_line = wizard.line_ids.filtered(lambda x: x.product_id == self.prod_1)
         wiz_line.units_included = qty + 2
-        wiz_line._onchange_units_included()
         wizard.action_accept()
         # Deliver extra qty and make a new invoice
         self.new_so.order_line.qty_delivered = qty + 2

--- a/sale_order_product_recommendation/tests/test_recommendation.py
+++ b/sale_order_product_recommendation/tests/test_recommendation.py
@@ -84,15 +84,9 @@ class RecommendationCaseTests(RecommendationCase):
         # Open the wizard and add more product qty
         wizard = self.wizard()
         wiz_line = wizard.line_ids.filtered(lambda x: x.product_id == self.prod_1)
-        wiz_line.units_included = qty + 2
+        qty += 2
+        wiz_line.units_included = qty
         wizard.action_accept()
-        # Deliver extra qty and make a new invoice
-        self.new_so.order_line.qty_delivered = qty + 2
-        adv_wiz = (
-            self.env["sale.advance.payment.inv"]
-            .with_context(active_ids=[self.new_so.id])
-            .create({"advance_payment_method": "delivered"})
-        )
-        adv_wiz.with_context(open_invoices=True).create_invoices()
-        self.assertEqual(2, len(self.new_so.invoice_ids))
-        self.assertEqual(qty, self.new_so.invoice_ids[:1].invoice_line_ids.quantity)
+        line = self.new_so.order_line.filtered(lambda x: x.product_id == self.prod_1)
+        self.assertTrue(line)
+        self.assertEqual(line.product_uom_qty, qty)

--- a/sale_order_product_recommendation/tests/test_recommendation_common.py
+++ b/sale_order_product_recommendation/tests/test_recommendation_common.py
@@ -7,6 +7,8 @@ class RecommendationCase(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # Make sure user has UoM activated for Forms to work
+        cls.env.user.groups_id = [(4, cls.env.ref("uom.group_uom").id)]
         cls.partner = cls.env["res.partner"].create({"name": "Mr. Odoo"})
         cls.product_obj = cls.env["product.product"]
         cls.prod_1 = cls.product_obj.create(

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -123,7 +123,9 @@ class SaleOrderRecommendation(models.TransientModel):
         so_line_obj = self.env["sale.order.line"]
         so_line_ids = []
         sequence = max(self.order_id.mapped("order_line.sequence") or [0])
-        for wiz_line in self.line_ids.filtered("is_modified"):
+        for wiz_line in self.line_ids.filtered(
+            lambda x: x.sale_line_id or x.units_included
+        ):
             # Use preexisting line if any
             if wiz_line.sale_line_id:
                 if wiz_line.units_included:
@@ -162,7 +164,6 @@ class SaleOrderRecommendationLine(models.TransientModel):
     )
     sale_line_id = fields.Many2one(comodel_name="sale.order.line")
     sale_uom_id = fields.Many2one(related="sale_line_id.product_uom")
-    is_modified = fields.Boolean()
 
     @api.depends("partner_id", "product_id", "pricelist_id", "units_included")
     def _compute_price_unit(self):
@@ -172,10 +173,6 @@ class SaleOrderRecommendationLine(models.TransientModel):
                 pricelist=one.pricelist_id.id,
                 quantity=one.units_included,
             ).price
-
-    @api.onchange("units_included")
-    def _onchange_units_included(self):
-        self.is_modified = bool(self.sale_line_id or self.units_included)
 
     def _prepare_update_so_line(self):
         """So we can extend PO update"""

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -1,5 +1,6 @@
 # Copyright 2017 Jairo Llopis <jairo.llopis@tecnativa.com>
 # Copyright 2018 Carlos Dauden <carlos.dauden@tecnativa.com>
+# Copyright 2020 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from datetime import datetime, timedelta
@@ -60,6 +61,21 @@ class SaleOrderRecommendation(models.TransientModel):
             ("qty_delivered", "!=", 0.0),
         ]
 
+    def _prepare_recommendation_line_vals(self, group_line, so_line=False):
+        """Return the vals dictionary for creating a new recommendation line.
+        @param group_line: Dictionary returned by the read_group operation.
+        @param so_line: Optional sales order line
+        """
+        vals = {
+            "product_id": group_line["product_id"][0],
+            "times_delivered": group_line.get("product_id_count", 0),
+            "units_delivered": group_line.get("qty_delivered", 0),
+        }
+        if so_line:
+            vals["units_included"] = so_line.product_uom_qty
+            vals["sale_line_id"] = so_line.id
+        return vals
+
     @api.onchange("order_id", "months", "line_amount")
     def _generate_recommendations(self):
         """Generate lines according to context sale order."""
@@ -86,15 +102,11 @@ class SaleOrderRecommendation(models.TransientModel):
         existing_product_ids = set()
         # Always recommend all products already present in the linked SO
         for line in self.order_id.order_line:
-            found_line = found_dict.get(line.product_id.id, {})
+            found_line = found_dict.get(
+                line.product_id.id, {"product_id": (line.product_id.id, False)}
+            )
             new_line = recommendation_lines.new(
-                {
-                    "product_id": line.product_id.id,
-                    "times_delivered": found_line.get("product_id_count", 0),
-                    "units_delivered": found_line.get("qty_delivered", 0),
-                    "units_included": line.product_uom_qty,
-                    "sale_line_id": line.id,
-                }
+                self._prepare_recommendation_line_vals(found_line, line)
             )
             recommendation_lines += new_line
             existing_product_ids.add(line.product_id.id)
@@ -104,11 +116,7 @@ class SaleOrderRecommendation(models.TransientModel):
             if line["product_id"][0] in existing_product_ids:
                 continue
             new_line = recommendation_lines.new(
-                {
-                    "product_id": line["product_id"][0],
-                    "times_delivered": line["product_id_count"],
-                    "units_delivered": line["qty_delivered"],
-                }
+                self._prepare_recommendation_line_vals(line)
             )
             recommendation_lines += new_line
             # limit number of results. It has to be done here, as we need to

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -6,6 +6,7 @@
 from datetime import datetime, timedelta
 
 from odoo import api, fields, models
+from odoo.tests import Form
 
 
 class SaleOrderRecommendation(models.TransientModel):
@@ -128,26 +129,28 @@ class SaleOrderRecommendation(models.TransientModel):
 
     def action_accept(self):
         """Propagate recommendations to sale order."""
-        so_line_obj = self.env["sale.order.line"]
-        so_line_ids = []
         sequence = max(self.order_id.mapped("order_line.sequence") or [0])
+        order_form = Form(self.order_id.sudo())
+        to_remove = []
         for wiz_line in self.line_ids.filtered(
             lambda x: x.sale_line_id or x.units_included
         ):
-            # Use preexisting line if any
             if wiz_line.sale_line_id:
+                index = self.order_id.order_line.ids.index(wiz_line.sale_line_id.id)
                 if wiz_line.units_included:
-                    wiz_line.sale_line_id.update(wiz_line._prepare_update_so_line())
-                    wiz_line.sale_line_id.product_uom_change()
+                    with order_form.order_line.edit(index) as line_form:
+                        wiz_line._prepare_update_so_line(line_form)
                 else:
-                    wiz_line.sale_line_id.unlink()
-                continue
-            sequence += 1
-            # Use a new in-memory line otherwise
-            so_line = so_line_obj.new(wiz_line._prepare_new_so_line(sequence))
-            so_line = wiz_line._trigger_so_line_onchanges(so_line)
-            so_line_ids.append(so_line.id)
-        self.order_id.order_line += so_line_obj.browse(so_line_ids)
+                    to_remove.append(index)
+            else:
+                sequence += 1
+                with order_form.order_line.new() as line_form:
+                    wiz_line._prepare_new_so_line(line_form, sequence)
+        # Remove at the end and in reverse order for not having problems
+        to_remove.reverse()
+        for index in to_remove:
+            order_form.order_line.remove(index)
+        order_form.save()
 
 
 class SaleOrderRecommendationLine(models.TransientModel):
@@ -182,21 +185,12 @@ class SaleOrderRecommendationLine(models.TransientModel):
                 quantity=one.units_included,
             ).price
 
-    def _prepare_update_so_line(self):
-        """So we can extend PO update"""
-        return {"product_uom_qty": self.units_included}
+    def _prepare_update_so_line(self, line_form):
+        """So we can extend SO update"""
+        line_form.product_uom_qty = self.units_included
 
-    def _prepare_new_so_line(self, sequence):
-        """So we can extend PO create"""
-        return {
-            "order_id": self.wizard_id.order_id.id,
-            "product_id": self.product_id.id,
-            "sequence": sequence,
-        }
-
-    def _trigger_so_line_onchanges(self, so_line):
-        """Extensible method for trigger needed onchanges of the so ling"""
-        so_line.product_id_change()
-        so_line.product_uom_qty = self.units_included
-        so_line.product_uom_change()
-        return so_line
+    def _prepare_new_so_line(self, line_form, sequence):
+        """So we can extend SO create"""
+        line_form.product_id = self.product_id
+        line_form.sequence = sequence
+        line_form.product_uom_qty = self.units_included

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -161,6 +161,7 @@ class SaleOrderRecommendationLine(models.TransientModel):
         readonly=True,
     )
     sale_line_id = fields.Many2one(comodel_name="sale.order.line")
+    sale_uom_id = fields.Many2one(related="sale_line_id.product_uom")
     is_modified = fields.Boolean()
 
     @api.depends("partner_id", "product_id", "pricelist_id", "units_included")

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2017 Jairo Llopis <jairo.llopis@tecnativa.com>
+     Copyright 2020 Tecnativa - Pedro M. Baeza
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
     <record id="sale_order_recommendation_view_form" model="ir.ui.view">
@@ -14,7 +15,7 @@
                         <field name="line_amount" />
                     </group>
                     <group>
-                        <field name="line_ids" nolabel="1">
+                        <field name="line_ids" nolabel="1" mode="tree,kanban">
                             <tree create="0" delete="0" editable="top">
                                 <field name="currency_id" invisible="1" />
                                 <field name="sale_line_id" invisible="1" />
@@ -25,6 +26,78 @@
                                 <field name="units_delivered" />
                                 <field name="units_included" />
                             </tree>
+                            <kanban
+                                class="o_kanban_mobile"
+                                quick_create="0"
+                                create="0"
+                                delete="0"
+                            >
+                                <field name="id" />
+                                <field name="product_id" />
+                                <field name="is_modified" />
+                                <field name="sale_line_id" />
+                                <field name="price_unit" />
+                                <field name="sale_uom_id" />
+                                <field name="times_delivered" />
+                                <field name="units_delivered" />
+                                <field name="units_included" />
+                                <field name="currency_id" />
+                                <templates>
+                                    <t t-name="kanban-box">
+                                        <div class="oe_kanban_global_click">
+                                            <div class="o_kanban_image">
+                                                <img
+                                                    t-att-src="kanban_image('product.template', 'image_small', record.product_id.raw_value)"
+                                                    alt="Product"
+                                                />
+                                            </div>
+                                            <div class="oe_kanban_details">
+                                                <div>
+                                                    <field name="product_id" />
+                                                </div>
+                                                <div>
+                                                    Price:
+                                                    <field
+                                                        name="price_unit"
+                                                        widget="monetary"
+                                                        options="{'currency_field': 'currency_id', 'field_digits': True}"
+                                                        class="mt-0 mb-0"
+                                                    />
+                                                </div>
+                                                <div>
+                                                    Delivered:
+                                                    <field name="times_delivered" />
+                                                    times -
+                                                    <field name="units_delivered" />
+                                                    <field name="sale_uom_id" />
+                                                </div>
+                                                <div>
+                                                    <strong>
+                                                        <span>To be included:</span>
+                                                        <field name="units_included" />
+                                                        <span />
+                                                        <field name="sale_uom_id" />
+                                                    </strong>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </t>
+                                </templates>
+                            </kanban>
+                            <form>
+                                <group>
+                                    <field
+                                        name="product_id"
+                                        readonly="1"
+                                        force_save="1"
+                                    />
+                                    <field name="price_unit" />
+                                    <field
+                                        name="units_included"
+                                        widget="numeric_step"
+                                    />
+                                </group>
+                            </form>
                         </field>
                     </group>
                 </sheet>

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
@@ -19,7 +19,6 @@
                             <tree create="0" delete="0" editable="top">
                                 <field name="currency_id" invisible="1" />
                                 <field name="sale_line_id" invisible="1" />
-                                <field name="is_modified" invisible="1" />
                                 <field name="product_id" readonly="1" force_save="1" />
                                 <field name="price_unit" />
                                 <field name="times_delivered" />
@@ -34,7 +33,6 @@
                             >
                                 <field name="id" />
                                 <field name="product_id" />
-                                <field name="is_modified" />
                                 <field name="sale_line_id" />
                                 <field name="price_unit" />
                                 <field name="sale_uom_id" />

--- a/sale_order_product_recommendation_secondary_unit/tests/test_recommendations.py
+++ b/sale_order_product_recommendation_secondary_unit/tests/test_recommendations.py
@@ -1,4 +1,5 @@
 # Copyright 2019 Tecnativa - David Vidal
+# Copyright 2020 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo.addons.sale_order_product_recommendation.tests import (
     test_recommendation_common,
@@ -78,11 +79,9 @@ class RecommendationCaseTests(test_recommendation_common.RecommendationCase):
         wl_prod2 = wizard.line_ids.filtered(lambda x: x.product_id == self.prod_2)
         wl_prod1.secondary_uom_qty = 2  # 20 units
         wl_prod1._onchange_secondary_uom()
-        wl_prod1._onchange_units_included()
         wl_prod2.secondary_uom_id = self.secondary_unit_p2
         wl_prod2.secondary_uom_qty = 2  # 48 units
         wl_prod2._onchange_secondary_uom()
-        wl_prod2._onchange_units_included()
         wizard.action_accept()
         self.assertEqual(len(self.new_so.order_line), 2)
         sl_p1 = self.new_so.order_line.filtered(lambda x: x.product_id == self.prod_1)
@@ -98,7 +97,6 @@ class RecommendationCaseTests(test_recommendation_common.RecommendationCase):
         wl_prod1 = wizard.line_ids.filtered(lambda x: x.product_id == self.prod_1)
         wl_prod1.secondary_uom_qty = 1  # 10 units
         wl_prod1._onchange_secondary_uom()
-        wl_prod1._onchange_units_included()
         wizard.action_accept()
         sl_p1 = self.new_so.order_line.filtered(lambda x: x.product_id == self.prod_1)
         self.assertEqual(sl_p1.secondary_uom_qty, 1)

--- a/sale_order_product_recommendation_secondary_unit/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation_secondary_unit/wizards/sale_order_recommendation.py
@@ -1,18 +1,32 @@
 # Copyright 2019 David Vidal <david.vidal@tecnativa.com>
+# Copyright 2020 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
 from odoo.tools.float_utils import float_compare, float_round
 
 
+class SaleOrderRecommendation(models.TransientModel):
+    _inherit = "sale.order.recommendation"
+
+    def _prepare_recommendation_line_vals(self, group_line, so_line=False):
+        vals = super()._prepare_recommendation_line_vals(group_line, so_line=so_line)
+        if so_line:
+            vals["secondary_uom_id"] = so_line.secondary_uom_id.id
+            vals["secondary_uom_qty"] = so_line.secondary_uom_qty
+        if not vals.get("secondary_uom_id"):
+            # Take default secondary unit from product if exists
+            product = self.env["product.product"].browse(vals["product_id"])
+            if product.sale_secondary_uom_id:
+                vals["secondary_uom_id"] = product.sale_secondary_uom_id.id
+        return vals
+
+
 class SaleOrderRecommendationLine(models.TransientModel):
     _inherit = "sale.order.recommendation.line"
 
-    secondary_uom_id = fields.Many2one(
-        comodel_name="product.secondary.unit",
-        related="product_id.sale_secondary_uom_id",
-    )
-    secondary_uom_name = fields.Char(related="secondary_uom_id.name",)
+    secondary_uom_id = fields.Many2one(comodel_name="product.secondary.unit")
+    secondary_uom_name = fields.Char(related="secondary_uom_id.name")
     secondary_uom_qty = fields.Float(
         string="Secondary Qty", digits="Product Unit of Measure"
     )

--- a/sale_order_product_recommendation_secondary_unit/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation_secondary_unit/wizards/sale_order_recommendation.py
@@ -12,6 +12,7 @@ class SaleOrderRecommendationLine(models.TransientModel):
         comodel_name="product.secondary.unit",
         related="product_id.sale_secondary_uom_id",
     )
+    secondary_uom_name = fields.Char(related="secondary_uom_id.name",)
     secondary_uom_qty = fields.Float(
         string="Secondary Qty", digits="Product Unit of Measure"
     )

--- a/sale_order_product_recommendation_secondary_unit/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation_secondary_unit/wizards/sale_order_recommendation.py
@@ -74,35 +74,16 @@ class SaleOrderRecommendationLine(models.TransientModel):
         ):
             self.secondary_uom_qty = qty
 
-    def _prepare_update_so_line(self):
-        res = super()._prepare_update_so_line()
-        if self.secondary_uom_id and self.secondary_uom_qty:
-            res.update(
-                {
-                    "secondary_uom_id": self.secondary_uom_id.id,
-                    "secondary_uom_qty": self.secondary_uom_qty,
-                }
-            )
+    def _prepare_update_so_line(self, line_form):
+        res = super()._prepare_update_so_line(line_form)
+        if self.secondary_uom_id:
+            line_form.secondary_uom_id = self.secondary_uom_id
+            line_form.secondary_uom_qty = self.secondary_uom_qty
         return res
 
-    def _prepare_new_so_line(self, sequence):
-        res = super()._prepare_new_so_line(sequence)
-        if self.secondary_uom_id and self.secondary_uom_qty:
-            res.update(
-                {
-                    "secondary_uom_id": self.secondary_uom_id.id,
-                    "secondary_uom_qty": self.secondary_uom_qty,
-                }
-            )
+    def _prepare_new_so_line(self, line_form, sequence):
+        res = super()._prepare_new_so_line(line_form, sequence)
+        if self.secondary_uom_id:
+            line_form.secondary_uom_id = self.secondary_uom_id
+            line_form.secondary_uom_qty = self.secondary_uom_qty
         return res
-
-    def _trigger_so_line_onchanges(self, so_line):
-        """We need to recompute secondary uom qty from the units in the line"""
-        secondary_uom_id = self.secondary_uom_id
-        so_line = super()._trigger_so_line_onchanges(so_line)
-        if secondary_uom_id and self.secondary_uom_qty:
-            # Prevent product defaults
-            if so_line.secondary_uom_id != secondary_uom_id:
-                so_line.secondary_uom_id = secondary_uom_id
-            so_line.onchange_secondary_unit_product_uom_qty()
-        return so_line

--- a/sale_order_product_recommendation_secondary_unit/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation_secondary_unit/wizards/sale_order_recommendation_view.xml
@@ -9,7 +9,10 @@
             ref="sale_order_product_recommendation.sale_order_recommendation_view_form"
         />
         <field name="arch" type="xml">
-            <field name="units_included" position="before">
+            <xpath
+                expr="//field[@name='line_ids']/tree//field[@name='units_included']"
+                position="before"
+            >
                 <field name="product_tmpl_id" invisible="1" />
                 <field
                     name="secondary_uom_id"
@@ -19,7 +22,40 @@
                     name="secondary_uom_qty"
                     attrs="{'invisible': [('secondary_uom_id', '=', False)]}"
                 />
-            </field>
+            </xpath>
+            <xpath
+                expr="//field[@name='line_ids']/kanban//field[@name='units_included']"
+                position="before"
+            >
+                <field name="secondary_uom_qty" />
+                <field name="secondary_uom_id" />
+                <field name="secondary_uom_name" />
+            </xpath>
+            <xpath
+                expr="//field[@name='line_ids']/kanban//t[@t-name='kanban-box']//field[@name='units_included']"
+                position="before"
+            >
+                <t t-if="record.secondary_uom_id.value">
+                    <field name="secondary_uom_qty" />
+                    <span />
+                    <field name="secondary_uom_name" />
+                    <span> - </span>
+                </t>
+            </xpath>
+            <xpath
+                expr="//field[@name='line_ids']/form//field[@name='units_included']"
+                position="before"
+            >
+                <field
+                    name="secondary_uom_id"
+                    attrs="{'invisible': [('secondary_uom_id', '=', False)]}"
+                />
+                <field
+                    name="secondary_uom_qty"
+                    attrs="{'invisible': [('secondary_uom_id', '=', False)]}"
+                    widget="numeric_step"
+                />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Forward-port of #1100 

- Mobile views: Add kanban + form for proper mobile usage.
- Remove useless flag `is_modified`: It's better to simply check the flag condition than to keep that field.
- Don't tie second. unit to product default one: Having a related field to default sale secondary UoM makes this recommendator to not fit possible different secondary UoM to be used. This commit fixes this behavior. A refactoring on the main module having a prepare method hook has been needed.
- Use Form for populating onchanges: Previous code was not very resilient to possible extra adaptations or require specific code to be added to the old hook `_trigger_so_line_onchanges`. With this, we make sure all onchanges are executed thanks to the odoo.tests.Form class. We lose a bit of performance, but it's better than to have issues with data not correctly synchronized.

cc @Tecnativa TT21495