### PR TITLE
[FIX] sale_order_type: Non reset the value when it's sitting by the user in the view.

### DIFF
--- a/sale_order_type/models/account_move.py
+++ b/sale_order_type/models/account_move.py
@@ -19,10 +19,12 @@ class AccountMove(models.Model):
 
     @api.depends("partner_id", "company_id")
     def _compute_sale_type_id(self):
-        self.sale_type_id = self.env["sale.order.type"]
-        for record in self.filtered(
-            lambda am: am.type in ["out_invoice", "out_refund"]
-        ):
+        for record in self:
+            if record.type not in ["out_invoice", "out_refund"]:
+                record.sale_type_id = self.env["sale.order.type"]
+                continue
+            else:
+                record.sale_type_id = record.sale_type_id
             if not record.partner_id:
                 record.sale_type_id = self.env["sale.order.type"].search(
                     [("company_id", "in", [self.env.company.id, False])], limit=1


### PR DESCRIPTION

In this way we reset so that if I choose a value in the view this value is not stepped on by the compute method, before the change it always stepped on regardless that there are any value to replace about on the outcome of the logic.