### PR TITLE
[12.0][FIX] sale_order_lot_generator: Prevent error in test with other addons that use same base products

### DIFF
--- a/sale_order_lot_generator/readme/CONTRIBUTORS.rst
+++ b/sale_order_lot_generator/readme/CONTRIBUTORS.rst
@@ -4,3 +4,7 @@ Akretion:
 * Florian da Costa <florian.dacosta@akretion.com>
 * Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
 * David BEAL <david.beal@akretion.com>
+
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+    * Víctor Martínez

--- a/sale_order_lot_generator/tests/test_sale_order_lot_generator.py
+++ b/sale_order_lot_generator/tests/test_sale_order_lot_generator.py
@@ -1,4 +1,5 @@
 # © 2017 Akretion, Mourad EL HADJ MIMOUNE <mourad.elhadj.mimoune@akretion.com>
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import odoo.tests.common as test_common
@@ -49,4 +50,4 @@ class TestSaleOrderLotGenerator(test_common.SingleTransactionCase):
             if line.product_id.id == self.prd_flipover.id:
                 self.assertEqual(line.lot_id, self.sol1.lot_id)
             if line.product_id.id == self.prd_acoustic.id:
-                self.assertEqual(line.restrict_lot_id, self.sol2.lot_id)
+                self.assertEqual(line.lot_id, self.sol2.lot_id)


### PR DESCRIPTION
Related to https://github.com/OCA/sale-workflow/issues/1446 (It solve only one of these errors)

Locked by:
- [ ] https://github.com/OCA/sale-workflow/pull/1458

Please @CarlosRoca13 and @chienandalu can you review it?

@Tecnativa TT28247