### PR TITLE
[13.0][ADD] sale_by_packaging: add possibility to force the qty during SO line create/update

### DIFF
--- a/sale_by_packaging/models/product_packaging.py
+++ b/sale_by_packaging/models/product_packaging.py
@@ -9,3 +9,12 @@ class ProductPackaging(models.Model):
     can_be_sold = fields.Boolean(
         related="packaging_type_id.can_be_sold", readonly=True,
     )
+    force_sale_qty = fields.Boolean(
+        string="Force sale quantity",
+        help="Determine if during the creation of a sale order line, the "
+        "quantity should be forced with a multiple of the packaging.\n"
+        "Example:\n"
+        "You sell a product by packaging of 5 products.\n"
+        "When the user will put 3 as quantity, the system can force the "
+        "quantity to the superior unit (5 for this example).",
+    )

--- a/sale_by_packaging/models/product_product.py
+++ b/sale_by_packaging/models/product_product.py
@@ -2,11 +2,40 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
-from odoo.tools import float_is_zero
+from odoo.tools import float_compare, float_is_zero, float_round
 
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
+
+    def _convert_packaging_qty(self, qty, uom, packaging):
+        """
+        Convert the given qty with given UoM to the packaging uom.
+        To do that, first transform the qty to the reference UoM and then
+        transform using the packaging UoM.
+        The given qty is not updated if the product has sell_only_by_packaging
+        set to False or if the packaging is not set.
+        Inspired from sale_stock/models.sale_order.py _check_package(...)
+        :param qty: float
+        :return: float
+        """
+        if not self or not packaging:
+            return qty
+        self.ensure_one()
+        if self.sell_only_by_packaging and packaging.force_sale_qty:
+            q = self.uom_id._compute_quantity(packaging.qty, uom)
+            if (
+                qty
+                and q
+                and float_compare(
+                    qty / q,
+                    float_round(qty / q, precision_rounding=1.0),
+                    precision_rounding=0.001,
+                )
+                != 0
+            ):
+                qty = qty - (qty % q) + q
+        return qty
 
     def get_first_packaging_with_multiple_qty(self, qty):
         """ Return multiple of product packaging for one quantity if exist.

--- a/sale_by_packaging/models/sale_order_line.py
+++ b/sale_by_packaging/models/sale_order_line.py
@@ -70,8 +70,21 @@ class SaleOrderLine(models.Model):
                 )
         return res
 
+    def _force_qty_with_package(self):
+        """
+
+        :return:
+        """
+        self.ensure_one()
+        qty = self.product_id._convert_packaging_qty(
+            self.product_uom_qty, self.product_uom, packaging=self.product_packaging
+        )
+        self.product_uom_qty = qty
+        return True
+
     @api.onchange("product_uom_qty")
     def _onchange_product_uom_qty(self):
+        self._force_qty_with_package()
         res = super()._onchange_product_uom_qty()
         if not res:
             res = self._check_qty_is_pack_multiple()

--- a/sale_by_packaging/readme/CONFIGURE.rst
+++ b/sale_by_packaging/readme/CONFIGURE.rst
@@ -9,3 +9,6 @@ which product can only be sold by packaging.
   sales of these products if no packaging is selected on the sale order line.
   If no packaging is selected, it will either be auto-assigned if the quantity
   on the sale order line matches a packaging quantity or an error will be raised.
+
+* Force sale quantity (on the packaging): force rounds up the quantity during
+  creation/modification of the sale order line with the factor set on the packaging.

--- a/sale_by_packaging/readme/CONTRIBUTORS.rst
+++ b/sale_by_packaging/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Akim Juillerat <akim.juillerat@camptocamp.com>
 * Thomas Nowicki <thomas.nowicki@camptocamp.com>
+* François Honoré <francois.honore@acsone.eu>

--- a/sale_by_packaging/readme/DESCRIPTION.rst
+++ b/sale_by_packaging/readme/DESCRIPTION.rst
@@ -1,2 +1,11 @@
 This module provides different configuration option to manage packagings on
 sale orders.
+
+By default there is a Warning message during the modification/creation of a sale order line
+to notice the user when the quantity to sell doesn't fit with the factor set on the packaging.
+
+It's also possible to force the quantity to sell during creation/modification of the sale order line
+if the "Force sale quantity" is ticked on the packaging.
+
+For example, if your packaging is set to sell by 5 units and the employee fill
+the quantity with 3, the quantity will be automatically replaced by 5 (it always rounds up).

--- a/sale_by_packaging/tests/test_sale_only_by_packaging.py
+++ b/sale_by_packaging/tests/test_sale_only_by_packaging.py
@@ -1,7 +1,9 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields
 from odoo.exceptions import ValidationError
-from odoo.tests import SavepointCase
+from odoo.tests import Form, SavepointCase
+from odoo.tools import mute_logger
 
 
 class TestSaleProductByPackagingOnly(SavepointCase):
@@ -9,12 +11,14 @@ class TestSaleProductByPackagingOnly(SavepointCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.SaleOrder = cls.env["sale.order"]
         cls.partner = cls.env.ref("base.res_partner_12")
         cls.product = cls.env.ref("product.product_product_9")
         cls.packaging = cls.env["product.packaging"].create(
             {"name": "Test packaging", "product_id": cls.product.id, "qty": 5.0}
         )
         cls.order = cls.env["sale.order"].create({"partner_id": cls.partner.id})
+        cls.precision = cls.env["decimal.precision"].precision_get("Product Price")
 
     def test_onchange_qty_is_pack_multiple(self):
         order_line = self.env["sale.order.line"].create(
@@ -108,3 +112,63 @@ class TestSaleProductByPackagingOnly(SavepointCase):
                     "product_uom_qty": 2,
                 }
             )
+
+    @mute_logger("odoo.tests.common.onchange")
+    def test_convert_packaging_qty(self):
+        """
+        Test if the function _convert_packaging_qty is correctly applied
+        during SO line create/edit and if qties are corrects.
+        :return:
+        """
+        self.product.sell_only_by_packaging = True
+        packaging = fields.first(self.product.packaging_ids)
+        # For this step, the qty is not forced on the packaging so nothing
+        # should happens if the qty doesn't match with packaging multiple.
+        with Form(self.SaleOrder) as sale_order:
+            sale_order.partner_id = self.partner
+            with sale_order.order_line.new() as so_line:
+                so_line.product_id = self.product
+                so_line.product_packaging = packaging
+                so_line.product_uom_qty = 12
+                self.assertAlmostEqual(
+                    so_line.product_uom_qty, 12, places=self.precision
+                )
+                so_line.product_uom_qty = 10
+                self.assertAlmostEqual(
+                    so_line.product_uom_qty, 10, places=self.precision
+                )
+                so_line.product_uom_qty = 36
+                self.assertAlmostEqual(
+                    so_line.product_uom_qty, 36, places=self.precision
+                )
+        # Now force the qty on the packaging
+        packaging.force_sale_qty = True
+        with Form(self.SaleOrder) as sale_order:
+            sale_order.partner_id = self.partner
+            with sale_order.order_line.new() as so_line:
+                so_line.product_id = self.product
+                so_line.product_packaging = packaging
+                so_line.product_uom_qty = 12
+                self.assertAlmostEqual(
+                    so_line.product_uom_qty, 15, places=self.precision
+                )
+                so_line.product_uom_qty = 10
+                self.assertAlmostEqual(
+                    so_line.product_uom_qty, 10, places=self.precision
+                )
+                so_line.product_uom_qty = 8
+                self.assertAlmostEqual(
+                    so_line.product_uom_qty, 10, places=self.precision
+                )
+                so_line.product_uom_qty = 11
+                self.assertAlmostEqual(
+                    so_line.product_uom_qty, 15, places=self.precision
+                )
+                so_line.product_uom_qty = 208
+                self.assertAlmostEqual(
+                    so_line.product_uom_qty, 210, places=self.precision
+                )
+                so_line.product_uom_qty = 209.98
+                self.assertAlmostEqual(
+                    so_line.product_uom_qty, 210, places=self.precision
+                )

--- a/sale_by_packaging/views/product_packaging.xml
+++ b/sale_by_packaging/views/product_packaging.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <field name="qty" position="after">
                 <field name="can_be_sold" />
+                <field name="force_sale_qty" />
             </field>
         </field>
     </record>
@@ -17,6 +18,7 @@
         <field name="arch" type="xml">
             <field name="barcode" position="before">
                 <field name="can_be_sold" />
+                <field name="force_sale_qty" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Add feature in the module `sale_by_packaging`.

For now, the module display a warning (during onchange) if the qty set in the SO line is not a multiple of the packaging.
This module add the possibility to force the qty of the SO line with this packaging's multiple.

**Ex:**
You set your packaging to sell only by 5 units.
If a user set `qty = 3`, the onchange is triggered and the `qty` will be 5.