### PR TITLE
12.0 automatic workflow skip invalid records

### DIFF
--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -145,5 +145,8 @@ class AutomaticWorkflowJob(models.Model):
         """ Must be called from ir.cron """
         sale_workflow_process = self.env['sale.workflow.process']
         for sale_workflow in sale_workflow_process.search([]):
-            self.run_with_workflow(sale_workflow)
+            try:
+                self.run_with_workflow(sale_workflow)
+            except:
+                continue
         return True

--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -144,9 +144,12 @@ class AutomaticWorkflowJob(models.Model):
     def run(self):
         """ Must be called from ir.cron """
         sale_workflow_process = self.env['sale.workflow.process']
+        skip = 0
         for sale_workflow in sale_workflow_process.search([]):
             try:
                 self.run_with_workflow(sale_workflow)
             except:
+                skip += 1
                 continue
+        _logger.info('Automatic workflow ran skipping %s Records' % skip)
         return True


### PR DESCRIPTION
If the Automatic Workflow job encounters an error on any record the entire cronjob will exit with error.
Put in a generic error management to make it just log how many invalid records were encountered and always terminate with success. 

For example if i have an invoice that cannot be confirmed because of a currency error raised , the entire cronjob will be blocked with no feedback to user. If user puts cronjob on infinite retries the cron will endlessly run hogging a lot of system resources.