### PR TITLE
[13.0] [FIX] sale_order_type: Only show the type field in sales

### DIFF
--- a/sale_order_type/models/account_move.py
+++ b/sale_order_type/models/account_move.py
@@ -18,7 +18,10 @@ class AccountMove(models.Model):
 
     @api.depends("partner_id", "company_id")
     def _compute_sale_type_id(self):
-        for record in self:
+        self.sale_type_id = self.env["sale.order.type"]
+        for record in self.filtered(
+            lambda am: am.type in ["out_invoice", "out_refund"]
+        ):
             if not record.partner_id:
                 record.sale_type_id = self.env["sale.order.type"].search([], limit=1)
             else:

--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -11,7 +11,9 @@ class TestSaleOrderType(common.TransactionCase):
         super(TestSaleOrderType, self).setUp()
         self.sale_type_model = self.env["sale.order.type"]
         self.sale_order_model = self.env["sale.order"]
-        self.invoice_model = self.env["account.move"]
+        self.invoice_model = self.env["account.move"].with_context(
+            default_type="out_invoice"
+        )
         self.partner = self.env.ref("base.res_partner_1")
         self.partner_child_1 = self.env["res.partner"].create(
             {"name": "Test child", "parent_id": self.partner.id, "sale_type": False}
@@ -27,6 +29,7 @@ class TestSaleOrderType(common.TransactionCase):
         self.journal = self.env["account.journal"].search(
             [("type", "=", "sale")], limit=1
         )
+        self.default_sale_type_id = self.env["sale.order.type"].search([], limit=1)
         self.warehouse = self.env["stock.warehouse"].create(
             {"name": "Warehouse Test", "code": "WT"}
         )
@@ -127,6 +130,10 @@ class TestSaleOrderType(common.TransactionCase):
         self.assertEqual(invoice.sale_type_id, self.sale_type)
         invoice = self.invoice_model.new({"partner_id": self.partner_child_1.id})
         self.assertEqual(invoice.sale_type_id, self.sale_type)
+
+    def test_invoice_without_partner(self):
+        invoice = self.invoice_model.new()
+        self.assertEqual(invoice.sale_type_id, self.default_sale_type_id)
 
     def test_sale_order_flow_route(self):
         order = self.sale_order_model.create(self.get_sale_order_vals())

--- a/sale_order_type/views/account_move_views.xml
+++ b/sale_order_type/views/account_move_views.xml
@@ -7,7 +7,7 @@
             <field name="journal_id" position="before">
                 <field
                     name="sale_type_id"
-                    attrs="{'invisible': [('type', 'not in', ['in_invoice', 'in_refund', 'out_invoice', 'out_refund'])]}"
+                    attrs="{'invisible': [('type', 'not in', ['out_invoice', 'out_refund'])]}"
                 />
             </field>
         </field>


### PR DESCRIPTION
Actualy the field type is showed in all of the invoice types (customer and vendors) however, for the vendors invoices it's not necesary to show it . Also the same apply for the compute method for that field.

![Screenshot (25)](https://user-images.githubusercontent.com/7657373/92732895-6d4cc300-f34d-11ea-87a6-8ef223ee184e.png)
