### PR TITLE
[13.0][FIX] sale_stock_delivery_address: do not remove procurements not comming from a SO

### DIFF
--- a/sale_stock_delivery_address/models/procurement_group.py
+++ b/sale_stock_delivery_address/models/procurement_group.py
@@ -34,4 +34,6 @@ class ProcurementGroup(models.Model):
                         procurement.values,
                     )
                 )
+            else:
+                new_procs.append(procurement)
         return super(ProcurementGroup, self).run(new_procs)


### PR DESCRIPTION
For instance, MTO procurement chains are stopped due to this.

@ForgeFlow