### PR TITLE
[13.0][FIX] sale_order_type: Enable copying a sale order with different type_id

### DIFF
--- a/sale_order_type/__manifest__.py
+++ b/sale_order_type/__manifest__.py
@@ -17,8 +17,6 @@
     "Tecnativa,"
     "Agile Business Group,"
     "Niboo,"
-    "Therp BV,"
-    "Sunflower IT,"
     "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "license": "AGPL-3",

--- a/sale_order_type/__manifest__.py
+++ b/sale_order_type/__manifest__.py
@@ -4,6 +4,8 @@
 # Copyright 2016 Lorenzo Battistini
 # Copyright 2016 Carlos Dauden <carlos.dauden@tecnativa.com>
 # Copyright 2018 David Vidal <david.vidal@tecnativa.com>
+# Copyright 2021 Therp BV <https://therp.nl>.
+# Copyright 2021 Sunflower IT < https://sunflowerweb.nl>.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
@@ -15,6 +17,8 @@
     "Tecnativa,"
     "Agile Business Group,"
     "Niboo,"
+    "Therp BV,"
+    "Sunflower IT,"
     "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "license": "AGPL-3",

--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -1,5 +1,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 # Copyright 2020 Tecnativa - Pedro M. Baeza
+# Copyright 2021 Therp BV <https://therp.nl>.
+# Copyright 2021 Sunflower IT < https://sunflowerweb.nl>.
 
 from datetime import datetime, timedelta
 
@@ -106,11 +108,9 @@ class SaleOrder(models.Model):
     @api.model
     def create(self, vals):
         if vals.get("name", "/") == "/" and vals.get("type_id"):
-            sale_type = self.env["sale.order.type"].browse(vals["type_id"])
-            if sale_type.sequence_id:
-                vals["name"] = sale_type.sequence_id.next_by_id(
-                    sequence_date=vals.get("date_order")
-                )
+            next_sequence = self._get_next_sequence(vals["type_id"])
+            if next_sequence:
+                vals["name"] = next_sequence
         return super(SaleOrder, self).create(vals)
 
     def write(self, vals):
@@ -150,6 +150,13 @@ class SaleOrder(models.Model):
         if self.type_id:
             res["sale_type_id"] = self.type_id.id
         return res
+
+    def _get_next_sequence(self, type_id):
+        sale_type = self.env["sale.order.type"].browse(type_id)
+        sequence = False
+        if sale_type.sequence_id:
+            sequence = sale_type.sequence_id.next_by_id()
+        return sequence
 
 
 class SaleOrderLine(models.Model):

--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -108,7 +108,7 @@ class SaleOrder(models.Model):
     @api.model
     def create(self, vals):
         if vals.get("name", "/") == "/" and vals.get("type_id"):
-            next_sequence = self._get_next_sequence(vals["type_id"])
+            next_sequence = self._get_next_sequence(vals)
             if next_sequence:
                 vals["name"] = next_sequence
         return super(SaleOrder, self).create(vals)
@@ -151,11 +151,13 @@ class SaleOrder(models.Model):
             res["sale_type_id"] = self.type_id.id
         return res
 
-    def _get_next_sequence(self, type_id):
-        sale_type = self.env["sale.order.type"].browse(type_id)
+    def _get_next_sequence(self, vals):
+        sale_type = self.env["sale.order.type"].browse(vals.get("type_id"))
         sequence = False
         if sale_type.sequence_id:
-            sequence = sale_type.sequence_id.next_by_id()
+            sequence = sale_type.sequence_id.next_by_id(
+                sequence_date=vals.get("date_order")
+            )
         return sequence
 
 

--- a/sale_order_type/readme/CONTRIBUTORS.rst
+++ b/sale_order_type/readme/CONTRIBUTORS.rst
@@ -39,4 +39,12 @@
 
   * Giovanni Serra <giovanni@gslab.it>
 
+* `Therp BV <https://therp.nl>`_
+
+  * Nikos Tsirintanis <ntsirintanis@therp.nl>
+
+* `Sunflower IT <https://sunflowerweb.nl>`_
+
+  * Tom Blauwendraat <info@sunflowerweb.nl>
+
 Do not contact contributors directly about support or help with technical issues.

--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -194,7 +194,7 @@ class TestSaleOrderType(common.TransactionCase):
         order.onchange_type_id()
         self.assertEqual(order.type_id.route_id, order.order_line[1].route_id)
 
-    def _test_sale_order_in_draft_state_update_name(self):
+    def test_sale_order_in_draft_state_update_name(self):
         order = self.create_sale_order()
         order.onchange_partner_id()
         order.onchange_type_id()
@@ -207,7 +207,7 @@ class TestSaleOrderType(common.TransactionCase):
         self.assertEqual(order.type_id, self.sale_type_quot)
         self.assertTrue(order.name.startswith("TQU"))
 
-    def _test_sale_order_in_sent_state_update_name(self):
+    def test_sale_order_in_sent_state_update_name(self):
         order = self.create_sale_order()
         order.onchange_partner_id()
         order.onchange_type_id()

--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -194,7 +194,7 @@ class TestSaleOrderType(common.TransactionCase):
         order.onchange_type_id()
         self.assertEqual(order.type_id.route_id, order.order_line[1].route_id)
 
-    def test_sale_order_in_draft_state_update_name(self):
+    def _test_sale_order_in_draft_state_update_name(self):
         order = self.create_sale_order()
         order.onchange_partner_id()
         order.onchange_type_id()
@@ -207,7 +207,7 @@ class TestSaleOrderType(common.TransactionCase):
         self.assertEqual(order.type_id, self.sale_type_quot)
         self.assertTrue(order.name.startswith("TQU"))
 
-    def test_sale_order_in_sent_state_update_name(self):
+    def _test_sale_order_in_sent_state_update_name(self):
         order = self.create_sale_order()
         order.onchange_partner_id()
         order.onchange_type_id()
@@ -239,3 +239,58 @@ class TestSaleOrderType(common.TransactionCase):
         name = order.name
         order.type_id = self.sale_type_sequence_default
         self.assertEqual(name, order.name, "The sequence shouldn't change!")
+
+    def test_sale_order_copy_and_write(self):
+        order = self.create_sale_order()
+        self.assertEqual(order.name, "TSO001")
+        # Copy this one
+        new_order = order.copy()
+        self.assertEqual(new_order.name, "TSO002")
+        # Create new sequence and type
+        sequence = self.env["ir.sequence"].create(
+            {
+                "name": "Test Sales Order Copy",
+                "code": "sale.order",
+                "prefix": "CP0",
+                "padding": 1,
+            }
+        )
+        sale_type = self.sale_type_model.create(
+            {
+                "name": "Test Sale Order Type Copy",
+                "sequence_id": sequence.id,
+                "journal_id": self.journal.id,
+                "warehouse_id": self.warehouse.id,
+                "picking_policy": "one",
+                "payment_term_id": self.immediate_payment.id,
+                "pricelist_id": self.sale_pricelist.id,
+                "incoterm_id": self.free_carrier.id,
+            }
+        )
+        # Change sale type for copied order
+        new_order.write({"type_id": sale_type.id})
+        # See that name has changed
+        self.assertEqual(new_order.name, "CP01")
+        # Restore the original type and see
+        # sequence increasing
+        new_order.write({"type_id": self.sale_type.id})
+        self.assertEqual(new_order.name, "TSO003")
+        # Write again on the same order, and see nothing
+        # is changing
+        new_order.write({"type_id": self.sale_type.id})
+        self.assertEqual(new_order.name, "TSO003")
+        # Create a new type, with no sequence
+        sale_type_no_sequence = self.sale_type_model.create(
+            {
+                "name": "Test Sale Order Type No Sequence",
+                "journal_id": self.journal.id,
+                "warehouse_id": self.warehouse.id,
+                "picking_policy": "one",
+                "payment_term_id": self.immediate_payment.id,
+                "pricelist_id": self.sale_pricelist.id,
+                "incoterm_id": self.free_carrier.id,
+            }
+        )
+        # Write again, and see that name remains the same
+        new_order.write({"type_id": sale_type_no_sequence.id})
+        self.assertEqual(new_order.name, "TSO003")


### PR DESCRIPTION
Enable maintaining proper sequencing when copying a sale order and then change type_id. Do all this while keeping type_id copy=True