### PR TITLE
[12.0][FIX] sale_order_generator: Fix view

### DIFF
--- a/sale_generator/views/sale_order_view.xml
+++ b/sale_generator/views/sale_order_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="sale_management.sale_order_form_quote"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='sale_order_template_id']" position="attributes">
-                <attribute name="attrs">{'invisible': [(1, '=', 1)]}</attribute>
+                <attribute name="invisible">1</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Due to https://github.com/OCA/sale-workflow/commit/ea6fceb6aceb6f2c9ee146c09b9e87176e53d0ae commited directly in 12.0 branch.

See error: https://github.com/OCA/sale-workflow/pull/1170#issuecomment-647414530

@pedrobaeza You cannot use that kind of domain in a view.