### PR TITLE
[FIX] sale_order_line_date: remove dependency to 'sale_stock' module

### DIFF
--- a/sale_order_line_date/__manifest__.py
+++ b/sale_order_line_date/__manifest__.py
@@ -18,7 +18,7 @@
     "category": "Sale",
     "license": "AGPL-3",
     "depends": [
-        "sale_stock",
+        "sale",
     ],
     "data": [
         "views/sale_order_view.xml",


### PR DESCRIPTION
The module has no real need to depend on 'sale_stock' module, it only depends on fields and methods defined within 'sale' module.
Replacing 'sale_stock' with 'sale' will avoid installing an unused module (and its dependencies).