### PR TITLE
[13.0][IMP] sale_by_packaging can be sold

### DIFF
--- a/sale_by_packaging/models/product_packaging.py
+++ b/sale_by_packaging/models/product_packaging.py
@@ -1,14 +1,15 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ProductPackaging(models.Model):
     _inherit = "product.packaging"
 
     can_be_sold = fields.Boolean(
-        related="packaging_type_id.can_be_sold", readonly=True,
+        string="Can be sold", compute="_compute_can_be_sold", readonly=False, store=True
     )
+
     force_sale_qty = fields.Boolean(
         string="Force sale quantity",
         help="Determine if during the creation of a sale order line, the "
@@ -18,3 +19,8 @@ class ProductPackaging(models.Model):
         "When the user will put 3 as quantity, the system can force the "
         "quantity to the superior unit (5 for this example).",
     )
+
+    @api.depends("packaging_type_id")
+    def _compute_can_be_sold(self):
+        for record in self:
+            record.can_be_sold = record.packaging_type_id.can_be_sold


### PR DESCRIPTION
This change allows to be more specific on which product.packaging can be
sold or not.
By default the value from the product.packaging.type is used. But it is
editable afterwards, with this change.