### PR TITLE
Support pricelist with excluded discounts

### DIFF
--- a/sale_product_multi_add/readme/CONTRIBUTORS.rst
+++ b/sale_product_multi_add/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Denis Roussel <denis.roussel@acsone.eu>
 * Cédric Pigeon <cedric.pigeon@acsone.eu>
+* David Dufresne <27902736+ddufresne@users.noreply.github.com>

--- a/sale_product_multi_add/tests/test_sale.py
+++ b/sale_product_multi_add/tests/test_sale.py
@@ -3,39 +3,69 @@
 import odoo.tests.common as common
 
 
-class TestSale(common.TransactionCase):
+class TestSale(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-    def setUp(self):
-        super(TestSale, self).setUp()
+        cls.env.user.groups_id |= cls.env.ref("sale.group_discount_per_so_line")
 
-        self.product_9 = self.env.ref("product.product_product_9")
-        self.product_11 = self.env.ref("product.product_product_11")
+        cls.product_9 = cls.env.ref("product.product_product_9")
+        cls.product_11 = cls.env.ref("product.product_product_11")
+
+        cls.pricelist = cls.env["product.pricelist"].create({"name": "My Pricelist"})
+        cls.env["product.pricelist.item"].create(
+            {
+                "pricelist_id": cls.pricelist.id,
+                "applied_on": "3_global",
+                "base": "list_price",
+                "compute_price": "formula",
+                "price_discount": 10,
+            }
+        )
+        cls.product_9.list_price = 20
+
+        cls.order = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.env.ref("base.res_partner_2").id,
+                "pricelist_id": cls.pricelist.id,
+            }
+        )
+
+        wiz_obj = cls.env["sale.import.products"].with_context(
+            active_id=cls.order.id, active_model="sale.order"
+        )
+        cls.wizard = wiz_obj.create({})
 
     def test_import_product(self):
-        """ Create SO
-            Import products
-            Check products are presents
-        """
+        self.wizard.products = self.product_9 | self.product_11
+        self.wizard.create_items()
+        self.wizard.items[0].quantity = 4
+        self.wizard.items[1].quantity = 6
+        self.wizard.select_products()
 
-        so = self.env["sale.order"].create(
-            {"partner_id": self.env.ref("base.res_partner_2").id})
+        self.assertEqual(len(self.order.order_line), 2)
 
-        wiz_obj = self.env['sale.import.products']
-        wizard = wiz_obj.with_context(active_id=so.id,
-                                      active_model='sale.order')
-
-        products = [(6, 0, [self.product_9.id, self.product_11.id])]
-
-        wizard_id = wizard.create({'products': products})
-        wizard_id.create_items()
-        wizard_id.items[0].quantity = 4
-        wizard_id.items[1].quantity = 6
-        wizard_id.select_products()
-
-        self.assertEqual(len(so.order_line), 2)
-
-        for line in so.order_line:
+        for line in self.order.order_line:
             if line.product_id.id == self.product_9.id:
                 self.assertEqual(line.product_uom_qty, 4)
             else:
                 self.assertEqual(line.product_uom_qty, 6)
+
+    def test_pricelist_discount_included(self):
+        self.pricelist.discount_policy = "with_discount"
+        self.wizard.products = self.product_9
+        self.wizard.create_items()
+        self.wizard.items.quantity = 1
+        self.wizard.select_products()
+        assert self.order.order_line.price_unit == 18  # 20 * (1 - 10%)
+        assert self.order.order_line.discount == 0
+
+    def test_pricelist_discount_excluded(self):
+        self.pricelist.discount_policy = "without_discount"
+        self.wizard.products = self.product_9
+        self.wizard.create_items()
+        self.wizard.items.quantity = 1
+        self.wizard.select_products()
+        assert self.order.order_line.price_unit == 20
+        assert self.order.order_line.discount == 10

--- a/sale_product_multi_add/wizards/sale_import_products.py
+++ b/sale_product_multi_add/wizards/sale_import_products.py
@@ -43,6 +43,7 @@ class SaleImportProducts(models.TransientModel):
             'price_unit': item.product_id.list_price
         })
         sale_line.product_id_change()
+        sale_line._onchange_discount()
         line_values = sale_line._convert_to_write(sale_line._cache)
         return line_values
 


### PR DESCRIPTION
Before this commit, discounts defined in pricelists for a products worked
if the price was included in the unit price.

It would not work if the pricelist is parametrized with prices and discounts shown separately.