### PR TITLE
[FIX] 11.0 Sale Fixed Discount

### DIFF
--- a/sale_fixed_discount/models/sale_order.py
+++ b/sale_fixed_discount/models/sale_order.py
@@ -38,16 +38,68 @@ class SaleOrderLine(models.Model):
         help="Fixed amount discount.")
 
     @api.onchange('discount')
-    def _onchange_discount(self):
-        res = super(SaleOrderLine, self)._onchange_discount()
+    def _onchange_discount2(self):
         if self.discount:
             self.discount_fixed = 0.0
-        return res
 
     @api.onchange('discount_fixed')
     def _onchange_discount_fixed(self):
         if self.discount_fixed:
             self.discount = 0.0
+
+    @api.onchange('product_id', 'price_unit', 'product_uom', 'product_uom_qty',
+                  'tax_id')
+    def _onchange_discount(self):
+        res = super(SaleOrderLine, self)._onchange_discount()
+
+        if not (self.product_id and self.product_uom and
+                self.order_id.partner_id and self.order_id.pricelist_id and
+                self.order_id.pricelist_id.discount_policy == 'without_discount' and
+                self.env.user.has_group('sale.group_discount_per_so_line')):
+            return res
+
+        product = self.product_id.with_context(
+            lang=self.order_id.partner_id.lang,
+            partner=self.order_id.partner_id.id,
+            quantity=self.product_uom_qty,
+            date=self.order_id.date_order,
+            pricelist=self.order_id.pricelist_id.id,
+            uom=self.product_uom.id,
+            fiscal_position=self.env.context.get('fiscal_position')
+        )
+        product_context = dict(self.env.context,
+                               partner_id=self.order_id.partner_id.id,
+                               date=self.order_id.date_order,
+                               uom=self.product_uom.id)
+
+        price, rule_id = self.order_id \
+            .pricelist_id \
+            .with_context(product_context) \
+            .get_product_price_rule(self.product_id,
+                                    self.product_uom_qty or 1.0,
+                                    self.order_id.partner_id)
+
+        rule = self.env['product.pricelist.item'].browse(rule_id)
+        if rule.compute_price == 'fixed':
+            new_list_price, currency_id = self.with_context(
+                product_context
+            )._get_real_price_currency(product,
+                                       rule_id, self.product_uom_qty,
+                                       self.product_uom,
+                                       self.order_id.pricelist_id.id)
+            if new_list_price != 0:
+                if self.order_id.pricelist_id.currency_id.id != currency_id:
+                    # we need new_list_price in the same currency as price,
+                    # which is in the SO's pricelist's currency
+                    new_list_price = self.env['res.currency'].browse(
+                        currency_id
+                    ).with_context(product_context).compute(
+                        new_list_price, self.order_id.pricelist_id.currency_id)
+                discount = new_list_price - price
+                if discount > 0:
+                    self.discount_fixed = discount
+                    self.discount = 0.0
+        return res
 
     @api.constrains('discount', 'discount_fixed')
     def _check_only_one_discount(self):

--- a/sale_fixed_discount/models/sale_order.py
+++ b/sale_fixed_discount/models/sale_order.py
@@ -38,7 +38,7 @@ class SaleOrderLine(models.Model):
         help="Fixed amount discount.")
 
     @api.onchange('discount')
-    def _onchange_discount2(self):
+    def _onchange_discount_percent(self):
         if self.discount:
             self.discount_fixed = 0.0
 

--- a/sale_fixed_discount/models/sale_order.py
+++ b/sale_fixed_discount/models/sale_order.py
@@ -97,8 +97,8 @@ class SaleOrderLine(models.Model):
                         new_list_price, self.order_id.pricelist_id.currency_id)
                 discount = new_list_price - price
                 if discount > 0:
-                    self.discount_fixed = discount
                     self.discount = 0.0
+                    self.discount_fixed = discount
         return res
 
     @api.constrains('discount', 'discount_fixed')

--- a/sale_fixed_discount/tests/test_sale_fixed_discount.py
+++ b/sale_fixed_discount/tests/test_sale_fixed_discount.py
@@ -47,7 +47,7 @@ class TestSaleFixedDiscount(SavepointCase):
         self.sale_line1._onchange_discount_fixed()
         self.sale_line1.discount_fixed = 0.0
         self.sale_line1.discount = 50.0
-        self.sale_line1._onchange_discount()
+        self.sale_line1._onchange_discount_percent()
         self.assertEqual(self.sale.amount_total, 115.00)
 
     def test_02_discounts_multiple_lines(self):

--- a/sale_fixed_discount/tests/test_sale_fixed_discount.py
+++ b/sale_fixed_discount/tests/test_sale_fixed_discount.py
@@ -81,6 +81,10 @@ class TestSaleFixedDiscount(SavepointCase):
 
     def test_03_discounts_rule_fixed(self):
         """ Tests fixed pricelist item discount."""
+        discount_group = self.env.ref('sale.group_discount_per_so_line')
+        self.env.user.write({
+            'groups_id': [(4, discount_group.id, False)]
+        })
         self.sale.pricelist_id = self.pricelist
         self.product.list_price = 200
         self.sale_line1._onchange_discount()

--- a/sale_fixed_discount/tests/test_sale_fixed_discount.py
+++ b/sale_fixed_discount/tests/test_sale_fixed_discount.py
@@ -34,6 +34,16 @@ class TestSaleFixedDiscount(SavepointCase):
             'product_id': cls.product.id,
             'tax_id': [(6, 0, [cls.tax.id])],
         })
+        cls.pricelist = cls.env['product.pricelist'].create({
+            'name': 'Test Pricelist',
+            'discount_policy': 'without_discount',
+        })
+        cls.pricelist.item_ids[0].write({
+            'pricelist_id': cls .pricelist.id,
+            'applied_on': '3_global',
+            'compute_price': 'fixed',
+            'fixed_price': 100.00,
+        })
 
     def test_01_discounts(self):
         """ Tests multiple discounts in line with taxes."""
@@ -68,3 +78,12 @@ class TestSaleFixedDiscount(SavepointCase):
         self.assertEqual(self.sale.amount_total, 630.0)
         self.sale_line1.discount = 50.0
         self.assertEqual(self.sale.amount_total, 515.0)
+
+    def test_03_discounts_rule_fixed(self):
+        """ Tests fixed pricelist item discount."""
+        self.sale.pricelist_id = self.pricelist
+        self.product.list_price = 200
+        self.sale_line1._onchange_discount()
+        self.assertEqual(self.sale_line1.discount_fixed, 100.00)
+        self.assertEqual(self.sale_line1.discount, 0.00)
+        self.assertEqual(self.sale.amount_total, 115.00)


### PR DESCRIPTION
Fix
===
`_onchange_discount` method was shadowing the original _onchange_discount
and all its field triggers had been replaced by `discount`. As the new method's
trigger is the field `discount`, the name should be `_onchange_discount`.
But the name is already taken. Hence `_onchange_discount2`. I'm not aware of
a better naming convention in cases like this.

**EDIT:** checked 12.0 and 13.0 branches and saw that `_onchange_discount`
has been renamed to `_onchange_discount_percent`. Already changed it.

**EDIT2** changed `_onchange_discount` call on tests for `_onchange_discount_percent`.

Also, the way the method was implemented, it was impossible to change the
discount manually if the pricelist had a discount, because that would
trigger the `_onchange_discount`, call to super, and get the discount
from the pricelist.

Improve
=======
Override orginal `_onchange_discount` in order to get the value for the
fixed discount in case the price rule method is `fixed`. It basically
repeats what the original method does, so not very DRYish. I don't know
if there is a better approach (I can only think of monkey path, but I
don't like it either)