### PR TITLE
[IMP][sale_order_line_packaging_qty] Sell product / unit or packaging

### DIFF
--- a/sale_order_line_packaging_qty/__manifest__.py
+++ b/sale_order_line_packaging_qty/__manifest__.py
@@ -11,6 +11,10 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": ["sale_stock"],
-    "data": ["views/sale_order.xml"],
+    "depends": ["sale_stock", "product", "product_packaging_type"],
+    "data": [
+        "views/product_packaging_type.xml",
+        "views/product_template.xml",
+        "views/sale_order.xml",
+    ],
 }

--- a/sale_order_line_packaging_qty/models/__init__.py
+++ b/sale_order_line_packaging_qty/models/__init__.py
@@ -1,1 +1,4 @@
+from . import product_packaging_type
+from . import product_template
+from . import product_product
 from . import sale_order_line

--- a/sale_order_line_packaging_qty/models/product_packaging_type.py
+++ b/sale_order_line_packaging_qty/models/product_packaging_type.py
@@ -1,0 +1,9 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ProductPackagingType(models.Model):
+    _inherit = "product.packaging.type"
+
+    can_be_sold = fields.Boolean(string="Can be sold", default=True,)

--- a/sale_order_line_packaging_qty/models/product_product.py
+++ b/sale_order_line_packaging_qty/models/product_product.py
@@ -1,0 +1,21 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _which_pack_multiple(self, qty):
+        """ Return multiple of product packaging for one quantity if exist.
+        """
+        self.ensure_one()
+        pack_multiple = False
+        if qty:
+            for pack in self.packaging_ids.sorted("qty", reverse=True):
+                if pack.packaging_type_id.can_be_sold and pack.qty:
+                    if (qty % pack.qty) == 0:
+                        pack_multiple = pack
+                        break
+        return pack_multiple

--- a/sale_order_line_packaging_qty/models/product_template.py
+++ b/sale_order_line_packaging_qty/models/product_template.py
@@ -1,0 +1,11 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    sell_only_by_packaging = fields.Boolean(
+        string="Only sell by packaging", default=False,
+    )

--- a/sale_order_line_packaging_qty/models/sale_order_line.py
+++ b/sale_order_line_packaging_qty/models/sale_order_line.py
@@ -37,6 +37,7 @@ class SaleOrderLine(models.Model):
             sol.product_packaging_qty = product_qty / sol.product_packaging.qty
 
     def _prepare_product_packaging_qty_values(self):
+        self.ensure_one()
         return {
             "product_uom_qty": self.product_packaging.qty * self.product_packaging_qty,
             "product_uom": self.product_packaging.product_uom_id.id,
@@ -86,5 +87,60 @@ class SaleOrderLine(models.Model):
         # TODO Drop once https://github.com/odoo/odoo/pull/49150/ is merged
         res = super()._onchange_product_uom_qty()
         if not res:
-            res = self._check_package()
+            res = self._check_package() or self._check_qty_is_pack_multiple()
         return res
+
+    @api.onchange("product_id")
+    def product_id_change(self):
+        res = super().product_id_change()
+        if self.product_id.sell_only_by_packaging:
+            self.product_uom_qty = min(self.product_id.packaging_ids.mapped("qty"))
+        return res
+
+    def _check_qty_is_pack_multiple(self):
+        """ Check only for product with sell_only_by_packaging
+        """
+        # and we dont want to have this warning when we had the product
+        if self.product_id.sell_only_by_packaging:
+            if not self._is_pack_multiple():
+                warning_msg = {
+                    "title": _("Product quantity can not be packed"),
+                    "message": _(
+                        "For the product {prod}\n"
+                        "The {qty} is not the multiple of any pack.\n"
+                        "Please add a package"
+                    ).format(prod=self.product_id.name, qty=self.product_uom_qty),
+                }
+                return {"warning": warning_msg}
+        return {}
+
+    def _is_pack_multiple(self):
+        return bool(self.product_id._which_pack_multiple(self.product_uom_qty))
+
+    def write(self, vals):
+        # Fill the packaging if they are empty and the quantity is a multiple
+        for line in self:
+            product_uom_qty = vals.get("product_uom_qty")
+            product_packaging = vals.get("product_packaging")
+            if line.product_id.sell_only_by_packaging and (
+                not line.product_packaging
+                or ("product_packaging" in vals and not product_packaging)
+            ):
+                pack_multiple = line.product_id._which_pack_multiple(product_uom_qty)
+                if pack_multiple:
+                    vals.update({"product_packaging": pack_multiple.id})
+        return super().write(vals)
+
+    @api.model
+    def create(self, vals):
+
+        # Fill the packaging if they are empty and the quantity is a multiple
+        product = self.env["product.product"].browse(vals.get("product_id"))
+        product_uom_qty = vals.get("product_uom_qty")
+        product_packaging = vals.get("product_packaging")
+
+        if product and product.sell_only_by_packaging and not product_packaging:
+            pack_multiple = product._which_pack_multiple(product_uom_qty)
+            if pack_multiple:
+                vals.update({"product_packaging": pack_multiple.id})
+        return super().create(vals)

--- a/sale_order_line_packaging_qty/tests/test_sale_order_line_packaging_qty.py
+++ b/sale_order_line_packaging_qty/tests/test_sale_order_line_packaging_qty.py
@@ -30,3 +30,98 @@ class TestSaleOrderLinePackagingQty(SavepointCase):
         self.assertEqual(order_line.product_packaging_qty, 1.0)
         order_line.write({"product_packaging_qty": 3.0})
         self.assertEqual(order_line.product_uom_qty, 15.0)
+
+    def test_onchange_qty_is_pack_multiple(self):
+        order = self.env["sale.order"].create({"partner_id": self.partner.id})
+        order_line = self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.product.id,
+                "product_uom": self.product.uom_id.id,
+            }
+        )
+        self.assertFalse(order_line._onchange_product_uom_qty())
+
+        self.product.write({"sell_only_by_packaging": True})
+        self.assertTrue(order_line._onchange_product_uom_qty())
+
+        order_line.product_id_change()
+        self.assertFalse(order_line._onchange_product_uom_qty())
+
+        order_line.write({"product_uom_qty": 3.0})
+        self.assertTrue(order_line._onchange_product_uom_qty())
+
+        order_line.write({"product_uom_qty": self.packaging.qty * 2})
+        self.assertFalse(order_line._onchange_product_uom_qty())
+
+    def test_write_auto_fill_packaging(self):
+        order = self.env["sale.order"].create({"partner_id": self.partner.id})
+        order_line = self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.product.id,
+                "product_uom": self.product.uom_id.id,
+            }
+        )
+        self.assertFalse(order_line.product_packaging)
+        self.assertFalse(order_line.product_packaging_qty)
+
+        order_line.write({"product_uom_qty": 3.0})
+        self.assertFalse(order_line.product_packaging)
+        self.assertFalse(order_line.product_packaging_qty)
+
+        self.product.write({"sell_only_by_packaging": True})
+        self.assertFalse(order_line.product_packaging)
+        self.assertFalse(order_line.product_packaging_qty)
+
+        order_line.write({"product_uom_qty": self.packaging.qty * 2})
+        self.assertTrue(order_line.product_packaging)
+        self.assertTrue(order_line.product_packaging_qty)
+        self.assertEqual(order_line.product_packaging.name, "Test packaging")
+        self.assertEqual(order_line.product_packaging_qty, 2)
+
+        packaging_10 = self.env["product.packaging"].create(
+            {"name": "Test packaging 10", "product_id": self.product.id, "qty": 15.0}
+        )
+        order_line.write({"product_packaging": False})
+        order_line.write({"product_uom_qty": packaging_10.qty * 2})
+        self.assertEqual(order_line.product_packaging.name, "Test packaging 10")
+
+    def test_create_auto_fill_packaging(self):
+        order = self.env["sale.order"].create({"partner_id": self.partner.id})
+        # sell_only_by_packaging is default False
+        order_line_1 = self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.product.id,
+                "product_uom": self.product.uom_id.id,
+                "product_uom_qty": self.packaging.qty * 2,
+            }
+        )
+        self.assertFalse(order_line_1.product_packaging)
+        self.assertFalse(order_line_1.product_packaging_qty)
+
+        self.product.write({"sell_only_by_packaging": True})
+        order_line_1 = self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.product.id,
+                "product_uom": self.product.uom_id.id,
+                "product_uom_qty": self.packaging.qty * 2,
+            }
+        )
+        self.assertTrue(order_line_1.product_packaging)
+        self.assertTrue(order_line_1.product_packaging_qty)
+        self.assertEqual(order_line_1.product_packaging.name, "Test packaging")
+        self.assertEqual(order_line_1.product_packaging_qty, 2)
+
+        order_line_2 = self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.product.id,
+                "product_uom": self.product.uom_id.id,
+                "product_uom_qty": 2,
+            }
+        )
+        self.assertFalse(order_line_2.product_packaging)
+        self.assertFalse(order_line_2.product_packaging_qty)

--- a/sale_order_line_packaging_qty/views/product_packaging_type.xml
+++ b/sale_order_line_packaging_qty/views/product_packaging_type.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2020 Camptocamp License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="view_product_packaging_type_form" model="ir.ui.view">
+        <field name="model">product.packaging.type</field>
+        <field
+            name="inherit_id"
+            ref="product_packaging_type.view_product_packaging_type_form"
+        />
+        <field name="arch" type="xml">
+            <field name="code" position="after">
+                <field name="can_be_sold" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/sale_order_line_packaging_qty/views/product_template.xml
+++ b/sale_order_line_packaging_qty/views/product_template.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2020 Camptocamp License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.form.view</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <div name="options" position="inside">
+                <div>
+                    <field name="sell_only_by_packaging" />
+                    <label for="sell_only_by_packaging" />
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
**Context:**

We want to be able to only sell by packaging some product (forbidden to
 sell by unit). Also, we want to choose which packaging is eligible to
 sell.

**Usage**

When I encode a sale order line, I must fill up the packaging and
related quantity if the product is set as "Only sell by packaging".
I cannot enter a quantity in the standard Odoo field quantity that
is not a multiple of a sellable packaging
(product.packaging can be sold = True).

Is the product is not configured as "Only sell by packaging",
then I am allowed to fill up a line with no packaging.

On every packaging I can chose if it is sellable or not. By default it is.

I can chose at product level if i restrict the quantity to sell
to existing sellable packaging.

**Dev**

* Add a check box in product "Only sell by packaging multiple" (default False), aside of "Can be sold" in the header
* Add a boolean on the packaging "Can be sold" (default True)
* On the list of available packaging in a SO line, only display packaging with "can be sold = True"
* When a SO line is encoded *with a product that can only be sold by packaging*:
    * The quantity field cannot contain a quantity that is not a multiple of a sellable packaging (can be sold = True) -> raise a warning (triggered on the on_change please, not create/write as we still want to be able to save it e.g. in case of an EDI order) -> "The quantity is not a multiple of a defined sellable packaging. Please complete the packaging first."
    * On create / write method, *if packaging and packaging quantity is empty*, fulfill the info if a multiple of an existing sellable packaging (can be sold = True) is found
        * e.g. if my product is sold by packaging only and I have packaging of box: 10, Karton: 200, and pallet:1000, if the quantity entered is 400, I expect the system to complete the packaging with Karton and packaging quantity with 2
        * e.g. if my product is sold by packaging only and I have packaging of box: 10, Karton: 200, and pallet:1000, if the quantity entered is 420, I expect the system to complete the packaging with box and packaging quantity with 42
        * e.g.. if my product is sold by packaging only and I have packaging of box: 10, Karton: 200, and pallet:1000, if the quantity entered is 405, I expect the system to leave it empty
    * Make the message "You must define a package before setting a quantity of said package." a user warning and not a blocking point AND only raise this warning for product that have "Only sell by packaging multiple = True"


-----


![OCA 2020-06-25 08-40](https://user-images.githubusercontent.com/32262135/85669657-5be60a00-b6c0-11ea-9ffe-5d8dc1046ede.gif)
