### PR TITLE
[12.0][FIX] sale_order_invoicing_finished_task: invoiceable field is not updated...

### DIFF
--- a/sale_order_invoicing_finished_task/views/project_view.xml
+++ b/sale_order_invoicing_finished_task/views/project_view.xml
@@ -38,4 +38,17 @@
     </field>
 </record>
 
+<!-- Need to get related field invoicing_finished_task when _onchange_stage_id
+     and save invoiceable value in kanban view -->
+<record id="view_task_kanban" model="ir.ui.view">
+    <field name="model">project.task</field>
+    <field name="inherit_id" ref="project.view_task_kanban" />
+    <field name="arch" type="xml">
+        <field name="user_id" position="after">
+            <field name="sale_line_id" />
+            <field name="invoiceable" />
+        </field>
+    </field>
+</record>
+
 </odoo>


### PR DESCRIPTION
… properly in kanban view drag and drop.

The field invoicing_finished_task is False If sale_line_id is not defined in kanban view.
The field invoiceable is not saved If it is not defined in kanban view.

https://github.com/OCA/sale-workflow/blob/25fdf052e5e2aebdbdbc75779357814086467e17/sale_order_invoicing_finished_task/models/project.py#L24-L25
https://github.com/OCA/sale-workflow/blob/25fdf052e5e2aebdbdbc75779357814086467e17/sale_order_invoicing_finished_task/models/project.py#L29-L34

@Tecnativa TT27765