### PR TITLE
[13.0][FIX] sale_force_invoiced: force the status always

### DIFF
--- a/sale_force_invoiced/model/sale_order.py
+++ b/sale_force_invoiced/model/sale_order.py
@@ -21,6 +21,6 @@ class SaleOrder(models.Model):
     def _get_invoice_status(self):
         super(SaleOrder, self)._get_invoice_status()
         for order in self.filtered(
-            lambda so: so.force_invoiced and so.invoice_status == "to invoice"
+            lambda so: so.force_invoiced and so.state in ("sale", "done")
         ):
             order.invoice_status = "invoiced"


### PR DESCRIPTION
Sometimes you have a SO that Odoo computes as "Nothing to invoice"
but you want to force it to "Fully invoiced" anyway.

Example: SO with 2 lines, line one is delivered and invoiced,
second line is never going to be delivered nor invoiced (
because of different bussiness reasons). In this situation you
still want to mark the SO as fully invoiced.

@ForgeFlow