### PR TITLE
[13.0][IMP] sale_order_line_packaging_qty - packaging selection

### DIFF
--- a/sale_order_line_packaging_qty/views/sale_order.xml
+++ b/sale_order_line_packaging_qty/views/sale_order.xml
@@ -38,9 +38,10 @@
                     name="product_packaging"
                     attrs="{'invisible': [('product_id', '=', False)]}"
                     context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}"
-                    domain="[('product_id','=',product_id)]"
+                    domain="[('product_id','=',product_id), ('qty', '>', 0)]"
                     groups="product.group_stock_packaging"
                     optional="show"
+                    options="{'no_create': True}"
                 />
                 <field
                     name="product_packaging_qty"


### PR DESCRIPTION
On sale order line filter out packaging that have a quantity of zero.
Also remove the option to create a new packaging from the sale order
line.