### PR TITLE
[13.0][FIX] sale_order_product_recommendation: commercial_partner_id on delivery_address

### DIFF
--- a/sale_order_product_recommendation/i18n/es.po
+++ b/sale_order_product_recommendation/i18n/es.po
@@ -96,12 +96,12 @@ msgstr "ID"
 #. module: sale_order_product_recommendation
 #: model_terms:ir.ui.view,arch_db:sale_order_product_recommendation.res_config_settings_view_form_sale
 msgid ""
-"If this is selected, we will take care by default on\n"
+"If this is selected, it will take care by default on\n"
 "                            Delivery Address instead of customer on sale "
 "orders\n"
 "                            recommendation"
 msgstr ""
-"Si se selecciona, vamos a tener en cuenta por defecto la\n"
+"Si se selecciona, se va a tener en cuenta por defecto la\n"
 "                            Direccion de entrega en lugar del cliente en el\n"
 "                            recomendador de productos"
 

--- a/sale_order_product_recommendation/i18n/sale_order_product_recommendation.pot
+++ b/sale_order_product_recommendation/i18n/sale_order_product_recommendation.pot
@@ -90,7 +90,7 @@ msgstr ""
 #. module: sale_order_product_recommendation
 #: model_terms:ir.ui.view,arch_db:sale_order_product_recommendation.res_config_settings_view_form_sale
 msgid ""
-"If this is selected, we will take care by default on\n"
+"If this is selected, it will take care by default on\n"
 "                            Delivery Address instead of customer on sale orders\n"
 "                            recommendation"
 msgstr ""

--- a/sale_order_product_recommendation/views/res_config_settings_views.xml
+++ b/sale_order_product_recommendation/views/res_config_settings_views.xml
@@ -29,7 +29,7 @@
                     <div class="o_setting_right_pane">
                         <span class="o_form_label">Use delivery address</span>
                         <div class="text-muted">
-                            If this is selected, we will take care by default on
+                            If this is selected, it will take care by default on
                             Delivery Address instead of customer on sale orders
                             recommendation
                         </div>

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -65,11 +65,7 @@ class SaleOrderRecommendation(models.TransientModel):
         )
         other_sales = self.env["sale.order"].search(
             [
-                (
-                    sale_order_partner_field,
-                    "child_of",
-                    partner.commercial_partner_id.id,
-                ),
+                (sale_order_partner_field, "child_of", partner.id),
                 ("date_order", ">=", start),
             ]
         )


### PR DESCRIPTION
On delivery address we want to take into account just this field and not
the commercial_partner_id.

And fixed 1 term to make it impersonal.

cc @Tecnativa TT29597

please @pedrobaeza @victoralmau review this