### PR TITLE
[13.0][FIX] sale_sourced_by_line: Fix routes

### DIFF
--- a/sale_sourced_by_line/README.rst
+++ b/sale_sourced_by_line/README.rst
@@ -47,6 +47,7 @@ Contributors
 * Eficent Business and IT Consulting Services S.L. <contact@eficent.com>
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 * Info A Tout Prix <huret.emmanuel@infoatoutprix.fr>
+* Denis Roussel <denis.roussel@acsone.eu>
 
 Do not contact contributors directly about support or help with technical issues.
 


### PR DESCRIPTION
Since Odoo commit https://github.com/odoo/odoo/commit/51b7960f7e30aab471bb846cb890efd95c7b2dcc
the stock rules are enforced for admin user to be filtered
by current company.

So, no convenient rule was found when evaluating https://github.com/odoo/odoo/commit/51b7960f7e30aab471bb846cb890efd95c7b2dcc#diff-a8e268c29293c3896cc7bf77c5a0809a394ffe929388180b6e96cce485177956R434