### PR TITLE
[FIX] sale_order_action_invoice_create_hook

### DIFF
--- a/sale_order_action_invoice_create_hook/__manifest__.py
+++ b/sale_order_action_invoice_create_hook/__manifest__.py
@@ -6,7 +6,7 @@
     "summary": "Add more flexibility in the grouping parameters "
                "for the creation of invoices",
     "author": "Eficent, Odoo Community Association (OCA)",
-    "version": "12.0.1.0.1",
+    "version": "12.0.1.0.2",
     "category": "Sale Workflow",
     "website": "https://github.com/OCA/sale-workflow",
     "license": 'LGPL-3',

--- a/sale_order_action_invoice_create_hook/model/sale_order.py
+++ b/sale_order_action_invoice_create_hook/model/sale_order.py
@@ -21,6 +21,10 @@ class SaleOrder(models.Model):
     def _get_draft_invoices(self, invoices, references):
         return invoices, references
 
+    @api.model
+    def _modify_invoices(self, invoices):
+        return invoices
+
     @api.model_cr
     def _register_hook(self):
 
@@ -133,6 +137,7 @@ class SaleOrder(models.Model):
                     not self.env.context.get('no_check_lines', False):
                 raise UserError(_('There is no invoicable line.'))
             # END HOOK
+            self._modify_invoices(invoices)
 
             for invoice in invoices.values():
                 invoice.compute_taxes()


### PR DESCRIPTION
PROBLEM DETECTED:
    When the "sale_order_action_invoice_create_hook" module is installed, Odoo executes the internal function "new_action_invoice_create" instead of the generic "action_invoice_create", so the latter is not executed. So the functionality of the original function "action_invoice_create" and "new_action_invoice_create" cannot be inherited from another module because the latter function is private and is not known from outside.

PROPOSED SOLUTION:
    A new generic function "_modify_invoices" is added outside the hook and it is called from within "new_action_invoice_create" to be able to inherit it in other modules and to be able to make the necessary modifications.