### PR TITLE
[FIX] use same version as other oca projects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/OCA/openupgradelib.git@master
+git+https://github.com/OCA/openupgradelib.git


### PR DESCRIPTION
This cause a conflict in some tools thinking they are different
versions.

    The conflict is caused by:
      The user requested openupgradelib 3.0.0 (from git+https://github.com/OCA/openupgradelib.git)
      The user requested openupgradelib 3.0.0 (from git+https://github.com/OCA/openupgradelib.git@master)