### PR TITLE
[ADD] sale_coupon_multi_use: init

### DIFF
--- a/sale_coupon_multi_currency/__init__.py
+++ b/sale_coupon_multi_currency/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_coupon_multi_currency/__manifest__.py
+++ b/sale_coupon_multi_currency/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Sale Coupon Multi Currency",
+    "summary": "Allow to use custom currency on coupon/promotion program",
+    "version": "13.0.1.0.0",
+    "category": "Sale",
+    "website": "https://github.com/OCA/sale-workflow",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": ["sale_coupon"],
+    "installable": True,
+    "data": ["views/sale_coupon_program_views.xml"],
+}

--- a/sale_coupon_multi_currency/i18n/fr.po
+++ b/sale_coupon_multi_currency/i18n/fr.po
@@ -1,0 +1,31 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale_coupon_multi_currency
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 13.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-11-25 14:45+0000\n"
+"PO-Revision-Date: 2020-11-25 14:45+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_coupon_multi_currency
+#: model:ir.model.fields,field_description:sale_coupon_multi_currency.field_sale_coupon_program__currency_id
+msgid "Currency"
+msgstr "Devise"
+
+#. module: sale_coupon_multi_currency
+#: model:ir.model.fields,field_description:sale_coupon_multi_currency.field_sale_coupon_program__currency_custom_id
+msgid "Custom Currency"
+msgstr "Devise personnalisée"
+
+#. module: sale_coupon_multi_currency
+#: model:ir.model,name:sale_coupon_multi_currency.model_sale_coupon_program
+msgid "Sales Coupon Program"
+msgstr "Campagne de bons de réduction"

--- a/sale_coupon_multi_currency/models/__init__.py
+++ b/sale_coupon_multi_currency/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_coupon_program

--- a/sale_coupon_multi_currency/models/sale_coupon_program.py
+++ b/sale_coupon_multi_currency/models/sale_coupon_program.py
@@ -1,0 +1,29 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class SaleCouponProgram(models.Model):
+    """Extend to add logic that control multi coupon usage."""
+
+    _inherit = "sale.coupon.program"
+
+    # Changing existing related field to computed to allow changing
+    # currency.
+    currency_id = fields.Many2one(
+        "res.currency",
+        related=None,
+        compute="_compute_currency_id",
+        inverse="_inverse_currency_id",
+    )
+    currency_custom_id = fields.Many2one("res.currency", "Custom Currency")
+
+    @api.depends("company_id.currency_id", "currency_custom_id")
+    def _compute_currency_id(self):
+        for rec in self:
+            rec.currency_id = rec.currency_custom_id or rec.company_id.currency_id
+
+    def _inverse_currency_id(self):
+        for rec in self:
+            rec.currency_custom_id = rec.currency_id

--- a/sale_coupon_multi_currency/readme/CONTRIBUTORS.rst
+++ b/sale_coupon_multi_currency/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Andrius Laukavičius <andrius@focusate.eu>

--- a/sale_coupon_multi_currency/readme/DESCRIPTION.rst
+++ b/sale_coupon_multi_currency/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+Makes currency field visible on coupon/promotion program.
+
+Can set custom currency instead of just using company currency.

--- a/sale_coupon_multi_currency/tests/__init__.py
+++ b/sale_coupon_multi_currency/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_coupon_multi_currency

--- a/sale_coupon_multi_currency/tests/common.py
+++ b/sale_coupon_multi_currency/tests/common.py
@@ -1,0 +1,24 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo.tests.common import SavepointCase
+
+
+class TestSaleCouponMultiCurrencyCommon(SavepointCase):
+    """Common class for multi currency program tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up common data for multi currency coupon tests."""
+        super().setUpClass()
+        # Records.
+        # Coupon Programs.
+        cls.program_coupon_percentage = cls.env.ref("sale_coupon.10_percent_coupon")
+        # Currencies.
+        cls.company_main = cls.env.ref("base.main_company")
+        cls.currency_company = cls.company_main.currency_id
+        cls.usd = cls.env.ref("base.USD")
+        cls.eur = cls.env.ref("base.EUR")
+        # Depending on modules installed, company currency can be
+        # different, so we set other currency, the one that is not
+        # set on company currency.
+        cls.currency_other = cls.usd if cls.currency_company != cls.usd else cls.eur

--- a/sale_coupon_multi_currency/tests/test_sale_coupon_multi_currency.py
+++ b/sale_coupon_multi_currency/tests/test_sale_coupon_multi_currency.py
@@ -1,0 +1,30 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from .common import TestSaleCouponMultiCurrencyCommon
+
+
+class TestSaleCouponMultiCurrency(TestSaleCouponMultiCurrencyCommon):
+    """Test custom currency on program."""
+
+    def test_01_program_multi_currency(self):
+        """Set custom currency.
+
+        Case 1: set custom currency other than company currency.
+        Case 2: unset custom currency to use company currency.
+        """
+        # Case 1.
+        self.program_coupon_percentage.currency_id = self.currency_other.id
+        self.assertEqual(
+            self.program_coupon_percentage.currency_id, self.currency_other
+        )
+        self.assertEqual(
+            self.program_coupon_percentage.currency_custom_id, self.currency_other
+        )
+        self.assertEqual(self.company_main.currency_id, self.currency_company)
+        # Case 2.
+        self.program_coupon_percentage.currency_custom_id = False
+        self.assertEqual(
+            self.program_coupon_percentage.currency_id, self.currency_company
+        )
+        self.assertFalse(self.program_coupon_percentage.currency_custom_id)
+        self.assertEqual(self.company_main.currency_id, self.currency_company)

--- a/sale_coupon_multi_currency/views/sale_coupon_program_views.xml
+++ b/sale_coupon_multi_currency/views/sale_coupon_program_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="sale_coupon_program_view_form_common" model="ir.ui.view">
+        <field name="name">sale.coupon.program.form.currency</field>
+        <field name="model">sale.coupon.program</field>
+        <field
+            name="inherit_id"
+            ref="sale_coupon.sale_coupon_program_view_form_common"
+        />
+        <field name="arch" type="xml">
+            <field name="company_id" position="before">
+                <field
+                    name="currency_id"
+                    readonly="False"
+                    required="True"
+                    groups="base.group_multi_currency"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/sale_coupon_multi_use/__init__.py
+++ b/sale_coupon_multi_use/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizards

--- a/sale_coupon_multi_use/__manifest__.py
+++ b/sale_coupon_multi_use/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Sale Coupon Multi Use",
+    "summary": "Allow to use same coupon multiple times",
+    "version": "13.0.1.0.0",
+    "category": "Sale",
+    "website": "https://github.com/OCA/sale-workflow",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": ["sale_coupon"],
+    "data": [
+        "security/ir.model.access.csv",
+        "views/sale_coupon_program_views.xml",
+        "views/sale_coupon_views.xml",
+    ],
+    "installable": True,
+}

--- a/sale_coupon_multi_use/__manifest__.py
+++ b/sale_coupon_multi_use/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Camptocamp
+# Copyright 2021 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Sale Coupon Multi Use",

--- a/sale_coupon_multi_use/i18n/fr.po
+++ b/sale_coupon_multi_use/i18n/fr.po
@@ -1,0 +1,129 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * sale_coupon_multi_use
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 13.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-11-06 12:26+0000\n"
+"PO-Revision-Date: 2020-11-06 12:26+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__amount
+msgid "Amount"
+msgstr "Montant"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon__consumption_line_ids
+msgid "Consumption Lines"
+msgstr "Lignes de consommation"
+
+#. module: sale_coupon_multi_use
+#: code:addons/sale_coupon_multi_use/models/sale_coupon.py:0
+#, python-format
+msgid ""
+"Consumption Lines can't be deleted directly. To do that, delete related sale"
+" order line."
+msgstr "Les lignes de consommation ne peuvent pas être modifiées via cette interface. Pour cela, il faut modifier les lignes correspondantes sur les bons de commande."
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__coupon_id
+msgid "Coupon"
+msgstr "Bon de réduction"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__create_uid
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__create_date
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__display_name
+msgid "Display Name"
+msgstr "Nom"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon__discount_fixed_amount_delta
+msgid "Fixed Amount Delta"
+msgstr "Montant restant"
+
+#. module: sale_coupon_multi_use
+#: code:addons/sale_coupon_multi_use/models/sale_coupon_program.py:0
+#, python-format
+msgid ""
+"Fixed Amount can't be changed when there are Multi Use coupons already."
+msgstr "Le montant restant ne peut pas être modifié quand un bon de réduction a déjà été utilisé plusieurs fois."
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__id
+msgid "ID"
+msgstr "ID"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line____last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__write_uid
+msgid "Last Updated by"
+msgstr "Dernière mise à jour par"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__write_date
+msgid "Last Updated on"
+msgstr "Dernière mise à jour le"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon__multi_use
+msgid "Multi Use"
+msgstr "Sécable"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_program__coupon_multi_use
+msgid "Multi Use Coupons"
+msgstr "Bon de réduction sécable"
+
+#. module: sale_coupon_multi_use
+#: code:addons/sale_coupon_multi_use/models/sale_coupon_program.py:0
+#, python-format
+msgid ""
+"Multi Use Coupons program must have Coupon Program Type, Discount Reward and"
+" Fixed Amount as Apply Discount"
+msgstr "Les bons de réductions sécables doivent être de type Remise et Montant fixe"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model,name:sale_coupon_multi_use.model_sale_coupon_consumption_line
+msgid "Sale Coupon Consumption Line"
+msgstr "Lignes de consommation du bon de réduction"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__sale_order_line_id
+msgid "Sale Order Line"
+msgstr "Ligne de bon de commande"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model,name:sale_coupon_multi_use.model_sale_coupon
+msgid "Sales Coupon"
+msgstr "Bons de réduction"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model,name:sale_coupon_multi_use.model_sale_coupon_apply_code
+msgid "Sales Coupon Apply Code"
+msgstr "Code du bon de réduction"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model,name:sale_coupon_multi_use.model_sale_coupon_program
+msgid "Sales Coupon Program"
+msgstr "Campagne de bons de réduction"

--- a/sale_coupon_multi_use/i18n/fr.po
+++ b/sale_coupon_multi_use/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-10 12:45+0000\n"
-"PO-Revision-Date: 2020-11-10 12:45+0000\n"
+"POT-Creation-Date: 2020-11-25 14:46+0000\n"
+"PO-Revision-Date: 2020-11-25 14:46+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -50,6 +50,12 @@ msgstr "Créé par"
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__create_date
 msgid "Created on"
 msgstr "Créé le"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon__currency_program_id
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__currency_program_id
+msgid "Currency"
+msgstr "Devise"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__display_name
@@ -133,3 +139,8 @@ msgstr "Code du bon de réduction"
 #: model:ir.model,name:sale_coupon_multi_use.model_sale_coupon_program
 msgid "Sales Coupon Program"
 msgstr "Campagne de bons de réduction"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model,name:sale_coupon_multi_use.model_sale_order
+msgid "Sales Order"
+msgstr "Bon de commande"

--- a/sale_coupon_multi_use/i18n/fr.po
+++ b/sale_coupon_multi_use/i18n/fr.po
@@ -1,13 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#   * sale_coupon_multi_use
+# 	* sale_coupon_multi_use
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-06 12:26+0000\n"
-"PO-Revision-Date: 2020-11-06 12:26+0000\n"
+"POT-Creation-Date: 2020-11-10 12:45+0000\n"
+"PO-Revision-Date: 2020-11-10 12:45+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -26,12 +26,15 @@ msgid "Consumption Lines"
 msgstr "Lignes de consommation"
 
 #. module: sale_coupon_multi_use
-#: code:addons/sale_coupon_multi_use/models/sale_coupon.py:0
+#: code:addons/sale_coupon_multi_use/models/sale_coupon_consumption_line.py:0
 #, python-format
 msgid ""
 "Consumption Lines can't be deleted directly. To do that, delete related sale"
 " order line."
-msgstr "Les lignes de consommation ne peuvent pas être modifiées via cette interface. Pour cela, il faut modifier les lignes correspondantes sur les bons de commande."
+msgstr ""
+"Les lignes de consommation ne peuvent pas être modifiées via cette "
+"interface. Pour cela, il faut modifier les lignes correspondantes sur les "
+"bons de commande."
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__coupon_id
@@ -63,12 +66,14 @@ msgstr "Montant restant"
 #, python-format
 msgid ""
 "Fixed Amount can't be changed when there are Multi Use coupons already."
-msgstr "Le montant restant ne peut pas être modifié quand un bon de réduction a déjà été utilisé plusieurs fois."
+msgstr ""
+"Le montant restant ne peut pas être modifié quand un bon de réduction a déjà"
+" été utilisé plusieurs fois."
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__id
 msgid "ID"
-msgstr "ID"
+msgstr "Identifiant"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line____last_update
@@ -101,7 +106,8 @@ msgstr "Bon de réduction sécable"
 msgid ""
 "Multi Use Coupons program must have Coupon Program Type, Discount Reward and"
 " Fixed Amount as Apply Discount"
-msgstr "Les bons de réductions sécables doivent être de type Remise et Montant fixe"
+msgstr ""
+"Les bons de réductions sécables doivent être de type Remise et Montant fixe"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model,name:sale_coupon_multi_use.model_sale_coupon_consumption_line

--- a/sale_coupon_multi_use/i18n/fr.po
+++ b/sale_coupon_multi_use/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-12-03 12:46+0000\n"
-"PO-Revision-Date: 2020-12-03 12:46+0000\n"
+"POT-Creation-Date: 2021-02-11 07:07+0000\n"
+"PO-Revision-Date: 2021-02-11 07:07+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -27,24 +27,24 @@ msgstr "Appliqué sur les bons de commandes"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon__consumption_line_ids
-msgid "Consumption Lines"
-msgstr "Lignes de consommation"
-
-#. module: sale_coupon_multi_use
-#: code:addons/sale_coupon_multi_use/models/sale_coupon_consumption_line.py:0
-#, python-format
-msgid ""
-"Consumption Lines can't be deleted directly. To do that, delete related sale"
-" order line."
-msgstr ""
-"Les lignes de consommation ne peuvent pas être modifiées via cette "
-"interface. Pour cela, il faut modifier les lignes correspondantes sur les "
-"bons de commande."
+msgid "Consumption Line"
+msgstr "Ligne de consommation"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__coupon_id
 msgid "Coupon"
 msgstr "Bon de réduction"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_order_line__coupon_consumption_line_ids
+msgid "Coupon Consumption Line"
+msgstr "Lignes de consommation des bons de réduction"
+
+#. module: sale_coupon_multi_use
+#: code:addons/sale_coupon_multi_use/models/sale_coupon_program.py:0
+#, python-format
+msgid "Coupon multi use can't be changed with existing coupons."
+msgstr "Le bon de réduction sécable ne peut pas être modifié avec des bons de réduction existants."
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__create_uid
@@ -103,10 +103,6 @@ msgstr "Dernière mise à jour le"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon__multi_use
-msgid "Multi Use"
-msgstr "Sécable"
-
-#. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_program__coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_order__coupon_multi_use_ids
 msgid "Multi Use Coupons"
@@ -161,3 +157,8 @@ msgstr "Bon de commande"
 #: model:ir.model,name:sale_coupon_multi_use.model_sale_order_line
 msgid "Sales Order Line"
 msgstr "Ligne de bons de commande"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__sale_order_state
+msgid "Status"
+msgstr "Statut"

--- a/sale_coupon_multi_use/i18n/fr.po
+++ b/sale_coupon_multi_use/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-25 14:46+0000\n"
-"PO-Revision-Date: 2020-11-25 14:46+0000\n"
+"POT-Creation-Date: 2020-12-03 12:46+0000\n"
+"PO-Revision-Date: 2020-12-03 12:46+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -19,6 +19,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_consumption_line__amount
 msgid "Amount"
 msgstr "Montant"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon__sale_multi_use_ids
+msgid "Applied on Orders"
+msgstr "Appliqué sur les bons de commandes"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon__consumption_line_ids
@@ -103,6 +108,7 @@ msgstr "Sécable"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_coupon_program__coupon_multi_use
+#: model:ir.model.fields,field_description:sale_coupon_multi_use.field_sale_order__coupon_multi_use_ids
 msgid "Multi Use Coupons"
 msgstr "Bon de réduction sécable"
 
@@ -114,6 +120,12 @@ msgid ""
 " Fixed Amount as Apply Discount"
 msgstr ""
 "Les bons de réductions sécables doivent être de type Remise et Montant fixe"
+
+#. module: sale_coupon_multi_use
+#: code:addons/sale_coupon_multi_use/models/sale_coupon.py:0
+#, python-format
+msgid "Multi-Use Coupon is already applied for the same reward"
+msgstr "Le coupon a déjà été appliqué sur la même récompense"
 
 #. module: sale_coupon_multi_use
 #: model:ir.model,name:sale_coupon_multi_use.model_sale_coupon_consumption_line
@@ -144,3 +156,8 @@ msgstr "Campagne de bons de réduction"
 #: model:ir.model,name:sale_coupon_multi_use.model_sale_order
 msgid "Sales Order"
 msgstr "Bon de commande"
+
+#. module: sale_coupon_multi_use
+#: model:ir.model,name:sale_coupon_multi_use.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Ligne de bons de commande"

--- a/sale_coupon_multi_use/models/__init__.py
+++ b/sale_coupon_multi_use/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_coupon_program
+from . import sale_coupon

--- a/sale_coupon_multi_use/models/__init__.py
+++ b/sale_coupon_multi_use/models/__init__.py
@@ -2,3 +2,4 @@ from . import sale_coupon_program
 from . import sale_coupon
 from . import sale_coupon_consumption_line
 from . import sale_order
+from . import sale_order_line

--- a/sale_coupon_multi_use/models/__init__.py
+++ b/sale_coupon_multi_use/models/__init__.py
@@ -1,2 +1,4 @@
 from . import sale_coupon_program
 from . import sale_coupon
+from . import sale_coupon_consumption_line
+from . import sale_order

--- a/sale_coupon_multi_use/models/sale_coupon.py
+++ b/sale_coupon_multi_use/models/sale_coupon.py
@@ -1,0 +1,154 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class SaleCoupon(models.Model):
+    """Extend to implement multi use coupon rule."""
+
+    _inherit = "sale.coupon"
+
+    # Takes value from related program (coupon_multi_use field), when
+    # it is generated.
+    multi_use = fields.Boolean("Multi Use", readonly=True)
+    consumption_line_ids = fields.One2many(
+        "sale.coupon.consumption_line", "coupon_id", "Consumption Lines", readonly=True,
+    )
+    discount_fixed_amount_delta = fields.Float(
+        "Fixed Amount Delta", compute="_compute_discount_fixed_amount_delta"
+    )
+
+    def _get_discount_fixed_amount_delta(self):
+        self.ensure_one()
+        amount_total = self.program_id.discount_fixed_amount
+        amount_consumed = sum(self.consumption_line_ids.mapped("amount"))
+        return amount_total - amount_consumed
+
+    @api.depends("program_id.discount_fixed_amount", "consumption_line_ids.amount")
+    def _compute_discount_fixed_amount_delta(self):
+        for rec in self:
+            rec.discount_fixed_amount_delta = rec._get_discount_fixed_amount_delta()
+
+    def _is_multi_use_triggered(self, vals):
+        # We expect multi_use coupon will be updated one by one only.
+        return (
+            len(self) == 1
+            and self.multi_use
+            # Must have amount to split.
+            and self.discount_fixed_amount_delta > 0
+            # Indicating for coupon to be consumed.
+            and vals.get("state") == "used"
+        )
+
+    def _get_compared_discount_with_delta(self, coupon_order_data):
+        sale_order = coupon_order_data["order"]
+        amount_total_orig = coupon_order_data["amount_total"]
+        discount = amount_total_orig - sale_order.amount_total
+        new_delta = self.discount_fixed_amount_delta - discount
+        return new_delta, discount
+
+    def _adjust_discount_on_sale_order(self, order, amount_to_adjust):
+        self.ensure_one()
+        discount_product = self.program_id.discount_line_product_id
+        # Supposed to be only one such line.
+        coupon_line = order.order_line.filtered(
+            lambda r: r.product_id == discount_product
+        )
+        coupon_line.price_unit += amount_to_adjust
+
+    def _get_related_sale_order_line(self, sale_order):
+        self.ensure_one()
+        discount_product = self.program_id.discount_line_product_id
+        # Supposed to be only one such line.
+        return sale_order.order_line.filtered(
+            lambda r: r.product_id == discount_product
+        )[0]
+
+    def _prepare_consumption_line(self, amount_consumed, sale_order):
+        self.ensure_one()
+        line = self._get_related_sale_order_line(sale_order)
+        return {
+            "coupon_id": self.id,
+            "amount": amount_consumed,
+            "sale_order_line_id": line.id,
+        }
+
+    def _create_consumption_line(self, amount_consumed, sale_order):
+        vals = self._prepare_consumption_line(amount_consumed, sale_order)
+        return self.env["sale.coupon.consumption_line"].create(vals)
+
+    def _consume_line(self, discount, sale_order):
+        self.ensure_one()
+        amount_consumed = min(discount, self.discount_fixed_amount_delta)
+        consumption_line = self._create_consumption_line(amount_consumed, sale_order)
+        consumption_line._normalize_discount()
+        return consumption_line
+
+    def _handle_multi_use(self, coupon_order_data):
+        self.ensure_one()
+        new_delta, discount = self._get_compared_discount_with_delta(coupon_order_data)
+        self._consume_line(discount, coupon_order_data["order"])
+        # Indicates whether coupon was fully consumed.
+        return new_delta <= 0
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Extend to pick up coupon_multi_use value from program."""
+        for vals in vals_list:
+            multi_use = (
+                self.env["sale.coupon.program"]
+                .browse(vals.get("program_id"))
+                .coupon_multi_use
+            )
+            if "multi_use" not in vals:
+                vals["multi_use"] = multi_use
+        return super().create(vals_list)
+
+    def write(self, vals):
+        """Extend to manage multi_use coupons."""
+        if self._is_multi_use_triggered(vals):
+            coupon_order_data = self._context.get("coupon_order_data")
+            if coupon_order_data:
+                coupon_consumed = self._handle_multi_use(coupon_order_data)
+                if not coupon_consumed:
+                    # Makes it so coupon that coupon is not used up yet.
+                    del vals["state"]
+        return super().write(vals)
+
+
+class SaleCouponConsumptionLine(models.Model):
+    """Model that stores data for single coupon multiple uses."""
+
+    _name = "sale.coupon.consumption_line"
+    _description = "Sale Coupon Consumption Line"
+
+    coupon_id = fields.Many2one("sale.coupon", "Coupon", required=True, index=True)
+    # ondelete takes care of automatically removing consumption line,
+    # when discount line is removed on related sale order.
+    sale_order_line_id = fields.Many2one(
+        "sale.order.line", "Sale Order Line", required=True, ondelete="cascade"
+    )
+    amount = fields.Float()
+
+    def _normalize_discount(self):
+        """Adjust SOL discount to match consumed discount."""
+        self.ensure_one()
+        # Discount initially won't match, when standard functionality
+        # applies full discount from coupon. But because we split
+        # coupon amount, we want to apply maximum possible discount.
+        sol = self.sale_order_line_id
+        sol_discount = abs(sol.price_unit)
+        amount_to_adjust = sol_discount - self.amount
+        if amount_to_adjust > 0:
+            # Reducing negative amount here.
+            sol.price_unit += amount_to_adjust
+
+    def unlink(self):
+        """Override to prevent direct unlink."""
+        if not self._context.get("force_unlink_coupon_consumption_lines"):
+            raise UserError(
+                _(
+                    "Consumption Lines can't be deleted directly. To do that, "
+                    "delete related sale order line."
+                )
+            )
+        return super().unlink()

--- a/sale_coupon_multi_use/models/sale_coupon_consumption_line.py
+++ b/sale_coupon_multi_use/models/sale_coupon_consumption_line.py
@@ -16,7 +16,8 @@ class SaleCouponConsumptionLine(models.Model):
     sale_order_line_id = fields.Many2one(
         "sale.order.line", "Sale Order Line", required=True, ondelete="cascade"
     )
-    amount = fields.Float()
+    currency_program_id = fields.Many2one(related="coupon_id.program_id.currency_id")
+    amount = fields.Monetary(currency_field="currency_program_id")
 
     def _get_consumption_lines_to_unlink(self, order_lines):
         return self.filtered(lambda r: r.sale_order_line_id in order_lines)

--- a/sale_coupon_multi_use/models/sale_coupon_consumption_line.py
+++ b/sale_coupon_multi_use/models/sale_coupon_consumption_line.py
@@ -1,0 +1,38 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+
+
+class SaleCouponConsumptionLine(models.Model):
+    """Model that stores data for single coupon multiple uses."""
+
+    _name = "sale.coupon.consumption_line"
+    _description = "Sale Coupon Consumption Line"
+
+    coupon_id = fields.Many2one("sale.coupon", "Coupon", required=True, index=True)
+    # ondelete takes care of automatically removing consumption line,
+    # when discount line is removed on related sale order.
+    sale_order_line_id = fields.Many2one(
+        "sale.order.line", "Sale Order Line", required=True, ondelete="cascade"
+    )
+    amount = fields.Float()
+
+    def _get_consumption_lines_to_unlink(self, order_lines):
+        return self.filtered(lambda r: r.sale_order_line_id in order_lines)
+
+    def _unlink_consumption_lines(self, order_lines):
+        to_unlink = self._get_consumption_lines_to_unlink(order_lines)
+        if to_unlink:
+            to_unlink.with_context(force_unlink_coupon_consumption_lines=True).unlink()
+
+    def unlink(self):
+        """Override to prevent direct unlink."""
+        if not self._context.get("force_unlink_coupon_consumption_lines"):
+            raise UserError(
+                _(
+                    "Consumption Lines can't be deleted directly. To do that, "
+                    "delete related sale order line."
+                )
+            )
+        return super().unlink()

--- a/sale_coupon_multi_use/models/sale_coupon_program.py
+++ b/sale_coupon_multi_use/models/sale_coupon_program.py
@@ -1,0 +1,61 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class SaleCouponProgram(models.Model):
+    """Extend to add logic that control multi coupon usage."""
+
+    _inherit = "sale.coupon.program"
+
+    coupon_multi_use = fields.Boolean("Multi Use Coupons")
+
+    def _prepare_multi_use_vals(self):
+        self.ensure_one()
+        return {
+            "program_type": "coupon_program",
+            "reward_type": "discount",
+            "discount_type": "fixed_amount",
+        }
+
+    @api.onchange("coupon_multi_use")
+    def _onchange_coupon_multi_use(self):
+        if self.coupon_multi_use:
+            self.update(self._prepare_multi_use_vals())
+
+    def _get_multi_use_coupons(self):
+        self.ensure_one()
+        return self.coupon_ids.filtered(lambda r: r.multi_use)
+
+    @api.constrains("discount_fixed_amount")
+    def _check_discount_fixed_amount(self):
+        for rec in self:
+            if rec._get_multi_use_coupons():
+                raise ValidationError(
+                    _(
+                        "Fixed Amount can't be changed when there are Multi Use "
+                        "coupons already."
+                    )
+                )
+
+    def _validate_coupon_multi_use_field_values(self):
+        self.ensure_one()
+        for fname, value in self._prepare_multi_use_vals().items():
+            if self[fname] != value:
+                return False
+        return True
+
+    @api.constrains("coupon_multi_use", "reward_type", "discount_type", "program_type")
+    def _check_coupon_multi_use_options(self):
+        for rec in self:
+            if (
+                rec.coupon_multi_use or rec._get_multi_use_coupons()
+            ) and not rec._validate_coupon_multi_use_field_values():
+                raise ValidationError(
+                    _(
+                        "Multi Use Coupons program must have Coupon Program Type, "
+                        "Discount Reward and Fixed Amount as Apply Discount"
+                    )
+                )

--- a/sale_coupon_multi_use/models/sale_coupon_program.py
+++ b/sale_coupon_multi_use/models/sale_coupon_program.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Camptocamp SA
+# Copyright 2021 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
@@ -20,19 +20,29 @@ class SaleCouponProgram(models.Model):
             "discount_type": "fixed_amount",
         }
 
+    def _check_can_change_coupon_multi_use(self):
+        self.ensure_one()
+        if self.coupon_ids:
+            raise ValidationError(
+                _("Coupon multi use can't be changed with existing coupons.")
+            )
+
     @api.onchange("coupon_multi_use")
     def _onchange_coupon_multi_use(self):
+        self._check_can_change_coupon_multi_use()
         if self.coupon_multi_use:
             self.update(self._prepare_multi_use_vals())
 
-    def _get_multi_use_coupons(self):
-        self.ensure_one()
-        return self.coupon_ids.filtered("multi_use")
+    def write(self, values):
+        for program in self:
+            if "coupon_multi_use" in values:
+                program._check_can_change_coupon_multi_use()
+        return super().write(values)
 
     @api.constrains("discount_fixed_amount")
     def _check_discount_fixed_amount(self):
         for rec in self:
-            if rec._get_multi_use_coupons():
+            if rec.coupon_multi_use and rec.coupon_ids:
                 raise ValidationError(
                     _(
                         "Fixed Amount can't be changed when there are Multi"
@@ -51,8 +61,9 @@ class SaleCouponProgram(models.Model):
     def _check_coupon_multi_use_options(self):
         for rec in self:
             if (
-                rec.coupon_multi_use or rec._get_multi_use_coupons()
-            ) and not rec._validate_coupon_multi_use_field_values():
+                rec.coupon_multi_use
+                and not rec._validate_coupon_multi_use_field_values()
+            ):
                 raise ValidationError(
                     _(
                         "Multi Use Coupons program must have Coupon Program Type, "
@@ -61,11 +72,11 @@ class SaleCouponProgram(models.Model):
                 )
 
     def _compute_program_multi_use_amount(
-        self, coupon_multi_use, sale_order, currency_to
+        self, multi_use_coupon, sale_order, currency_to
     ):
         # Only using remaining amount (original implementation
         # always uses full amount specified on related program).
-        amount_delta = coupon_multi_use.discount_fixed_amount_delta
+        amount_delta = multi_use_coupon.discount_fixed_amount_delta
         amount_delta = self.currency_id._convert(
             amount_delta, currency_to, self.company_id, fields.Date.today()
         )
@@ -74,20 +85,26 @@ class SaleCouponProgram(models.Model):
     def _compute_program_amount(self, field, currency_to):
         """Extend to consume correct multi-use coupon amount."""
         self.ensure_one()
-        coupon_code = self._context.get("coupon_code")
-        sale_order = self._context.get("coupon_sale_order")
-        if coupon_code and sale_order and field == "discount_fixed_amount":
-            coupon_multi_use = self.env["sale.coupon"].search(
-                [
-                    ("multi_use", "=", True),
-                    ("code", "=", coupon_code),
-                    ("state", "=", "new"),
-                ],
-                limit=1,
-            )
-            if coupon_multi_use:
-                return self._compute_program_multi_use_amount(
-                    coupon_multi_use, sale_order, currency_to
-                )
+        if field != "discount_fixed_amount":
+            # Just want to customize program amount
+            # when compute the final dicsount
+            return super()._compute_program_amount(field, currency_to)
+        multi_use_coupon = self.env.context.get("multi_use_coupon")
+        current_order = self.env.context.get("current_order")
+        if not (self.coupon_multi_use and multi_use_coupon and current_order):
+            return super()._compute_program_amount(field, currency_to)
+        # Case of multi use
+        return self._compute_program_multi_use_amount(
+            multi_use_coupon, current_order, currency_to
+        )
 
-        return super()._compute_program_amount(field, currency_to)
+    def action_view_sales_orders(self):
+        result = super().action_view_sales_orders()
+        if self.coupon_multi_use:
+            # Override domain to remove order state filter,
+            # because for coupon multi use programs all sale orders count.
+            # Canceled sale orders are not linked anymore to coupon,
+            # because reward line is removed when cancel sale order.
+            orders = self.mapped("coupon_ids.sale_multi_use_ids")
+            result["domain"] = [("id", "in", orders.ids)]
+        return result

--- a/sale_coupon_multi_use/models/sale_coupon_program.py
+++ b/sale_coupon_multi_use/models/sale_coupon_program.py
@@ -61,11 +61,11 @@ class SaleCouponProgram(models.Model):
                 )
 
     def _compute_program_multi_use_amount(
-        self, multi_use_coupon, sale_order, currency_to
+        self, coupon_multi_use, sale_order, currency_to
     ):
         # Only using remaining amount (original implementation
         # always uses full amount specified on related program).
-        amount_delta = multi_use_coupon.discount_fixed_amount_delta
+        amount_delta = coupon_multi_use.discount_fixed_amount_delta
         amount_delta = self.currency_id._convert(
             amount_delta, currency_to, self.company_id, fields.Date.today()
         )
@@ -77,7 +77,7 @@ class SaleCouponProgram(models.Model):
         coupon_code = self._context.get("coupon_code")
         sale_order = self._context.get("coupon_sale_order")
         if coupon_code and sale_order and field == "discount_fixed_amount":
-            multi_use_coupon = self.env["sale.coupon"].search(
+            coupon_multi_use = self.env["sale.coupon"].search(
                 [
                     ("multi_use", "=", True),
                     ("code", "=", coupon_code),
@@ -85,9 +85,9 @@ class SaleCouponProgram(models.Model):
                 ],
                 limit=1,
             )
-            if multi_use_coupon:
+            if coupon_multi_use:
                 return self._compute_program_multi_use_amount(
-                    multi_use_coupon, sale_order, currency_to
+                    coupon_multi_use, sale_order, currency_to
                 )
 
         return super()._compute_program_amount(field, currency_to)

--- a/sale_coupon_multi_use/models/sale_coupon_program.py
+++ b/sale_coupon_multi_use/models/sale_coupon_program.py
@@ -35,8 +35,8 @@ class SaleCouponProgram(models.Model):
             if rec._get_multi_use_coupons():
                 raise ValidationError(
                     _(
-                        "Fixed Amount can't be changed when there are Multi Use "
-                        "coupons already."
+                        "Fixed Amount can't be changed when there are Multi"
+                        " Use coupons already."
                     )
                 )
 
@@ -66,10 +66,10 @@ class SaleCouponProgram(models.Model):
         # Only using remaining amount (original implementation
         # always uses full amount specified on related program).
         amount_delta = multi_use_coupon.discount_fixed_amount_delta
-        amount = min(amount_delta, sale_order.amount_total)
-        return self.currency_id._convert(
-            amount, currency_to, self.company_id, fields.Date.today()
+        amount_delta = self.currency_id._convert(
+            amount_delta, currency_to, self.company_id, fields.Date.today()
         )
+        return min(amount_delta, sale_order.amount_total)
 
     def _compute_program_amount(self, field, currency_to):
         """Extend to consume correct multi-use coupon amount."""

--- a/sale_coupon_multi_use/models/sale_order.py
+++ b/sale_coupon_multi_use/models/sale_order.py
@@ -1,0 +1,32 @@
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    """Extend to modify action_confirm for multi-use coupons."""
+
+    _inherit = "sale.order"
+
+    # TODO: implement multi-use coupon relation on sale.order ->
+    # applied_coupon_ids is o2m, which removes coupon if same coupon
+    # is applied on another SO. But for multi-use coupon, it must be
+    # able to keep same coupon on multiple sale orders.
+    # TODO: action_draft seems buggy, because it does not reset back
+    # coupons to new state (you can abuse coupon this way and use normal
+    # coupon multiple times).
+
+    def action_confirm(self):
+        """Extend to pass coupon_sale_order context."""
+        for order in self:
+            order = order.with_context(coupon_sale_order=order)
+            super(SaleOrder, order).action_confirm()
+        return True
+
+    def action_cancel(self):
+        """Extend to pass coupon_sale_order context."""
+        # NOTE. Can't rely on coupon/SO relation, because
+        # applied_coupon_ids is o2m field, meaning same coupon used on
+        # another SO, would make lose relation on previous SO.
+        for order in self:
+            order = order.with_context(coupon_sale_order=order)
+            super(SaleOrder, order).action_cancel()
+        return True

--- a/sale_coupon_multi_use/models/sale_order.py
+++ b/sale_coupon_multi_use/models/sale_order.py
@@ -1,6 +1,6 @@
-from odoo import fields, models
-
-ORDER_CTX_KEY = "coupon_sale_order"
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
 
 
 class SaleOrder(models.Model):
@@ -9,102 +9,35 @@ class SaleOrder(models.Model):
     _inherit = "sale.order"
 
     coupon_multi_use_ids = fields.Many2many(
-        "sale.coupon",
-        "sale_order_coupon_multi_rel",
-        "sale_id",
-        "coupon_id",
+        comodel_name="sale.coupon",
+        compute="_compute_coupon_multi_use_ids",
         string="Multi Use Coupons",
-        copy=False,
-        readonly=True,
     )
 
-    def _get_multi_use_coupons(self):
-        self.ensure_one()
-        # NOTE. This method must be called with ORDER_CTX_KEY on order.
-        return self.coupon_multi_use_ids - self.applied_coupon_ids
+    @api.depends("order_line.coupon_consumption_line_ids")
+    def _compute_coupon_multi_use_ids(self):
+        for rec in self:
+            rec.coupon_multi_use_ids = rec.mapped(
+                "order_line.coupon_consumption_line_ids.coupon_id"
+            )
 
-    def action_confirm(self):
-        """Extend to pass coupon_sale_order context."""
-        for order in self:
-            # Mimic same behavior as for single-user coupon.
-            order = order.with_context(**{ORDER_CTX_KEY: order})
-            super(SaleOrder, order).action_confirm()
-            order._get_multi_use_coupons().consume_coupons()
-        return True
+    def _get_applied_programs(self):
+        programs = super()._get_applied_programs()
+        programs |= self.coupon_multi_use_ids.mapped("program_id")
+        return programs
+
+    def _get_valid_applied_coupon_program(self):
+        programs = super()._get_valid_applied_coupon_program()
+        add_programs = self.coupon_multi_use_ids.mapped("program_id")
+        add_programs = add_programs._filter_programs_from_common_rules(self)
+        return programs | add_programs
 
     def action_cancel(self):
-        """Extend to pass coupon_sale_order context."""
+        """Extend to remove lines from multi use coupons."""
+        result = super().action_cancel()
         for order in self:
-            order = order = order.with_context(**{ORDER_CTX_KEY: order})
-            super(SaleOrder, order).action_cancel()
-            order._get_multi_use_coupons().reset_coupons()
-            # Mimic applied_coupon_ids logic.
-            order.coupon_multi_use_ids = [(5,)]
-        return True
-
-    def write(self, vals):
-        """Extend to add multi-use coupons."""
-        res = super().write(vals)
-        applied_coupon_ids = vals.get("applied_coupon_ids", [])
-        # Only care to move if coupons were added (4 or 6 cmd).
-        if any(cmd[0] in (4, 6) for cmd in applied_coupon_ids):
-            # Not very optimal to write multiple times, but moving ids
-            # between 2many commands (before write) is more complicated.
-            for order in self:
-                ids_to_move = order.applied_coupon_ids.filtered("multi_use").ids
-                if ids_to_move:
-                    order.write(
-                        {
-                            # Detach from single use coupons.
-                            "applied_coupon_ids": [(3, _id) for _id in ids_to_move],
-                            # Must use cmd 4 instead of 6, to not overwrite existing
-                            # coupons.
-                            "coupon_multi_use_ids": [(4, _id) for _id in ids_to_move],
-                        }
-                    )
-        return res
-
-
-class SaleOrderLine(models.Model):
-    """Extend to reverse relate with consumption line."""
-
-    _inherit = "sale.order.line"
-
-    def unlink(self):
-        """Extend to reactivate/reset removed multi-use coupons."""
-        related_program_lines = self.env["sale.order.line"]
-        # Reactivate coupons related to unlinked reward line
-        for line in self.filtered(lambda line: line.is_reward_line):
-            order = line.order_id
-            coupons_to_detach = order.coupon_multi_use_ids.filtered(
-                lambda r: r.program_id.discount_line_product_id == line.product_id
+            lines_from_multi_use_coupon = order.order_line.filtered(
+                "coupon_consumption_line_ids"
             )
-            # We can only reactivate coupons that are not part of
-            # applied_coupon_ids, because that part will signal
-            # reactivate too.
-            coupons_to_reactivate = (
-                coupons_to_detach
-                - order.applied_coupon_ids.filtered(
-                    lambda r: r.program_id.discount_line_product_id == line.product_id
-                )
-            )
-            coupons_to_reactivate.reset_coupons()
-            order.coupon_multi_use_ids -= coupons_to_detach
-            # Remove the program from the order if the deleted line is
-            # the reward line of the program.
-            # And delete the other lines from this program (It's the
-            # case when discount is split per different taxes)
-            related_program = self.env["sale.coupon.program"].search(
-                [("discount_line_product_id", "=", line.product_id.id)]
-            )
-            if related_program:
-                # No need to remove promotions, because multi-use
-                # coupons are not related with promotions.
-                related_program_lines |= (
-                    order.order_line.filtered(
-                        lambda l: l.product_id
-                        == related_program.discount_line_product_id
-                    )
-                    - line
-                )
-        return super(SaleOrderLine, self | related_program_lines).unlink()
+            lines_from_multi_use_coupon.unlink()
+        return result

--- a/sale_coupon_multi_use/models/sale_order.py
+++ b/sale_coupon_multi_use/models/sale_order.py
@@ -1,4 +1,6 @@
-from odoo import models
+from odoo import fields, models
+
+ORDER_CTX_KEY = "coupon_sale_order"
 
 
 class SaleOrder(models.Model):
@@ -6,27 +8,103 @@ class SaleOrder(models.Model):
 
     _inherit = "sale.order"
 
-    # TODO: implement multi-use coupon relation on sale.order ->
-    # applied_coupon_ids is o2m, which removes coupon if same coupon
-    # is applied on another SO. But for multi-use coupon, it must be
-    # able to keep same coupon on multiple sale orders.
-    # TODO: action_draft seems buggy, because it does not reset back
-    # coupons to new state (you can abuse coupon this way and use normal
-    # coupon multiple times).
+    coupon_multi_use_ids = fields.Many2many(
+        "sale.coupon",
+        "sale_order_coupon_multi_rel",
+        "sale_id",
+        "coupon_id",
+        string="Multi Use Coupons",
+        copy=False,
+        readonly=True,
+    )
+
+    def _get_multi_use_coupons(self):
+        self.ensure_one()
+        # NOTE. This method must be called with ORDER_CTX_KEY on order.
+        return self.coupon_multi_use_ids - self.applied_coupon_ids
 
     def action_confirm(self):
         """Extend to pass coupon_sale_order context."""
         for order in self:
-            order = order.with_context(coupon_sale_order=order)
+            # Mimic same behavior as for single-user coupon.
+            order = order.with_context(**{ORDER_CTX_KEY: order})
             super(SaleOrder, order).action_confirm()
+            order._get_multi_use_coupons().consume_coupons()
         return True
 
     def action_cancel(self):
         """Extend to pass coupon_sale_order context."""
-        # NOTE. Can't rely on coupon/SO relation, because
-        # applied_coupon_ids is o2m field, meaning same coupon used on
-        # another SO, would make lose relation on previous SO.
         for order in self:
-            order = order.with_context(coupon_sale_order=order)
+            order = order = order.with_context(**{ORDER_CTX_KEY: order})
             super(SaleOrder, order).action_cancel()
+            order._get_multi_use_coupons().reset_coupons()
+            # Mimic applied_coupon_ids logic.
+            order.coupon_multi_use_ids = [(5,)]
         return True
+
+    def write(self, vals):
+        """Extend to add multi-use coupons."""
+        res = super().write(vals)
+        applied_coupon_ids = vals.get("applied_coupon_ids", [])
+        # Only care to move if coupons were added (4 or 6 cmd).
+        if any(cmd[0] in (4, 6) for cmd in applied_coupon_ids):
+            # Not very optimal to write multiple times, but moving ids
+            # between 2many commands (before write) is more complicated.
+            for order in self:
+                ids_to_move = order.applied_coupon_ids.filtered("multi_use").ids
+                if ids_to_move:
+                    order.write(
+                        {
+                            # Detach from single use coupons.
+                            "applied_coupon_ids": [(3, _id) for _id in ids_to_move],
+                            # Must use cmd 4 instead of 6, to not overwrite existing
+                            # coupons.
+                            "coupon_multi_use_ids": [(4, _id) for _id in ids_to_move],
+                        }
+                    )
+        return res
+
+
+class SaleOrderLine(models.Model):
+    """Extend to reverse relate with consumption line."""
+
+    _inherit = "sale.order.line"
+
+    def unlink(self):
+        """Extend to reactivate/reset removed multi-use coupons."""
+        related_program_lines = self.env["sale.order.line"]
+        # Reactivate coupons related to unlinked reward line
+        for line in self.filtered(lambda line: line.is_reward_line):
+            order = line.order_id
+            coupons_to_detach = order.coupon_multi_use_ids.filtered(
+                lambda r: r.program_id.discount_line_product_id == line.product_id
+            )
+            # We can only reactivate coupons that are not part of
+            # applied_coupon_ids, because that part will signal
+            # reactivate too.
+            coupons_to_reactivate = (
+                coupons_to_detach
+                - order.applied_coupon_ids.filtered(
+                    lambda r: r.program_id.discount_line_product_id == line.product_id
+                )
+            )
+            coupons_to_reactivate.reset_coupons()
+            order.coupon_multi_use_ids -= coupons_to_detach
+            # Remove the program from the order if the deleted line is
+            # the reward line of the program.
+            # And delete the other lines from this program (It's the
+            # case when discount is split per different taxes)
+            related_program = self.env["sale.coupon.program"].search(
+                [("discount_line_product_id", "=", line.product_id.id)]
+            )
+            if related_program:
+                # No need to remove promotions, because multi-use
+                # coupons are not related with promotions.
+                related_program_lines |= (
+                    order.order_line.filtered(
+                        lambda l: l.product_id
+                        == related_program.discount_line_product_id
+                    )
+                    - line
+                )
+        return super(SaleOrderLine, self | related_program_lines).unlink()

--- a/sale_coupon_multi_use/models/sale_order_line.py
+++ b/sale_coupon_multi_use/models/sale_order_line.py
@@ -1,0 +1,24 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    """Extend to reverse relate with consumption line."""
+
+    _inherit = "sale.order.line"
+
+    coupon_consumption_line_ids = fields.One2many(
+        comodel_name="sale.coupon.consumption_line",
+        inverse_name="sale_order_line_id",
+        readonly=True,
+    )
+
+    def unlink(self):
+        consumption_lines = self.mapped("coupon_consumption_line_ids")
+        if consumption_lines:
+            # Remove related consumption lines
+            # Using sudo because no user can remove consumption lines
+            consumption_lines.sudo().unlink()
+        return super().unlink()

--- a/sale_coupon_multi_use/readme/CONTRIBUTORS.rst
+++ b/sale_coupon_multi_use/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Andrius Laukavičius <andrius@focusate.eu>

--- a/sale_coupon_multi_use/readme/CONTRIBUTORS.rst
+++ b/sale_coupon_multi_use/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Andrius Laukavičius <andrius@focusate.eu>
+* Julien Coux <julien.coux@camptocamp.com>

--- a/sale_coupon_multi_use/readme/DESCRIPTION.rst
+++ b/sale_coupon_multi_use/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+Allows to consume same coupon multiple times. Can only be used when discount has fixed amount. Discount fixed amount can't be changed if there are coupons with multi_use flag set.
+
+Can specify value of coupon and that value can be consumed per multiple
+sale orders.
+
+If discount is removed from sale order, so is consumption line from
+coupon.

--- a/sale_coupon_multi_use/readme/DESCRIPTION.rst
+++ b/sale_coupon_multi_use/readme/DESCRIPTION.rst
@@ -1,4 +1,8 @@
-Allows to consume same coupon multiple times. Can only be used when discount has fixed amount. Discount fixed amount can't be changed if there are coupons with multi_use flag set.
+Allows to consume same coupon multiple times.
+
+Can only be used when discount has fixed amount.
+
+Discount fixed amount can't be changed if there are generated coupons.
 
 Can specify value of coupon and that value can be consumed per multiple
 sale orders.

--- a/sale_coupon_multi_use/security/ir.model.access.csv
+++ b/sale_coupon_multi_use/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
+access_sale_coupon_consumption_line_salesman,sale.coupon.consumption_line salesman,model_sale_coupon_consumption_line,sales_team.group_sale_salesman,1,0,0,0
+access_sale_coupon_consumption_line_manager,sale.coupon.consumption_line manager,model_sale_coupon_consumption_line,sales_team.group_sale_manager,1,1,1,0

--- a/sale_coupon_multi_use/tests/__init__.py
+++ b/sale_coupon_multi_use/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_coupon_use

--- a/sale_coupon_multi_use/tests/common.py
+++ b/sale_coupon_multi_use/tests/common.py
@@ -1,0 +1,27 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from odoo.tests.common import SavepointCase
+
+
+class TestSaleCouponMultiUseCommon(SavepointCase):
+    """Common class for multi use coupon tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up common data for multi use coupon tests."""
+        super().setUpClass()
+        # Models.
+        cls.SaleCoupon = cls.env["sale.coupon"]
+        cls.SaleCouponProgram = cls.env["sale.coupon.program"]
+        cls.SaleCouponGenerate = cls.env["sale.coupon.generate"]
+        cls.SaleCouponApplyCode = cls.env["sale.coupon.apply.code"]
+        # Records.
+        # Coupon Programs.
+        cls.program_coupon_percentage = cls.env.ref("sale_coupon.10_percent_coupon")
+        # Sales.
+        # amount_total = 9705
+        cls.sale_1 = cls.env.ref("sale.sale_order_1")
+        # amount_total = 2947.5
+        cls.sale_2 = cls.env.ref("sale.sale_order_2")

--- a/sale_coupon_multi_use/tests/common.py
+++ b/sale_coupon_multi_use/tests/common.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Camptocamp SA
+# Copyright 2021 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo.tests.common import SavepointCase
 

--- a/sale_coupon_multi_use/tests/common.py
+++ b/sale_coupon_multi_use/tests/common.py
@@ -1,8 +1,8 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
-
 from odoo.tests.common import SavepointCase
+
+DISCOUNT_AMOUNT = 5000
 
 
 class TestSaleCouponMultiUseCommon(SavepointCase):
@@ -17,11 +17,34 @@ class TestSaleCouponMultiUseCommon(SavepointCase):
         cls.SaleCouponProgram = cls.env["sale.coupon.program"]
         cls.SaleCouponGenerate = cls.env["sale.coupon.generate"]
         cls.SaleCouponApplyCode = cls.env["sale.coupon.apply.code"]
-        # Records.
-        # Coupon Programs.
+        # Programs.
         cls.program_coupon_percentage = cls.env.ref("sale_coupon.10_percent_coupon")
         # Sales.
         # amount_total = 9705
         cls.sale_1 = cls.env.ref("sale.sale_order_1")
         # amount_total = 2947.5
         cls.sale_2 = cls.env.ref("sale.sale_order_2")
+        cls.program_multi_use = cls.SaleCouponProgram.create(
+            {
+                "name": "Multi Use Coupon Program",
+                "program_type": "coupon_program",
+                "reward_type": "discount",
+                "discount_type": "fixed_amount",
+                "discount_fixed_amount": DISCOUNT_AMOUNT,
+                "coupon_multi_use": True,
+            }
+        )
+        # Generate one coupon for usage.
+        cls.coupon_generate_wiz = cls.SaleCouponGenerate.with_context(
+            active_id=cls.program_multi_use.id
+        ).create({})
+        cls.coupon_generate_wiz.generate_coupon()
+        cls.coupon_multi_use_1 = cls.program_multi_use.coupon_ids[0]
+        # Prepare coupon apply wizard.
+        cls.coupon_apply_wiz = cls.SaleCouponApplyCode.create(
+            {"coupon_code": cls.coupon_multi_use_1.code}
+        )
+        cls.company_main = cls.env.ref("base.main_company")
+        cls.eur = cls.env.ref("base.EUR")
+        cls.usd = cls.env.ref("base.USD")
+        cls.pricelist_public = cls.env.ref("product.list0")

--- a/sale_coupon_multi_use/tests/test_sale_coupon_use.py
+++ b/sale_coupon_multi_use/tests/test_sale_coupon_use.py
@@ -1,0 +1,237 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo.exceptions import UserError, ValidationError
+
+from .common import TestSaleCouponMultiUseCommon
+
+DISCOUNT_AMOUNT = 5000
+
+
+class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
+    """Test class for coupon multi use cases."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up data for multi use coupon tests."""
+        super().setUpClass()
+        cls.program_multi_use = cls.SaleCouponProgram.create(
+            {
+                "name": "Multi Use Coupon Program",
+                "program_type": "coupon_program",
+                "reward_type": "discount",
+                "discount_type": "fixed_amount",
+                "discount_fixed_amount": DISCOUNT_AMOUNT,
+                "coupon_multi_use": True,
+            }
+        )
+        # Generate one coupon for usage.
+        cls.coupon_generate_wiz = cls.SaleCouponGenerate.with_context(
+            active_id=cls.program_multi_use.id
+        ).create({})
+        cls.coupon_generate_wiz.generate_coupon()
+        cls.coupon_multi_use_1 = cls.program_multi_use.coupon_ids[0]
+        # Prepare coupon apply wizard.
+        cls.coupon_apply_wiz = cls.SaleCouponApplyCode.create(
+            {"coupon_code": cls.coupon_multi_use_1.code}
+        )
+
+    def _remove_so_discount_lines(self, order):
+        order.order_line.filtered(lambda r: r.price_unit < 0).unlink()
+
+    def test_01_coupon_single_use(self):
+        """Apply coupon normally without multi_use functionality."""
+        # Sanity check.
+        self.assertTrue(self.coupon_multi_use_1.multi_use)
+        self.program_multi_use.coupon_multi_use = False
+        # Generate second coupon.
+        self.coupon_generate_wiz.generate_coupon()
+        coupon_2 = self.program_multi_use.coupon_ids[-1]
+        self.assertFalse(coupon_2.multi_use)
+        self.coupon_apply_wiz.coupon_code = coupon_2.code
+        amount_total_expected = self.sale_1.amount_total - DISCOUNT_AMOUNT
+        self.coupon_apply_wiz.with_context(active_id=self.sale_1.id).process_coupon()
+        # Sanity check.
+        self.assertEqual(self.sale_1.amount_total, amount_total_expected)
+        self.assertFalse(self.coupon_multi_use_1.consumption_line_ids)
+
+    def test_02_coupon_multi_use(self):
+        """Apply coupon to consume all amount in one use.
+
+        Case 1: consume all value on single SO.
+        Case 2: try to consume again on another SO.
+        Case 3: remove discount on SO line.
+        """
+        # Case 1.
+        # SO 1 amount 9705 > 5000.
+        amount_total_orig = self.sale_1.amount_total
+        amount_total_expected = amount_total_orig - DISCOUNT_AMOUNT
+        self.coupon_apply_wiz.with_context(active_id=self.sale_1.id).process_coupon()
+        self.assertEqual(self.sale_1.amount_total, amount_total_expected)
+        consume_lines = self.coupon_multi_use_1.consumption_line_ids
+        self.assertEqual(len(consume_lines), 1)
+        self.assertEqual(consume_lines[0].amount, DISCOUNT_AMOUNT)
+        self.assertEqual(self.coupon_multi_use_1.discount_fixed_amount_delta, 0)
+        self.assertEqual(self.coupon_multi_use_1.state, "used")
+        # Case 2.
+        with self.assertRaises(UserError):
+            self.coupon_apply_wiz.with_context(
+                active_id=self.sale_2.id
+            ).process_coupon()
+        # Case 3.
+        self._remove_so_discount_lines(self.sale_1)
+        self.assertEqual(self.sale_1.amount_total, amount_total_orig)
+        self.assertFalse(self.coupon_multi_use_1.consumption_line_ids)
+        self.assertEqual(
+            self.coupon_multi_use_1.discount_fixed_amount_delta, DISCOUNT_AMOUNT
+        )
+        self.assertEqual(self.coupon_multi_use_1.state, "new")
+
+    def test_03_coupon_multi_use(self):
+        """Apply coupon to consume all amount in two uses.
+
+        Case 1: consume part of coupon amount on SO2.
+        Case 2: consume remaining amount on SO1.
+        Case 3: remove discount from SO1.
+        Case 4: remove discount from SO2.
+        """
+        # Case 1:
+        amount_total_orig_1 = self.sale_2.amount_total
+        amount_total_expected = 0  # must make SO free.
+        self.coupon_apply_wiz.with_context(active_id=self.sale_2.id).process_coupon()
+        self.assertEqual(self.sale_2.amount_total, amount_total_expected)
+        consumption_line_so_2 = self.coupon_multi_use_1.consumption_line_ids
+        self.assertEqual(len(consumption_line_so_2), 1)
+        self.assertEqual(consumption_line_so_2[0].amount, amount_total_orig_1)
+        remaining_discount = DISCOUNT_AMOUNT - amount_total_orig_1
+        # Delta showing left amount that can be consumed.
+        self.assertEqual(
+            self.coupon_multi_use_1.discount_fixed_amount_delta, remaining_discount
+        )
+        self.assertEqual(self.coupon_multi_use_1.state, "new")
+        # Case 2.
+        amount_total_expected = self.sale_1.amount_total - remaining_discount
+        self.coupon_apply_wiz.with_context(active_id=self.sale_1.id).process_coupon()
+        self.assertEqual(self.sale_1.amount_total, amount_total_expected)
+        consume_lines = self.coupon_multi_use_1.consumption_line_ids
+        self.assertEqual(len(consume_lines), 2)
+        # First consumed amount is total of first whole SO total.
+        self.assertEqual(consume_lines[0].amount, amount_total_orig_1)
+        # Second consumed amount is all remaining coupon value.
+        self.assertEqual(consume_lines[1].amount, remaining_discount)
+        self.assertEqual(self.coupon_multi_use_1.discount_fixed_amount_delta, 0)
+        self.assertEqual(self.coupon_multi_use_1.state, "used")
+        # Case 3.
+        self._remove_so_discount_lines(self.sale_1)
+        consume_lines = self.coupon_multi_use_1.consumption_line_ids
+        # Should have only line that is related with SO2.
+        self.assertEqual(
+            self.coupon_multi_use_1.consumption_line_ids, consumption_line_so_2
+        )
+        # Amount on existing line must be unchanged.
+        self.assertEqual(consumption_line_so_2.amount, amount_total_orig_1)
+        # Should have remaining amount as it had when only SO2 used
+        # coupon.
+        self.assertEqual(
+            self.coupon_multi_use_1.discount_fixed_amount_delta, remaining_discount
+        )
+        self.assertEqual(self.coupon_multi_use_1.state, "new")
+        # Case 4.
+        self._remove_so_discount_lines(self.sale_2)
+        self.assertFalse(self.coupon_multi_use_1.consumption_line_ids)
+        self.assertEqual(
+            self.coupon_multi_use_1.discount_fixed_amount_delta, DISCOUNT_AMOUNT
+        )
+        self.assertEqual(self.coupon_multi_use_1.state, "new")
+
+    def _raise_multi_use_constraints(self, program):
+        """Expect to raise exceptions when multi use coupons are used.
+
+        Constraints are those where values can't be changed if
+        coupon_multi_use=True, regardless if there are any coupons
+        generated.
+
+        Case 1: try to change discount type.
+        Case 2: try to change reward type.
+        Case 3: try to change program type.
+        """
+        # Case 1.
+        with self.assertRaises(ValidationError):
+            program.discount_type = "percentage"
+        # Case 2.
+        with self.assertRaises(ValidationError):
+            program.reward_type = "product"
+        # Case 3.
+        with self.assertRaises(ValidationError):
+            self.program_multi_use.program_type = "promotion_program"
+
+    def _not_raise_multi_use_constraints(self, program):
+        """Expect not to raise exceptions.
+
+        Case 1: change discount type.
+        Case 2: change reward type.
+        Case 3: change program type.
+        """
+        try:
+            # Case 1.
+            program.discount_type = "percentage"
+            # Case 2.
+            program.reward_type = "product"
+            # Case 3.
+            program.program_type = "promotion_program"
+        except ValidationError:
+            self.fail(
+                "Multi Use exceptions must not trigger if "
+                "coupon_multi_use=False and no multi_use coupons generated."
+            )
+
+    def test_04_unlink_consumption_line(self):
+        """Check if consumption line not allowed to unlink."""
+        with self.assertRaises(UserError):
+            self.coupon_multi_use_1.consumption_line_ids.unlink()
+
+    def test_05_coupon_program_constraints(self):
+        """Check coupon constraints when multi use coupon is generated.
+
+        Case 1: multi_use=True
+        Case 2: multi_use=False
+        """
+        # Case 1.
+        with self.assertRaises(ValidationError):
+            self.program_multi_use.discount_fixed_amount = 3000
+        self._raise_multi_use_constraints(self.program_multi_use)
+        # Case 2.
+        with self.assertRaises(ValidationError):
+            self.program_multi_use.discount_fixed_amount = 3000
+        self._raise_multi_use_constraints(self.program_multi_use)
+
+    def test_06_coupon_program_constraints(self):
+        """Check constraints when multi use coupon is not generated.
+
+        Case 1: multi_use=True
+        Case 2: multi_use=False
+        """
+
+        def pass_discount_fixed_amount(program):
+            fail_msg = (
+                "There are no multi use coupons generated, so must be able"
+                " to change amount."
+            )
+            try:
+                program.discount_fixed_amount = 3000
+            except ValidationError:
+                self.fail(fail_msg)
+
+        # Copy program, so it would not have coupons.
+        program = self.program_multi_use.copy()
+        # Case 1.
+        pass_discount_fixed_amount(program)
+        self._raise_multi_use_constraints(program)
+        # Case 2.
+        program.coupon_multi_use = False
+        pass_discount_fixed_amount(program)
+        self._not_raise_multi_use_constraints(program)
+
+    def test_07_coupon_program_constraints(self):
+        """Try to use coupon_multi_use, when other options are incorrect."""
+        with self.assertRaises(ValidationError):
+            self.program_coupon_percentage.coupon_multi_use = True

--- a/sale_coupon_multi_use/tests/test_sale_coupon_use.py
+++ b/sale_coupon_multi_use/tests/test_sale_coupon_use.py
@@ -1,39 +1,24 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo.exceptions import UserError, ValidationError
+from odoo.fields import Date
 
-from .common import TestSaleCouponMultiUseCommon
+from .common import DISCOUNT_AMOUNT, TestSaleCouponMultiUseCommon
 
-DISCOUNT_AMOUNT = 5000
+_today = Date.today()
 
 
 class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
     """Test class for coupon multi use cases."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Set up data for multi use coupon tests."""
-        super().setUpClass()
-        cls.program_multi_use = cls.SaleCouponProgram.create(
-            {
-                "name": "Multi Use Coupon Program",
-                "program_type": "coupon_program",
-                "reward_type": "discount",
-                "discount_type": "fixed_amount",
-                "discount_fixed_amount": DISCOUNT_AMOUNT,
-                "coupon_multi_use": True,
-            }
-        )
-        # Generate one coupon for usage.
-        cls.coupon_generate_wiz = cls.SaleCouponGenerate.with_context(
-            active_id=cls.program_multi_use.id
-        ).create({})
-        cls.coupon_generate_wiz.generate_coupon()
-        cls.coupon_multi_use_1 = cls.program_multi_use.coupon_ids[0]
-        # Prepare coupon apply wizard.
-        cls.coupon_apply_wiz = cls.SaleCouponApplyCode.create(
-            {"coupon_code": cls.coupon_multi_use_1.code}
-        )
+    def _separate_pricelist_company_currency(self, pricelist, company):
+        if pricelist.currency_id == company.currency_id:
+            # Make pricelist currency different than company one.
+            if pricelist.currency_id == self.eur:
+                pricelist.currency_id = self.usd
+            else:
+                pricelist.currency_id = self.eur
+        return pricelist.currency_id, company.currency_id
 
     def _remove_so_discount_lines(self, order):
         order.order_line.filtered(lambda r: r.price_unit < 0).unlink()
@@ -144,6 +129,53 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
         self.assertEqual(self.coupon_multi_use_1.state, "new")
 
     def test_04_coupon_multi_use(self):
+        """Apply multi use coupon on SO with different currency.
+
+        Case 1: consume part of coupon amount on SO2.
+        Case 2: consume remaining amount on SO1.
+        """
+        (
+            currency_pricelist,
+            currency_company,
+        ) = self._separate_pricelist_company_currency(
+            self.pricelist_public, self.company_main
+        )
+        # Case 1.
+        amount_total_orig_1 = self.sale_2.amount_total
+        amount_total_expected = 0  # must make SO free.
+        self.coupon_apply_wiz.with_context(active_id=self.sale_2.id).process_coupon()
+        self.assertEqual(self.sale_2.amount_total, amount_total_expected)
+        consumption_line_so_2 = self.coupon_multi_use_1.consumption_line_ids
+        self.assertEqual(len(consumption_line_so_2), 1)
+        amount_consumption_line_1 = currency_pricelist._convert(
+            amount_total_orig_1, currency_company, self.company_main, _today
+        )
+        self.assertEqual(consumption_line_so_2[0].amount, amount_consumption_line_1)
+        # In company currency
+        remaining_discount = DISCOUNT_AMOUNT - amount_consumption_line_1
+        # Delta showing left amount that can be consumed.
+        self.assertAlmostEqual(
+            self.coupon_multi_use_1.discount_fixed_amount_delta,
+            remaining_discount,
+            places=8,
+        )
+        self.assertEqual(self.coupon_multi_use_1.state, "new")
+        # Case 2.
+        amount_total_expected = self.sale_1.amount_total - currency_company._convert(
+            remaining_discount, currency_pricelist, self.company_main, _today,
+        )
+        self.coupon_apply_wiz.with_context(active_id=self.sale_1.id).process_coupon()
+        self.assertEqual(self.sale_1.amount_total, amount_total_expected)  # USD
+        consume_lines = self.coupon_multi_use_1.consumption_line_ids
+        self.assertEqual(len(consume_lines), 2)
+        # First consumed amount is total of first whole SO total.
+        self.assertEqual(consume_lines[0].amount, amount_consumption_line_1)
+        # Second consumed amount is all remaining coupon value.
+        self.assertAlmostEqual(consume_lines[1].amount, remaining_discount, places=8)
+        self.assertEqual(self.coupon_multi_use_1.discount_fixed_amount_delta, 0)
+        self.assertEqual(self.coupon_multi_use_1.state, "used")
+
+    def test_05_coupon_multi_use(self):
         """Apply multiple coupons and confirm SO.
 
         Case 1: apply first coupon (single use).
@@ -189,7 +221,7 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
             self.coupon_multi_use_1.discount_fixed_amount_delta, remaining_discount
         )
 
-    def test_05_coupon_multi_use(self):
+    def test_06_coupon_multi_use(self):
         """Apply multi use coupon on SO and cancel SO."""
         self.coupon_apply_wiz.with_context(active_id=self.sale_1.id).process_coupon()
         # Sanity check.
@@ -239,27 +271,31 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
                 "coupon_multi_use=False and no multi_use coupons generated."
             )
 
-    def test_05_unlink_consumption_line(self):
+    def test_07_unlink_consumption_line(self):
         """Check if consumption line not allowed to unlink."""
         with self.assertRaises(UserError):
             self.coupon_multi_use_1.consumption_line_ids.unlink()
 
-    def test_06_coupon_program_constraints(self):
+    def test_08_coupon_program_constraints(self):
         """Check coupon constraints when multi use coupon is generated.
 
-        Case 1: multi_use=True
-        Case 2: multi_use=False
+        Case: multi_use=True
         """
-        # Case 1.
-        with self.assertRaises(ValidationError):
-            self.program_multi_use.discount_fixed_amount = 3000
-        self._raise_multi_use_constraints(self.program_multi_use)
-        # Case 2.
         with self.assertRaises(ValidationError):
             self.program_multi_use.discount_fixed_amount = 3000
         self._raise_multi_use_constraints(self.program_multi_use)
 
-    def test_07_coupon_program_constraints(self):
+    def test_09_coupon_program_constraints(self):
+        """Check coupon constraints when multi use coupon is generated.
+
+        Case: multi_use=False
+        """
+        self.program_multi_use.coupon_multi_use = False
+        with self.assertRaises(ValidationError):
+            self.program_multi_use.discount_fixed_amount = 3000
+        self._raise_multi_use_constraints(self.program_multi_use)
+
+    def test_10_coupon_program_constraints(self):
         """Check constraints when multi use coupon is not generated.
 
         Case 1: multi_use=True
@@ -269,7 +305,7 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
         def pass_discount_fixed_amount(program):
             fail_msg = (
                 "There are no multi use coupons generated, so must be able"
-                " to change amount."
+                " to change discount_fixed_amount."
             )
             try:
                 program.discount_fixed_amount = 3000
@@ -286,7 +322,7 @@ class TestSaleCouponMultiUse(TestSaleCouponMultiUseCommon):
         pass_discount_fixed_amount(program)
         self._not_raise_multi_use_constraints(program)
 
-    def test_08_coupon_program_constraints(self):
+    def test_11_coupon_program_constraints(self):
         """Try to use coupon_multi_use, when other options are incorrect."""
         with self.assertRaises(ValidationError):
             self.program_coupon_percentage.coupon_multi_use = True

--- a/sale_coupon_multi_use/views/sale_coupon_program_views.xml
+++ b/sale_coupon_multi_use/views/sale_coupon_program_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="sale_coupon_program_view_form" model="ir.ui.view">
+        <field name="name">sale.coupon.program.form.multi_use</field>
+        <field name="model">sale.coupon.program</field>
+        <field name="inherit_id" ref="sale_coupon.sale_coupon_program_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='validity']" position="inside">
+                <field name="coupon_multi_use" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_coupon_multi_use/views/sale_coupon_views.xml
+++ b/sale_coupon_multi_use/views/sale_coupon_views.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="sale_coupon_view_tree" model="ir.ui.view">
+        <field name="name">sale.coupon.form.multi_use</field>
+        <field name="model">sale.coupon</field>
+        <field name="inherit_id" ref="sale_coupon.sale_coupon_view_tree" />
+        <field name="arch" type="xml">
+            <field name="expiration_date" position="after">
+                <field name="multi_use" />
+            </field>
+        </field>
+    </record>
+    <record id="sale_coupon_view_form_inherit" model="ir.ui.view">
+        <field name="name">sale.coupon.form.multi_use</field>
+        <field name="model">sale.coupon</field>
+        <field name="inherit_id" ref="sale_coupon.sale_coupon_view_form" />
+        <field name="arch" type="xml">
+            <field name="expiration_date" position="after">
+                <field name="multi_use" />
+            </field>
+            <xpath expr="/form/sheet/group" position="after">
+                <field
+                    name="consumption_line_ids"
+                    attrs="{'invisible': [('multi_use', '=', False)]}"
+                >
+                    <tree>
+                        <field name="sale_order_line_id" />
+                        <field name="amount" />
+                    </tree>
+                </field>
+                <group
+                    class="oe_subtotal_footer oe_right"
+                    colspan="2"
+                    name="multi_use_delta"
+                    attrs="{'invisible': [('multi_use', '=', False)]}"
+                >
+                    <field name="discount_fixed_amount_delta" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_coupon_multi_use/views/sale_coupon_views.xml
+++ b/sale_coupon_multi_use/views/sale_coupon_views.xml
@@ -31,10 +31,16 @@
                     name="consumption_line_ids"
                     attrs="{'invisible': [('multi_use', '=', False)]}"
                 >
-                    <tree>
+                    <!-- Add color on draft sale orders to easily distinguish draft/sent and confirmed orders-->
+                    <tree decoration-info="sale_order_state in ['draft', 'sent']">
                         <field name="currency_program_id" invisible="1" />
                         <field name="sale_order_line_id" />
-                        <field name="amount" />
+                        <field name="sale_order_state" />
+                        <field
+                            name="amount"
+                            widget="monetary"
+                            options="{'currency_field': 'currency_program_id'}"
+                        />
                     </tree>
                 </field>
                 <group
@@ -43,7 +49,11 @@
                     name="multi_use_delta"
                     attrs="{'invisible': [('multi_use', '=', False)]}"
                 >
-                    <field name="discount_fixed_amount_delta" />
+                    <field
+                        name="discount_fixed_amount_delta"
+                        widget="monetary"
+                        options="{'currency_field': 'currency_program_id'}"
+                    />
                 </group>
             </xpath>
         </field>

--- a/sale_coupon_multi_use/views/sale_coupon_views.xml
+++ b/sale_coupon_multi_use/views/sale_coupon_views.xml
@@ -19,6 +19,13 @@
                 <field name="currency_program_id" invisible="1" />
                 <field name="multi_use" />
             </field>
+            <field name="sales_order_id" position="after">
+                <field
+                    name="sale_multi_use_ids"
+                    widget="many2many_tags"
+                    attrs="{'invisible': [('multi_use', '=', False)]}"
+                />
+            </field>
             <xpath expr="/form/sheet/group" position="after">
                 <field
                     name="consumption_line_ids"

--- a/sale_coupon_multi_use/views/sale_coupon_views.xml
+++ b/sale_coupon_multi_use/views/sale_coupon_views.xml
@@ -16,6 +16,7 @@
         <field name="inherit_id" ref="sale_coupon.sale_coupon_view_form" />
         <field name="arch" type="xml">
             <field name="expiration_date" position="after">
+                <field name="currency_program_id" invisible="1" />
                 <field name="multi_use" />
             </field>
             <xpath expr="/form/sheet/group" position="after">
@@ -24,6 +25,7 @@
                     attrs="{'invisible': [('multi_use', '=', False)]}"
                 >
                     <tree>
+                        <field name="currency_program_id" invisible="1" />
                         <field name="sale_order_line_id" />
                         <field name="amount" />
                     </tree>

--- a/sale_coupon_multi_use/wizards/__init__.py
+++ b/sale_coupon_multi_use/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_coupon_apply_code

--- a/sale_coupon_multi_use/wizards/sale_coupon_apply_code.py
+++ b/sale_coupon_multi_use/wizards/sale_coupon_apply_code.py
@@ -1,0 +1,19 @@
+from odoo import models
+
+
+class SaleCouponApplyCode(models.TransientModel):
+    """Extend to modify apply_coupon method for multi coupon usage."""
+
+    _inherit = "sale.coupon.apply.code"
+
+    def apply_coupon(self, order, coupon_code):
+        """Extend to pass order coupon ctx for multi coupon usage."""
+        self = self.with_context(
+            coupon_order_data={
+                "order": order,
+                # To save original amount, before any discounts are
+                # applied.
+                "amount_total": order.amount_total,
+            }
+        )
+        return super(SaleCouponApplyCode, self).apply_coupon(order, coupon_code)

--- a/sale_coupon_multi_use/wizards/sale_coupon_apply_code.py
+++ b/sale_coupon_multi_use/wizards/sale_coupon_apply_code.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Camptocamp SA
+# Copyright 2021 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models
 
@@ -9,6 +9,22 @@ class SaleCouponApplyCode(models.TransientModel):
     _inherit = "sale.coupon.apply.code"
 
     def apply_coupon(self, order, coupon_code):
-        """Extend to pass order coupon ctx for multi coupon usage."""
-        self = self.with_context(coupon_sale_order=order, coupon_code=coupon_code)
-        return super(SaleCouponApplyCode, self).apply_coupon(order, coupon_code)
+        # If coupon_code from program with promo code: return super
+        program_model = self.env["sale.coupon.program"]
+        program = program_model.search([("promo_code", "=", coupon_code)])
+        if program:
+            return super().apply_coupon(order, coupon_code)
+        # If coupon_code from non multi-use coupon: return super
+        coupon_model = self.env["sale.coupon"]
+        coupon = coupon_model.search([("code", "=", coupon_code)], limit=1)
+        if not coupon.multi_use:
+            return super().apply_coupon(order, coupon_code)
+        # If multi-use coupon, call super with passing coupon/order in context
+        # to allow program compute correctly the reward line amount.
+        # Not ideal,
+        # but code core is not easily to override to custom this part.
+        self = self.with_context(multi_use_coupon=coupon, current_order=order)
+        error_status = super().apply_coupon(order, coupon_code)
+        if not error_status:
+            coupon.move_to_multi_use()
+        return error_status

--- a/sale_coupon_multi_use/wizards/sale_coupon_apply_code.py
+++ b/sale_coupon_multi_use/wizards/sale_coupon_apply_code.py
@@ -1,3 +1,5 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models
 
 
@@ -8,12 +10,5 @@ class SaleCouponApplyCode(models.TransientModel):
 
     def apply_coupon(self, order, coupon_code):
         """Extend to pass order coupon ctx for multi coupon usage."""
-        self = self.with_context(
-            coupon_order_data={
-                "order": order,
-                # To save original amount, before any discounts are
-                # applied.
-                "amount_total": order.amount_total,
-            }
-        )
+        self = self.with_context(coupon_sale_order=order, coupon_code=coupon_code)
         return super(SaleCouponApplyCode, self).apply_coupon(order, coupon_code)

--- a/sale_coupon_multi_use_currency/__init__.py
+++ b/sale_coupon_multi_use_currency/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_coupon_multi_use_currency/__manifest__.py
+++ b/sale_coupon_multi_use_currency/__manifest__.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Sale Coupon Multi Use Currency",
+    "summary": "Prevents in changing currency if multi coupon is in use",
+    "version": "13.0.1.0.0",
+    "category": "Sale",
+    "website": "https://github.com/OCA/sale-workflow",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": ["sale_coupon_multi_use", "sale_coupon_multi_currency"],
+    "installable": True,
+    "auto_install": True,
+}

--- a/sale_coupon_multi_use_currency/__manifest__.py
+++ b/sale_coupon_multi_use_currency/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Camptocamp
+# Copyright 2021 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Sale Coupon Multi Use Currency",

--- a/sale_coupon_multi_use_currency/i18n/fr.po
+++ b/sale_coupon_multi_use_currency/i18n/fr.po
@@ -1,0 +1,27 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale_coupon_multi_use_currency
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 13.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-11-25 14:49+0000\n"
+"PO-Revision-Date: 2020-11-25 14:49+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_coupon_multi_use_currency
+#: code:addons/sale_coupon_multi_use_currency/models/sale_coupon_program.py:0
+#, python-format
+msgid "Currency can't be changed when there are Multi Use coupons already."
+msgstr "La devise ne peut être changée quand on a déjà plusieurs utilisations du coupon."
+
+#. module: sale_coupon_multi_use_currency
+#: model:ir.model,name:sale_coupon_multi_use_currency.model_sale_coupon_program
+msgid "Sales Coupon Program"
+msgstr "Campagne de bons de réduction"

--- a/sale_coupon_multi_use_currency/models/__init__.py
+++ b/sale_coupon_multi_use_currency/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_coupon_program

--- a/sale_coupon_multi_use_currency/models/sale_coupon_program.py
+++ b/sale_coupon_multi_use_currency/models/sale_coupon_program.py
@@ -1,0 +1,22 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class SaleCouponProgram(models.Model):
+    """Extend to add logic that control multi coupon usage."""
+
+    _inherit = "sale.coupon.program"
+
+    @api.constrains("currency_custom_id")
+    def _check_currency_custom_id(self):
+        for rec in self:
+            if rec._get_multi_use_coupons():
+                raise ValidationError(
+                    _(
+                        "Currency can't be changed when there are Multi"
+                        " Use coupons already."
+                    )
+                )

--- a/sale_coupon_multi_use_currency/models/sale_coupon_program.py
+++ b/sale_coupon_multi_use_currency/models/sale_coupon_program.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Camptocamp SA
+# Copyright 2021 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, models
@@ -13,7 +13,7 @@ class SaleCouponProgram(models.Model):
     @api.constrains("currency_custom_id")
     def _check_currency_custom_id(self):
         for rec in self:
-            if rec._get_multi_use_coupons():
+            if rec.coupon_multi_use and rec.coupon_ids:
                 raise ValidationError(
                     _(
                         "Currency can't be changed when there are Multi"

--- a/sale_coupon_multi_use_currency/readme/CONTRIBUTORS.rst
+++ b/sale_coupon_multi_use_currency/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Andrius Laukavičius <andrius@focusate.eu>

--- a/sale_coupon_multi_use_currency/readme/DESCRIPTION.rst
+++ b/sale_coupon_multi_use_currency/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+Bridge module between sale_coupon_multi_use and sale_coupon_multi_currency.
+
+Updates constraint to not allow changing program currency if multi-use coupon is already in use.

--- a/sale_coupon_multi_use_currency/tests/__init__.py
+++ b/sale_coupon_multi_use_currency/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_coupon_use_currency

--- a/sale_coupon_multi_use_currency/tests/test_sale_coupon_use_currency.py
+++ b/sale_coupon_multi_use_currency/tests/test_sale_coupon_use_currency.py
@@ -1,0 +1,56 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo.exceptions import ValidationError
+
+from odoo.addons.sale_coupon_multi_currency.tests.common import (
+    TestSaleCouponMultiCurrencyCommon,
+)
+from odoo.addons.sale_coupon_multi_use.tests.common import TestSaleCouponMultiUseCommon
+
+
+class TestSaleCouponUseCurrency(
+    TestSaleCouponMultiCurrencyCommon, TestSaleCouponMultiUseCommon
+):
+    """Test class for coupon multi use with currency."""
+
+    def test_01_check_currency_custom_id(self):
+        """Check program currency when multi use coupon is generated.
+
+        Case: multi_use=True
+        """
+        with self.assertRaises(ValidationError):
+            self.program_multi_use.currency_custom_id = self.currency_other.id
+
+    def test_02_check_currency_custom_id(self):
+        """Check program currency when multi use coupon is generated.
+
+        Case: multi_use=False
+        """
+        self.program_multi_use.coupon_multi_use = False
+        with self.assertRaises(ValidationError):
+            self.program_multi_use.currency_custom_id = self.currency_other.id
+
+    def test_03_check_currency_custom_id(self):
+        """Check program currency when multi use coupon is not generated.
+
+        Case 1: multi_use=True
+        Case 2: multi_use=False
+        """
+
+        def pass_currency(program):
+            fail_msg = (
+                "There are no multi use coupons generated, so must be able"
+                " to change currency_custom_id."
+            )
+            try:
+                program.currency_custom_id = self.currency_other.id
+            except ValidationError:
+                self.fail(fail_msg)
+
+        # Copy program, so it would not have coupons.
+        program = self.program_multi_use.copy()
+        # Case 1.
+        pass_currency(program)
+        # Case 2.
+        program.coupon_multi_use = False
+        pass_currency(program)

--- a/sale_coupon_multi_use_currency/tests/test_sale_coupon_use_currency.py
+++ b/sale_coupon_multi_use_currency/tests/test_sale_coupon_use_currency.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Camptocamp SA
+# Copyright 2021 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo.exceptions import ValidationError
 
@@ -18,17 +18,27 @@ class TestSaleCouponUseCurrency(
 
         Case: multi_use=True
         """
-        with self.assertRaises(ValidationError):
-            self.program_multi_use.currency_custom_id = self.currency_other.id
+        with self.assertRaises(ValidationError) as error:
+            self.program_multi_use.currency_custom_id = self.currency_other
+        self.assertTrue(
+            "Currency can't be changed when there are Multi"
+            " Use coupons already." in error.exception.name
+        )
+        # Without coupons we can change currency
+        self.program_multi_use.coupon_ids.unlink()
+        self.program_multi_use.currency_custom_id = self.currency_other
 
     def test_02_check_currency_custom_id(self):
         """Check program currency when multi use coupon is generated.
 
         Case: multi_use=False
         """
+        # Remove coupons because
+        # we can't change coupon_multi_use flag when existing coupons
+        self.program_multi_use.coupon_ids.unlink()
         self.program_multi_use.coupon_multi_use = False
-        with self.assertRaises(ValidationError):
-            self.program_multi_use.currency_custom_id = self.currency_other.id
+        self.coupon_generate_wiz.generate_coupon()
+        self.program_multi_use.currency_custom_id = self.currency_other
 
     def test_03_check_currency_custom_id(self):
         """Check program currency when multi use coupon is not generated.

--- a/setup/sale_coupon_multi_currency/odoo/addons/sale_coupon_multi_currency
+++ b/setup/sale_coupon_multi_currency/odoo/addons/sale_coupon_multi_currency
@@ -1,0 +1,1 @@
+../../../../sale_coupon_multi_currency

--- a/setup/sale_coupon_multi_currency/setup.py
+++ b/setup/sale_coupon_multi_currency/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/sale_coupon_multi_use/odoo/addons/sale_coupon_multi_use
+++ b/setup/sale_coupon_multi_use/odoo/addons/sale_coupon_multi_use
@@ -1,0 +1,1 @@
+../../../../sale_coupon_multi_use

--- a/setup/sale_coupon_multi_use/setup.py
+++ b/setup/sale_coupon_multi_use/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/sale_coupon_multi_use_currency/odoo/addons/sale_coupon_multi_use_currency
+++ b/setup/sale_coupon_multi_use_currency/odoo/addons/sale_coupon_multi_use_currency
@@ -1,0 +1,1 @@
+../../../../sale_coupon_multi_use_currency

--- a/setup/sale_coupon_multi_use_currency/setup.py
+++ b/setup/sale_coupon_multi_use_currency/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Allows to consume same coupon multiple times. Can only be used when
discount has fixed amount. Discount fixed amount can't be changed if
there are coupons with `multi_use` flag set.

Can specify value of coupon and that value can be consumed per multiple
sale orders.

If discount is removed from sale order, so is consumption line from
coupon.