### PR TITLE
[ADD] sale_coupon_product_management: init

### DIFF
--- a/sale_coupon_product_management/__init__.py
+++ b/sale_coupon_product_management/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_coupon_product_management/__manifest__.py
+++ b/sale_coupon_product_management/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Sale Coupon Product Management",
+    "summary": "Improves related product management via sale coupons",
+    "version": "13.0.1.0.0",
+    "category": "Sale",
+    "website": "https://github.com/OCA/sale-workflow",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": ["sale_coupon"],
+    "data": [
+        "views/product_category_views.xml",
+        "views/product_product_views.xml",
+        "views/sale_coupon_program_views.xml",
+    ],
+    "installable": True,
+}

--- a/sale_coupon_product_management/i18n/fr.po
+++ b/sale_coupon_product_management/i18n/fr.po
@@ -1,0 +1,111 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale_coupon_product_management
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 13.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-02-12 13:55+0000\n"
+"PO-Revision-Date: 2021-02-12 13:55+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_coupon_product_management
+#: model:ir.model.fields,field_description:sale_coupon_product_management.field_product_category__default_promotion_next_order_category
+msgid "Default Promotion Next Order Category"
+msgstr ""
+"Catégorie par défaut pour promotion applicable sur une commande ultérieure"
+
+#. module: sale_coupon_product_management
+#: model:ir.model.fields,field_description:sale_coupon_product_management.field_sale_coupon_program__discount_line_product_chosen
+msgid "Discount Line Product Chosen"
+msgstr "Produit de ligne de récompense choisi"
+
+#. module: sale_coupon_product_management
+#: model:ir.model.fields,field_description:sale_coupon_product_management.field_sale_coupon_program__force_product_categ_id
+msgid "Force Product Categ"
+msgstr "Forcer la catégorie du produit"
+
+#. module: sale_coupon_product_management
+#: model:ir.model.fields,field_description:sale_coupon_product_management.field_sale_coupon_program__force_product_default_code
+msgid "Force Product Default Code"
+msgstr "Forcer la référence interne du produit"
+
+#. module: sale_coupon_product_management
+#: code:addons/sale_coupon_product_management/models/product_product.py:0
+#, python-format
+msgid "Invalid 'Can be sold' value corresponding to program category options."
+msgstr "Invalide valeur 'Peut être vendu' correspondant aux options de la catégorie de programme"
+
+#. module: sale_coupon_product_management
+#: model:ir.model.fields,field_description:sale_coupon_product_management.field_product_category__is_program_category
+msgid "Is Program Category"
+msgstr "Est une catégorie de programme"
+
+#. module: sale_coupon_product_management
+#: model:ir.model,name:sale_coupon_product_management.model_product_product
+msgid "Product"
+msgstr "Article"
+
+#. module: sale_coupon_product_management
+#: model:ir.model,name:sale_coupon_product_management.model_product_category
+msgid "Product Category"
+msgstr "Catégorie d'article"
+
+#. module: sale_coupon_product_management
+#: model_terms:ir.ui.view,arch_db:sale_coupon_product_management.sale_coupon_program_view_form_common
+msgid "Product Data"
+msgstr "Information produit"
+
+#. module: sale_coupon_product_management
+#: model:ir.model.fields,help:sale_coupon_product_management.field_sale_coupon_program__discount_line_product_readonly_id
+msgid ""
+"Product used in the sales order to apply the discount. Each coupon program "
+"has its own reward product for reporting purpose"
+msgstr ""
+"Le produit utilisé pour appliquer la remise sur le bon de commande. Tous les"
+" programmes de coupons possèdent un produit de récompense spécifique afin de"
+" permettre leur différenciation."
+
+#. module: sale_coupon_product_management
+#: model:ir.model.fields,field_description:sale_coupon_product_management.field_product_category__program_product_discount_fixed_amount
+#: model:ir.model.fields,field_description:sale_coupon_product_management.field_product_product__program_product_discount_fixed_amount
+msgid "Program Product Discount Fixed Amount"
+msgstr "Prix de vente du produit défini sur le programme"
+
+#. module: sale_coupon_product_management
+#: model:ir.model.fields,field_description:sale_coupon_product_management.field_product_category__program_product_sale_ok
+#: model:ir.model.fields,field_description:sale_coupon_product_management.field_product_product__program_product_sale_ok
+msgid "Program Product Sale Ok"
+msgstr "Le produit peut être vendu"
+
+#. module: sale_coupon_product_management
+#: model:ir.model.fields,field_description:sale_coupon_product_management.field_sale_coupon_program__discount_line_product_readonly_id
+msgid "Reward Line Product"
+msgstr "Produit de ligne de récompense"
+
+#. module: sale_coupon_product_management
+#: model:ir.model,name:sale_coupon_product_management.model_sale_coupon_program
+msgid "Sales Coupon Program"
+msgstr "Programme de coupon de vente"
+
+#. module: sale_coupon_product_management
+#: code:addons/sale_coupon_product_management/models/sale_coupon_program.py:0
+#, python-format
+msgid "This reward line product is already used into another program."
+msgstr "Ce produit de ligne de récompense est déjà utilisé dans un autre programme."
+
+#. module: sale_coupon_product_management
+#: code:addons/sale_coupon_product_management/models/sale_coupon_program.py:0
+#, python-format
+msgid ""
+"With 'program_product_discount_fixed_amount' category, the reward type must "
+"be 'discount' and the discount type must be 'Fixed Amount'."
+msgstr ""
+"Avec une catégorie 'Prix de vente du produit défini sur le programme', le type de remise doit "
+"être 'remise' and le type de remise doit être 'Prix fixe'."

--- a/sale_coupon_product_management/models/__init__.py
+++ b/sale_coupon_product_management/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_category
+from . import product_product
+from . import sale_coupon_program

--- a/sale_coupon_product_management/models/product_category.py
+++ b/sale_coupon_product_management/models/product_category.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class ProductCategory(models.Model):
+
+    _inherit = "product.category"
+
+    is_program_category = fields.Boolean()
+    program_product_sale_ok = fields.Boolean()
+    program_product_discount_fixed_amount = fields.Boolean()
+    default_promotion_next_order_category = fields.Boolean(copy=False)
+
+    @api.onchange("is_program_category")
+    def _onchange_is_program_category(self):
+        if not self.is_program_category:
+            self.program_product_sale_ok = False
+            self.program_product_discount_fixed_amount = False
+            self.default_promotion_next_order_category = False

--- a/sale_coupon_product_management/models/product_product.py
+++ b/sale_coupon_product_management/models/product_product.py
@@ -1,0 +1,43 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class ProductProduct(models.Model):
+
+    _inherit = "product.product"
+
+    program_product_sale_ok = fields.Boolean(related="categ_id.program_product_sale_ok")
+    program_product_discount_fixed_amount = fields.Boolean(
+        related="categ_id.program_product_discount_fixed_amount"
+    )
+
+    @api.onchange("categ_id")
+    def _onchange_program_categ_id(self):
+        category = self.categ_id
+        if category.is_program_category:
+            self.sale_ok = self.program_product_sale_ok
+            # In case of existing product, we don't reset the price.
+            if (
+                self.program_product_discount_fixed_amount
+                and isinstance(self.id, models.NewId)
+                and not self.id.origin
+            ):
+                self.lst_price = False
+
+    @api.constrains("categ_id", "sale_ok")
+    def _check_program_product_sale_ok(self):
+        for rec in self:
+            category = rec.categ_id
+            if (
+                category.is_program_category
+                and rec.sale_ok != category.program_product_sale_ok
+            ):
+                raise UserError(
+                    _(
+                        "Invalid 'Can be sold' value corresponding "
+                        "to program category options."
+                    )
+                )

--- a/sale_coupon_product_management/models/sale_coupon_program.py
+++ b/sale_coupon_product_management/models/sale_coupon_program.py
@@ -1,0 +1,179 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class SaleCouponProgram(models.Model):
+    """Extend to improve product related product management."""
+
+    _inherit = "sale.coupon.program"
+
+    force_product_default_code = fields.Char()
+    # We would have "force_product_categ_id" required,
+    # but to not break all unit tests on coupon programs on other modules,
+    # we just add a required into the form view,
+    # and do nothing in this code if not set.
+    force_product_categ_id = fields.Many2one(
+        comodel_name="product.category", domain=[("is_program_category", "=", True)],
+    )
+    discount_line_product_chosen = fields.Boolean()
+    discount_line_product_readonly_id = fields.Many2one(
+        related="discount_line_product_id",
+    )
+
+    @api.onchange("program_type", "promo_applicability")
+    def _onchange_promo_applicability(self):
+        if (
+            self.program_type == "promotion_program"
+            and self.promo_applicability == "on_next_order"
+            and not self.force_product_categ_id
+        ):
+            # If several default categories found, just take the first
+            default_categ = self.env["product.category"].search(
+                [("default_promotion_next_order_category", "=", True)], limit=1
+            )
+            if default_categ:
+                self.force_product_categ_id = default_categ.id
+
+    @api.onchange("discount_line_product_chosen")
+    def _onchange_discount_line_product_chosen(self):
+        for rec in self:
+            rec.force_product_default_code = False
+            if rec.discount_line_product_id:
+                rec.discount_line_product_id = False
+
+    @api.onchange("force_product_categ_id")
+    def _onchange_force_product_categ_id(self):
+        for rec in self:
+            rec.discount_line_product_id = False
+
+    @api.constrains("force_product_categ_id", "reward_type", "discount_type")
+    def _check_program_options(self):
+        for rec in self:
+            category = rec.force_product_categ_id
+            if (
+                category
+                and category.program_product_discount_fixed_amount
+                and not (
+                    rec.reward_type == "discount"
+                    and rec.discount_type == "fixed_amount"
+                )
+            ):
+                raise UserError(
+                    _(
+                        "With 'program_product_discount_fixed_amount' category, "
+                        "the reward type must be 'discount' and "
+                        "the discount type must be 'Fixed Amount'."
+                    )
+                )
+
+    def _check_no_product_duplicate(self):
+        for rec in self:
+            other_program_found = self.search_count(
+                [
+                    ("discount_line_product_id", "=", rec.discount_line_product_id.id),
+                    ("id", "!=", rec.id),
+                ]
+            )
+            if other_program_found:
+                raise UserError(
+                    _(
+                        "This reward line product is already used "
+                        "into another program."
+                    )
+                )
+
+    def _force_values_on_product(self):
+        product = self.discount_line_product_id
+        # Check and force product category
+        if product.categ_id != self.force_product_categ_id:
+            product.categ_id = self.force_product_categ_id
+        # Check and force product sale_ok code from category
+        if product.sale_ok != product.categ_id.program_product_sale_ok:
+            product.sale_ok = product.categ_id.program_product_sale_ok
+        # Check and force product price from program
+        if self.force_product_categ_id.program_product_discount_fixed_amount:
+            product.lst_price = self.discount_fixed_amount
+        if not self.discount_line_product_chosen:
+            # Check and force product name from program
+            if not self.discount_line_product_chosen:
+                product.name = self.name
+            # Check and force product default code from program
+            if self.force_product_default_code:
+                product.default_code = self.force_product_default_code
+
+    def _create_custom_discount_line_product(self, name, category):
+        values = {
+            "name": name,
+            "categ_id": category.id,
+            "type": "service",
+            "taxes_id": False,
+            "supplier_taxes_id": False,
+            "sale_ok": category.program_product_sale_ok,
+            "purchase_ok": False,
+            "invoice_policy": "order",
+            "lst_price": 0,
+        }
+        return self.env["product.product"].create(values)
+
+    @api.model
+    def create(self, vals):
+        if not vals.get("force_product_categ_id"):
+            # Do nothing: we provides from unit tests or specific code
+            return super().create(vals)
+        if not vals.get("discount_line_product_id"):
+            category = self.env["product.category"].browse(
+                vals["force_product_categ_id"]
+            )
+            product = self._create_custom_discount_line_product(vals["name"], category)
+            vals["discount_line_product_id"] = product.id
+        program = super().create(vals)
+        # Force values on generated product
+        program._force_values_on_product()
+        # Check we don't have a same product used on 2 programs
+        program._check_no_product_duplicate()
+        return program
+
+    def write(self, vals):
+        for program in self:
+            if not program.force_product_categ_id and not vals.get(
+                "force_product_categ_id"
+            ):
+                # Do nothing: we provides from unit tests or specific code
+                super(SaleCouponProgram, program).write(vals)
+                continue
+            if vals.get(
+                "discount_line_product_chosen", program.discount_line_product_chosen
+            ):
+                # Save the product name to restore it after core override
+                if "discount_line_product_id" in vals:
+                    product = self.env["product.product"].browse(
+                        vals["discount_line_product_id"]
+                    )
+                    current_product_name = product.name
+                else:
+                    current_product_name = program.discount_line_product_id.name
+            else:
+                current_product_name = False
+            # Call super to update program
+            super(SaleCouponProgram, program).write(vals)
+            # Create default product if missing and not chosen
+            if not program.discount_line_product_chosen:
+                if not program.discount_line_product_id:
+                    product = self._create_custom_discount_line_product(
+                        program.name, program.force_product_categ_id
+                    )
+                    program.discount_line_product_id = product
+            # Restore original product name
+            if (
+                current_product_name
+                and program.discount_line_product_id.name != current_product_name
+            ):
+                program.discount_line_product_id.name = current_product_name
+            # Force values on generated product
+            program._force_values_on_product()
+            # Check we don't have a same product used on 2 programs
+            program._check_no_product_duplicate()
+        return True

--- a/sale_coupon_product_management/readme/CONTRIBUTORS.rst
+++ b/sale_coupon_product_management/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Andrius Laukavičius <andrius@focusate.eu>
+* Julien Coux <julien.coux@camptocamp.com>

--- a/sale_coupon_product_management/readme/DESCRIPTION.rst
+++ b/sale_coupon_product_management/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+Allows to manage some fields for related product directly on sale coupon or promotion program.
+
+Adds mandatory product category on program where need to define specific categories meant for
+program product.

--- a/sale_coupon_product_management/tests/__init__.py
+++ b/sale_coupon_product_management/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_coupon_manage

--- a/sale_coupon_product_management/tests/common.py
+++ b/sale_coupon_product_management/tests/common.py
@@ -1,0 +1,40 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import SavepointCase
+
+NAME_COUPON_PROGRAM = "Dummy Coupon Program"
+CODE_COUPON_PROGRAM = "MYCODE123"
+
+
+class TestSaleCouponProductManageCommon(SavepointCase):
+    """Common class for program product tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up common data for multi use coupon tests."""
+        super().setUpClass()
+        # Models.
+        cls.SaleCouponProgram = cls.env["sale.coupon.program"]
+        cls.ProductCategory = cls.env["product.category"]
+        # Records.
+        cls.product_category_not_program = cls.ProductCategory.create(
+            {"name": "Dummy Not Program Category", "is_program_category": False}
+        )
+        cls.product_category_program = cls.ProductCategory.create(
+            {"name": "Dummy Program Category", "is_program_category": True}
+        )
+        cls.product_category_program_default = cls.ProductCategory.create(
+            {"name": "Dummy Program Category Default", "is_program_category": True}
+        )
+        cls.program = cls.SaleCouponProgram.create(
+            {
+                "name": NAME_COUPON_PROGRAM,
+                "program_type": "coupon_program",
+                "reward_type": "discount",
+                "discount_type": "fixed_amount",
+                "discount_fixed_amount": 1000,
+                "force_product_default_code": CODE_COUPON_PROGRAM,
+                "force_product_categ_id": cls.product_category_program.id,
+            }
+        )

--- a/sale_coupon_product_management/tests/test_sale_coupon_manage.py
+++ b/sale_coupon_product_management/tests/test_sale_coupon_manage.py
@@ -1,0 +1,162 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import UserError
+from odoo.tests.common import Form
+
+from .common import (
+    CODE_COUPON_PROGRAM,
+    NAME_COUPON_PROGRAM,
+    TestSaleCouponProductManageCommon,
+)
+
+
+class TestSaleCouponManage(TestSaleCouponProductManageCommon):
+    """Test class for program management use cases."""
+
+    def test_01_program_discount_product_rel_vals(self):
+        """Check created program with related product.
+
+        Check if related values are propagated to related product.
+
+        Case 1: create promotion initially.
+        Case 2: update promotion/related product related values.
+        """
+        # Case 1.
+        program = self.program
+        product = program.discount_line_product_id
+        self.assertEqual(product.default_code, CODE_COUPON_PROGRAM)
+        self.assertEqual(product.categ_id, self.product_category_program)
+        # Must match program name exactly.
+        self.assertEqual(product.name, NAME_COUPON_PROGRAM)
+        # Case 2.
+        name_2 = "Product Name"
+        # Clear context, so it would be treated as separate update.
+        product = product.with_context(forced_product_vals={})
+        product.name = name_2
+        self.assertEqual(program.name, NAME_COUPON_PROGRAM)
+        self.assertEqual(product.name, name_2)
+        name_3 = "Program Name"
+        program.name = name_3
+        self.assertEqual(program.name, name_3)
+        self.assertEqual(product.name, name_3)
+        # Make sure old dependencies dont update name the old way.
+        program.discount_fixed_amount = 300
+        self.assertEqual(program.name, name_3)
+        self.assertEqual(product.name, name_3)
+        code_2 = "MYCODE321"
+        program.force_product_default_code = code_2
+        self.assertEqual(product.default_code, code_2)
+        program.discount_line_product_id.default_code = CODE_COUPON_PROGRAM
+        self.assertEqual(product.default_code, CODE_COUPON_PROGRAM)
+        # Sanity check.
+        self.assertFalse(product.sale_ok)
+
+    def test_02_program_discount_product_rel_vals(self):
+        """Check if option values are passed to product.
+
+        Case: on program create - passing sale_ok, lst_price.
+        """
+        self.product_category_program.write(
+            {
+                "program_product_sale_ok": True,
+                "program_product_discount_fixed_amount": True,
+            }
+        )
+        program = self.SaleCouponProgram.create(
+            {
+                "name": "Coupon Program 2",
+                "program_type": "coupon_program",
+                "reward_type": "discount",
+                "discount_type": "fixed_amount",
+                "discount_fixed_amount": 1000,
+                "force_product_default_code": CODE_COUPON_PROGRAM,
+                "force_product_categ_id": self.product_category_program.id,
+            }
+        )
+        product = program.discount_line_product_id
+        self.assertTrue(product.sale_ok)
+        self.assertEqual(product.lst_price, 1000)
+
+    def test_03_check_program_options(self):
+        """Validate if program values match its related options.
+
+        Case 1: values match.
+        Case 2: values not match.
+        """
+        # Case 1.
+        self.program.force_product_categ_id = self.product_category_not_program
+        product = self.program.discount_line_product_id
+        product.sale_ok = True  # to not trigger constraint on product.
+        self.product_category_program.write(
+            {
+                "program_product_sale_ok": True,
+                "program_product_discount_fixed_amount": True,
+            }
+        )
+        self.program.force_product_categ_id = self.product_category_program
+        # Case 2.
+        with self.assertRaises(UserError):
+            self.program.discount_type = "percentage"
+        with self.assertRaises(UserError):
+            self.program.reward_type = "product"
+
+    def test_04_check_product_options(self):
+        """Validate if program product values match its related options.
+
+        Case 1: values match.
+        Case 2: values not match.
+        """
+        # Case 1.
+        product = self.program.discount_line_product_id
+        product.write(
+            {"sale_ok": True, "categ_id": self.product_category_not_program.id}
+        )
+        self.product_category_program.write(
+            {
+                "program_product_sale_ok": True,
+                "program_product_discount_fixed_amount": True,
+            }
+        )
+        product.categ_id = self.product_category_program.id
+        # Case 2.
+        with self.assertRaises(UserError):
+            product.sale_ok = False
+
+    def test_05_default_promotion_next_order_category(self):
+        """Check if default category is set on next order type promo.
+
+        Case 1: onchange with promo_applicability = on_current_order
+        Case 2: onchange with promo_applicability = on_next_order
+        Case 3: check if only one default categ can be used.
+        """
+        # Case 1.
+        self.product_category_program_default.default_promotion_next_order_category = (
+            True
+        )
+        with Form(
+            self.SaleCouponProgram,
+            view="sale_coupon.sale_coupon_program_view_promo_program_form",
+        ) as program:
+            program.name = "Promotion Program"
+            program.program_type = "promotion_program"
+            program.promo_applicability = "on_current_order"
+            program.reward_type = "discount"
+            program.discount_type = "fixed_amount"
+            program.discount_fixed_amount = 1000
+            program.force_product_default_code = CODE_COUPON_PROGRAM
+            self.assertFalse(program.force_product_categ_id)
+            # Case 2.
+            program.promo_applicability = "on_next_order"
+            self.assertEqual(
+                program.force_product_categ_id, self.product_category_program_default
+            )
+
+    def test_06_onchange_product_categ_with_opts(self):
+        """Onchange product category that has program option."""
+        product = self.program.discount_line_product_id
+        self.assertFalse(product.sale_ok)
+        self.product_category_program.program_product_sale_ok = True
+        with Form(product) as p:
+            p.categ_id = self.product_category_program
+            self.assertTrue(p.sale_ok)

--- a/sale_coupon_product_management/views/product_category_views.xml
+++ b/sale_coupon_product_management/views/product_category_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="product_category_form_view" model="ir.ui.view">
+        <field name="name">product.category.form.program.option</field>
+        <field name="model">product.category</field>
+        <field name="inherit_id" ref="product.product_category_form_view" />
+        <field name="arch" type="xml">
+            <field name="parent_id" position="after">
+                <field name="is_program_category" />
+                <field
+                    name="default_promotion_next_order_category"
+                    attrs="{'invisible': [('is_program_category', '=', False)]}"
+                />
+                <field
+                    name="program_product_sale_ok"
+                    attrs="{'invisible': [('is_program_category', '=', False)]}"
+                />
+                <field
+                    name="program_product_discount_fixed_amount"
+                    attrs="{'invisible': [('is_program_category', '=', False)]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/sale_coupon_product_management/views/product_product_views.xml
+++ b/sale_coupon_product_management/views/product_product_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="product_normal_form_view" model="ir.ui.view">
+        <field name="name">product.product.form.program.option</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view" />
+        <field name="arch" type="xml">
+            <field name="lst_price" position="before">
+                <field name="program_product_sale_ok" invisible="1" />
+                <field name="program_product_discount_fixed_amount" invisible="1" />
+            </field>
+            <field name="sale_ok" position="attributes">
+                <attribute name="attrs">
+                    {'readonly': [('program_product_discount_fixed_amount', '=', True)]}
+                </attribute>
+            </field>
+            <field name="lst_price" position="attributes">
+                <attribute name="attrs">
+                    {'readonly': ['|', ('product_variant_count', '&gt;', 1), ('program_product_discount_fixed_amount', '=', True)]}
+                </attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/sale_coupon_product_management/views/sale_coupon_program_views.xml
+++ b/sale_coupon_product_management/views/sale_coupon_program_views.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="sale_coupon_program_view_form_common" model="ir.ui.view">
+        <field name="name">sale.coupon.program.common.form.product</field>
+        <field name="model">sale.coupon.program</field>
+        <field
+            name="inherit_id"
+            ref="sale_coupon.sale_coupon_program_view_form_common"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='validity']" position="after">
+                <group string="Product Data" name="product_data">
+                    <field name="discount_line_product_chosen" />
+                    <field
+                        name="force_product_categ_id"
+                        context="{'default_is_program_category': True}"
+                        required="1"
+                    />
+                    <field
+                        name="force_product_default_code"
+                        attrs="{'invisible': [('discount_line_product_chosen', '=', True)]}"
+                    />
+                </group>
+            </xpath>
+            <field name="discount_line_product_id" position="attributes">
+                <attribute name="attrs">
+                    {'invisible': [('discount_line_product_chosen', '=', False)], 'required': [('discount_line_product_chosen', '=', True)]}
+                </attribute>
+                <attribute name="domain">
+                    [('categ_id', '=', force_product_categ_id)]
+                </attribute>
+                <attribute name="context">
+                    {'default_categ_id': force_product_categ_id}
+                </attribute>
+                <attribute name="readonly">False</attribute>
+            </field>
+            <field name="discount_line_product_id" position="after">
+                <!-- discount_line_product_readonly_id is used to allow to see the generated product on the program when not chose product -->
+                <field
+                    name="discount_line_product_readonly_id"
+                    attrs="{'invisible': [('discount_line_product_chosen', '=', True)]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/setup/sale_coupon_product_management/odoo/addons/sale_coupon_product_management
+++ b/setup/sale_coupon_product_management/odoo/addons/sale_coupon_product_management
@@ -1,0 +1,1 @@
+../../../../sale_coupon_product_management

--- a/setup/sale_coupon_product_management/setup.py
+++ b/setup/sale_coupon_product_management/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Implemented related fields update from program to product. Changed the
product name value passed from program to product (no longer uses
reward record display_name) - now it only uses name field from program
directly.

Implemented constraints and onchanges to fill up data from related
program options for program and its product.

Implemented product option values passing when program is created,
added boolean to specify default category for next order promotion program.

Added access rights for sale.coupon.program.option, views for module.