### PR TITLE
[13.0][FIX] sales_team_security: Remove team_id field in partner_view

### DIFF
--- a/sales_team_security/views/res_partner_view.xml
+++ b/sales_team_security/views/res_partner_view.xml
@@ -5,12 +5,6 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//page[@name='sales_purchases']//field[@name='user_id']"
-                position="after"
-            >
-                <field name="team_id" />
-            </xpath>
             <xpath expr="//field[@name='child_ids']/form" position="inside">
                 <field name="user_id" invisible="1" />
                 <field name="team_id" invisible="1" />


### PR DESCRIPTION
Remove team_id field in partner_view because is duplicated from sales_team view.

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT29262