### PR TITLE
[12.0][IMP] sales_team_security: Auto-followers (create and remove) in child partners

### DIFF
--- a/partner_contact_sale_info_propagation/tests/test_partner_contact_sale_info_propagation.py
+++ b/partner_contact_sale_info_propagation/tests/test_partner_contact_sale_info_propagation.py
@@ -9,7 +9,9 @@ class TestPartnerContactSaleInfoPropagation(TransactionCase):
 
     def setUp(self):
         super(TestPartnerContactSaleInfoPropagation, self).setUp()
-        self.partner_model = self.env['res.partner']
+        self.partner_model = self.env['res.partner'].with_context(
+            test_propagation=True
+        )
         self.parent_company = self.partner_model.create({
             'name': 'Parent company',
             'company_type': 'company',

--- a/sales_team_security/README.rst
+++ b/sales_team_security/README.rst
@@ -37,6 +37,13 @@ from the assigned salesman):
 It also handles the propagation of the sales team from commercial partners to
 the contacts, which standard doesn't do.
 
+It also handles the sync (auto-creation and remove) of followers in company partners
+and childs of them according to salesmans. Any example about it:
+- Partner company > Salesman: Admin
+- Partner company, Contact 1 > Without salesman
+- Partner company, Contact 2 > Salesman: Demo
+All these partners have these followers: Admin + Demo
+
 And finally, there are rules for partners to be restricted to the own ones for
 the group "User: Own Documents Only" for being coherent with the permission
 scheme. Someone with this permission will see:
@@ -45,6 +52,9 @@ scheme. Someone with this permission will see:
 - Contacts without salesman assigned, but the same channel.
 - Contacts with them as salesman, independently from the channel.
 - Contacts with them as follower.
+
+For keeping consistent accesses, followers of the main and shipping/invoice
+contacts are synced according the salesman of the children contacts
 
 **Table of contents**
 
@@ -55,7 +65,8 @@ Installation
 ============
 
 At installation time, this module sets in all the contacts that have the sales
-team empty the sales team of the parent. If you have a lot of contacts, this
+team empty the sales team of the parent, and sync followers in parent contacts
+and invoice/shipping addresses. If you have a lot of contacts, this
 operation can take a while.
 
 Configuration
@@ -97,6 +108,7 @@ Contributors
 * `Tecnativa <https://www.tecnativa.com>`__:
 
   * Pedro M. Baeza
+  * Víctor Martínez
 
 * `Guadaltech <https://www.guadaltech.es>`__:
 

--- a/sales_team_security/__manifest__.py
+++ b/sales_team_security/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sales documents permissions by channels (teams)",
     "summary": "New group for seeing only sales channel's documents",
-    "version": "12.0.2.0.1",
+    "version": "12.0.3.0.0",
     "category": "Sales",
     "website": "https://github.com/OCA/sale-workflow",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/sales_team_security/hooks.py
+++ b/sales_team_security/hooks.py
@@ -1,6 +1,8 @@
 # Copyright 2018-2016 Tecnativa - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from odoo import api, SUPERUSER_ID
+
 
 def post_init_hook(cr, registry):
     """At installation time, propagate the parent sales team to the children
@@ -15,3 +17,14 @@ def post_init_hook(cr, registry):
         AND res_partner.parent_id = parent.id
         AND res_partner.team_id IS NULL"""
     )
+    # At installation time, we need to sync followers
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        partners = env['res.partner'].search([
+            ('parent_id', '=', False),
+            ('is_company', '=', True),
+            '|',
+            ('user_id', '!=', False),
+            ('child_ids.user_id', '!=', False)
+        ])
+        partners._add_followers_from_salesmans()

--- a/sales_team_security/migrations/12.0.3.0.0/pre-migration.py
+++ b/sales_team_security/migrations/12.0.3.0.0/pre-migration.py
@@ -1,0 +1,48 @@
+# Copyright 2021 Tecnativa - Pedro M. Baeza
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    """Adjust record rules according new definition."""
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    record = env.ref("sales_team_security.sales_team_team_rule", False)
+    if record:
+        record.groups = [
+            (3, env.ref("sales_team_security.group_sale_team_manager").id),
+            (4, env.ref("sales_team.group_sale_salesman").id),
+        ]
+    record = env.ref("sales_team_security.sale_order_team_rule", False)
+    if record:
+        record.domain_force = (
+            "['|', ('user_id','=',user.id), ('user_id','=',False), '|', "
+            "('team_id', '=', user.sale_team_id.id), ('team_id', '=', False)]"
+        )
+    record = env.ref("sales_team_security.sale_order_report_team_rule", False)
+    if record:
+        record.domain_force = (
+            "['|', ('user_id','=',user.id), ('user_id','=',False), '|', "
+            "('team_id', '=', user.sale_team_id.id), ('team_id', '=', False)]"
+        )
+    record = env.ref("sales_team_security.sale_order_line_team_rule", False)
+    if record:
+        record.domain_force = (
+            "['|', '|', ('salesman_id', '=', user.id), "
+            "('salesman_id', '=', False), '|', "
+            "('order_id.team_id', '=', user.sale_team_id.id), "
+            "('order_id.team_id', '=', False)]"
+        )
+    record = env.ref("sales_team_security.crm_lead_team_rule", False)
+    if record:
+        record.domain_force = (
+            "['|', ('user_id','=',user.id), ('user_id','=',False), '|', "
+            "('team_id', '=', user.sale_team_id.id), ('team_id', '=', False)]"
+        )
+    record = env.ref("sales_team_security.crm_activity_report_team", False)
+    if record:
+        record.domain_force = (
+            "['|', ('user_id','=',user.id), ('user_id','=',False), '|', "
+            "('team_id', '=', user.sale_team_id.id), ('team_id', '=', False)]"
+        )

--- a/sales_team_security/models/res_partner.py
+++ b/sales_team_security/models/res_partner.py
@@ -1,12 +1,17 @@
 # Copyright 2016-2018 Tecnativa - Pedro M. Baeza
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import api, models
+from odoo import api, fields, models
 from lxml import etree
 
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
+
+    # add indexes for better performance on record rules
+    user_id = fields.Many2one(index=True)
+    team_id = fields.Many2one(index=True)
 
     @api.model
     def fields_view_get(self, view_id=None, view_type='form', toolbar=False,
@@ -34,14 +39,51 @@ class ResPartner(models.Model):
 
     @api.onchange('parent_id')
     def _onchange_parent_id_sales_team_security(self):
-        """
-        If assigning a parent partner and the contact doesn't have
-        team, we put the parent's one (if any).
+        """If assigning a parent partner and the contact doesn't have
+        team or salesman, we put the parent's one (if any).
         """
         if self.parent_id and self.parent_id.team_id and not self.team_id:
             self.team_id = self.parent_id.team_id.id
+        if self.parent_id and self.parent_id.user_id and not self.user_id:
+            self.user_id = self.parent_id.user_id.id
 
     @api.onchange("user_id")
     def _onchange_user_id_sales_team_security(self):
         if self.user_id.sale_team_id:
             self.team_id = self.user_id.sale_team_id
+
+    def _remove_key_followers(self, partner):
+        for record in self.mapped("commercial_partner_id"):
+            record.message_unsubscribe(partner_ids=partner.ids)
+            # Look for delivery and invoice addresses
+            childrens = record.child_ids.filtered(
+                lambda x: x.type in {"invoice", "delivery"}
+            )
+            (childrens + record).message_unsubscribe(partner_ids=partner.ids)
+
+    def _add_followers_from_salesmans(self):
+        """Sync followers in commercial partner + delivery/invoice contacts."""
+        for record in self.mapped("commercial_partner_id"):
+            followers = (record.child_ids + record).mapped("user_id.partner_id")
+            record.message_subscribe(partner_ids=followers.ids)
+            # Look for delivery and invoice addresses
+            childrens = record.child_ids.filtered(
+                lambda x: x.type in {"invoice", "delivery"}
+            )
+            (childrens + record).message_subscribe(partner_ids=followers.ids)
+
+    @api.multi
+    def write(self, vals):
+        """If the salesman is changed, first remove the old salesman as follower
+        of the key contacts (commercial + delivery/invoice), and then sync for
+        the new ones.
+
+        It performs as well the followers sync on contact type change.
+        """
+        if "user_id" in vals:
+            for record in self.filtered("user_id"):
+                record._remove_key_followers(record.user_id.partner_id)
+        result = super().write(vals)
+        if "user_id" in vals or vals.get("type") in {"invoice", "delivery"}:
+            self._add_followers_from_salesmans()
+        return result

--- a/sales_team_security/readme/CONTRIBUTORS.rst
+++ b/sales_team_security/readme/CONTRIBUTORS.rst
@@ -1,6 +1,7 @@
 * `Tecnativa <https://www.tecnativa.com>`__:
 
   * Pedro M. Baeza
+  * Víctor Martínez
 
 * `Guadaltech <https://www.guadaltech.es>`__:
 

--- a/sales_team_security/readme/DESCRIPTION.rst
+++ b/sales_team_security/readme/DESCRIPTION.rst
@@ -10,6 +10,13 @@ from the assigned salesman):
 It also handles the propagation of the sales team from commercial partners to
 the contacts, which standard doesn't do.
 
+It also handles the sync (auto-creation and remove) of followers in company partners
+and childs of them according to salesmans. Any example about it:
+- Partner company > Salesman: Admin
+- Partner company, Contact 1 > Without salesman
+- Partner company, Contact 2 > Salesman: Demo
+All these partners have these followers: Admin + Demo
+
 And finally, there are rules for partners to be restricted to the own ones for
 the group "User: Own Documents Only" for being coherent with the permission
 scheme. Someone with this permission will see:
@@ -18,3 +25,6 @@ scheme. Someone with this permission will see:
 - Contacts without salesman assigned, but the same channel.
 - Contacts with them as salesman, independently from the channel.
 - Contacts with them as follower.
+
+For keeping consistent accesses, followers of the main and shipping/invoice
+contacts are synced according the salesman of the children contacts

--- a/sales_team_security/readme/INSTALL.rst
+++ b/sales_team_security/readme/INSTALL.rst
@@ -1,3 +1,4 @@
 At installation time, this module sets in all the contacts that have the sales
-team empty the sales team of the parent. If you have a lot of contacts, this
+team empty the sales team of the parent, and sync followers in parent contacts
+and invoice/shipping addresses. If you have a lot of contacts, this
 operation can take a while.

--- a/sales_team_security/security/sales_team_security.xml
+++ b/sales_team_security/security/sales_team_security.xml
@@ -16,35 +16,35 @@
         <record id="sale_order_team_rule" model="ir.rule">
             <field name="name">Sales Channel Orders</field>
             <field ref="sale.model_sale_order" name="model_id"/>
-            <field name="domain_force">['|', ('team_id', '=', user.sale_team_id.id), ('team_id', '=', False)]</field>
+            <field name="domain_force">['|', '|', ('user_id', '=', user.id), ('user_id', '=', False), '|', ('team_id', '=', user.sale_team_id.id), ('team_id', '=', False)]</field>
             <field name="groups" eval="[(4, ref('group_sale_team_manager'))]"/>
         </record>
 
         <record id="sale_order_report_team_rule" model="ir.rule">
             <field name="name">Sales Channel Orders Analysis</field>
             <field ref="sale.model_sale_report" name="model_id"/>
-            <field name="domain_force">['|', ('team_id', '=', user.sale_team_id.id), ('team_id', '=', False)]</field>
+            <field name="domain_force">['|', ('user_id','=',user.id), ('user_id','=',False), '|', ('team_id', '=', user.sale_team_id.id), ('team_id', '=', False)]</field>
             <field name="groups" eval="[(4, ref('group_sale_team_manager'))]"/>
         </record>
 
         <record id="sale_order_line_team_rule" model="ir.rule">
             <field name="name">Sales Channel Order Lines</field>
             <field ref="sale.model_sale_order_line" name="model_id"/>
-            <field name="domain_force">['|', ('order_id.team_id', '=', user.sale_team_id.id), ('order_id.team_id', '=', False)]</field>
+            <field name="domain_force">['|', '|', ('salesman_id', '=', user.id), ('salesman_id', '=', False), '|', ('order_id.team_id', '=', user.sale_team_id.id), ('order_id.team_id', '=', False)]</field>
             <field name="groups" eval="[(4, ref('group_sale_team_manager'))]"/>
         </record>
 
         <record id="crm_lead_team_rule" model="ir.rule">
             <field name="name">Sales Channel Leads/Opportunities</field>
             <field ref="crm.model_crm_lead" name="model_id"/>
-            <field name="domain_force">['|', ('team_id', '=', user.sale_team_id.id), ('team_id', '=', False)]</field>
+            <field name="domain_force">['|', ('user_id','=',user.id), ('user_id','=',False), '|', ('team_id', '=', user.sale_team_id.id), ('team_id', '=', False)]</field>
             <field name="groups" eval="[(4, ref('group_sale_team_manager'))]"/>
         </record>
 
         <record id="crm_activity_report_team" model="ir.rule">
             <field name="name">Activities Analysis by Channel</field>
             <field ref="crm.model_crm_activity_report" name="model_id"/>
-            <field name="domain_force">['|', ('team_id', '=', user.sale_team_id.id), ('team_id', '=', False)]</field>
+            <field name="domain_force">['|', ('user_id','=',user.id), ('user_id','=',False), '|', ('team_id', '=', user.sale_team_id.id), ('team_id', '=', False)]</field>
             <field name="groups" eval="[(4, ref('group_sale_team_manager'))]"/>
         </record>
 
@@ -52,7 +52,7 @@
             <field name="name">Own Sales Channels</field>
             <field ref="sales_team.model_crm_team" name="model_id"/>
             <field name="domain_force">[('id', '=', user.sale_team_id.id)]</field>
-            <field name="groups" eval="[(4, ref('group_sale_team_manager'))]"/>
+            <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
         </record>
 
     </data>

--- a/sales_team_security/static/description/index.html
+++ b/sales_team_security/static/description/index.html
@@ -379,6 +379,12 @@ from the assigned salesman):</p>
 </ul>
 <p>It also handles the propagation of the sales team from commercial partners to
 the contacts, which standard doesn’t do.</p>
+<p>It also handles the sync (auto-creation and remove) of followers in company partners
+and childs of them according to salesmans. Any example about it:
+- Partner company &gt; Salesman: Admin
+- Partner company, Contact 1 &gt; Without salesman
+- Partner company, Contact 2 &gt; Salesman: Demo
+All these partners have these followers: Admin + Demo</p>
 <p>And finally, there are rules for partners to be restricted to the own ones for
 the group “User: Own Documents Only” for being coherent with the permission
 scheme. Someone with this permission will see:</p>
@@ -388,6 +394,8 @@ scheme. Someone with this permission will see:</p>
 <li>Contacts with them as salesman, independently from the channel.</li>
 <li>Contacts with them as follower.</li>
 </ul>
+<p>For keeping consistent accesses, followers of the main and shipping/invoice
+contacts are synced according the salesman of the children contacts</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -406,7 +414,8 @@ scheme. Someone with this permission will see:</p>
 <div class="section" id="installation">
 <h1><a class="toc-backref" href="#id1">Installation</a></h1>
 <p>At installation time, this module sets in all the contacts that have the sales
-team empty the sales team of the parent. If you have a lot of contacts, this
+team empty the sales team of the parent, and sync followers in parent contacts
+and invoice/shipping addresses. If you have a lot of contacts, this
 operation can take a while.</p>
 </div>
 <div class="section" id="configuration">
@@ -447,6 +456,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Pedro M. Baeza</li>
+<li>Víctor Martínez</li>
 </ul>
 </li>
 <li><a class="reference external" href="https://www.guadaltech.es">Guadaltech</a>:<ul>

--- a/sales_team_security/tests/test_sales_team_security.py
+++ b/sales_team_security/tests/test_sales_team_security.py
@@ -17,7 +17,7 @@ class TestSalesTeamSecurity(common.SavepointCase):
         cls.team2 = cls.env['crm.team'].create({
             'name': 'Test channel 2',
         })
-        cls.partner = cls.env['res.partner'].create({
+        cls.partner = cls.env["res.partner"].create({
             'name': 'Test partner',
             'team_id': cls.team.id,
         })
@@ -51,14 +51,6 @@ class TestSalesTeamSecurity(common.SavepointCase):
             "user_id": cls.user.id,
             "team_id": cls.team.id,
         })
-
-    def _is_module_installed(self, name):
-        return bool(
-            self.env['ir.module.module'].search([
-                ('name', '=', name),
-                ('state', '=', 'installed')
-            ])
-        )
 
     def test_onchange_parent_id(self):
         contact = self.env['res.partner'].create({


### PR DESCRIPTION
Auto-followers (create and remove) in child partners when salesman is changed (write function)

Please @pedrobaeza review it.

Locked by: 
- [x] https://github.com/OCA/sale-workflow/issues/1446 `sale_order_lot_selection`

@Tecnativa TT27986