### PR TITLE
[13.0][FIX] sale_stock_delivery_addres: order_partner_id not being stored

### DIFF
--- a/sale_stock_delivery_address/__manifest__.py
+++ b/sale_stock_delivery_address/__manifest__.py
@@ -8,6 +8,7 @@
     "website": "https://github.com/OCA/sale-workflow/",
     "category": "Sales Management",
     "license": "LGPL-3",
+    "development_status": "Production/Stable",
     "depends": ["sale_stock", "sale_procurement_group_by_line"],
     "data": ["views/sale_order_view.xml", "views/res_partner_view.xml"],
     "installable": True,

--- a/sale_stock_delivery_address/views/sale_order_view.xml
+++ b/sale_stock_delivery_address/views/sale_order_view.xml
@@ -10,7 +10,6 @@
                     name="dest_address_id"
                     attrs="{'readonly': [('product_updatable', '=', False)]}"
                 />
-                <field name="order_partner_id" invisible="1" />
             </xpath>
             <xpath
                 expr="//field[@name='order_line']/form//field[@name='route_id']"
@@ -20,7 +19,6 @@
                     name="dest_address_id"
                     attrs="{'readonly': [('product_updatable', '=', False)]}"
                 />
-                <field name="order_partner_id" invisible="1" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Include the related stored field `order_partner_id` in the views has the side effect of preventing it to be stored, even when it is invisible. ORM issues appart it is better to just remove it in this case, as the field is not needed anymore in the view by this module.

@ForgeFlow