### PR TITLE
[FIX][12.0] sale_global_discount: sale order templates compatibility

### DIFF
--- a/sale_global_discount/models/sale_order.py
+++ b/sale_global_discount/models/sale_order.py
@@ -53,7 +53,7 @@ class SaleOrder(models.Model):
         if not self.global_discount_ids:
             return True
         taxes_keys = {}
-        for line in self.order_line:
+        for line in self.order_line.filtered(lambda l: not l.display_type):
             if not line.tax_id:
                 raise exceptions.UserError(_(
                     "With global discounts, taxes in lines are required."


### PR DESCRIPTION
If you happen to use line sections or notes on sales order lines, you can now avoid the '... taxes in lines are required.' error and actually use global discounts.