### PR TITLE
[13.0][Fix] sale_order_line_packaging_qty zero qty

### DIFF
--- a/sale_order_line_packaging_qty/views/sale_order.xml
+++ b/sale_order_line_packaging_qty/views/sale_order.xml
@@ -38,7 +38,7 @@
                     name="product_packaging"
                     attrs="{'invisible': [('product_id', '=', False)]}"
                     context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}"
-                    domain="[('product_id','=',product_id)]"
+                    domain="[('product_id','=',product_id), ('qty', '&gt;', 0)]"
                     groups="product.group_stock_packaging"
                     optional="show"
                 />


### PR DESCRIPTION
If a packaging as a quantity set to zero it should not be available for
selection on a sale order line.