### PR TITLE
[13.0][FIX]sale_procurement_group_by_line: fix fill previous_product_…

### DIFF
--- a/sale_procurement_group_by_line/model/sale.py
+++ b/sale_procurement_group_by_line/model/sale.py
@@ -116,7 +116,7 @@ class SaleOrderLine(models.Model):
                 self.env["procurement.group"].run(procurements)
                 # We store the procured quantity in the UoM of the line to avoid
                 # duplicated procurements, specially for dropshipping and kits.
-                previous_product_uom_qty = {line.id: product_qty_uom}
+                previous_product_uom_qty[line.id] = product_qty_uom
             except UserError as error:
                 errors.append(error.name)
         if errors:


### PR DESCRIPTION
This fix prevents having duplicated procurements when having several order lines involving any operation that has a specific `<sale.order.line>._get_qty_procurement` relying on `previous_product_uom_qty` (Manufacturing kits, dropshipping..)

A fix was implemented in https://github.com/OCA/sale-workflow/commit/c9b483ce3f08f053f806d8ab14c225618121a3b3 but it was only filling the previous_product_uom_qty for the last line.