### PR TITLE
[IMP] sale_promotion_programs: Apply coupon on first sale order only

### DIFF
--- a/sale_coupon_advanced_option/__init__.py
+++ b/sale_coupon_advanced_option/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_coupon_advanced_option/__manifest__.py
+++ b/sale_coupon_advanced_option/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "Sale Coupon Advanced Features",
+    "summary": """Extended features for Sale Coupon""",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "category": "sale",
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "depends": ["sale_coupon"],
+    "data": ["views/sale_coupon.xml"],
+    "demo": [],
+    "installable": True,
+}

--- a/sale_coupon_advanced_option/i18n/fr.po
+++ b/sale_coupon_advanced_option/i18n/fr.po
@@ -1,0 +1,34 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale_coupon_first_order
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 13.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-08-27 07:15+0000\n"
+"PO-Revision-Date: 2020-08-27 07:15+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_coupon_first_order
+#: model:ir.model.fields,field_description:sale_coupon_first_order.field_sale_coupon_program__first_order_only
+msgid "Apply only on the first order of each client matching the conditions"
+msgstr ""
+"Appliquer seulement sur la première commande de chaque client répondant aux "
+"conditions"
+
+#. module: sale_coupon_first_order
+#: code:addons/sale_coupon_first_order/models/sale_coupon_program.py:0
+#, python-format
+msgid "Coupon can be used only for the first sale order!"
+msgstr "Le coupon ne peut être utilisé que pour la première commande!"
+
+#. module: sale_coupon_first_order
+#: model:ir.model,name:sale_coupon_first_order.model_sale_coupon_program
+msgid "Sales Coupon Program"
+msgstr "Programme de coupon de vente"

--- a/sale_coupon_advanced_option/models/__init__.py
+++ b/sale_coupon_advanced_option/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_coupon_program

--- a/sale_coupon_advanced_option/models/sale_coupon_program.py
+++ b/sale_coupon_advanced_option/models/sale_coupon_program.py
@@ -1,0 +1,52 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import _, api, fields, models
+
+
+class SaleCouponProgram(models.Model):
+    _inherit = "sale.coupon.program"
+
+    # Add possibility to use discount only on first order of a customer
+    first_order_only = fields.Boolean(
+        string="Apply only first",
+        default=False,
+        help="Apply only on the first order of each client matching the conditions",
+    )
+
+    def _check_promo_code(self, order, coupon_code):
+        if (
+            self.first_order_only
+            and len(
+                self.env["sale.order"].search(
+                    [("partner_id", "=", order.partner_id.id),("state","!=","cancel")]
+                )
+            )
+            > 1
+        ):
+            return {"error": _("Coupon can be used only for the first sale order!")}
+        else:
+            return super()._check_promo_code(order,coupon_code)
+
+    def _filter_programs_by_sale_order_count(self, order):
+        if (
+            self.env["sale.order"].search_count(
+                [
+                    ("partner_id", "=", order.partner_id.id),
+                    ("state","!=", "cancel")
+                ]
+            )
+            <= 1
+        ):
+            return self.filtered(lambda program: program.first_order_only is True)
+        else:
+            return self.filtered(lambda program: not program.first_order_only)
+
+    @api.model
+    def _filter_programs_from_common_rules(self, order, next_order=False):
+        """ Return the programs if every conditions is met
+            :param bool next_order: is the reward given from a previous order
+        """
+        programs = super()._filter_programs_from_common_rules(order, next_order)
+        programs = programs and programs._filter_programs_by_sale_order_count(order)
+        return programs

--- a/sale_coupon_advanced_option/tests/__init__.py
+++ b/sale_coupon_advanced_option/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_first_so_program_only

--- a/sale_coupon_advanced_option/tests/test_first_so_program_only.py
+++ b/sale_coupon_advanced_option/tests/test_first_so_program_only.py
@@ -1,0 +1,255 @@
+from odoo.exceptions import UserError
+
+from odoo.addons.sale_coupon.tests.common import TestSaleCouponCommon
+
+
+class TestProgramForFirstSaleOrder(TestSaleCouponCommon):
+    def setUp(self):
+        super(TestProgramForFirstSaleOrder, self).setUp()
+
+        self.env["sale.coupon.program"].search([]).write({"active": False})
+
+        self.product_A = self.env["product.product"].create(
+            {"name": "Product A", "list_price": 60, "sale_ok": True}
+        )
+
+        self.program1 = self.env["sale.coupon.program"].create(
+            {
+                "name": "Get 10% discount for 1st order",
+                "program_type": "promotion_program",
+                "reward_type": "discount",
+                "discount_type": "percentage",
+                "discount_percentage": 10.0,
+                "rule_min_quantity": 1,
+                "rule_minimum_amount": 100.00,
+                "promo_applicability": "on_current_order",
+                "promo_code_usage": "no_code_needed",
+                "maximum_use_number": 0,
+                "first_order_only": True,
+                "active": True,
+            }
+        )
+
+        self.program2 = self.env["sale.coupon.program"].create(
+            {
+                "name": "Get 50% discount",
+                "program_type": "promotion_program",
+                "reward_type": "discount",
+                "discount_type": "percentage",
+                "discount_percentage": 50.0,
+                "rule_min_quantity": 1,
+                "rule_minimum_amount": 100.00,
+                "promo_applicability": "on_current_order",
+                "promo_code_usage": "no_code_needed",
+                "maximum_use_number": 0,
+                "active": False,
+            }
+        )
+
+        self.program3 = self.env["sale.coupon.program"].create(
+            {
+                "name": "Get 30% discount with code",
+                "program_type": "promotion_program",
+                "reward_type": "discount",
+                "discount_type": "percentage",
+                "discount_percentage": 30.0,
+                "rule_min_quantity": 1,
+                "rule_minimum_amount": 100.00,
+                "promo_applicability": "on_current_order",
+                "promo_code_usage": "code_needed",
+                "promo_code": "30_discount",
+                "maximum_use_number": 0,
+                "first_order_only": True,
+                "active": True,
+            }
+        )
+
+        self.partner1 = self.env["res.partner"].create({"name": "Jane Doe"})
+
+        self.partner2 = self.env["res.partner"].create({"name": "John Doe"})
+
+        self.partner3 = self.env["res.partner"].create({"name": "John Deere"})
+
+    def test_first_sale_order_program(self):
+
+        #  test first sale order program
+
+        order1 = self.env["sale.order"].create({"partner_id": self.partner1.id})
+        order1.write(
+            {
+                "order_line": [
+                    (
+                        0,
+                        False,
+                        {
+                            "product_id": self.product_A.id,
+                            "name": "Product A",
+                            "product_uom_qty": 2.0,
+                            "product_uom": self.uom_unit.id,
+                        },
+                    ),
+                ]
+            }
+        )
+
+        order1.recompute_coupon_lines()
+        discounts = set(order1.order_line.mapped("name")) - {"Product A"}
+        self.assertEqual(len(discounts), 1, "Order should contain one discount")
+        self.assertTrue(
+            "Get 10% discount for 1st order" in discounts.pop(),
+            "The discount should be a 10% discount",
+        )
+        self.assertEqual(
+            len(order1.order_line.ids), 2, "The order should contain 2 lines"
+        )
+
+        #  test non first sale order
+
+        order2 = self.env["sale.order"].create({"partner_id": self.partner1.id})
+        order2.write(
+            {
+                "order_line": [
+                    (
+                        0,
+                        False,
+                        {
+                            "product_id": self.product_A.id,
+                            "name": "Product A",
+                            "product_uom_qty": 3.0,
+                            "product_uom": self.uom_unit.id,
+                        },
+                    ),
+                ]
+            }
+        )
+
+        order2.recompute_coupon_lines()
+        self.assertEqual(
+            len(order2.order_line.ids), 1, "The order should contain 1 line"
+        )
+        discounts = set(order2.order_line.mapped("name")) - {"Product A"}
+        self.assertEqual(len(discounts), 0, "Order should contain no discount")
+
+        self.program2.write({"active": True})
+        order2.recompute_coupon_lines()
+        self.assertEqual(
+            len(order2.order_line.ids), 2, "The order should contain 2 lines"
+        )
+        discounts = set(order2.order_line.mapped("name")) - {
+            "Product A"
+        }  # to check by content of name that 2nd program was applied
+        self.assertEqual(len(discounts), 1, "Order should contain 1 discount")
+        self.assertTrue(
+            "Get 50% discount" in discounts.pop(),
+            "The discount should be a 50% discount",
+        )
+
+        # test first sale order another partner
+
+        order3 = self.env["sale.order"].create({"partner_id": self.partner2.id})
+
+        order3.write(
+            {
+                "order_line": [
+                    (
+                        0,
+                        False,
+                        {
+                            "product_id": self.product_A.id,
+                            "name": "Product A",
+                            "product_uom_qty": 3.0,
+                            "product_uom": self.uom_unit.id,
+                        },
+                    ),
+                ]
+            }
+        )
+
+        order3.recompute_coupon_lines()
+        discounts = set(order3.order_line.mapped("name")) - {"Product A"}
+
+        self.assertEqual(
+            len(order3.order_line.ids), 2, "The order should contain 2 lines"
+        )
+        self.assertEqual(
+            len(discounts),
+            1,
+            "the order should contain 1 Product A line and a discount",
+        )
+
+        # test first sale order with promo code
+
+        self.env["sale.coupon.generate"].with_context(
+            active_id=self.program3.id
+        ).create({"generation_type": "nbr_coupon", "nbr_coupons": 1}).generate_coupon()
+
+        order4 = self.env["sale.order"].create({"partner_id": self.partner3.id})
+
+        order4.write(
+            {
+                "order_line": [
+                    (
+                        0,
+                        False,
+                        {
+                            "product_id": self.product_A.id,
+                            "name": "Product A",
+                            "product_uom_qty": 2.0,
+                            "product_uom": self.uom_unit.id,
+                        },
+                    ),
+                ]
+            }
+        )
+
+        self.env["sale.coupon.apply.code"].with_context(active_id=order4.id).create(
+            {"coupon_code": "30_discount"}
+        ).process_coupon()
+
+        discounts = set(order3.order_line.mapped("name")) - {"Product A"}
+
+        self.assertEqual(
+            len(order3.order_line.ids), 2, "The order should contain 2 lines"
+        )
+        self.assertEqual(
+            len(discounts),
+            1,
+            "the order should contain 1 Product A line and a discount",
+        )
+
+        # next so for old partner with 1st SO only code usage
+
+        order5 = self.env["sale.order"].create({"partner_id": self.partner3.id})
+
+        order5.write(
+            {
+                "order_line": [
+                    (
+                        0,
+                        False,
+                        {
+                            "product_id": self.product_A.id,
+                            "name": "Product A",
+                            "product_uom_qty": 5.0,
+                            "product_uom": self.uom_unit.id,
+                        },
+                    ),
+                ]
+            }
+        )
+
+        with self.assertRaises(UserError):
+            self.env["sale.coupon.apply.code"].with_context(active_id=order5.id).create(
+                {"coupon_code": "30_discount"}
+            ).process_coupon()
+
+        discounts = set(order5.order_line.mapped("name")) - {"Product A"}
+
+        self.assertEqual(
+            len(order5.order_line.ids), 1, "The order should contain 1 line"
+        )
+        self.assertEqual(
+            len(discounts),
+            0,
+            "the order should contain 1 Product A line and no discounts",
+        )

--- a/sale_coupon_advanced_option/views/sale_coupon.xml
+++ b/sale_coupon_advanced_option/views/sale_coupon.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="sale_coupon_program_view_promo_program_form_inherit" model="ir.ui.view">
+        <field name="name">sale.coupon.program.view.promo_program.form</field>
+        <field name="model">sale.coupon.program</field>
+        <field
+            name="inherit_id"
+            ref="sale_coupon.sale_coupon_program_view_promo_program_form"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='rule_date_to']" position="after">
+                <field name="first_order_only" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Aim of this PR is to add possibility to use promotion on first sale order only for each customer.
To achieve that new field is added to promotion form view.

As per behavior in original feature, promotion can be used when predefined code is entered in Sale Order or without that (automatically). 

in case of code usage we need to ensure that this is the first SO of this customer  -> added condition in _check_promo_code()
In case of promotion applied without code,  _filter_programs_from_common_rules() is called. This method filters promotions relevant for particular sale order, based on the requirements -> there we check if there are already some existing sale orders for this customer, if not, this is the first SO so promotion can be applied.

![promo](https://user-images.githubusercontent.com/59824990/91273276-528b2380-e77d-11ea-86d5-771643ec98b6.png)

![promo_code](https://user-images.githubusercontent.com/59824990/91273287-56b74100-e77d-11ea-854f-2582b3903d90.png)



