### PR TITLE
[FIX][sale_order_line_packaging_qty] Prevent product.packaging without quantity case

### DIFF
--- a/sale_order_line_packaging_qty/models/sale_order_line.py
+++ b/sale_order_line_packaging_qty/models/sale_order_line.py
@@ -94,7 +94,9 @@ class SaleOrderLine(models.Model):
     def product_id_change(self):
         res = super().product_id_change()
         if self.product_id.sell_only_by_packaging:
-            self.product_uom_qty = min(self.product_id.packaging_ids.mapped("qty"))
+            quantites = self.product_id.packaging_ids.mapped("qty")
+            if quantites:
+                self.product_uom_qty = min(quantites)
         return res
 
     def _check_qty_is_pack_multiple(self):


### PR DESCRIPTION
Issue to fix by this PR

* Flag a product as "Only sell by packaging"
* Ensure there is no defined packaging for this product
* Create a SO and add a line you have a crash

```python
File "/odoo/external-src/sale-workflow/sale_order_line_packaging_qty/models/sale_order_line.py", line 97, in product_id_change
self.product_uom_qty = min(self.product_id.packaging_ids.mapped("qty"))
ValueError: min() arg is an empty sequence
```