### PR TITLE
[13.0][IMP] sale_order_product_recommendation: Sort optimization in order_lines when recommendation lines accept

### DIFF
--- a/sale_order_product_recommendation/readme/CONTRIBUTORS.rst
+++ b/sale_order_product_recommendation/readme/CONTRIBUTORS.rst
@@ -4,3 +4,4 @@
   * David Vidal
   * Alexandre Díaz
   * Pedro M. Baeza
+  * Víctor Martínez

--- a/sale_order_product_recommendation/tests/test_recommendation.py
+++ b/sale_order_product_recommendation/tests/test_recommendation.py
@@ -1,5 +1,6 @@
 # Copyright 2017 Tecnativa - Jairo Llopis
 # Copyright 2020 Tecnativa - Pedro M. Baeza
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo.exceptions import UserError
 
@@ -25,16 +26,19 @@ class RecommendationCaseTests(RecommendationCase):
         # Order came in from context
         self.assertEqual(wizard.order_id, self.new_so)
         self.assertEqual(len(wizard.line_ids), 3)
-        # Product 1 is first recommendation because it's in the SO already
-        self.assertEqual(wizard.line_ids[0].product_id, self.prod_1)
-        self.assertEqual(wizard.line_ids[0].times_delivered, 1)
-        self.assertEqual(wizard.line_ids[0].units_delivered, 25)
-        self.assertEqual(wizard.line_ids[0].units_included, 3)
-        # Product 2 appears second
+        self.assertEqual(wizard.line_ids[0].product_id, self.prod_2)
+        self.assertEqual(wizard.line_ids[1].product_id, self.prod_1)
+        self.assertEqual(wizard.line_ids[2].product_id, self.prod_3)
+        # Product 2 is first
         wiz_line_prod2 = wizard.line_ids.filtered(lambda x: x.product_id == self.prod_2)
         self.assertEqual(wiz_line_prod2.times_delivered, 2)
         self.assertEqual(wiz_line_prod2.units_delivered, 100)
         self.assertEqual(wiz_line_prod2.units_included, 0)
+        # Product 1 appears second
+        wiz_line_prod1 = wizard.line_ids.filtered(lambda x: x.product_id == self.prod_1)
+        self.assertEqual(wiz_line_prod1.times_delivered, 1)
+        self.assertEqual(wiz_line_prod1.units_delivered, 25)
+        self.assertEqual(wiz_line_prod1.units_included, 3)
         # Product 3 appears third
         wiz_line_prod3 = wizard.line_ids.filtered(lambda x: x.product_id == self.prod_3)
         self.assertEqual(wiz_line_prod3.times_delivered, 1)


### PR DESCRIPTION
Sort optimization in order_lines when recommendation lines accept.

When user opens the product recommendation wizard always sort by times delivered desc (even if the sale order already has any line).

Related to 12.0: https://github.com/OCA/sale-workflow/pull/1442

Please @sergio-teruel can you review it?

@Tecnativa TT27976