### PR TITLE
[13.0] [FIX] sale_order_type: Not allowed to delete a sale order type if them is used in an sale order.

### DIFF
--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -15,6 +15,7 @@ class SaleOrder(models.Model):
         readonly=True,
         states={"draft": [("readonly", False)], "sent": [("readonly", False)]},
         default=lambda so: so._default_type_id(),
+        ondelete="restrict",
     )
 
     @api.model


### PR DESCRIPTION
So keep in mind that if you accidentally delete a sales type, it is protected until you remove it from the sales order.
In case you need to perform an operation such as printing the report and the sales order is already confirmed. Because the field is required only per view.