### PR TITLE
[13.0][IMP][sale_order_type] Sale Order Type: Fix view and readonly

### DIFF
--- a/sale_order_type/models/account_move.py
+++ b/sale_order_type/models/account_move.py
@@ -11,8 +11,9 @@ class AccountMove(models.Model):
         comodel_name="sale.order.type",
         string="Sale Type",
         compute="_compute_sale_type_id",
-        readonly=False,
         store=True,
+        readonly=True,
+        states={"draft": [("readonly", False)]},
     )
 
     @api.depends("partner_id", "company_id")

--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -11,8 +11,9 @@ class SaleOrder(models.Model):
         comodel_name="sale.order.type",
         string="Type",
         compute="_compute_sale_type_id",
-        readonly=False,
         store=True,
+        readonly=True,
+        states={"draft": [("readonly", False)], "sent": [("readonly", False)]},
     )
 
     @api.depends("partner_id", "company_id")

--- a/sale_order_type/views/account_move_views.xml
+++ b/sale_order_type/views/account_move_views.xml
@@ -4,8 +4,11 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form" />
         <field name="arch" type="xml">
-            <field name="invoice_payment_term_id" position="after">
-                <field name="sale_type_id" />
+            <field name="journal_id" position="before">
+                <field
+                    name="sale_type_id"
+                    attrs="{'invisible': [('type', 'not in', ['in_invoice', 'in_refund', 'out_invoice', 'out_refund'])]}"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Hello,

This PR addresses two topics:

### 1. Fixes the sale_type_id field in account.move (Invoice) form view.

Before:
![befoer](https://user-images.githubusercontent.com/1914185/87161553-fc454c80-c2c4-11ea-8278-7cc32562d4e4.png)

After:
![image](https://user-images.githubusercontent.com/1914185/87161589-08c9a500-c2c5-11ea-99c3-08d81deaf4e3.png)

It also makes sure the field is only shown on actual invoices, and not on other account.moves

------

### 2. Makes the sale_type_id field in both sale.order and account.move models readonly depending on the state, to be consistent with Odoo workflows.

Before, it was possible to change the sale_type_id in Invoices that where already posted, for instance. 

That's undesireable because the sale.order.type may try to change the journal, for instance.