### PR TITLE
[10.0][ADD] sale_exception: rewrite exception code to reflect name changes in eval context

### DIFF
--- a/sale_exception/migrations/10.0.2.0.0/post-migration.py
+++ b/sale_exception/migrations/10.0.2.0.0/post-migration.py
@@ -36,7 +36,7 @@ def migrate(cr, version=None):
         return
     cr.execute(
         'select id, code from exception_rule where model in %s',
-        (tuple('sale.order', 'sale.order.line'),),
+        (('sale.order', 'sale.order.line'),),
     )
     for exception_id, code in cr.fetchall():
         new_code = astunparse.unparse(RewriteNames().visit(ast.parse(code)))

--- a/sale_exception/migrations/10.0.2.0.0/post-migration.py
+++ b/sale_exception/migrations/10.0.2.0.0/post-migration.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# (c) 2021 Hunki Enterprises BV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import ast
+import logging
+try:
+    import astunparse
+except ImportError:
+    astunparse = False
+
+
+class RewriteNames(ast.NodeTransformer):
+    def visit_Name(self, node):
+        if node.id == 'order' or node.id == 'line':
+            return ast.copy_location(ast.Name(id='object', ctx=node.ctx), node)
+        else:
+            return node
+
+
+def migrate(cr, version=None):
+    """ Rename variables `order` and `line` in exception expressions as those
+    names are not available any more in v10 onwards """
+
+    if not astunparse:
+        logging.getLogger(__name__).warning(
+            'Python lib astunparse is not installed, using sloppy version of '
+            'code rewriting. '
+            'If your exceptions break, install it and rerun the migration.'
+        )
+        cr.execute(
+            """update exception_rule set
+            code=regexp_replace(code, ' (line|order)\\.', ' object.', 'g')
+            where model in ('sale.order', 'sale.order.line')"""
+        )
+        return
+    cr.execute(
+        'select id, code from exception_rule where model in %s',
+        (tuple('sale.order', 'sale.order.line'),),
+    )
+    for exception_id, code in cr.fetchall():
+        new_code = astunparse.unparse(RewriteNames().visit(ast.parse(code)))
+        cr.execute(
+            'update exception_rule set code=%s where id=%s',
+            (new_code, exception_id),
+        )


### PR DESCRIPTION
earlier versions of this used [order](https://github.com/OCA/sale-workflow/blob/9.0/sale_exception/models/sale.py#L192) and [line](https://github.com/OCA/sale-workflow/blob/9.0/sale_exception/models/sale.py#L201), but in v10 we call it [sale](https://github.com/OCA/sale-workflow/blob/10.0/sale_exception/models/sale.py#L29) and [sale_line](https://github.com/OCA/sale-workflow/blob/10.0/sale_exception/models/sale_order_line.py#L38).

I think it's prudent to not use those when rewriting, but `object` as that exists in all upper versions.