### PR TITLE
[13.0][FIX] sale_fixed_discount: remove obsolete colspan calculation

### DIFF
--- a/sale_fixed_discount/reports/report_sale_order.xml
+++ b/sale_fixed_discount/reports/report_sale_order.xml
@@ -12,16 +12,15 @@
                 t-value="any([l.discount_fixed for l in doc.order_line])"
             />
         </xpath>
-        <xpath expr="//th[@t-if='display_discount']" position="after">
+        <th name="th_discount" position="after">
             <th
                 t-if="display_discount_fixed"
                 class="text-right"
                 groups="product.group_discount_per_so_line"
             >
                 <span>Disc. Fixed Amount</span>
-                <t t-set="colspan" t-value="colspan+1" />
             </th>
-        </xpath>
+        </th>
         <xpath expr="//td[@t-if='display_discount']" position="after">
             <td
                 t-if="display_discount_fixed"


### PR DESCRIPTION
1. Remove obsolete colspan calculation
2. Use new named table header (th_discount) to place discount_fixed table header (Change in Odoo [here](https://github.com/odoo/odoo/commit/93157ebe19f4ac82cadb65d38a7e63cfd185d035#diff-74b7a7e0356fe940ba9ca90f10b9318987a823a9aa6a66c66991189b900d6ae7))

Fixes #1333


![fixed_discount_pdf](https://user-images.githubusercontent.com/226753/99880782-c79fb500-2c15-11eb-9996-890127b096c4.png)




