### PR TITLE
[13.0][FIX] sale_product_multi_add: fix missing call to _onchange_discount()

### DIFF
--- a/sale_product_multi_add/tests/test_sale.py
+++ b/sale_product_multi_add/tests/test_sale.py
@@ -38,3 +38,45 @@ class TestSale(common.TransactionCase):
                 self.assertEqual(line.product_uom_qty, 4)
             else:
                 self.assertEqual(line.product_uom_qty, 6)
+
+    def test_import_product_discount(self):
+        pricelist1 = self.env['product.pricelist'].create(
+            {
+                "name": "Pricelist 1",
+                'discount_policy': 'without_discount',
+                "item_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "compute_price": "percentage",
+                            "base": "list_price",
+                            "percent_price": 10,
+                            "applied_on": "3_global",
+                            "name": "Discount 1",
+                        },
+                    )
+                ],
+            }
+        )
+        group_discount_id = self.ref("product.group_discount_per_so_line")
+        self.env.user.write({"groups_id": [(4, group_discount_id.id, 0)]})
+        so = self.env["sale.order"].create(
+            {"partner_id": self.env.ref("base.res_partner_2").id,
+             "pricelist_id": pricelist1.id}
+        )
+
+        wiz_obj = self.env["sale.import.products"]
+        wizard = wiz_obj.with_context(active_id=so.id,
+                                      active_model="sale.order")
+
+        products = [(6, 0, [self.product_9.id])]
+
+        wizard_id = wizard.create({"products": products})
+        wizard_id.create_items()
+        wizard_id.items[0].quantity = 4
+        wizard_id.select_products()
+
+        self.assertEqual(len(so.order_line), 1)
+        line = so.order_line[0]
+        self.assertEqual(line.discount, 10)

--- a/sale_product_multi_add/wizards/sale_import_products.py
+++ b/sale_product_multi_add/wizards/sale_import_products.py
@@ -46,6 +46,7 @@ class SaleImportProducts(models.TransientModel):
             }
         )
         sale_line.product_id_change()
+        sale_line._onchange_discount()
         line_values = sale_line._convert_to_write(sale_line._cache)
         return line_values
 


### PR DESCRIPTION
When using the addon feature, discounts defined on list price are not correctly applied