### PR TITLE
 [FIX] sale_invoice_policy: set correct default value for field product.template default_invoice_policy

### DIFF
--- a/sale_invoice_policy/models/product_template.py
+++ b/sale_invoice_policy/models/product_template.py
@@ -15,7 +15,7 @@ class ProductTemplate(models.Model):
              'ordered.\n'
              'Delivered Quantity: Invoiced based on the quantity the vendor '
              'delivered (time or deliveries).',
-        default='order')
+        default=lambda x: x._default_default_invoice_policy())
 
     invoice_policy = fields.Selection(
         compute="_compute_invoice_policy",
@@ -24,6 +24,9 @@ class ProductTemplate(models.Model):
         search='_search_invoice_policy',
         inverse='_inverse_invoice_policy',
     )
+
+    def _default_default_invoice_policy(self):
+        return self.env['ir.default'].get('product.template', 'invoice_policy')
 
     @api.multi
     def _inverse_invoice_policy(self):


### PR DESCRIPTION
in Odoo core, there is a field named in res.config that store the default value of ``product_template.invoice_policy``.

Ref : https://github.com/odoo/odoo/blob/12.0/addons/sale/models/res_config_settings.py#L41

With the module ``sale_invoice_policy`` installed, the field ``invoice_policy`` is hidden, and replaced by ``default_invoice_policy``. The problem is that for this new field the default value of the ``res.config`` is not recovered.

this trivial patch fixes this bug.