### PR TITLE
[11.0][FIX] sale_stock_delivery_address: do not limit destination address,

### DIFF
--- a/sale_stock_delivery_address/models/sale_order_line.py
+++ b/sale_stock_delivery_address/models/sale_order_line.py
@@ -12,8 +12,6 @@ class SaleOrderLine(models.Model):
         string="Destination Address",
         help="If set this address will be the delivery address instead of the "
              "one specified in the Sales Order header.",
-        domain="['|', ('id', '=', order_partner_id), "
-               "('parent_id', '=', order_partner_id)]",
     )
 
     @api.multi


### PR DESCRIPTION
can be used as a dropshipping mechanism.

I have encountered the problem that @rousseldenis [already anticipated](https://github.com/OCA/sale-workflow/pull/1068#discussion_r380604623) and I thought won't be an issue. "It is wise to rectify" elders say :older_man:

@ForgeFlow