### PR TITLE
[FIX] sale_commercial_partner: compute_sudo

### DIFF
--- a/sale_commercial_partner/models/sale.py
+++ b/sale_commercial_partner/models/sale.py
@@ -12,5 +12,6 @@ class SaleOrder(models.Model):
         related='partner_id.commercial_partner_id',
         store=True,
         string='Commercial Entity',
-        index=True
+        compute_sudo=True,
+        index=True,
     )


### PR DESCRIPTION
In a multi-company scenario, a partner could have sale orders belonging to
different companies, wich will raise an security exception due to record
rules

cc @Tecnativa TT26729