### PR TITLE
[12.0][FIX] sale_cancel_reason: fix access for salesteam salesman users

### DIFF
--- a/sale_cancel_reason/security/ir.model.access.csv
+++ b/sale_cancel_reason/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_sale_order_cancel_reason_user,access_sale_order_cancel_reason user,model_sale_order_cancel_reason,sales_team.group_sale_manager,1,0,0,0
+access_sale_order_cancel_reason_user,access_sale_order_cancel_reason user,model_sale_order_cancel_reason,sales_team.group_sale_salesman,1,0,0,0
 access_sale_order_cancel_reason_manager,access_sale_order_cancel_reason manager,model_sale_order_cancel_reason,sales_team.group_sale_manager,1,1,1,1


### PR DESCRIPTION
Current behavior before PR:

1.  Salesman user can't cancel sale order.

![sale_order_cancel_reason](https://user-images.githubusercontent.com/226753/83802178-97397e00-a6aa-11ea-88d6-e7443926c8f2.png)

Desired behavior after PR is merged:

- Sales team user with salesman access rights can cancel sales orders without permission errors
