### PR TITLE
[14.0][FIX] sale_product_seasonality: Fix using templates on sale order

### DIFF
--- a/sale_product_seasonality/views/sale_order.xml
+++ b/sale_product_seasonality/views/sale_order.xml
@@ -28,6 +28,15 @@
                 >[('id', 'in', season_allowed_product_ids)]</attribute>
                 <attribute name="options">{"no_create": True}</attribute>
             </xpath>
+            <xpath
+                expr="//field[@name='order_line']//tree//field[@name='product_template_id']"
+                position="attributes"
+            >
+                <attribute
+                    name="domain"
+                >[('product_variant_ids.id', 'in', season_allowed_product_ids)]</attribute>
+                <attribute name="options">{"no_create": True}</attribute>
+            </xpath>
             <xpath expr="//notebook" position="inside">
                 <page
                     name="season_allowed_products"


### PR DESCRIPTION
By default, the field `product_template_id` is hidden on sale order
lines, but we can display it.

If it's displayed, we want to have product templates limites to allowed
products.