### PR TITLE
sale_product_set: fix SO line vals get

### DIFF
--- a/sale_product_set/__manifest__.py
+++ b/sale_product_set/__manifest__.py
@@ -9,7 +9,7 @@
     "version": "13.0.1.2.0",
     "website": "https://github.com/OCA/sale-workflow",
     "summary": "Sale product set",
-    "depends": ["sale"],
+    "depends": ["sale", "onchange_helper"],
     "data": [
         "security/ir.model.access.csv",
         "security/rule_product_set.xml",

--- a/sale_product_set/wizard/product_set_add.py
+++ b/sale_product_set/wizard/product_set_add.py
@@ -123,11 +123,9 @@ class ProductSetAdd(models.TransientModel):
 
     def prepare_sale_order_line_data(self, set_line, max_sequence=0):
         self.ensure_one()
-        sale_line = self.env["sale.order.line"].new(
-            set_line.prepare_sale_order_line_values(
-                self.order_id, self.quantity, max_sequence=max_sequence
-            )
+        line_values = set_line.prepare_sale_order_line_values(
+            self.order_id, self.quantity, max_sequence=max_sequence
         )
-        sale_line.product_id_change()
-        line_values = sale_line._convert_to_write(sale_line._cache)
+        sol_model = self.env["sale.order.line"]
+        line_values.update(sol_model.play_onchanges(line_values, line_values.keys()))
         return line_values


### PR DESCRIPTION
Ensure all required onchanges are applied on new SO line values.

Not all the modules rely on 'product_id_change'
to change values related to products.

A typical case is 'sale_stock' whereas product lead time
is handled by '_onchange_product_id_set_customer_lead'.

In this example, without this change,
all lines added via product set wizard will have a wrong lead time.