### PR TITLE
[13.0][IMP] sale_discount_display_amount. Update hooks

### DIFF
--- a/sale_discount_display_amount/hooks.py
+++ b/sale_discount_display_amount/hooks.py
@@ -10,25 +10,33 @@ _logger = logging.getLogger(__name__)
 
 def pre_init_hook(cr):
     _logger.info("Create discount columns in database")
+    # Use IF NOT EXISTS to alter table because when the module is already
+    # installed (v9.0 for example) and you migrate to this 13.0, the column
+    # already exists but the module is considered as new.
+    # So this hook is triggered and it raise an exception.
     cr.execute(
         """
-        ALTER TABLE sale_order ADD COLUMN price_total_no_discount numeric;
+        ALTER TABLE sale_order
+        ADD COLUMN IF NOT EXISTS price_total_no_discount numeric;
     """
     )
     cr.execute(
         """
-        ALTER TABLE sale_order ADD COLUMN discount_total numeric;
+        ALTER TABLE sale_order
+        ADD COLUMN IF NOT EXISTS discount_total numeric;
     """
     )
     cr.execute(
         """
-        ALTER TABLE sale_order_line ADD COLUMN price_total_no_discount
+        ALTER TABLE sale_order_line
+        ADD COLUMN IF NOT EXISTS price_total_no_discount
         numeric;
     """
     )
     cr.execute(
         """
-        ALTER TABLE sale_order_line ADD COLUMN discount_total numeric;
+        ALTER TABLE sale_order_line
+        ADD COLUMN IF NOT EXISTS discount_total numeric;
     """
     )
 


### PR DESCRIPTION
In some case, the hook is triggered and columns could already exists. That raise an exception and block the Odoo start/update process. It could happens when you already use this module on a previous version (9.0 for example) then your DB is migrated to 13.0 and you re-use this module.