### PR TITLE
[13.0][FIX]sale_procurement_group_by_line: use SO company as the procurement company

### DIFF
--- a/sale_procurement_group_by_line/model/sale.py
+++ b/sale_procurement_group_by_line/model/sale.py
@@ -109,7 +109,7 @@ class SaleOrderLine(models.Model):
                         line.order_id.partner_shipping_id.property_stock_customer,
                         line.name,
                         line.order_id.name,
-                        self.env.company,
+                        line.order_id.company_id,
                         values,
                     )
                 )


### PR DESCRIPTION
When creating procurements for sales order lines, use the company in the sales order to prevent selecting the current active company, as in multi-company environments this can lead to inconsistencies between the company in the stock moves created and the actual company of the order.