### PR TITLE
[13.0][FIX] sale_order_product_recommendation: Get product image form product.product model instead of product.template in wizard kanban view.

### DIFF
--- a/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
@@ -45,7 +45,7 @@
                                         <div class="oe_kanban_global_click">
                                             <div class="o_kanban_image">
                                                 <img
-                                                    t-att-src="kanban_image('product.template', 'image_small', record.product_id.raw_value)"
+                                                    t-att-src="kanban_image('product.product', 'image_small', record.product_id.raw_value)"
                                                     alt="Product"
                                                 />
                                             </div>


### PR DESCRIPTION
cc @Tecnativa TT26749
ping @pedrobaeza @chienandalu 
Ported from https://github.com/OCA/sale-workflow/pull/1331