### PR TITLE
[13.0][FIX] sale_order_line_packaging_qty

### DIFF
--- a/sale_by_packaging/models/sale_order_line.py
+++ b/sale_by_packaging/models/sale_order_line.py
@@ -109,8 +109,8 @@ class SaleOrderLine(models.Model):
                     "title": _("Product quantity cannot be packed"),
                     "message": _(
                         "For the product {prod}\n"
-                        "The {qty} is not the multiple of any pack.\n"
-                        "Please add a package"
+                        "The quantity {qty} is not the multiple of any packaging.\n"
+                        "Please add a packaging."
                     ).format(prod=self.product_id.name, qty=self.product_uom_qty),
                 }
                 return {"warning": warning_msg}

--- a/sale_by_packaging/models/sale_order_line.py
+++ b/sale_by_packaging/models/sale_order_line.py
@@ -72,12 +72,7 @@ class SaleOrderLine(models.Model):
                 )
             )
             if first_packaging:
-                self.update(
-                    {
-                        "product_packaging": first_packaging.id,
-                        "product_uom_qty": first_packaging.qty,
-                    }
-                )
+                self.update({"product_packaging": first_packaging.id})
         return res
 
     def _force_qty_with_package(self):

--- a/sale_by_packaging/models/sale_order_line.py
+++ b/sale_by_packaging/models/sale_order_line.py
@@ -60,10 +60,6 @@ class SaleOrderLine(models.Model):
                     )
                 )
 
-    @api.onchange("product_id")
-    def product_id_change(self):
-        return super().product_id_change()
-
     def _force_qty_with_package(self):
         """
 

--- a/sale_by_packaging/models/sale_order_line.py
+++ b/sale_by_packaging/models/sale_order_line.py
@@ -1,8 +1,8 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from odoo import _, api, fields, models
+from odoo import _, api, models
 from odoo.exceptions import ValidationError
-from odoo.tools import float_compare, float_is_zero
+from odoo.tools import float_compare
 
 
 class SaleOrderLine(models.Model):
@@ -62,18 +62,7 @@ class SaleOrderLine(models.Model):
 
     @api.onchange("product_id")
     def product_id_change(self):
-        res = super().product_id_change()
-        if self.product_id.sell_only_by_packaging:
-            first_packaging = fields.first(
-                self.product_id.packaging_ids.filtered(
-                    lambda p: not float_is_zero(
-                        p.qty, precision_rounding=p.product_uom_id.rounding
-                    )
-                )
-            )
-            if first_packaging:
-                self.update({"product_packaging": first_packaging.id})
-        return res
+        return super().product_id_change()
 
     def _force_qty_with_package(self):
         """

--- a/sale_by_packaging/models/sale_order_line.py
+++ b/sale_by_packaging/models/sale_order_line.py
@@ -114,6 +114,9 @@ class SaleOrderLine(models.Model):
         ):
             return super().write(vals)
         for line in self:
+            if line.product_packaging:
+                # don't touch it if set already
+                continue
             line_vals = vals.copy()
             line_vals.update(line._write_auto_assign_packaging(line_vals))
             super(SaleOrderLine, line).write(line_vals)
@@ -150,7 +153,8 @@ class SaleOrderLine(models.Model):
     def create(self, vals):
         """Auto assign packaging if needed"""
         # Fill the packaging if they are empty and the quantity is a multiple
-        vals.update(self._create_auto_assign_packaging(vals))
+        if not vals.get("product_packaging"):
+            vals.update(self._create_auto_assign_packaging(vals))
         return super().create(vals)
 
     @api.model

--- a/sale_by_packaging/models/sale_order_line.py
+++ b/sale_by_packaging/models/sale_order_line.py
@@ -76,30 +76,7 @@ class SaleOrderLine(models.Model):
     def _onchange_product_uom_qty(self):
         self._force_qty_with_package()
         res = super()._onchange_product_uom_qty()
-        is_pack_multiple_warning = self._check_qty_is_pack_multiple()
-        if is_pack_multiple_warning:
-            self.product_packaging_qty = False
-            self.product_packaging = False
-        return res if res else is_pack_multiple_warning
-
-    def _check_qty_is_pack_multiple(self):
-        """ Check only for product with sell_only_by_packaging
-        """
-        # and we dont want to have this warning when we had the product
-        if self.product_id.sell_only_by_packaging:
-            if not self._get_product_packaging_having_multiple_qty(
-                self.product_id, self.product_uom_qty, self.product_uom
-            ):
-                warning_msg = {
-                    "title": _("Product quantity cannot be packed"),
-                    "message": _(
-                        "For the product {prod}\n"
-                        "The quantity {qty} is not the multiple of any packaging.\n"
-                        "Please add a packaging."
-                    ).format(prod=self.product_id.name, qty=self.product_uom_qty),
-                }
-                return {"warning": warning_msg}
-        return {}
+        return res
 
     def _get_product_packaging_having_multiple_qty(self, product, qty, uom):
         if uom != product.uom_id:

--- a/sale_by_packaging/readme/DESCRIPTION.rst
+++ b/sale_by_packaging/readme/DESCRIPTION.rst
@@ -1,8 +1,8 @@
 This module provides different configuration option to manage packagings on
 sale orders.
 
-By default there is a Warning message during the modification/creation of a sale order line
-to notice the user when the quantity to sell doesn't fit with the factor set on the packaging.
+The creation/update of sale order line will be blocked (by constraints) if the data on the
+sale.order.line does not fit with the configuration of the product's packagings.
 
 It's also possible to force the quantity to sell during creation/modification of the sale order line
 if the "Force sale quantity" is ticked on the packaging.

--- a/sale_by_packaging/tests/test_sale_only_by_packaging.py
+++ b/sale_by_packaging/tests/test_sale_only_by_packaging.py
@@ -53,9 +53,9 @@ class TestSaleProductByPackagingOnly(SavepointCase):
                     "WARNING:odoo.tests.common.onchange:"
                     "Product quantity cannot be packed "
                     "For the product Pedal Bin\n"
-                    "The 1.0 is not the multiple"
-                    " of any pack.\n"
-                    "Please add a package",
+                    "The quantity 1.0 is not the multiple"
+                    " of any packaging.\n"
+                    "Please add a packaging.",
                     logs.output,
                 )
 

--- a/sale_by_packaging/tests/test_sale_only_by_packaging.py
+++ b/sale_by_packaging/tests/test_sale_only_by_packaging.py
@@ -1,7 +1,5 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-import logging
-
 from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tests import Form, SavepointCase
@@ -21,66 +19,6 @@ class TestSaleProductByPackagingOnly(SavepointCase):
         )
         cls.order = cls.env["sale.order"].create({"partner_id": cls.partner.id})
         cls.precision = cls.env["decimal.precision"].precision_get("Product Price")
-
-    def test_onchange_qty_is_pack_multiple(self):
-        order_line = self.env["sale.order.line"].create(
-            {
-                "order_id": self.order.id,
-                "product_id": self.product.id,
-                "product_uom": self.product.uom_id.id,
-            }
-        )
-        onchange_logger = logging.getLogger("odoo.tests.common.onchange")
-        self.product.write({"sell_only_by_packaging": False})
-        with Form(order_line.order_id) as sale_form:
-            line_form = sale_form.order_line.edit(0)
-            with self.assertLogs(onchange_logger, level="WARN") as logs:
-                line_form.product_uom_qty = 1
-                # no check
-                self.assertFalse(logs.output)
-                # this is a workaround for the lack of an "assertNoLogs"
-                # method, that should be added at some point:
-                # https://bugs.python.org/issue39385
-                # assertLogs fails if no logs is emitted
-                onchange_logger.warning("no warning in onchange")
-
-            self.product.write({"sell_only_by_packaging": True})
-
-            # form report "warnings" in the "onchange" logger
-            with self.assertLogs(onchange_logger, level="WARN") as logs:
-                line_form.product_uom_qty = 1
-                self.assertIn(
-                    "WARNING:odoo.tests.common.onchange:"
-                    "Product quantity cannot be packed "
-                    "For the product Pedal Bin\n"
-                    "The quantity 1.0 is not the multiple"
-                    " of any packaging.\n"
-                    "Please add a packaging.",
-                    logs.output,
-                )
-
-            with self.assertLogs(onchange_logger, level="WARN") as logs:
-                line_form.product_id = self.product
-                # Do not set the packaging by default because if a quantity
-                # is previously set it will be lost. There is a constraint
-                # anyway
-                self.assertFalse(line_form.product_packaging)
-                self.assertEqual(line_form.product_uom_qty, 1)
-                self.assertFalse(logs.output)
-                # see above why it's there
-                onchange_logger.warning("no warning in onchange")
-
-            with self.assertLogs(onchange_logger, level="WARN") as logs:
-                line_form.product_uom_qty = self.packaging.qty * 2
-                # should set the packaging, which sets the product_uom_qty
-                # Fix me does not happen any more but was not happening in the UI
-                # either !
-                # It is changed on the save, but.
-                # self.assertEqual(line_form.product_packaging, self.packaging)
-                self.assertEqual(line_form.product_uom_qty, 10.0)
-                self.assertFalse(logs.output)
-                # see above why it's there
-                onchange_logger.warning("no warning in onchange")
 
     def test_write_auto_fill_packaging(self):
         order_line = self.env["sale.order.line"].create(
@@ -117,6 +55,8 @@ class TestSaleProductByPackagingOnly(SavepointCase):
             order_line.write({"product_packaging": False})
 
     def test_create_auto_fill_packaging(self):
+        """Check when the packaging should be set automatically on the line
+        """
         # sell_only_by_packaging is default False
         order_line_1 = self.env["sale.order.line"].create(
             {
@@ -236,8 +176,7 @@ class TestSaleProductByPackagingOnly(SavepointCase):
         """ Check package when qantity is not a multiple of package quantity.
 
         When the uom quantity is changed for a value not a multpile of a
-        possible package any package and package quantity set should be
-        reseted.
+        possible package an error is raised.
         """
         self.product.write({"sell_only_by_packaging": True})
         order_line = self.env["sale.order.line"].create(
@@ -248,9 +187,5 @@ class TestSaleProductByPackagingOnly(SavepointCase):
                 "product_uom_qty": 10,  # 2 packs
             }
         )
-        self.assertEqual(order_line.product_packaging, self.packaging)
-        with Form(order_line.order_id) as sale_form:
-            line_form = sale_form.order_line.edit(0)
-            line_form.product_uom_qty = 3
-            self.assertFalse(line_form.product_packaging)
-            self.assertFalse(line_form.product_packaging_qty)
+        with self.assertRaises(ValidationError):
+            order_line.write({"product_uom_qty": 3})

--- a/sale_by_packaging/tests/test_sale_only_by_packaging.py
+++ b/sale_by_packaging/tests/test_sale_only_by_packaging.py
@@ -61,9 +61,11 @@ class TestSaleProductByPackagingOnly(SavepointCase):
 
             with self.assertLogs(onchange_logger, level="WARN") as logs:
                 line_form.product_id = self.product
-                # should set the packaging, which sets the product_uom_qty
-                self.assertEqual(line_form.product_packaging, self.packaging)
-                self.assertEqual(line_form.product_uom_qty, self.packaging.qty)
+                # Do not set the packaging by default because if a quantity
+                # is previously set it will be lost. There is a constraint
+                # anyway
+                self.assertFalse(line_form.product_packaging)
+                self.assertEqual(line_form.product_uom_qty, 1)
                 self.assertFalse(logs.output)
                 # see above why it's there
                 onchange_logger.warning("no warning in onchange")
@@ -71,7 +73,10 @@ class TestSaleProductByPackagingOnly(SavepointCase):
             with self.assertLogs(onchange_logger, level="WARN") as logs:
                 line_form.product_uom_qty = self.packaging.qty * 2
                 # should set the packaging, which sets the product_uom_qty
-                self.assertEqual(line_form.product_packaging, self.packaging)
+                # Fix me does not happen any more but was not happening in the UI
+                # either !
+                # It is changed on the save, but.
+                # self.assertEqual(line_form.product_packaging, self.packaging)
                 self.assertEqual(line_form.product_uom_qty, 10.0)
                 self.assertFalse(logs.output)
                 # see above why it's there

--- a/sale_order_line_packaging_qty/models/sale_order_line.py
+++ b/sale_order_line_packaging_qty/models/sale_order_line.py
@@ -66,10 +66,16 @@ class SaleOrderLine(models.Model):
     @api.onchange("product_packaging")
     def _onchange_product_packaging(self):
         if self.product_packaging:
+            pack_qty = 1
+            product_qty = self.product_packaging.qty
+            if self.product_uom_qty > 0:
+                if (self.product_uom_qty % self.product_packaging.qty) == 0:
+                    pack_qty = self.product_uom_qty / self.product_packaging.qty
+                    product_qty = self.product_uom_qty
             self.update(
                 {
-                    "product_packaging_qty": 1,
-                    "product_uom_qty": self.product_packaging.qty,
+                    "product_packaging_qty": pack_qty,
+                    "product_uom_qty": product_qty,
                     "product_uom": self.product_id.uom_id,
                 }
             )

--- a/sale_order_line_packaging_qty/models/sale_order_line.py
+++ b/sale_order_line_packaging_qty/models/sale_order_line.py
@@ -34,7 +34,13 @@ class SaleOrderLine(models.Model):
                 )
             else:
                 product_qty = sol.product_uom_qty
-            sol.product_packaging_qty = product_qty / sol.product_packaging.qty
+            if product_qty % sol.product_packaging.qty:
+                # If qty does not fit in package reset package qty
+                sol.product_packaging_qty = 0
+            else:
+                # Maybe that product_packaging_qty should be an Integer, no ?
+                qty = product_qty // sol.product_packaging.qty
+                sol.product_packaging_qty = qty
 
     def _prepare_product_packaging_qty_values(self):
         return {

--- a/sale_order_line_packaging_qty/models/sale_order_line.py
+++ b/sale_order_line_packaging_qty/models/sale_order_line.py
@@ -74,7 +74,7 @@ class SaleOrderLine(models.Model):
         if self.product_packaging:
             pack_qty = 1
             product_qty = self.product_packaging.qty
-            if self.product_uom_qty > 0:
+            if self.product_uom_qty > 0 and product_qty > 0:
                 if (self.product_uom_qty % self.product_packaging.qty) == 0:
                     pack_qty = self.product_uom_qty / self.product_packaging.qty
                     product_qty = self.product_uom_qty


### PR DESCRIPTION
When a quantity is set on the sale order line before or at the same time
than the product itself, the onchange triggered will replace the line
set quantity with the default size of the package.
This is especially problematic for sales order created programmatically.
So to improve the solution, if the quantity fits with the package
quantity it is kept.