### PR TITLE
[13.0] [FIX] sale_order_lot_selection: Change position of lot because…

### DIFF
--- a/sale_order_lot_selection/view/sale_view.xml
+++ b/sale_order_lot_selection/view/sale_view.xml
@@ -5,7 +5,7 @@
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
             <xpath
-                expr="//field[@name='order_line']/tree/field[@name='product_id']"
+                expr="//field[@name='order_line']/tree/field[@name='product_template_id']"
                 position="after"
             >
                 <field


### PR DESCRIPTION
… the sale confi. product.

If you have installed the module sale_product_configurator, this module hide the product_id field in the sol and show only product_template_id due this the field lot is appers before the field product template and the UX is not clear.