### PR TITLE
[12.0][IMP] sale_order_invoicing_finished_task: Avoid cancel SO with invoiced tasks

### DIFF
--- a/sale_order_invoicing_finished_task/i18n/es.po
+++ b/sale_order_invoicing_finished_task/i18n/es.po
@@ -8,16 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-05 10:53+0200\n"
-"PO-Revision-Date: 2021-03-19 17:46+0000\n"
-"Last-Translator: Daniel Martinez Vila <daniel.martinez@qubiq.es>\n"
+"POT-Creation-Date: 2021-02-15 12:03+0000\n"
+"PO-Revision-Date: 2021-02-15 13:05+0100\n"
+"Last-Translator: Carlos Dauden <carlos.dauden@tecnativa.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.3\n"
 
 #. module: sale_order_invoicing_finished_task
 #: model:ir.model.fields,help:sale_order_invoicing_finished_task.field_product_product__invoicing_finished_task
@@ -49,7 +49,7 @@ msgstr "Plantilla de producto"
 #. module: sale_order_invoicing_finished_task
 #: model:ir.model,name:sale_order_invoicing_finished_task.model_sale_order
 msgid "Sale Order"
-msgstr "Línea de pedido de venta"
+msgstr "Pedido de venta"
 
 #. module: sale_order_invoicing_finished_task
 #: model:ir.model,name:sale_order_invoicing_finished_task.model_sale_order_line
@@ -72,6 +72,16 @@ msgid "Tasks"
 msgstr "Tareas"
 
 #. module: sale_order_invoicing_finished_task
+#: code:addons/sale_order_invoicing_finished_task/models/sale_order.py:29
+#, python-format
+msgid ""
+"You cannot cancel because these lines have invoiced tasks:\n"
+" %s"
+msgstr ""
+"No puede cancelar porque las siguientes lineas llevan asociadas tareas facturadas:\n"
+" %s"
+
+#. module: sale_order_invoicing_finished_task
 #: code:addons/sale_order_invoicing_finished_task/models/project.py:65
 #, python-format
 msgid ""
@@ -79,7 +89,4 @@ msgid ""
 "order line "
 msgstr ""
 "No puede crear/modificar una tarea relacionada con una línea de pedido "
-"facturada, realizada o cancelada "
-
-#~ msgid "Quotation"
-#~ msgstr "Presupuesto"
+"facturada, realizada o cancelada"

--- a/sale_order_invoicing_finished_task/i18n/sale_order_invoicing_finished_task.pot
+++ b/sale_order_invoicing_finished_task/i18n/sale_order_invoicing_finished_task.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-02-15 12:03+0000\n"
+"PO-Revision-Date: 2021-02-15 12:03+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -61,6 +63,13 @@ msgstr ""
 #. module: sale_order_invoicing_finished_task
 #: model:ir.model.fields,field_description:sale_order_invoicing_finished_task.field_sale_order_line__task_ids
 msgid "Tasks"
+msgstr ""
+
+#. module: sale_order_invoicing_finished_task
+#: code:addons/sale_order_invoicing_finished_task/models/sale_order.py:29
+#, python-format
+msgid "You cannot cancel because these lines have invoiced tasks:\n"
+" %s"
 msgstr ""
 
 #. module: sale_order_invoicing_finished_task


### PR DESCRIPTION
Avoid cancel SO with invoiced lines to don't have inconsistent lines if we want reconfirm _check_sale_line_state restrict raises error:
https://github.com/OCA/sale-workflow/blob/c38c050b81ac5f82a38c06ff90ebf7b65f5c9608/sale_order_invoicing_finished_task/models/project.py#L62-L66

@Tecnativa TT28217