### PR TITLE
[11.0] sale_exception: Remove side effect from api.constrains

### DIFF
--- a/sale_exception/models/sale.py
+++ b/sale_exception/models/sale.py
@@ -35,7 +35,31 @@ class SaleOrder(models.Model):
         order_set.test_exceptions()
         return True
 
-    @api.constrains('ignore_exception', 'order_line', 'state')
+    def _fields_trigger_check_exception(self):
+        return ['ignore_exception', 'order_line', 'state']
+
+    @api.model
+    def create(self, vals):
+        record = super(SaleOrder, self).create(vals)
+        check_exceptions = any(
+            field in vals for field
+            in self._fields_trigger_check_exception()
+        )
+        if check_exceptions:
+            record.sale_check_exception()
+        return record
+
+    @api.multi
+    def write(self, vals):
+        result = super(SaleOrder, self).write(vals)
+        check_exceptions = any(
+            field in vals for field
+            in self._fields_trigger_check_exception()
+        )
+        if check_exceptions:
+            self.sale_check_exception()
+        return result
+
     def sale_check_exception(self):
         orders = self.filtered(lambda s: s.state == 'sale')
         if orders:


### PR DESCRIPTION
This is a forward port of https://github.com/OCA/sale-workflow/pull/916 
Relates to https://github.com/OCA/server-tools/pull/1888

The method called by 'sale_check_exception' has a side effect, it writes
on 'exception.rule' + on the Many2many relation between it and
sale.order(.line). When decorated by @api.constrains, any error during
the method will be caught and re-raised as "ValidationError".
This part of code is very prone to concurrent updates as 2 sales having
the same exception will both write on the same 'exception.rule'.
A concurrent update (OperationalError) is re-raised as ValidationError,
and then is not retried properly.

Calling the same method in create/write has the same effect than
@api.constrains without shadowing the exception type.

Full explanation:
https://github.com/OCA/server-tools/issues/1642