### PR TITLE
[FIX] for drop shipping module

### DIFF
--- a/sale_manual_delivery/models/sale_order_line.py
+++ b/sale_manual_delivery/models/sale_order_line.py
@@ -38,7 +38,9 @@ class SaleOrderLine(models.Model):
         """
         for line in self:
             if line.qty_delivered_method == "stock_move":
-                line.qty_procured = line._get_qty_procurement()
+                line.qty_procured = line._get_qty_procurement(
+                    previous_product_uom_qty=False
+                )
 
     @api.depends("product_uom_qty", "qty_procured")
     def _compute_qty_to_procure(self):


### PR DESCRIPTION
* Purpose
The stock_dropshipping module do not have a default value:
https://github.com/odoo/odoo/blob/14.0/addons/stock_dropshipping/models/sale.py#L22
We need to force the parameter