### PR TITLE
[10.0][IMP] Force invoiced in allowed invoice status

### DIFF
--- a/sale_force_invoiced/model/sale_order.py
+++ b/sale_force_invoiced/model/sale_order.py
@@ -21,9 +21,16 @@ class SaleOrder(models.Model):
                                     copy=False,
                                     )
 
+    def _get_force_invoiced_allowed_invoice_status(self):
+        return ('to invoice',)
+
     @api.depends('force_invoiced')
     def _get_invoiced(self):
         super(SaleOrder, self)._get_invoiced()
+        allowed_status = self._get_force_invoiced_allowed_invoice_status()
         for order in self:
-            if order.force_invoiced and order.invoice_status == 'to invoice':
+            if (
+                order.force_invoiced and
+                order.invoice_status in allowed_status
+            ):
                 order.invoice_status = 'invoiced'


### PR DESCRIPTION
We want to have the option to chose the status where we can force the `invoice_status` field value.
For that I define a method `_get_force_invoiced_allowed_invoice_status` that can be overridden