### PR TITLE
[FIX] sale_order_lot_selection

### DIFF
--- a/sale_order_lot_selection/models/stock.py
+++ b/sale_order_lot_selection/models/stock.py
@@ -30,6 +30,6 @@ class StockMove(models.Model):
         vals = super()._prepare_move_line_vals(
             quantity=quantity, reserved_quant=reserved_quant
         )
-        if reserved_quant and self.sale_line_id:
+        if reserved_quant and self.sale_line_id.lot_id:
             vals["lot_id"] = self.sale_line_id.lot_id.id
         return vals


### PR DESCRIPTION
During migration to v13 (https://github.com/OCA/sale-workflow/commit/f46230288fe6264f15345935d04be8e52076b5b8) `lot_id` check was removed in function `_prepare_move_line_vals`. Therefore Odoo starts not correctly reserve product quantities and gets errors when you try to do other functions.

Fixes: https://github.com/OCA/sale-workflow/issues/1235

Before change:

https://user-images.githubusercontent.com/38809768/105172882-edb7d780-5b28-11eb-8c72-cbff2e4518bc.mp4

After change:

https://user-images.githubusercontent.com/38809768/105172996-13dd7780-5b29-11eb-83a7-293b8c82c767.mp4


