### PR TITLE
[13.0][FIX] sale_exception ignore after confirm

### DIFF
--- a/sale_exception/models/sale.py
+++ b/sale_exception/models/sale.py
@@ -66,11 +66,6 @@ class SaleOrder(models.Model):
         if orders:
             orders._check_exception()
 
-    @api.onchange("order_line")
-    def onchange_ignore_exception(self):
-        if self.state == "sale":
-            self.ignore_exception = False
-
     def action_confirm(self):
         if self.detect_exceptions():
             return self._popup_exceptions()


### PR DESCRIPTION
After the sale order has been confirmed, some fields can still be
changed, those changes can raise some more excetptions again.
Unfortunatelly those changes are raised as ValidationError and they are
blocking.

If during the confirmation of the sale.order the ignore excetpiton has
been used. Those same ignored exception will block some changes made
when the sale order is in `sale` state.

This change ensure that if exceptions have been ignored they will not be
locking in the `sale` state.