### PR TITLE
[12.0][IMP] sale_order_line_price_history: Add discount to the history + invisible column

### DIFF
--- a/sale_order_line_price_history/README.rst
+++ b/sale_order_line_price_history/README.rst
@@ -52,10 +52,6 @@ To use this module, you need to:
 Known issues / Roadmap
 ======================
 
-* The *Customer* column of the *price history lines* list is not hidden when
-  there is a specific client selected because odoo doesn't allow
-  showing/hiding a column from a *list view* dynamically
-  (based on any condition).
 * The number of entries of prices history in the wizard should be configurable,
   currently it is limited to 20.
 * In the sale order line, the new button with clock icon will not be activated

--- a/sale_order_line_price_history/readme/ROADMAP.rst
+++ b/sale_order_line_price_history/readme/ROADMAP.rst
@@ -1,7 +1,3 @@
-* The *Customer* column of the *price history lines* list is not hidden when
-  there is a specific client selected because odoo doesn't allow
-  showing/hiding a column from a *list view* dynamically
-  (based on any condition).
 * The number of entries of prices history in the wizard should be configurable,
   currently it is limited to 20.
 * In the sale order line, the new button with clock icon will not be activated

--- a/sale_order_line_price_history/static/description/index.html
+++ b/sale_order_line_price_history/static/description/index.html
@@ -403,10 +403,6 @@ click the smart button named <em>Set price</em>.</li>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#id2">Known issues / Roadmap</a></h1>
 <ul class="simple">
-<li>The <em>Customer</em> column of the <em>price history lines</em> list is not hidden when
-there is a specific client selected because odoo doesn’t allow
-showing/hiding a column from a <em>list view</em> dynamically
-(based on any condition).</li>
 <li>The number of entries of prices history in the wizard should be configurable,
 currently it is limited to 20.</li>
 <li>In the sale order line, the new button with clock icon will not be activated

--- a/sale_order_line_price_history/wizards/sale_order_line_price_history.py
+++ b/sale_order_line_price_history/wizards/sale_order_line_price_history.py
@@ -102,6 +102,9 @@ class SaleOrderLinePriceHistoryline(models.TransientModel):
     price_unit = fields.Float(
         related="sale_order_line_id.price_unit",
     )
+    discount = fields.Float(
+        related="sale_order_line_id.discount",
+    )
 
     @api.multi
     def action_set_price(self):

--- a/sale_order_line_price_history/wizards/sale_order_line_price_history.xml
+++ b/sale_order_line_price_history/wizards/sale_order_line_price_history.xml
@@ -39,7 +39,8 @@
                         </form>
                         <tree>
                             <field name="order_id"/>
-                            <field name="partner_id"/>
+                            <field name="partner_id"
+                                   attrs="{'column_invisible': [('parent.partner_id', '!=', False)]}"/>
                             <field name="sale_order_date_order"/>
                             <field name="product_uom_qty"/>
                             <field name="price_unit"/>

--- a/sale_order_line_price_history/wizards/sale_order_line_price_history.xml
+++ b/sale_order_line_price_history/wizards/sale_order_line_price_history.xml
@@ -31,6 +31,10 @@
                                 <field name="sale_order_date_order"/>
                                 <field name="product_uom_qty"/>
                                 <field name="price_unit"/>
+                                <label for="discount" groups="sale.group_discount_per_so_line"/>
+                                <div name="discount" groups="sale.group_discount_per_so_line">
+                                    <field name="discount" class="oe_inline"/> %%
+                                </div>
                             </group>
                         </form>
                         <tree>
@@ -39,6 +43,7 @@
                             <field name="sale_order_date_order"/>
                             <field name="product_uom_qty"/>
                             <field name="price_unit"/>
+                            <field name="discount" groups="sale.group_discount_per_so_line"/>
                         </tree>
                     </field>
                 </group>


### PR DESCRIPTION

Add a new column to list view in the history wizard to show the discount.

cc @Tecnativa TT24303