### PR TITLE
[13.0] Compute shipping rate on carrier auto-assign

### DIFF
--- a/sale_order_carrier_auto_assign/models/sale_order.py
+++ b/sale_order_carrier_auto_assign/models/sale_order.py
@@ -19,7 +19,7 @@ class SaleOrder(models.Model):
     def _add_delivery_carrier_on_confirmation(self):
         """Automatically add delivery.carrier on sale order confirmation"""
         for order in self:
-            if order.carrier_id or any(line.is_delivery for line in order.order_line):
+            if order.delivery_set:
                 continue
             delivery_wiz_action = order.action_open_delivery_wizard()
             delivery_wiz_context = delivery_wiz_action.get("context", {})
@@ -30,4 +30,5 @@ class SaleOrder(models.Model):
                 .with_context(**delivery_wiz_context)
                 .create({})
             )
+            delivery_wiz._get_shipment_rate()
             delivery_wiz.button_confirm()

--- a/sale_order_carrier_auto_assign/tests/test_sale_order_carrier_auto_assign.py
+++ b/sale_order_carrier_auto_assign/tests/test_sale_order_carrier_auto_assign.py
@@ -13,6 +13,7 @@ class TestSaleOrderCarrierAutoAssign(SavepointCase):
         cls.partner = cls.env.ref("base.res_partner_2")
         product = cls.env.ref("product.product_product_9")
         cls.normal_delivery_carrier = cls.env.ref("delivery.normal_delivery_carrier")
+        cls.normal_delivery_carrier.fixed_price = 10
         sale_order_form = Form(cls.env["sale.order"])
         sale_order_form.partner_id = cls.partner
         with sale_order_form.order_line.new() as line_form:
@@ -27,6 +28,10 @@ class TestSaleOrderCarrierAutoAssign(SavepointCase):
         self.sale_order.action_confirm()
         self.assertEqual(self.sale_order.state, "sale")
         self.assertEqual(self.sale_order.carrier_id, self.normal_delivery_carrier)
+        delivery_line = self.sale_order.order_line.filtered(lambda l: l.is_delivery)
+        self.assertEqual(
+            delivery_line.price_unit, self.normal_delivery_carrier.fixed_price
+        )
 
     def test_sale_order_carrier_auto_assign_no_carrier(self):
         self.partner.property_delivery_carrier_id = False


### PR DESCRIPTION
The computation of the rate was not called, so the line would always be free.
Include also this suggestion: https://github.com/OCA/sale-workflow/pull/1210#discussion_r466378910