### PR TITLE
[13.0] s_partner_delivery_window: improve err message

### DIFF
--- a/sale_partner_delivery_window/models/res_partner.py
+++ b/sale_partner_delivery_window/models/res_partner.py
@@ -34,7 +34,10 @@ class ResPartner(models.Model):
         for dwin_start in datetime_windows:
             if dwin_start >= from_date:
                 return dwin_start
-        raise UserError(_("Something went wrong trying to find next delivery window"))
+        raise UserError(
+            _("Something went wrong trying to find next delivery window. Date: %s")
+            % str(from_date)
+        )
 
     def get_next_windows_start_datetime(self, from_datetime, to_datetime):
         """Get all delivery windows start time.


### PR DESCRIPTION
EDIT: Original issue fixed in https://github.com/OCA/stock-logistics-workflow/pull/862

Old description:

> Error reported here #1621 https://travis-ci.com/github/OCA/sale-workflow/jobs/516775218#L2129
> 
> Might be related to `sale_by_packaging` tests using NewId records that could make `sale_stock.models.sale_order._compute_qty_at_date` fail.
> 
> This method is overridden by `sale_partner_delivery_window` that's why is reported on the traceback but it does not change its behavior.
> 
> I'll get back to this.
