### PR TITLE
[13.0] sale_by_packaging: no pkging override if already set

### DIFF
--- a/sale_by_packaging/models/sale_order_line.py
+++ b/sale_by_packaging/models/sale_order_line.py
@@ -61,8 +61,9 @@ class SaleOrderLine(models.Model):
                     )
                 )
             )
-            if first_packaging:
-                self.update(
+            if first_packaging and self.product_packaging != first_packaging:
+                # Force packacing and its qty if not set already
+                self.with_context(_force_auto_assign=True).update(
                     {
                         "product_packaging": first_packaging.id,
                         "product_uom_qty": first_packaging.qty,
@@ -106,7 +107,9 @@ class SaleOrderLine(models.Model):
             # setting the packaging directly, skip auto assign
             return super().write(vals)
         for line in self:
-            if line.product_packaging:
+            if line.product_packaging and not self.env.context.get(
+                "_force_auto_assign"
+            ):
                 # don't touch it if set already
                 continue
             line_vals = vals.copy()

--- a/sale_by_packaging/models/sale_order_line.py
+++ b/sale_by_packaging/models/sale_order_line.py
@@ -86,28 +86,7 @@ class SaleOrderLine(models.Model):
     def _onchange_product_uom_qty(self):
         self._force_qty_with_package()
         res = super()._onchange_product_uom_qty()
-        if not res:
-            res = self._check_qty_is_pack_multiple()
         return res
-
-    def _check_qty_is_pack_multiple(self):
-        """ Check only for product with sell_only_by_packaging
-        """
-        # and we dont want to have this warning when we had the product
-        if self.product_id.sell_only_by_packaging:
-            if not self._get_product_packaging_having_multiple_qty(
-                self.product_id, self.product_uom_qty, self.product_uom
-            ):
-                warning_msg = {
-                    "title": _("Product quantity cannot be packed"),
-                    "message": _(
-                        "For the product {prod}\n"
-                        "The {qty} is not the multiple of any pack.\n"
-                        "Please add a package"
-                    ).format(prod=self.product_id.name, qty=self.product_uom_qty),
-                }
-                return {"warning": warning_msg}
-        return {}
 
     def _get_product_packaging_having_multiple_qty(self, product, qty, uom):
         if uom != product.uom_id:

--- a/sale_by_packaging/models/sale_order_line.py
+++ b/sale_by_packaging/models/sale_order_line.py
@@ -122,6 +122,9 @@ class SaleOrderLine(models.Model):
         ):
             return super().write(vals)
         for line in self:
+            if line.product_packaging:
+                # don't touch it if set already
+                continue
             line_vals = vals.copy()
             line_vals.update(line._write_auto_assign_packaging(line_vals))
             super(SaleOrderLine, line).write(line_vals)
@@ -158,7 +161,8 @@ class SaleOrderLine(models.Model):
     def create(self, vals):
         """Auto assign packaging if needed"""
         # Fill the packaging if they are empty and the quantity is a multiple
-        vals.update(self._create_auto_assign_packaging(vals))
+        if not vals.get("product_packaging"):
+            vals.update(self._create_auto_assign_packaging(vals))
         return super().create(vals)
 
     @api.model

--- a/sale_by_packaging/models/sale_order_line.py
+++ b/sale_by_packaging/models/sale_order_line.py
@@ -114,12 +114,17 @@ class SaleOrderLine(models.Model):
             qty = uom._compute_quantity(qty, product.uom_id)
         return product.get_first_packaging_with_multiple_qty(qty)
 
+    def _inverse_product_packaging_qty(self):
+        # Force skipping of auto assign
+        # if we are writing the product_uom_qty directly via inverse
+        super(
+            SaleOrderLine, self.with_context(_skip_auto_assign=True)
+        )._inverse_product_packaging_qty()
+
     def write(self, vals):
         """Auto assign packaging if needed"""
-        fields_to_check = ["product_id", "product_uom_qty", "product_uom"]
-        if vals.get("product_packaging") or not any(
-            fname in vals for fname in fields_to_check
-        ):
+        if vals.get("product_packaging") or self.env.context.get("_skip_auto_assign"):
+            # setting the packaging directly, skip auto assign
             return super().write(vals)
         for line in self:
             if line.product_packaging:


### PR DESCRIPTION
Before this change the packaging was always overridden
hence the user had not control on the packaging to be used on SO line.

TODO:

- [x] rewrite tests