### PR TITLE
[14.0][FIX] sale_order_type: call to create from copy crashes

### DIFF
--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -74,7 +74,7 @@ class SaleOrder(models.Model):
             sale_type = self.env["sale.order.type"].browse(vals["type_id"])
             if sale_type.sequence_id:
                 vals["name"] = sale_type.sequence_id.next_by_id(
-                    sequence_date=vals["date_order"]
+                    sequence_date=vals.get("date_order")
                 )
         return super(SaleOrder, self).create(vals)
 


### PR DESCRIPTION
When a record is created in odoo, all its fields are sent to the dictionary received by `create`, even if empty. However, this is not the case when we copy a record, in which case `create` is called without those fields having `copy=False`.

The previous implementation asumed that we would always have the field `date_order` when calling the `create` of the sale.order, without taking into account that being non-copy, it wouldn't be sent. As a result, the code crashed.

To fix this, the method `get` has been used instead of the index operator. If the key `date_order` is not found in `vals`, then `get` will return `None`, that makes everything go well.