### PR TITLE
[11.0][FIX] sale_global_discount: Constraint tax lines combinations

### DIFF
--- a/sale_global_discount/README.rst
+++ b/sale_global_discount/README.rst
@@ -64,6 +64,13 @@ To use this module, you need to:
 #. When you create an invoice from the order, the proper global discounts will
    be applied on it.
 
+Known issues / Roadmap
+======================
+
+* Not all the taxes combination can be compatible with global discounts. An
+  error is raised in that cases.
+* Currently, taxes in invoice lines are mandatory with global discounts.
+
 Bug Tracker
 ===========
 

--- a/sale_global_discount/readme/ROADMAP.rst
+++ b/sale_global_discount/readme/ROADMAP.rst
@@ -1,0 +1,3 @@
+* Not all the taxes combination can be compatible with global discounts. An
+  error is raised in that cases.
+* Currently, taxes in invoice lines are mandatory with global discounts.

--- a/sale_global_discount/static/description/index.html
+++ b/sale_global_discount/static/description/index.html
@@ -375,11 +375,12 @@ and accounting.</p>
 <ul class="simple">
 <li><a class="reference internal" href="#configuration" id="id1">Configuration</a></li>
 <li><a class="reference internal" href="#usage" id="id2">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id3">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -415,8 +416,16 @@ the order by default.</li>
 be applied on it.</li>
 </ol>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id3">Known issues / Roadmap</a></h1>
+<ul class="simple">
+<li>Not all the taxes combination can be compatible with global discounts. An
+error is raised in that cases.</li>
+<li>Currently, taxes in invoice lines are mandatory with global discounts.</li>
+</ul>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/sale-workflow/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -424,15 +433,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id4">Credits</a></h1>
+<h1><a class="toc-backref" href="#id5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id5">Authors</a></h2>
+<h2><a class="toc-backref" href="#id6">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id7">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a><ul>
 <li>David Vidal</li>
@@ -441,7 +450,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose


### PR DESCRIPTION
Not all taxes combinations are possible with global discounts when they are later invoiced and posted, so we need to constraint them early.

OCA/account-invoicing#745 addresses the problem at invoice level, posting correctly taxes for supported cases, and constraining the rest.

We apply here the same constraints at sales order level. Existing tests have been changed because they were using one of the forbidden taxes combination, and 2 new tests have been added for covering the new constraints.

@Tecnativa TT24526