### PR TITLE
[FIX] Search for sale order type in current company

### DIFF
--- a/sale_order_type/models/account_move.py
+++ b/sale_order_type/models/account_move.py
@@ -24,8 +24,8 @@ class AccountMove(models.Model):
             lambda am: am.type in ["out_invoice", "out_refund"]
         ):
             if not record.partner_id:
-                record.sale_type_id = self.env["sale.order.type"].search([(
-                    'company_id', '=', self.env.company.id)], limit=1)
+                record.sale_type_id = self.env["sale.order.type"].search([
+                    ('company_id', '=', self.env.company.id)], limit=1)
             else:
                 sale_type = (
                     record.partner_id.with_context(

--- a/sale_order_type/models/account_move.py
+++ b/sale_order_type/models/account_move.py
@@ -24,7 +24,8 @@ class AccountMove(models.Model):
             lambda am: am.type in ["out_invoice", "out_refund"]
         ):
             if not record.partner_id:
-                record.sale_type_id = self.env["sale.order.type"].search([], limit=1)
+                record.sale_type_id = self.env["sale.order.type"].search([
+                    ('company_id', '=', self.env.company.id)], limit=1)
             else:
                 sale_type = (
                     record.partner_id.with_context(

--- a/sale_order_type/models/account_move.py
+++ b/sale_order_type/models/account_move.py
@@ -24,8 +24,9 @@ class AccountMove(models.Model):
             lambda am: am.type in ["out_invoice", "out_refund"]
         ):
             if not record.partner_id:
-                record.sale_type_id = self.env["sale.order.type"].search([
-                    ('company_id', '=', self.env.company.id)], limit=1)
+                record.sale_type_id = self.env["sale.order.type"].search(
+                    [('company_id', '=', self.env.company.id)], limit=1
+                )
             else:
                 sale_type = (
                     record.partner_id.with_context(

--- a/sale_order_type/models/account_move.py
+++ b/sale_order_type/models/account_move.py
@@ -24,8 +24,8 @@ class AccountMove(models.Model):
             lambda am: am.type in ["out_invoice", "out_refund"]
         ):
             if not record.partner_id:
-                record.sale_type_id = self.env["sale.order.type"].search([('company_id', '=', self.env.company.id)],
-                                                                         limit=1)
+                record.sale_type_id = self.env["sale.order.type"].search([(
+                    'company_id', '=', self.env.company.id)], limit=1)
             else:
                 sale_type = (
                     record.partner_id.with_context(

--- a/sale_order_type/models/account_move.py
+++ b/sale_order_type/models/account_move.py
@@ -24,7 +24,8 @@ class AccountMove(models.Model):
             lambda am: am.type in ["out_invoice", "out_refund"]
         ):
             if not record.partner_id:
-                record.sale_type_id = self.env["sale.order.type"].search([], limit=1)
+                record.sale_type_id = self.env["sale.order.type"].search([('company_id', '=', self.env.company.id)],
+                                                                         limit=1)
             else:
                 sale_type = (
                     record.partner_id.with_context(

--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -31,7 +31,8 @@ class SaleOrder(models.Model):
     def _compute_sale_type_id(self):
         for record in self:
             if not record.partner_id:
-                record.type_id = self.env["sale.order.type"].search([('company_id', '=', self.env.company.id)], limit=1)
+                record.type_id = self.env["sale.order.type"].search([
+                    ('company_id', '=', self.env.company.id)], limit=1)
             else:
                 sale_type = (
                     record.partner_id.with_context(

--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -31,7 +31,8 @@ class SaleOrder(models.Model):
     def _compute_sale_type_id(self):
         for record in self:
             if not record.partner_id:
-                record.type_id = self.env["sale.order.type"].search([], limit=1)
+                record.type_id = self.env["sale.order.type"].search([
+                    ('company_id', '=', self.env.company.id)], limit=1)
             else:
                 sale_type = (
                     record.partner_id.with_context(

--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -31,7 +31,7 @@ class SaleOrder(models.Model):
     def _compute_sale_type_id(self):
         for record in self:
             if not record.partner_id:
-                record.type_id = self.env["sale.order.type"].search([], limit=1)
+                record.type_id = self.env["sale.order.type"].search([('company_id', '=', self.env.company.id)], limit=1)
             else:
                 sale_type = (
                     record.partner_id.with_context(

--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -31,8 +31,9 @@ class SaleOrder(models.Model):
     def _compute_sale_type_id(self):
         for record in self:
             if not record.partner_id:
-                record.type_id = self.env["sale.order.type"].search([
-                    ('company_id', '=', self.env.company.id)], limit=1)
+                record.type_id = self.env["sale.order.type"].search(
+                    [('company_id', '=', self.env.company.id)], limit=1
+                )
             else:
                 sale_type = (
                     record.partner_id.with_context(


### PR DESCRIPTION
A user can be active in multiple companies, when searching for a sale order type when none is set this should be taken into account.

@pedrobaeza 