### PR TITLE
[13.0] sale_by_packaging: Fix constrains using dotted path

### DIFF
--- a/sale_by_packaging/models/product_packaging_type.py
+++ b/sale_by_packaging/models/product_packaging_type.py
@@ -1,10 +1,31 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import _, api, exceptions, fields, models
 
 
 class ProductPackagingType(models.Model):
     _inherit = "product.packaging.type"
 
-    can_be_sold = fields.Boolean(string="Can be sold", default=True,)
+    can_be_sold = fields.Boolean(string="Can be sold", default=True)
+    packaging_ids = fields.One2many(
+        comodel_name="product.packaging", inverse_name="packaging_type_id"
+    )
+
+    @api.constrains("can_be_sold")
+    def _check_sell_only_by_packaging_can_be_sold_packaging_ids(self):
+        for record in self:
+            if record.can_be_sold:
+                continue
+            products = record.packaging_ids.product_id
+            templates = products.product_tmpl_id
+            try:
+                templates._check_sell_only_by_packaging_can_be_sold_packaging_ids()
+            except exceptions.ValidationError:
+                raise exceptions.ValidationError(
+                    _(
+                        'Packaging type "{}" must stay with "Can be sold",'
+                        ' at least one product configured as "sell only'
+                        ' by packaging" is using it.'
+                    ).format(record.display_name)
+                )

--- a/sale_by_packaging/models/product_template.py
+++ b/sale_by_packaging/models/product_template.py
@@ -27,18 +27,6 @@ class ProductTemplate(models.Model):
                 )
 
     @api.constrains("sell_only_by_packaging", "packaging_ids")
-    def _check_sell_only_by_packaging_packaging_ids(self):
-        for product in self:
-            if product.sell_only_by_packaging and not product.packaging_ids:
-                raise ValidationError(
-                    _(
-                        "Product %s cannot be defined to be sold only by "
-                        "packaging if it does not have any packaging defined."
-                    )
-                    % product.name
-                )
-
-    @api.constrains("sell_only_by_packaging", "packaging_ids")
     def _check_sell_only_by_packaging_can_be_sold_packaging_ids(self):
         for product in self:
             if product.sell_only_by_packaging and not any(

--- a/sale_by_packaging/models/product_template.py
+++ b/sale_by_packaging/models/product_template.py
@@ -38,9 +38,7 @@ class ProductTemplate(models.Model):
                     % product.name
                 )
 
-    @api.constrains(
-        "sell_only_by_packaging", "packaging_ids", "packaging_ids.can_be_sold"
-    )
+    @api.constrains("sell_only_by_packaging", "packaging_ids")
     def _check_sell_only_by_packaging_can_be_sold_packaging_ids(self):
         for product in self:
             if product.sell_only_by_packaging and not any(


### PR DESCRIPTION
Following warning is shown at runtime:

WARNING odoodb_test odoo.models: method product.template._check_sell_only_by_packaging_can_be_sold_packaging_ids: @constrains parameter 'packaging_ids.can_be_sold' is not a field name

Only fields of the current model can be used in a constrains.