### PR TITLE
[12.0] Add sale_automatic_workflow_job

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -7,3 +7,4 @@ server-ux
 web
 bank-payment
 stock-logistics-warehouse
+queue

--- a/sale_automatic_workflow/tests/test_automatic_workflow.py
+++ b/sale_automatic_workflow/tests/test_automatic_workflow.py
@@ -11,6 +11,18 @@ from odoo.tests import tagged
 @tagged('post_install', '-at_install')
 class TestAutomaticWorkflow(TestAutomaticWorkflowBase):
 
+    def setUp(self):
+        super().setUp()
+        self.env = self.env(
+            context=dict(
+                self.env.context, tracking_disable=True,
+                # Compatibility with sale_automatic_workflow_job: even if
+                # the module is installed, ensure we don't delay a job.
+                # Thus, we test the usual flow.
+                _job_force_sync=True,
+            )
+        )
+
     def test_full_automatic(self):
         workflow = self.create_full_automatic()
         sale = self.create_sale_order(workflow)

--- a/sale_automatic_workflow/tests/test_multicompany.py
+++ b/sale_automatic_workflow/tests/test_multicompany.py
@@ -8,6 +8,9 @@ from odoo.tests import tagged
 @tagged('post_install', '-at_install')
 class TestMultiCompany(SavepointCase):
 
+    def setUp(self):
+        super().setUp()
+
     @classmethod
     def create_company(cls, values):
         company = cls.env['res.company'].create(values)
@@ -25,7 +28,15 @@ class TestMultiCompany(SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context, tracking_disable=True,
+                # Compatibility with sale_automatic_workflow_job: even if
+                # the module is installed, ensure we don't delay a job.
+                # Thus, we test the usual flow.
+                _job_force_sync=True,
+            )
+        )
         coa = cls.env.user.company_id.chart_template_id
         cls.company_fr = cls.create_company({
             'name': 'French company',

--- a/sale_automatic_workflow_job/__init__.py
+++ b/sale_automatic_workflow_job/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_automatic_workflow_job/__manifest__.py
+++ b/sale_automatic_workflow_job/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Sale Automatic Workflow Job",
+    "summary": "Execute sale automatic workflows in queue jobs",
+    "version": "12.0.1.0.0",
+    "category": "Sales Management",
+    "license": "AGPL-3",
+    "author": "Camptocamp, "
+              "Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/sale-workflow",
+    "depends": [
+        "sale_automatic_workflow",
+        "queue_job",
+    ],
+}

--- a/sale_automatic_workflow_job/models/__init__.py
+++ b/sale_automatic_workflow_job/models/__init__.py
@@ -1,0 +1,1 @@
+from . import automatic_workflow_job

--- a/sale_automatic_workflow_job/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow_job/models/automatic_workflow_job.py
@@ -1,0 +1,150 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import functools
+
+from odoo import _, models
+from odoo.addons.queue_job.job import job, identity_exact
+
+
+# TODO integrate in queue_job
+def job_auto_delay(func=None, default_channel="root", retry_pattern=None):
+    """Decorator to automatically delay as job method when called
+
+    The decorator applies ``odoo.addons.queue_job.job`` at the same time,
+    so the decorated method is listed in job functions. The arguments
+    are the same, propagated to the ``job`` decorator.
+
+    When a method is decorated by ``job_auto_delay``, any call to the method
+    will not directly execute the method's body, but will instead enqueue a
+    job.
+
+    The options of the job usually passed to ``with_delay()`` (priority,
+    description, identity_key, ...) can be returned in a dictionary by a method
+    named after the name of the method suffixed by ``_job_options`` which takes
+    the same parameters as the initial method.
+
+    It is still possible to directly execute the method by setting a key
+    ``_job_force_sync`` to True in the environment context.
+
+    Example:
+
+    .. code-block:: python
+
+        class ProductProduct(models.Model):
+            _inherit = 'product.product'
+
+            def foo_job_options(self, arg1):
+                return {
+                  "priority": 100,
+                  "description": "Saying hello to {}".format(arg1)
+                }
+
+            @job_auto_delay(default_channel="root.channel1")
+            def foo(self, arg1):
+                print("hello", arg1)
+
+            def button_x(self):
+                foo("world")
+
+    The result when ``button_x`` is called, is that a new job for ``foo`` is
+    delayed.
+
+    """
+    if func is None:
+        return functools.partial(
+            job_auto_delay,
+            default_channel=default_channel,
+            retry_pattern=retry_pattern
+        )
+
+    def auto_delay(self, *args, **kwargs):
+        if (self.env.context.get("job_uuid") or
+                self.env.context.get("_job_force_sync")):
+            # we are in the job execution
+            return func(self, *args, **kwargs)
+        else:
+            # replace the synchronous call by a job on itself
+            method_name = func.__name__
+            job_options_method = getattr(
+                self, "{}_job_options".format(method_name), None
+            )
+            job_options = {}
+            if job_options_method:
+                job_options.update(job_options_method(*args, **kwargs))
+            else:
+                job_options = {}
+            delayed = self.with_delay(**job_options)
+            getattr(delayed, method_name)(*args, **kwargs)
+
+    return functools.update_wrapper(
+        auto_delay,
+        job(
+            func,
+            default_channel=default_channel,
+            retry_pattern=retry_pattern
+        ),
+    )
+
+
+class AutomaticWorkflowJob(models.Model):
+    _inherit = "automatic.workflow.job"
+
+    def _do_validate_sale_order_job_options(self, sale):
+        description = _("Validate sales order {}").format(sale.display_name)
+        return {
+            "description": description,
+            "identity_key": identity_exact,
+        }
+
+    @job_auto_delay(default_channel="root.auto_workflow")
+    def _do_validate_sale_order(self, sale):
+        return super()._do_validate_sale_order(sale)
+
+    def _do_create_invoice_job_options(self, sale):
+        description = _(
+            "Create invoices for sales order {}"
+        ).format(sale.display_name)
+        return {
+            "description": description,
+            "identity_key": identity_exact,
+        }
+
+    @job_auto_delay(default_channel="root.auto_workflow")
+    def _do_create_invoice(self, sale):
+        return super()._do_create_invoice(sale)
+
+    def _do_validate_invoice_job_options(self, invoice):
+        description = _("Validate invoice {}").format(invoice.display_name)
+        return {
+            "description": description,
+            "identity_key": identity_exact,
+        }
+
+    @job_auto_delay(default_channel="root.auto_workflow")
+    def _do_validate_invoice(self, invoice):
+        return super()._do_validate_invoice(invoice)
+
+    def _do_validate_picking_job_options(self, picking):
+        description = _("Validate transfer {}").format(picking.display_name)
+        return {
+            "description": description,
+            "identity_key": identity_exact,
+        }
+
+    @job_auto_delay(default_channel="root.auto_workflow")
+    def _do_validate_picking(self, picking):
+        return super()._do_validate_picking(picking)
+
+    def _do_sale_done_job_options(self, sale):
+        description = _(
+            "Mark sales order {} as done"
+        ).format(sale.display_name)
+        return {
+            "description": description,
+            "identity_key": identity_exact,
+        }
+
+    @job_auto_delay(default_channel="root.auto_workflow")
+    def _do_sale_done(self, sale):
+        return super()._do_sale_done(sale)

--- a/sale_automatic_workflow_job/readme/CONTRIBUTORS.rst
+++ b/sale_automatic_workflow_job/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>

--- a/sale_automatic_workflow_job/readme/DESCRIPTION.rst
+++ b/sale_automatic_workflow_job/readme/DESCRIPTION.rst
@@ -1,0 +1,15 @@
+Use Queue Jobs to process the Sales Automatic Workflow actions.
+
+The default behavior of the automatic workflow module is to use a
+scheduled action that searches all the record that need a workflow
+action and sequentially process all of them.
+
+It can hit some limits when the number of records is too high.
+
+This module keeps the scheduled action to search the records, but
+instead of directly executing the actions (confirm a sales order,
+create invoices for a sales order, validate invoices, ...), it
+creates one job per operation to do.
+
+It uses an identity key on the jobs so it will not create the same
+job for the same record and same operation twice.

--- a/sale_automatic_workflow_job/tests/__init__.py
+++ b/sale_automatic_workflow_job/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_auto_workflow_job

--- a/sale_automatic_workflow_job/tests/test_auto_workflow_job.py
+++ b/sale_automatic_workflow_job/tests/test_auto_workflow_job.py
@@ -1,0 +1,107 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests import tagged
+
+from odoo.addons.queue_job.job import identity_exact
+from odoo.addons.queue_job.tests.common import mock_with_delay
+from odoo.addons.sale_automatic_workflow.tests.test_automatic_workflow_base import (  # noqa
+    TestAutomaticWorkflowBase
+)
+
+
+@tagged('post_install', '-at_install')
+class TestAutoWorkflowJob(TestAutomaticWorkflowBase):
+
+    def setUp(self):
+        super().setUp()
+        workflow = self.create_full_automatic()
+        self.sale = self.create_sale_order(workflow)
+
+    def assert_job_delayed(self, delayable_cls, delayable, method_name, args):
+        # .with_delay() has been called once
+        self.assertEqual(delayable_cls.call_count, 1)
+        delay_args, delay_kwargs = delayable_cls.call_args
+        # .with_delay() has been called on self.env["automatic.workflow.job"]
+        self.assertEqual(delay_args, (self.env["automatic.workflow.job"],))
+        # .with_delay() with the following options
+        self.assertEqual(delay_kwargs.get("identity_key"), identity_exact)
+        # check what's passed to the job method
+        method = getattr(delayable, method_name)
+        self.assertEqual(method.call_count, 1)
+        delay_args, delay_kwargs = method.call_args
+        self.assertEqual(delay_args, args)
+        self.assertDictEqual(delay_kwargs, {})
+
+    def test_validate_sale_order(self):
+        with mock_with_delay() as (delayable_cls, delayable):
+            self.progress()  # run automatic workflow cron
+            self.assert_job_delayed(
+                delayable_cls,
+                delayable,
+                "_do_validate_sale_order",
+                (self.sale,)
+            )
+
+    def test_create_invoice(self):
+        self.sale.action_confirm()
+        # don't care about transfers in this test
+        self.sale.picking_ids.state = "done"
+        with mock_with_delay() as (delayable_cls, delayable):
+            self.progress()  # run automatic workflow cron
+            self.assert_job_delayed(
+                delayable_cls,
+                delayable,
+                "_do_create_invoice",
+                (self.sale,)
+            )
+
+    def test_validate_invoice(self):
+        self.sale.action_confirm()
+        # don't care about transfers in this test
+        self.sale.picking_ids.state = "done"
+        self.sale.action_invoice_create()
+        invoice = self.sale.invoice_ids
+        with mock_with_delay() as (delayable_cls, delayable):
+            self.progress()  # run automatic workflow cron
+            self.assert_job_delayed(
+                delayable_cls,
+                delayable,
+                "_do_validate_invoice",
+                (invoice,)
+            )
+
+    def test_validate_picking(self):
+        self.sale.action_confirm()
+        picking = self.sale.picking_ids
+        # disable invoice creation in this test
+        self.sale.workflow_process_id.create_invoice = False
+        with mock_with_delay() as (delayable_cls, delayable):
+            self.progress()  # run automatic workflow cron
+            self.assert_job_delayed(
+                delayable_cls,
+                delayable,
+                "_do_validate_picking",
+                (picking,)
+            )
+
+    def test_sale_done(self):
+        self.sale.action_confirm()
+        # don't care about transfers in this test
+        self.sale.picking_ids.state = "done"
+        self.sale.action_invoice_create()
+
+        # disable invoice validation for we don't care
+        # in this test
+        self.sale.workflow_process_id.validate_invoice = False
+        # activate the 'sale done' workflow
+        self.sale.workflow_process_id.sale_done = True
+
+        with mock_with_delay() as (delayable_cls, delayable):
+            self.progress()  # run automatic workflow cron
+            self.assert_job_delayed(
+                delayable_cls,
+                delayable,
+                "_do_sale_done",
+                (self.sale,)
+            )

--- a/sale_automatic_workflow_payment_mode/tests/test_automatic_workflow_payment_mode.py
+++ b/sale_automatic_workflow_payment_mode/tests/test_automatic_workflow_payment_mode.py
@@ -8,6 +8,18 @@ from odoo.addons.sale_automatic_workflow.tests.test_automatic_workflow_base \
 
 class TestAutomaticWorkflowPaymentMode(TestAutomaticWorkflowBase):
 
+    def setUp(self):
+        super().setUp()
+        self.env = self.env(
+            context=dict(
+                self.env.context, tracking_disable=True,
+                # Compatibility with sale_automatic_workflow_job: even if
+                # the module is installed, ensure we don't delay a job.
+                # Thus, we test the usual flow.
+                _job_force_sync=True,
+            )
+        )
+
     def create_sale_order(self, workflow, override=None):
         new_order = super(TestAutomaticWorkflowPaymentMode, self).\
             create_sale_order(workflow, override)

--- a/setup/sale_automatic_workflow_job/odoo/addons/sale_automatic_workflow_job
+++ b/setup/sale_automatic_workflow_job/odoo/addons/sale_automatic_workflow_job
@@ -1,0 +1,1 @@
+../../../../sale_automatic_workflow_job

--- a/setup/sale_automatic_workflow_job/setup.py
+++ b/setup/sale_automatic_workflow_job/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Use Queue Jobs to process the Sales Automatic Workflow actions.

The default behavior of the automatic workflow module is to use a
scheduled action that searches all the record that need a workflow
action and sequentially process all of them.

It can hit some limits when the number of records is too high.

This module keeps the scheduled action to search the records, but
instead of directly executing the actions (confirm a sales order,
create invoices for a sales order, validate invoices, ...), it
creates one job per operation to do.

It uses an identity key on the jobs so it will not create the same
job for the same record and same operation twice.

~

I needed to extract methods in `sale_automatic_workflow` in order
to be able to execute them as jobs.

A new decorator "job_auto_delay" (to eventually move in queue_job) makes
these methods automatically delayed when called.
