### PR TITLE
[12.0][FIX] sale_order_line_price_history: set 'unit price' + 'discount'

### DIFF
--- a/sale_order_line_price_history/tests/test_sale_order_line_price_history.py
+++ b/sale_order_line_price_history/tests/test_sale_order_line_price_history.py
@@ -23,6 +23,7 @@ class TestSaleOrderLinePriceHistory(SavepointCase):
             'product_uom_qty': 2,
             'product_uom': cls.product.uom_id.id,
             'price_unit': 10,
+            'discount': 5,
         })
         cls.sale_order_1.action_confirm()
         cls.sale_order_2 = cls.env['sale.order'].create({
@@ -136,12 +137,13 @@ class TestSaleOrderLinePriceHistory(SavepointCase):
         # Set price of the history line shown.
         wizard.line_ids.action_set_price()
         self.assertEqual(self.sale_order_line_3.price_unit, 20)
+        self.assertEqual(self.sale_order_line_3.discount, 0)
         # Create a wizard from self.sale_order_line_3 again.
         wizard = self.launch_wizard(active_id=self.sale_order_line_3.id)
         wizard.partner_id = False
         wizard._onchange_partner_id()
         # Find the history line with price_unit == 10 and set this price
         history_line = wizard.line_ids.filtered(lambda r: r.price_unit == 10)
-        self.assertEqual(self.sale_order_line_3.price_unit, 20)
         history_line.action_set_price()
         self.assertEqual(self.sale_order_line_3.price_unit, 10)
+        self.assertEqual(self.sale_order_line_3.discount, 5)

--- a/sale_order_line_price_history/wizards/sale_order_line_price_history.py
+++ b/sale_order_line_price_history/wizards/sale_order_line_price_history.py
@@ -106,7 +106,17 @@ class SaleOrderLinePriceHistoryline(models.TransientModel):
         related="sale_order_line_id.discount",
     )
 
+    def _prepare_set_price_history_vals(self):
+        """ Hook method to prepare the values to update the
+        sales order line in context.
+
+        This method is invoke by action_set_price method in this model.
+        """
+        self.ensure_one()
+        return {'price_unit': self.price_unit, 'discount': self.discount}
+
     @api.multi
     def action_set_price(self):
         self.ensure_one()
-        self.history_sale_order_line_id.price_unit = self.price_unit
+        self.history_sale_order_line_id.write(
+            self._prepare_set_price_history_vals())


### PR DESCRIPTION
Now when the unit price of a previous sales order line is set, the discount of that previous line is set too

cc @Tecnativa TT25012