### PR TITLE
[12.0][FIX] sale_tier_validation add access_token to exception field

### DIFF
--- a/sale_tier_validation/models/sale_order.py
+++ b/sale_tier_validation/models/sale_order.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Open Source Integrators
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import models, api
 
 
 class SaleOrder(models.Model):
@@ -9,3 +9,9 @@ class SaleOrder(models.Model):
     _inherit = ['sale.order', 'tier.validation']
     _state_from = ['draft', 'sent', 'to approve']
     _state_to = ['sale', 'approved']
+
+    @api.model
+    def _get_under_validation_exceptions(self):
+        res = super()._get_under_validation_exceptions()
+        res.append('access_token')
+        return res


### PR DESCRIPTION
When confirming a sale order by a user who can do reviews, automatic validation is not done because immediately after that, the system generate an access token for portal access.

Since the access token does not affect the content of the sale order, it is best to add it to exception fields