### PR TITLE
[13.0] sale_automatic_workflow: Do not post invoices set back to draft

### DIFF
--- a/sale_automatic_workflow/data/automatic_workflow_data.xml
+++ b/sale_automatic_workflow/data/automatic_workflow_data.xml
@@ -29,7 +29,7 @@
     <record id="automatic_workflow_validate_invoice_filter" model="ir.filters">
         <field name="name">Automatic Workflow Validate Invoice Filter</field>
         <field name="model_id">account.move</field>
-        <field name="domain">[('state', '=', 'draft')]</field>
+        <field name="domain">[('state', '=', 'draft'), ('name', '=', '/')]</field>
         <field name="user_id" ref="base.user_root" />
     </record>
     <record id="automatic_workflow_sale_done_filter" model="ir.filters">

--- a/sale_automatic_workflow/migrations/13.0.1.2.0/noupdate_changes.xml
+++ b/sale_automatic_workflow/migrations/13.0.1.2.0/noupdate_changes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="automatic_workflow_validate_invoice_filter" model="ir.filters">
+        <field name="domain">[('state', '=', 'draft'), ('name', '=', '/')]</field>
+    </record>
+</odoo>

--- a/sale_automatic_workflow/migrations/13.0.1.2.0/post.py
+++ b/sale_automatic_workflow/migrations/13.0.1.2.0/post.py
@@ -1,0 +1,10 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from openupgradelib import openupgrade  # pylint: disable=W7936
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, "sale_automatic_workflow", "migrations/13.0.1.0.0/noupdate_changes.xml"
+    )


### PR DESCRIPTION
When sale automatic workflow is set to create and post invoices,
a posted invoice that is set back to draft by the user will be
posted again automatically on the next run of the sale automatic
workflow.

This change in the filter avoids to post the invoice automatically
and allows the user to do its changes before posting it manually.

Logic based on https://github.com/odoo/odoo/blob/13.0/addons/account/models/account_move.py#L1760