### PR TITLE
[13.0][sale_fixed_discount] fix sale portal view 

### DIFF
--- a/sale_fixed_discount/__manifest__.py
+++ b/sale_fixed_discount/__manifest__.py
@@ -14,6 +14,7 @@
     "data": [
         "views/sale_order_views.xml",
         "views/account_invoice_views.xml",
+        "views/sale_portal_templates.xml",
         "reports/report_sale_order.xml",
     ],
 }

--- a/sale_fixed_discount/views/sale_portal_templates.xml
+++ b/sale_fixed_discount/views/sale_portal_templates.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template
+        id="sale_order_portal_content_fixed_discount"
+        inherit_id="sale.sale_order_portal_content"
+    >
+        <xpath
+            expr="//section[@id='details']//t[@t-set='display_discount']"
+            position="after"
+        >
+            <t
+                t-set="display_discount_fixed"
+                t-value="True in [line.discount_fixed > 0 for line in sale_order.order_line]"
+            />
+        </xpath>
+        <xpath
+            expr="//section[@id='details']/table/thead//th[@t-if='display_discount']"
+            position="after"
+        >
+            <th
+                t-if="display_discount_fixed"
+                t-attf-class="text-right {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}"
+            >
+                <span>Disc. Fixed Amount</span>
+            </th>
+        </xpath>
+        <xpath
+            expr="//section[@id='details']/table/tbody//t[@t-foreach='sale_order.order_line']/tr//t[@t-if='not line.display_type']//td[3]/div"
+            position="replace"
+        >
+            <div
+                t-if="line.discount &gt;= 0 or line.fixed_discount &gt;= 0"
+                t-field="line.price_unit"
+                t-att-style="(line.discount or line.discount_fixed) and 'text-decoration: line-through' or None"
+                t-att-class="((line.discount or line.discount_fixed) and 'text-danger' or '') + ' text-right'"
+            />
+            <div t-if="line.discount_fixed">
+                <t
+                    t-esc="line.price_unit - line.discount_fixed"
+                    t-options='{"widget": "float", "decimal_precision": "Product Price"}'
+                />
+            </div>
+        </xpath>
+        <xpath
+            expr="//section[@id='details']/table/tbody//t[@t-foreach='sale_order.order_line']/tr//t[@t-if='not line.display_type']//td[@t-if='display_discount']"
+            position="after"
+        >
+            <td
+                t-if="display_discount_fixed"
+                t-attf-class="text-right {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}"
+            >
+                <strong t-if="line.discount_fixed &gt; 0" class="text-info">
+                    <t t-esc="line.discount_fixed" />
+                </strong>
+            </td>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
The sale order view in the portal was not displaying the fixed discount.

Now it's properly shown:
![image](https://user-images.githubusercontent.com/7683926/107432521-627aa200-6b28-11eb-9e7a-56c289597730.png)


cc @HviorForgeFlow @dcoleman-lulzbot

