### PR TITLE
[13.0] [FIX] sales_team_security: Show the group in the same droplist of sales.

### DIFF
--- a/sales_team_security/security/sales_team_security.xml
+++ b/sales_team_security/security/sales_team_security.xml
@@ -5,7 +5,7 @@
         <field
             name="comment"
         >the user will have an access to the documents of the sales channel he/she belongs to.</field>
-        <field name="category_id" ref="base.module_category_sales_management" />
+        <field name="category_id" ref="base.module_category_sales_sales" />
         <field name="implied_ids" eval="[(4, ref('sales_team.group_sale_salesman'))]" />
     </record>
     <record id="sales_team.group_sale_salesman_all_leads" model="res.groups">


### PR DESCRIPTION
In this case the group "Channel Manager" doesn't showed in the list of right of sales.
The category is different than the other gruops, we fix that in this commit.