### PR TITLE
[13.0] Fix sale_automatic_workflow: on some cases you ship more products than planned. You want to consider them as fully shipped

### DIFF
--- a/sale_automatic_workflow/models/sale_order.py
+++ b/sale_automatic_workflow/models/sale_order.py
@@ -32,7 +32,7 @@ class SaleOrder(models.Model):
                 or float_compare(
                     line.qty_delivered, line.product_uom_qty, precision_digits=precision
                 )
-                == 0
+                >= 0
                 for line in order.order_line
             )
 


### PR DESCRIPTION
Fix sale_automatic_workflow: on some cases you ship more products than planned.
You want to consider them as fully shipped.

Forward-port of https://github.com/OCA/sale-workflow/pull/1659