### PR TITLE
[12.0][FIX] fill type if null by default as it is now required

### DIFF
--- a/sale_order_type/__manifest__.py
+++ b/sale_order_type/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     "name": "Sale Order Type",
-    "version": "12.0.1.1.0",
+    "version": "12.0.1.1.1",
     "category": "Sales Management",
     "author": "Grupo Vermon,"
               "AvanzOSC,"

--- a/sale_order_type/migrations/12.0.1.1.1/post-migration.py
+++ b/sale_order_type/migrations/12.0.1.1.1/post-migration.py
@@ -1,0 +1,24 @@
+# Copyright 2020 Sergio Corato <https://github.com/sergiocorato>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def _fill_sale_order_type(cr):
+    _logger.info("Fill type_id in sale order if null as it is now required")
+
+    cr.execute(
+        """
+    UPDATE sale_order
+    SET
+        type_id=(SELECT id FROM sale_order_type ORDER BY id LIMIT 1)
+    WHERE
+        type_id is null
+        """
+    )
+
+
+def migrate(cr, version):
+    _fill_sale_order_type(cr)


### PR DESCRIPTION
`type_id` is required but can be null for migrated db, this fix it.
n.b.: TODO at-install hook to fill the field? (in other PR)
n.b.: merge with `nobump`