### PR TITLE
[13.0][FIX] sale_order_type Existing SO can't be cancelled after install.

### DIFF
--- a/sale_order_type/__init__.py
+++ b/sale_order_type/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models
+from .hooks import post_init_hook

--- a/sale_order_type/__manifest__.py
+++ b/sale_order_type/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     "name": "Sale Order Type",
-    "version": "13.0.1.3.6",
+    "version": "13.0.1.4.0",
     "category": "Sales Management",
     "author": "Grupo Vermon,"
     "AvanzOSC,"
@@ -29,5 +29,6 @@
         "views/res_partner_view.xml",
         "data/default_type.xml",
     ],
+    "post_init_hook": "post_init_hook",
     "installable": True,
 }

--- a/sale_order_type/hooks.py
+++ b/sale_order_type/hooks.py
@@ -1,22 +1,21 @@
 # Copyright 2021 jeo Software - Jorge Obiols
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, SUPERUSER_ID
+from odoo import SUPERUSER_ID, api
 
 def post_init_hook(cr, registry):
     env = api.Environment(cr, SUPERUSER_ID, {})
 
     # Ensure each company has at least one sale.order.type record
-    for company in env['res.company'].search([]):
-        if not env['sale.order.type'].search([('company_id','=', company.id)]):
-            env['sale.order.type'].create({
-                "name": "Normal Order",
-                "company_id": company.id
-            })
+    for company in env["res.company"].search([]):
+        if not env["sale.order.type"].search([("company_id", "=", company.id)]):
+            env["sale.order.type"].create(
+                {"name": "Normal Order", "company_id": company.id}
+            )
 
     # Ensure each SO has filled the type_id, according to the sale order company
-    sale_order_ids = env['sale.order'].search([('state','!=','draft')])
+    sale_order_ids = env["sale.order"].search([("state", "!=", "draft")])
     for so in sale_order_ids:
         so.type_id = env["sale.order.type"].search(
-                        [("company_id", "in", [so.company_id.id, False])], limit=1
-                )
+            [("company_id", "in", [so.company_id.id, False])], limit=1
+        )

--- a/sale_order_type/hooks.py
+++ b/sale_order_type/hooks.py
@@ -1,0 +1,22 @@
+# Copyright 2021 jeo Software - Jorge Obiols
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, SUPERUSER_ID
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    # Ensure each company has at least one sale.order.type record
+    for company in env['res.company'].search([]):
+        if not env['sale.order.type'].search([('company_id','=', company.id)]):
+            env['sale.order.type'].create({
+                "name": "Normal Order",
+                "company_id": company.id
+            })
+
+    # Ensure each SO has filled the type_id, according to the sale order company
+    sale_order_ids = env['sale.order'].search([('state','!=','draft')])
+    for so in sale_order_ids:
+        so.type_id = env["sale.order.type"].search(
+                        [("company_id", "in", [so.company_id.id, False])], limit=1
+                )

--- a/sale_product_set/tests/test_product_set.py
+++ b/sale_product_set/tests/test_product_set.py
@@ -143,16 +143,16 @@ class TestProductSet(common.SavepointCase):
         set_line = self.env["product.set.line"].create(
             {"product_id": product_test.id, "quantity": 1, "discount": 50}
         )
-        set = self.env["product.set"].create(
+        _set = self.env["product.set"].create(
             {"name": "Test", "set_line_ids": [(4, set_line.id)]}
         )
         so = self.env.ref("sale.sale_order_6")
         so_set = self.product_set_add.with_context(active_id=so.id).create(
-            {"product_set_id": set.id, "quantity": 1}
+            {"product_set_id": _set.id, "quantity": 1}
         )
         so_set.add_set()
         order_line = so.order_line.filtered(
-            lambda x: x.product_id == set.set_line_ids[0].product_id
+            lambda x: x.product_id == _set.set_line_ids[0].product_id
         )
         order_line.ensure_one()
         self.assertEqual(order_line.discount, set_line.discount)


### PR DESCRIPTION
**Fixing sale_order_type**

If this module is installed in a environment where there are sales orders not in draft state. The added field type_id is left null
then the order can't be cancelled. 

A hook is provided to fill the type_id with data. It is a hook but not a migration becouse it must run also at first install.
It was tested in a multicompany environment.
