### PR TITLE
[13.0][FIX] sale_cutoff_time_delivery: fix expected_date computation

### DIFF
--- a/sale_cutoff_time_delivery/tests/test_sale_cutoff_time_delivery.py
+++ b/sale_cutoff_time_delivery/tests/test_sale_cutoff_time_delivery.py
@@ -59,12 +59,18 @@ class TestSaleCutoffTimeDelivery(SavepointCase):
     @freeze_time("2020-03-25 08:00:00")
     def test_before_cutoff_time_delivery(self):
         order = self._create_order(partner=self.customer_partner)
+        self.assertEqual(
+            order.expected_date, fields.Datetime.to_datetime("2020-03-25 09:00:00")
+        )
         order.action_confirm()
         picking = order.picking_ids
         self.assertEqual(
             picking.scheduled_date, fields.Datetime.to_datetime("2020-03-24 09:00:00")
         )
         order = self._create_order(partner=self.customer_warehouse)
+        self.assertEqual(
+            order.expected_date, fields.Datetime.to_datetime("2020-03-25 10:00:00")
+        )
         order.action_confirm()
         picking = order.picking_ids
         self.assertEqual(
@@ -74,12 +80,18 @@ class TestSaleCutoffTimeDelivery(SavepointCase):
     @freeze_time("2020-03-25 18:00:00")
     def test_after_cutoff_time_delivery(self):
         order = self._create_order(partner=self.customer_partner)
+        self.assertEqual(
+            order.expected_date, fields.Datetime.to_datetime("2020-03-26 09:00:00")
+        )
         order.action_confirm()
         picking = order.picking_ids
         self.assertEqual(
             picking.scheduled_date, fields.Datetime.to_datetime("2020-03-25 09:00:00")
         )
         order = self._create_order(partner=self.customer_warehouse)
+        self.assertEqual(
+            order.expected_date, fields.Datetime.to_datetime("2020-03-26 10:00:00")
+        )
         order.action_confirm()
         picking = order.picking_ids
         self.assertEqual(
@@ -93,12 +105,18 @@ class TestSaleCutoffTimeDelivery(SavepointCase):
         # Frozen time is 2020-03-25 07:00:00 UTC, or 2020-03-25 08:00:00 GMT+1
         # what is before cutoff times
         order = self._create_order(partner=self.customer_partner)
+        self.assertEqual(
+            order.expected_date, fields.Datetime.to_datetime("2020-03-25 08:00:00")
+        )
         order.action_confirm()
         picking = order.picking_ids
         self.assertEqual(
             picking.scheduled_date, fields.Datetime.to_datetime("2020-03-24 08:00:00")
         )
         order = self._create_order(partner=self.customer_warehouse)
+        self.assertEqual(
+            order.expected_date, fields.Datetime.to_datetime("2020-03-25 09:00:00")
+        )
         order.action_confirm()
         picking = order.picking_ids
         self.assertEqual(
@@ -112,12 +130,18 @@ class TestSaleCutoffTimeDelivery(SavepointCase):
         # Frozen time is 2020-03-25 18:00:00 UTC, or 2020-03-25 19:00:00 GMT+1
         # what is after cutoff times
         order = self._create_order(partner=self.customer_partner)
+        self.assertEqual(
+            order.expected_date, fields.Datetime.to_datetime("2020-03-26 08:00:00")
+        )
         order.action_confirm()
         picking = order.picking_ids
         self.assertEqual(
             picking.scheduled_date, fields.Datetime.to_datetime("2020-03-25 08:00:00")
         )
         order = self._create_order(partner=self.customer_warehouse)
+        self.assertEqual(
+            order.expected_date, fields.Datetime.to_datetime("2020-03-26 09:00:00")
+        )
         order.action_confirm()
         picking = order.picking_ids
         self.assertEqual(

--- a/sale_partner_delivery_window/models/sale_order.py
+++ b/sale_partner_delivery_window/models/sale_order.py
@@ -23,7 +23,7 @@ class SaleOrder(models.Model):
     def _onchange_commitment_date(self):
         """Warns if commitment date is not a preferred window for delivery"""
         res = super()._onchange_commitment_date()
-        if "warning" in res:
+        if res and "warning" in res:
             return res
         ps = self.partner_shipping_id
         if self.commitment_date and ps.delivery_time_preference == "time_windows":


### PR DESCRIPTION
Fix the computation of `expected_date` + refactor the code to use the same computation both for `expected_date` and `date_planned`.

Address this FIXME/comment: https://github.com/OCA/sale-workflow/pull/1104#discussion_r406156787

Ref. 2369.