### PR TITLE
[13.0][ADD] sale_order_invoice_amount

### DIFF
--- a/sale_order_invoice_amount/__init__.py
+++ b/sale_order_invoice_amount/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_order_invoice_amount/__manifest__.py
+++ b/sale_order_invoice_amount/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2021 ForgeFlow S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+{
+    "name": "Sale Order Invoice Amount",
+    "version": "13.0.1.0.0",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/sale-workflow",
+    "category": "Sales",
+    "license": "LGPL-3",
+    "summary": "Display the invoiced and uninvoiced total in the sale order",
+    "depends": ["sale"],
+    "data": ["views/sale_order_view.xml"],
+    "installable": True,
+}

--- a/sale_order_invoice_amount/models/__init__.py
+++ b/sale_order_invoice_amount/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_order_invoice_amount/models/sale_order.py
+++ b/sale_order_invoice_amount/models/sale_order.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2021 ForgeFlow S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from odoo import api, fields, models
+
+
+class SaleOrder(models.Model):
+
+    _inherit = "sale.order"
+
+    invoiced_amount = fields.Monetary(
+        string="Invoiced Amount", compute="_compute_invoice_amount", store=True,
+    )
+
+    uninvoiced_amount = fields.Monetary(
+        string="Uninvoiced Amount", compute="_compute_invoice_amount", store=True,
+    )
+
+    @api.depends(
+        "state",
+        "invoice_ids",
+        "invoice_ids.amount_total_signed",
+        "amount_total",
+        "invoice_ids.state",
+    )
+    def _compute_invoice_amount(self):
+        for rec in self:
+            if rec.state != "cancel" and rec.invoice_ids:
+                rec.invoiced_amount = 0.0
+                for invoice in rec.invoice_ids:
+                    if invoice.state != "cancel":
+                        rec.invoiced_amount += invoice.amount_total_signed
+                rec.uninvoiced_amount = max(0, rec.amount_total - rec.invoiced_amount)
+            else:
+                rec.invoiced_amount = 0.0
+                if rec.state in ["draft", "sent", "cancel"]:
+                    rec.uninvoiced_amount = 0.0
+                else:
+                    rec.uninvoiced_amount = rec.amount_total

--- a/sale_order_invoice_amount/readme/CONTRIBUTORS.rst
+++ b/sale_order_invoice_amount/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Mateu Griful <mateu.griful@forgeflow.com>
+* Lois Rilo <lois.rilo@forgeflow.com>

--- a/sale_order_invoice_amount/readme/DESCRIPTION.rst
+++ b/sale_order_invoice_amount/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+The purpose of this module is to add two fields in the sale order model:
+
+* invoiced_amount: total invoiced amount.
+* uninvoiced_amount: total uninvoiced amount.

--- a/sale_order_invoice_amount/tests/__init__.py
+++ b/sale_order_invoice_amount/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_order_invoice_amount

--- a/sale_order_invoice_amount/tests/test_sale_order_invoice_amount.py
+++ b/sale_order_invoice_amount/tests/test_sale_order_invoice_amount.py
@@ -1,0 +1,113 @@
+# Copyright (C) 2021 ForgeFlow S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+
+from odoo.tests import common
+
+
+class TestSaleOrderInvoiceAmount(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Partners
+        cls.res_partner_1 = cls.env["res.partner"].create({"name": "Wood Corner"})
+        cls.res_partner_address_1 = cls.env["res.partner"].create(
+            {"name": "Willie Burke", "parent_id": cls.res_partner_1.id}
+        )
+        cls.res_partner_2 = cls.env["res.partner"].create({"name": "Partner 12"})
+
+        # Products
+        cls.product_1 = cls.env["product.product"].create(
+            {"name": "Desk Combination", "type": "product"}
+        )
+        cls.product_2 = cls.env["product.product"].create(
+            {"name": "Conference Chair", "type": "product"}
+        )
+        cls.product_3 = cls.env["product.product"].create(
+            {"name": "Repair Services", "type": "service"}
+        )
+
+        # Location
+        cls.stock_warehouse = cls.env["stock.warehouse"].search(
+            [("company_id", "=", cls.env.company.id)], limit=1
+        )
+        cls.stock_location_14 = cls.env["stock.location"].create(
+            {"name": "Shelf 2", "location_id": cls.stock_warehouse.lot_stock_id.id}
+        )
+        # Replenish products
+        cls.env["stock.quant"]._update_available_quantity(
+            cls.product_1, cls.stock_location_14, 10
+        )
+        cls.env["stock.quant"]._update_available_quantity(
+            cls.product_2, cls.stock_location_14, 10
+        )
+        # Sale Order
+        cls.tax = cls.env["account.tax"].create(
+            {"name": "Tax 15", "type_tax_use": "sale", "amount": 21}
+        )
+        cls.sale_order_1 = cls.env["sale.order"].create(
+            {"partner_id": cls.res_partner_1.id}
+        )
+        cls.order_line_1 = cls.env["sale.order.line"].create(
+            {
+                "order_id": cls.sale_order_1.id,
+                "product_id": cls.product_1.id,
+                "product_uom": cls.product_1.uom_id.id,
+                "product_uom_qty": 10.0,
+                "price_unit": 10.0,
+                "tax_id": cls.tax,
+            }
+        )
+        cls.order_line_2 = cls.env["sale.order.line"].create(
+            {
+                "order_id": cls.sale_order_1.id,
+                "product_id": cls.product_2.id,
+                "product_uom": cls.product_2.uom_id.id,
+                "product_uom_qty": 25.0,
+                "price_unit": 4.0,
+                "tax_id": cls.tax,
+            }
+        )
+        cls.order_line_3 = cls.env["sale.order.line"].create(
+            {
+                "order_id": cls.sale_order_1.id,
+                "product_id": cls.product_3.id,
+                "product_uom": cls.product_3.uom_id.id,
+                "product_uom_qty": 20.0,
+                "price_unit": 5.0,
+                "tax_id": cls.tax,
+            }
+        )
+
+    def test_sale_order_invoiced_amount(self):
+
+        self.assertEqual(
+            self.sale_order_1.invoiced_amount, 0.0, "Invoiced Amount should be 0.0",
+        )
+        context_payment = {
+            "active_ids": [self.sale_order_1.id],
+            "active_id": self.sale_order_1.id,
+        }
+        payment = (
+            self.env["sale.advance.payment.inv"]
+            .with_context(context_payment)
+            .create({"advance_payment_method": "fixed", "fixed_amount": 100})
+        )
+
+        payment.create_invoices()
+        self.assertEqual(
+            self.sale_order_1.invoiced_amount, 100.0, "Invoiced Amount should be 100",
+        )
+        self.assertEqual(
+            self.sale_order_1.uninvoiced_amount,
+            263.0,
+            "Uninvoiced Amount should be 263",
+        )
+
+        self.sale_order_1.action_confirm()
+        self.sale_order_1._create_invoices(final=True)
+        self.assertEqual(
+            self.sale_order_1.invoiced_amount,
+            363.0,
+            "Invoiced Amount should be calculated",
+        )

--- a/sale_order_invoice_amount/views/sale_order_view.xml
+++ b/sale_order_invoice_amount/views/sale_order_view.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_order_form_invoiced_amount" model="ir.ui.view">
+        <field name="name">sale.order.form.invoiced.amount</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <field name="amount_untaxed" position="after">
+                <field name="invoiced_amount" />
+                <field name="uninvoiced_amount" />
+            </field>
+        </field>
+    </record>
+    <record id="view_order_tree_invoiced_amount" model="ir.ui.view">
+        <field name="name">sale.order.tree.invoiced_amount</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='amount_tax']" position="after">
+                <field name="invoiced_amount" sum="Invoiced Total" optional="hide" />
+                <field
+                    name="uninvoiced_amount"
+                    sum="Uninvoiced Total"
+                    optional="hide"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/sale_order_invoice_amount/odoo/addons/sale_order_invoice_amount
+++ b/setup/sale_order_invoice_amount/odoo/addons/sale_order_invoice_amount
@@ -1,0 +1,1 @@
+../../../../sale_order_invoice_amount

--- a/setup/sale_order_invoice_amount/setup.py
+++ b/setup/sale_order_invoice_amount/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Addition of the module sale_order_invoice_amount for v13.
The module allows the user to see both the invoiced and the uninvoiced amounts in the sale order and in the sale order tree view. 
@LoisRForgeFlow 