### PR TITLE
[13.0] sale_fixed_discount - wrong value for the field price_reduce on SO line #1411 + Wrong tax_amount displayed on reporting #1424

### DIFF
--- a/sale_fixed_discount/README.rst
+++ b/sale_fixed_discount/README.rst
@@ -81,6 +81,7 @@ Contributors
 
 * Lois Rilo <lois.rilo@forgeflow.com> (www.forgeflow.com)
 * Jordi Ballester <jordi.ballester@forgeflow.com> (www.forgeflow.com)
+* Mallory Marcot <contact@mallory-marcot.com> (www.mallory-marcot.com)
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_fixed_discount/models/sale_order.py
+++ b/sale_fixed_discount/models/sale_order.py
@@ -1,8 +1,11 @@
 # Copyright 2017-20 ForgeFlow S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from functools import partial
+
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools.misc import formatLang
 
 
 class SaleOrderLine(models.Model):
@@ -55,7 +58,54 @@ class SaleOrderLine(models.Model):
             line.update(vals[line])
         return res
 
+    @api.depends("price_unit", "discount", "discount_fixed")
+    def _get_price_reduce(self):
+        for line in self:
+            line.price_reduce = line.price_unit * (1.0 - line.discount / 100.0) - (
+                line.discount_fixed or 0.0
+            )
+
     def _prepare_invoice_line(self):
         res = super(SaleOrderLine, self)._prepare_invoice_line()
         res.update({"discount_fixed": self.discount_fixed})
         return res
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _amount_by_group(self):
+        for order in self:
+            currency = order.currency_id or order.company_id.currency_id
+            fmt = partial(
+                formatLang,
+                self.with_context(lang=order.partner_id.lang).env,
+                currency_obj=currency,
+            )
+            res = {}
+            for line in order.order_line:
+                taxes = line.tax_id.compute_all(
+                    line.price_reduce,
+                    quantity=line.product_uom_qty,
+                    product=line.product_id,
+                    partner=order.partner_shipping_id,
+                )["taxes"]
+                for tax in line.tax_id:
+                    group = tax.tax_group_id
+                    res.setdefault(group, {"amount": 0.0, "base": 0.0})
+                    for t in taxes:
+                        if t["id"] == tax.id or t["id"] in tax.children_tax_ids.ids:
+                            res[group]["amount"] += t["amount"]
+                            res[group]["base"] += t["base"]
+            res = sorted(res.items(), key=lambda l: l[0].sequence)
+            order.amount_by_group = [
+                (
+                    l[0].name,
+                    l[1]["amount"],
+                    l[1]["base"],
+                    fmt(l[1]["amount"]),
+                    fmt(l[1]["base"]),
+                    len(res),
+                )
+                for l in res
+            ]

--- a/sale_fixed_discount/tests/test_sale_fixed_discount.py
+++ b/sale_fixed_discount/tests/test_sale_fixed_discount.py
@@ -41,6 +41,8 @@ class TestSaleFixedDiscount(SavepointCase):
         # Apply a fixed discount
         self.sale_line1.discount_fixed = 10.0
         self.assertEqual(self.sale.amount_total, 218.50)
+        self.assertEqual(self.sale.amount_by_group[0][1], 28.5)  # tax
+        self.assertEqual(self.sale.amount_by_group[0][2], 190.0)  # price tax excl
         # Try to add also a % discount
         with self.assertRaises(ValidationError):
             self.sale_line1.write({"discount": 50.0})
@@ -50,6 +52,8 @@ class TestSaleFixedDiscount(SavepointCase):
         self.sale_line1.discount = 50.0
         self.sale_line1._onchange_discount()
         self.assertEqual(self.sale.amount_total, 115.00)
+        self.assertEqual(self.sale.amount_by_group[0][1], 15.0)  # tax
+        self.assertEqual(self.sale.amount_by_group[0][2], 100.0)  # price tax excl
 
     def test_02_discounts_multiple_lines(self):
         """ Tests multiple lines with mixed taxes and dicount types."""


### PR DESCRIPTION
Hello,
This pull request aims to fix these issues on the branch 13.0:

- [12.0] sale_fixed_amount - Wrong tax_amount displayed on reporting #1424
- [13.0] sale_fixed_discount: price_reduce in database is wrong #1411

Im new to OCA contributing. This is my first PR. I sent the signed CLA yesterday, not sure if it is already taken in account.

Hope it's not a problem to fix 2 issues with the same PR

pull request for the branch 12.0 => #1443
