### PR TITLE
[12.0][FIX] sale_order_product_recommendation: Get product image form product.product model instead of product.template in wizard kanban view.

### DIFF
--- a/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
@@ -42,7 +42,7 @@
                                     <t t-name="kanban-box">
                                         <div class="oe_kanban_global_click">
                                             <div class="o_kanban_image">
-                                                <img t-att-src="kanban_image('product.template', 'image_small', record.product_id.raw_value)" alt="Product"/>
+                                                <img t-att-src="kanban_image('product.product', 'image_small', record.product_id.raw_value)" alt="Product"/>
                                             </div>
                                             <div class="oe_kanban_details">
                                                 <div><field name="product_id"/></div>


### PR DESCRIPTION
cc @Tecantiva TT26749
ping @pedrobaeza @chienandalu 