### PR TITLE
[13.0] sale_exception: add details on lines

### DIFF
--- a/sale_exception/models/sale_order_line.py
+++ b/sale_exception/models/sale_order_line.py
@@ -1,6 +1,8 @@
 # © 2019 Akretion
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import html
+
 from odoo import api, fields, models
 
 
@@ -8,9 +10,32 @@ class SaleOrderLine(models.Model):
     _inherit = ["sale.order.line", "base.exception.method"]
     _name = "sale.order.line"
 
+    exception_ids = fields.Many2many(
+        "exception.rule", string="Exceptions", copy=False, readonly=True
+    )
+    exceptions_summary = fields.Html(
+        readonly=True, compute="_compute_exceptions_summary"
+    )
     ignore_exception = fields.Boolean(
         related="order_id.ignore_exception", store=True, string="Ignore Exceptions"
     )
+
+    @api.depends("exception_ids", "ignore_exception")
+    def _compute_exceptions_summary(self):
+        for rec in self:
+            if rec.exception_ids and not rec.ignore_exception:
+                rec.exceptions_summary = rec._get_exception_summary()
+            else:
+                rec.exceptions_summary = False
+
+    def _get_exception_summary(self):
+        return "<ul>%s</ul>" % "".join(
+            [
+                "<li>%s: <i>%s</i></li>"
+                % tuple(map(html.escape, (e.name, e.description)))
+                for e in self.exception_ids
+            ]
+        )
 
     def _get_main_records(self):
         return self.mapped("order_id")
@@ -20,5 +45,10 @@ class SaleOrderLine(models.Model):
         return "sale_ids"
 
     def _detect_exceptions(self, rule):
-        records = super(SaleOrderLine, self)._detect_exceptions(rule)
+        records = super()._detect_exceptions(rule)
+        # Thanks to the new flush of odoo 13.0, queries will be optimized
+        # together at the end even if we update the exception_ids many times.
+        # On previous versions, this could be unoptimized.
+        (self - records).exception_ids = [(3, rule.id)]
+        records.exception_ids = [(4, rule.id)]
         return records.mapped("order_id")

--- a/sale_exception/tests/__init__.py
+++ b/sale_exception/tests/__init__.py
@@ -1,5 +1,3 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 from . import test_sale_exception
-
-# TODO: Re-add this test
-# from . import test_multi_records
+from . import test_multi_records

--- a/sale_exception/tests/test_multi_records.py
+++ b/sale_exception/tests/test_multi_records.py
@@ -1,9 +1,9 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo.addons.sale.tests.test_sale_order import TestSaleOrder
+from odoo.addons.sale.tests.test_sale_common import TestCommonSaleNoChart
 
 
-class TestSaleExceptionMultiRecord(TestSaleOrder):
+class TestSaleExceptionMultiRecord(TestCommonSaleNoChart):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/sale_exception/tests/test_multi_records.py
+++ b/sale_exception/tests/test_multi_records.py
@@ -90,6 +90,14 @@ class TestSaleExceptionMultiRecord(TestSaleOrder):
 
         self.assertTrue(so3.state == "draft")
         self.assertTrue(exception_no_dumping in so3.exception_ids)
+        self.assertEqual(
+            so3.order_line[0].exceptions_summary,
+            (
+                "<ul>"
+                "<li>No dumping: <i>A product is sold cheaper than his cost.</i></li>"
+                "</ul>"
+            ),
+        )
 
         # test return value of detect_exception()
 

--- a/sale_exception/views/sale_view.xml
+++ b/sale_exception/views/sale_view.xml
@@ -50,6 +50,29 @@
             <xpath expr="//field[@name='date_order']/.." position="inside">
                 <field name="ignore_exception" states="sale" />
             </xpath>
+            <xpath expr="//field[@name='order_line']/form/group[1]" position="before">
+                <div
+                    class="alert alert-danger"
+                    role="alert"
+                    style="margin-bottom:0px;"
+                    attrs="{'invisible': [('exceptions_summary', '=', False)]}"
+                >
+                    <p>
+                        <strong
+                        >There are exceptions on this line blocking the confirmation of this quotation:</strong>
+                    </p>
+                    <field name="exceptions_summary" />
+                </div>
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree" position="inside">
+                <field name="exception_ids" invisible="1" />
+                <field name="ignore_exception" invisible="1" />
+            </xpath>
+            <xpath expr="//field[@name='order_line']/tree" position="attributes">
+                <attribute
+                    name="decoration-danger"
+                >not ignore_exception and exception_ids</attribute>
+            </xpath>
         </field>
     </record>
     <record id="view_order_tree" model="ir.ui.view">


### PR DESCRIPTION
Take over and complete #1194
 
So we can:

* display the lines with an exception in red
* show the exception messages when we click on a line

It's a huge usability improvement when users have dozens or hundreds of
lines.