### PR TITLE
[14.0][FIX] sale_order_lot_generator: AttributeError: 'stock.move.line' object has no attribute 'restrict_lot_id'

### DIFF
--- a/sale_order_lot_generator/tests/test_sale_order_lot_generator.py
+++ b/sale_order_lot_generator/tests/test_sale_order_lot_generator.py
@@ -49,4 +49,4 @@ class TestSaleOrderLotGenerator(test_common.SingleTransactionCase):
             if line.product_id.id == self.prd_flipover.id:
                 self.assertEqual(line.lot_id, self.sol1.lot_id)
             if line.product_id.id == self.prd_acoustic.id:
-                self.assertEqual(line.restrict_lot_id, self.sol2.lot_id)
+                self.assertEqual(line.lot_id, self.sol2.lot_id)


### PR DESCRIPTION
![Selection_199](https://user-images.githubusercontent.com/24691983/109774599-1e645400-7c33-11eb-8a8e-488f031f7d76.png)
