### PR TITLE
[13.0][FIX] sale_order_warn_message display of warning

### DIFF
--- a/sale_order_warn_message/models/sale_order.py
+++ b/sale_order_warn_message/models/sale_order.py
@@ -16,7 +16,7 @@ class SaleOrder(models.Model):
     def _compute_sale_warn_msg(self):
         for rec in self:
             if rec.state not in ["draft", "sent"]:
-                rec.sale_warn_msg = ""
+                rec.sale_warn_msg = False
                 continue
             p = rec.partner_id.commercial_partner_id
             sale_warn_msg = ""
@@ -26,4 +26,4 @@ class SaleOrder(models.Model):
                 sale_warn_msg += p.sale_warn_msg
             if p != rec.partner_id and rec.partner_id.sale_warn == "warning":
                 sale_warn_msg += separator + rec.partner_id.sale_warn_msg
-            rec.sale_warn_msg = sale_warn_msg
+            rec.sale_warn_msg = False if sale_warn_msg == "" else sale_warn_msg

--- a/sale_order_warn_message/tests/test_sale_order_warn_message.py
+++ b/sale_order_warn_message/tests/test_sale_order_warn_message.py
@@ -70,3 +70,25 @@ class TestSaleOrderWarnMessage(SavepointCase):
         self.assertEqual(
             sale.sale_warn_msg, self.warn_msg_parent + "\n" + self.warn_msg
         )
+
+    def test_partner_without_warn_msg(self):
+        # set partner not to have warning
+        self.partner.update({"parent_id": None, "sale_warn": "no-message"})
+
+        sale = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.env.ref("product.product_product_4").id,
+                            "product_uom_qty": 1,
+                            "price_unit": 42,
+                        },
+                    ),
+                ],
+            }
+        )
+        self.assertEqual(sale.sale_warn_msg, False)


### PR DESCRIPTION
when no partner is selected or partner that has no sale warning set up. In that case empty warning bar is displayed because the condition is comparing to False and it is "": https://github.com/OCA/sale-workflow/blob/21a974a3796c626a3cd8621fe9d7af36e258804e/sale_order_warn_message/views/sale_order.xml#L11-L14

Here's how it looks.
![image](https://user-images.githubusercontent.com/19169467/110457480-f8273400-80ca-11eb-8d14-1be20a4057a5.png)
