### PR TITLE
[12.0][FIX] sale_stock_delivery_address: do not limit destination address,

### DIFF
--- a/sale_stock_delivery_address/models/sale_order_line.py
+++ b/sale_stock_delivery_address/models/sale_order_line.py
@@ -12,8 +12,6 @@ class SaleOrderLine(models.Model):
         string="Destination Address",
         help="If set this address will be the delivery address instead of the "
              "one specified in the Sales Order header.",
-        domain="['|', ('id', '=', order_partner_id), "
-               "('parent_id', '=', order_partner_id)]",
     )
 
     @api.multi


### PR DESCRIPTION
can be used as a dropshipping mechanism.

Forward port of https://github.com/OCA/sale-workflow/pull/1162.

@ForgeFlow