### PR TITLE
[14.0][IMP] sale_product_seasonality: Add product template management

### DIFF
--- a/sale_product_seasonality/tests/test_sale_order.py
+++ b/sale_product_seasonality/tests/test_sale_order.py
@@ -120,7 +120,7 @@ class TestSaleOrderCase(CommonCase):
         #     "friday": True,
         #     "saturday": True,
         #     "sunday": True,
-        #     "product_id": cls.prod2.id,
+        #     "product_template_id": cls.prod2.product_tmpl_id.id,
         # },
         form.commitment_date = "2021-05-09"
         # no product available before


### PR DESCRIPTION
Related to: https://github.com/OCA/product-attribute/pull/871 which add product template on config lines.