### PR TITLE
[FIX] sale_triple_discount: Onchange cache management

### DIFF
--- a/sale_triple_discount/models/sale_order.py
+++ b/sale_triple_discount/models/sale_order.py
@@ -9,14 +9,6 @@ from odoo import api, models
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    @api.depends('order_line.price_total')
-    def _amount_all(self):
-        prev_values = dict()
-        for order in self:
-            prev_values.update(order.order_line.triple_discount_preprocess())
-        super(SaleOrder, self)._amount_all()
-        self.env['sale.order.line'].triple_discount_postprocess(prev_values)
-
     @api.multi
     def _get_tax_amount_by_group(self):
         # Copy/paste from standard method in sale

--- a/sale_triple_discount/models/sale_order_line.py
+++ b/sale_triple_discount/models/sale_order_line.py
@@ -43,9 +43,15 @@ class SaleOrderLine(models.Model):
 
     @api.depends('discount2', 'discount3', 'discounting_type')
     def _compute_amount(self):
-        prev_values = self.triple_discount_preprocess()
-        super(SaleOrderLine, self)._compute_amount()
-        self.triple_discount_postprocess(prev_values)
+        for line in self:
+            prev_price_unit = line.price_unit
+            prev_discount = line.discount
+            price_unit = line.price_unit * (
+                1 - (line._get_final_discount() or 0.0) / 100.0
+            )
+            line.update({"price_unit": price_unit, "discount": 0.0})
+            super(SaleOrderLine, line)._compute_amount()
+            line.update({"price_unit": prev_price_unit, "discount": prev_discount})
 
     discount2 = fields.Float(
         'Disc. 2 (%)',
@@ -96,40 +102,8 @@ class SaleOrderLine(models.Model):
 
     @api.depends('discount2', 'discount3')
     def _get_price_reduce(self):
-        prev_values = self.triple_discount_preprocess()
-        super(SaleOrderLine, self)._get_price_reduce()
-        self.triple_discount_postprocess(prev_values)
-
-    @api.multi
-    def triple_discount_preprocess(self):
-        """Save the values of the discounts in a dictionary,
-        to be restored in postprocess.
-        Resetting discount2 and discount3 to 0.0 avoids issues if
-        this method is called multiple times.
-        Updating the cache provides consistency through recomputations."""
-        prev_values = dict()
-        self.invalidate_cache(
-            fnames=['discount', 'discount2', 'discount3'],
-            ids=self.ids)
         for line in self:
-            prev_values[line] = dict(
-                discount=line.discount,
-                discount2=line.discount2,
-                discount3=line.discount3,
+            super(SaleOrderLine, line)._get_price_reduce()
+            line.price_reduce = line.price_unit * (
+                1 - (line._get_final_discount() or 0.0) / 100.0
             )
-            line._cache.update({
-                'discount': line._get_final_discount(),
-                'discount2': 0.0,
-                'discount3': 0.0
-            })
-        return prev_values
-
-    @api.model
-    def triple_discount_postprocess(self, prev_values):
-        """Restore the discounts of the lines in the dictionary prev_values.
-        Updating the cache provides consistency through recomputations."""
-        self.invalidate_cache(
-            fnames=['discount', 'discount2', 'discount3'],
-            ids=[l.id for l in list(prev_values.keys())])
-        for line, prev_vals_dict in list(prev_values.items()):
-            line._cache.update(prev_vals_dict)


### PR DESCRIPTION
Fix [OCA/sale-workflow#1391](https://github.com/OCA/sale-workflow/issues/1391)

We've refactored and deleted some functions, based on this old commit [10e71eb69a63ffb356f8beb14e8137a514eb28df](https://github.com/OCA/sale-workflow/commit/10e71eb69a63ffb356f8beb14e8137a514eb28df#diff-4582452e086bfb5976b52fbcd310a94a933ef3f2ea620a7f9432784935ef3002R15).
We don't know exactly why the method to calculate the discounts was modified, but with these changes it works correctly for us