### PR TITLE
[12.0][FIX] sale order revision trailing space

### DIFF
--- a/sale_order_revision/models/sale_order.py
+++ b/sale_order_revision/models/sale_order.py
@@ -65,7 +65,7 @@ class SaleOrder(models.Model):
     def copy_revision_with_context(self):
         default_data = self.default_get([])
         new_rev_number = self.revision_number + 1
-        default_data .update({
+        default_data.update({
             'revision_number': new_rev_number,
             'unrevisioned_name': self.unrevisioned_name,
             'name': '%s-%02d' % (self.unrevisioned_name, new_rev_number),


### PR DESCRIPTION
Had a problem in an installation, where `unrevisioned_name` was different from base name in 3 cases, not replicable.
I don't know if this trailing space can cause a real problem.