### PR TITLE
[10.0][FIX] sale_procurement_group_by_line

### DIFF
--- a/sale_procurement_group_by_line/model/sale.py
+++ b/sale_procurement_group_by_line/model/sale.py
@@ -35,6 +35,13 @@ class SaleOrder(models.Model):
                 [('group_id', 'in', list(group_ids))])
             sale.delivery_count = len(sale.picking_ids)
 
+    @api.multi
+    def action_draft(self):
+        res = super(SaleOrder, self).action_draft()
+        for line in self.order_line:
+            line.write({'procurement_group_id': False})
+        return res
+
 
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'


### PR DESCRIPTION
Create new groups upon cancel and draft. This is necessary in order to respect the changes in the picking policy.

Test added for the new use case, and little improvements in existing tests.

cc @ForgeFlow
