### PR TITLE
[12.0][FIX] sale_triple_discount: Computed discount might exceed discount's precision

### DIFF
--- a/sale_triple_discount/models/sale_order_line.py
+++ b/sale_triple_discount/models/sale_order_line.py
@@ -109,6 +109,13 @@ class SaleOrderLine(models.Model):
         this method is called multiple times."""
         prev_values = dict()
 
+        # The newly computed discount might have
+        # more digits than allowed from field's precision,
+        # so let's increase it just for saving it correctly in cache
+        discount_field = self._fields['discount']
+        discount_original_digits = discount_field._digits
+        discount_field._digits = (16, 10)
+
         for line in self:
             prev_values[line] = dict(
                 discount=line.discount,
@@ -120,6 +127,9 @@ class SaleOrderLine(models.Model):
                 'discount2': 0.0,
                 'discount3': 0.0
             })
+
+        # Restore discount field's precision
+        discount_field._digits = discount_original_digits
         return prev_values
 
     @api.model

--- a/sale_triple_discount/tests/test_sale_triple_discount.py
+++ b/sale_triple_discount/tests/test_sale_triple_discount.py
@@ -150,3 +150,32 @@ class TestSaleOrder(common.SavepointCase):
         self.assertEqual(self.so_line2.price_subtotal, 300.0)
         self.assertEqual(self.order.amount_untaxed, 375.0)
         self.assertEqual(self.order.amount_tax, 56.25)
+
+    def test_increased_precision(self):
+        """
+        Check that final discount is computed correctly
+        when final discount's precision exceeds
+        discount field's allowed precision.
+        """
+        so_line = self.so_line1
+        discount_field = so_line._fields['discount']
+        self.assertEqual(discount_field.digits[1], 2)
+        so_line.discount = 45.0
+        so_line.discount2 = 10.0
+        so_line.discount3 = 5.0
+
+        self.assertAlmostEqual(
+            so_line._get_final_discount(),
+            52.975,
+            places=3,
+        )
+        so_line.triple_discount_preprocess()
+
+        # Check that the line's discount still has all the 3 digits
+        self.assertAlmostEqual(
+            so_line.discount,
+            52.975,
+            places=3,
+        )
+        # Check that field's precision is not changed
+        self.assertEqual(discount_field.digits[1], 2)


### PR DESCRIPTION
**Steps to reproduce**

1. Create a sale order
2. Add a line having:
    - price_unit = 420
    - discount = 45
    - discount2 = 10
    - discount3 = 5 
3. Save the sale order

**Actual behavior**
Subtotal for the line is 197.48

**Expected behavior**
Subtotal for the line is 197.51