### PR TITLE
[12.0][IMP] sale_order_type: add route field, optimize views, readonly confirmed order

### DIFF
--- a/sale_order_type/models/__init__.py
+++ b/sale_order_type/models/__init__.py
@@ -2,5 +2,6 @@
 
 from . import sale_order_type
 from . import sale_order
+from . import sale_order_line
 from . import res_partner
 from . import account_invoice

--- a/sale_order_type/models/account_invoice.py
+++ b/sale_order_type/models/account_invoice.py
@@ -11,7 +11,11 @@ class AccountInvoice(models.Model):
 
     sale_type_id = fields.Many2one(
         comodel_name='sale.order.type',
-        string='Sale Type', default=_get_order_type)
+        string='Sale Type',
+        default=_get_order_type,
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+    )
 
     @api.onchange('partner_id', 'company_id')
     def _onchange_partner_id(self):

--- a/sale_order_type/models/sale_order_line.py
+++ b/sale_order_type/models/sale_order_line.py
@@ -1,0 +1,14 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    @api.onchange("product_id")
+    def product_id_change(self):
+        res = super(SaleOrderLine, self).product_id_change()
+        if self.order_id.type_id.route_id:
+            self.update({"route_id": self.order_id.type_id.route_id})
+        return res

--- a/sale_order_type/models/sale_order_type.py
+++ b/sale_order_type/models/sale_order_type.py
@@ -40,3 +40,10 @@ class SaleOrderTypology(models.Model):
     payment_term_id = fields.Many2one('account.payment.term', 'Payment Term')
     pricelist_id = fields.Many2one('product.pricelist', 'Pricelist')
     incoterm_id = fields.Many2one('account.incoterms', 'Incoterm')
+    route_id = fields.Many2one(
+        "stock.location.route",
+        string="Route",
+        domain=[("sale_selectable", "=", True)],
+        ondelete="restrict",
+        check_company=True,
+    )

--- a/sale_order_type/readme/DESCRIPTION.rst
+++ b/sale_order_type/readme/DESCRIPTION.rst
@@ -1,7 +1,7 @@
 This module adds a typology for the sales orders. In each different type, you
-can define, invoicing and refunding journal, a warehouse, a sequence,
-the shipping policy, the invoicing policy, a payment term, a pricelist
-and an incoterm.
+can define, invoicing and refunding journal, a warehouse, a stock route,
+a sequence, the shipping policy, the invoicing policy, a payment term,
+a pricelist and an incoterm.
 
 You can see sale types as lines of business.
 

--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -43,6 +43,41 @@ class TestSaleOrderType(common.TransactionCase):
             'incoterm_id': self.free_carrier.id,
         })
         self.partner.sale_type = self.sale_type
+        self.sale_route = self.env["stock.location.route"].create(
+            {
+                "name": "SO -> Customer",
+                "product_selectable": True,
+                "sale_selectable": True,
+                "rule_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "SO -> Customer",
+                            "action": "pull",
+                            "picking_type_id": self.ref("stock.picking_type_in"),
+                            "location_src_id": self.ref(
+                                "stock.stock_location_components"
+                            ),
+                            "location_id": self.ref("stock.stock_location_customers"),
+                        },
+                    )
+                ],
+            }
+        )
+        self.sale_type_route = self.sale_type_model.create(
+            {
+                "name": "Test Sale Order Type-1",
+                "sequence_id": self.sequence.id,
+                "journal_id": self.journal.id,
+                "warehouse_id": self.warehouse.id,
+                "picking_policy": "one",
+                "payment_term_id": self.immediate_payment.id,
+                "pricelist_id": self.sale_pricelist.id,
+                "incoterm_id": self.free_carrier.id,
+                "route_id": self.sale_route.id,
+            }
+        )
 
     def get_sale_order_vals(self):
         sale_line_dict = {
@@ -98,6 +133,21 @@ class TestSaleOrderType(common.TransactionCase):
         })
         invoice._onchange_partner_id()
         self.assertEqual(invoice.sale_type_id, self.sale_type)
+
+    def test_sale_order_flow_route(self):
+        order = self.sale_order_model.create(self.get_sale_order_vals())
+        order.type_id = self.sale_type_route.id
+        order.onchange_type_id()
+        self.assertEqual(order.type_id.route_id, order.order_line[0].route_id)
+        sale_line_dict = {
+            "product_id": self.product.id,
+            "name": self.product.name,
+            "product_uom_qty": 2.0,
+            "price_unit": self.product.lst_price,
+        }
+        order.write({"order_line": [(0, 0, sale_line_dict)]})
+        order.onchange_type_id()
+        self.assertEqual(order.type_id.route_id, order.order_line[1].route_id)
 
     def test_prepare_invoice(self):
         sale_type = self.sale_type

--- a/sale_order_type/views/res_partner_view.xml
+++ b/sale_order_type/views/res_partner_view.xml
@@ -5,12 +5,9 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
-            <page name="sales_purchases" position="inside">
-                <group colspan="2" col="2" attrs="{'invisible':[('customer', '=', False)]}">
-                    <separator string="Sales Order Type" colspan="2"/>
-                    <field name="sale_type"/>
-                </group>
-            </page>
+            <group name="sale" position="inside">
+                <field name="sale_type" />
+            </group>
         </field>
     </record>
 </odoo>

--- a/sale_order_type/views/sale_order_type_view.xml
+++ b/sale_order_type/views/sale_order_type_view.xml
@@ -16,16 +16,24 @@
                     </group>
                     <group>
                         <group>
-                            <field name="warehouse_id" />
-                            <field name="company_id" attrs="{'invisible': [('warehouse_id', '=', False)]}"/>
+                            <field name="warehouse_id"
+                                  groups="stock.group_stock_multi_warehouses"/>
+                            <field name="company_id"
+                                  attrs="{'invisible': [('warehouse_id', '=', False)]}"
+                                  groups="base.group_multi_company"/>
+                            <field name="route_id"
+                                  attrs="{'invisible': [('warehouse_id', '=', False)]}"
+                                  groups="stock.group_adv_location"/>
                             <field name="sequence_id" />
                         </group>
                         <group>
                             <field name="journal_id" />
                             <field name="picking_policy" />
                             <field name="payment_term_id" />
-                            <field name="pricelist_id" />
-                            <field name="incoterm_id" />
+                            <field name="pricelist_id"
+                                  groups="product.group_product_pricelist,product.group_sale_pricelist" />
+                            <field name="incoterm_id"
+                                  groups="sale_stock.group_display_incoterm"/>
                         </group>
                     </group>
                     <group>
@@ -40,12 +48,17 @@
         <field name="name">sale.order.type.tree.view</field>
         <field name="model">sale.order.type</field>
         <field name="arch" type="xml">
-            <tree string="Type">
+            <tree>
                 <field name="name"/>
-                <field name="warehouse_id"/>
+                <field name="warehouse_id"
+                      groups="stock.group_stock_multi_warehouses"/>
                 <field name="sequence_id"/>
                 <field name="journal_id"/>
                 <field name="picking_policy" />
+                <field name="payment_term_id" />
+                <field name="pricelist_id" groups="product.group_product_pricelist,product.group_sale_pricelist" />
+                <field name="incoterm_id" groups="sale_stock.group_display_incoterm" />
+                <field name="company_id" groups="base.group_multi_company" />
                 <field name="description" />
             </tree>
         </field>
@@ -57,16 +70,19 @@
         <field name="arch" type="xml">
             <search string="Type">
                 <field name="name"/>
-                <field name="warehouse_id"/>
+                <field name="warehouse_id"
+                      groups="stock.group_stock_multi_warehouses"/>
                 <field name="sequence_id"/>
                 <field name="journal_id"/>
                 <field name="picking_policy" />
                 <field name="payment_term_id" />
-                <field name="pricelist_id" />
-                <field name="incoterm_id" />
+                <field name="pricelist_id" groups="product.group_product_pricelist,product.group_sale_pricelist" />
+                <field name="incoterm_id" groups="sale_stock.group_display_incoterm" />
+                <field name="company_id" groups="base.group_multi_company" />
                 <group expand="0" string="Group By">
                     <filter name="warehouse" string="Warehouse" domain="[]"
-                            context="{'group_by':'warehouse_id'}" />
+                            context="{'group_by':'warehouse_id'}"
+                            groups="stock.group_stock_multi_warehouses" />
                     <filter name="entry_sequence" string="Entry Sequence" domain="[]"
                             context="{'group_by':'sequence_id'}" />
                     <filter name="billing_journal" string="Billing Journal" domain="[]"
@@ -76,9 +92,11 @@
                     <filter name="payment_term" string="Payment Term" domain="[]"
                             context="{'group_by':'payment_term_id'}" />
                     <filter name="price_list" string="Price List" domain="[]"
-                            context="{'group_by':'pricelist_id'}" />
+                            context="{'group_by':'pricelist_id'}"
+                            groups="product.group_product_pricelist,product.group_sale_pricelist" />
                     <filter name="incoterm" string="Incoterm" domain="[]"
-                            context="{'group_by':'incoterm_id'}" />
+                            context="{'group_by':'incoterm_id'}"
+                            groups="sale_stock.group_display_incoterm" />
                 </group>
             </search>
         </field>

--- a/sale_order_type/views/sale_order_view.xml
+++ b/sale_order_type/views/sale_order_view.xml
@@ -10,4 +10,17 @@
             </field>
         </field>
     </record>
+
+    <record id="view_sales_order_filter" model="ir.ui.view">
+        <field name="name">sale.order.type.order.search</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_sales_order_filter"/>
+        <field name="arch" type="xml">
+            <filter name="salesperson" position="before">
+                <filter name="sale_order_type_groupby"
+                    string="Sale Order Type"
+                    context="{'group_by': 'type_id'}"/>
+            </filter>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Taking up from V13 pr #1190 and 3 commits before

- [x] Added route field in sale type
- [x] Move sale_order_type to Sales group
- [x] Add missing fields in view and use groups to hide unnecessary features (adding missing group product.group_sale_pricelist)
- [x] Do not allow to edit sale_order_type on confirmed records


further improvement:

- [x] add group filter for sale_order_type 