### PR TITLE
[13.0][FIX] sale_cutoff_time_delivery: Define external_dependencies

### DIFF
--- a/ requirements.txt 
+++ b/ requirements.txt 
@@ -1,0 +1,1 @@
+freezegun

--- a/sale_cutoff_time_delivery/__manifest__.py
+++ b/sale_cutoff_time_delivery/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Camptocamp SA
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 {
     "name": "Sale Cutoff Time Delivery",
@@ -11,6 +12,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
+    "external_dependencies": {"python": ["freezegun"]},
     "depends": ["sale_stock", "partner_tz"],
     "data": [
         "views/res_partner.xml",

--- a/sale_cutoff_time_delivery/readme/CONTRIBUTORS.rst
+++ b/sale_cutoff_time_delivery/readme/CONTRIBUTORS.rst
@@ -1,1 +1,5 @@
 * Akim Juillerat <akim.juillerat@camptocamp.com>
+
+* `Tecnativa <https://www.tecnativa.com>`_:",
+
+  * Víctor Martínez


### PR DESCRIPTION
Actually travis fail.

Define external_dependencies to prevent error in tests

Included in https://github.com/OCA/sale-workflow/pull/1464

@Tecnativa TT28285