### PR TITLE
[13.0][IMP] sale_order_product_availability_inline: set decimal precision

### DIFF
--- a/sale_order_product_availability_inline/models/product_product.py
+++ b/sale_order_product_availability_inline/models/product_product.py
@@ -12,10 +12,13 @@ class ProductProduct(models.Model):
             res = super().name_get()
             self = self.with_context(warehouse=self.env.context.get("warehouse"))
             availability = {r.id: [r.free_qty, r.uom_id.name] for r in self}
+            precision = self.env["decimal.precision"].precision_get(
+                "Product Unit of Measure"
+            )
             new_res = []
             for _i in res:
-                name = "{} ({} {})".format(
-                    _i[1], availability[_i[0]][0], availability[_i[0]][1],
+                name = "{} ({:.{}f} {})".format(
+                    _i[1], availability[_i[0]][0], precision, availability[_i[0]][1]
                 )
                 new_res.append((_i[0], name))
             return new_res

--- a/sale_order_product_availability_inline/tests/test_sale_order_product_availability_inline.py
+++ b/sale_order_product_availability_inline/tests/test_sale_order_product_availability_inline.py
@@ -64,6 +64,7 @@ class TestSaleOrderProductAvailabilityInline(SavepointCase):
         self.assertEqual(
             self.product.with_context(warehouse=self.warehouse1.id).free_qty, 10.0,
         )
+        self.env.ref("product.decimal_product_uom").write({"digits": 3})
         sale_order_form = Form(
             self.env["sale.order"].with_context(
                 warehouse=self.warehouse1.id, so_product_stock_inline=True
@@ -71,5 +72,7 @@ class TestSaleOrderProductAvailabilityInline(SavepointCase):
         )
         with sale_order_form.order_line.new() as line_form:
             line_form.product_id = self.product
-            self.assertTrue(line_form.product_id.display_name.endswith("(10.0 Units)"))
-            self.assertFalse(line_form.name.endswith("(10.0 Units)"))
+            self.assertTrue(
+                line_form.product_id.display_name.endswith("(10.000 Units)")
+            )
+            self.assertFalse(line_form.name.endswith("(10.000 Units)"))


### PR DESCRIPTION
cc @Tecnativa TT27082

Set a fixed number of decimal places for the availability shown in parentheses