### PR TITLE
[14.0][FIX] incompatible modules

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -6,7 +6,9 @@ dependency_installation_mode: PIP
 generate_requirements_txt: true
 include_wkhtmltopdf: false
 odoo_version: 14.0
-rebel_module_groups: []
+rebel_module_groups:
+- sale_partner_version
+- sale_quotation_number
 repo_description: 'TODO: add repo description.'
 repo_name: sale-workflow
 repo_slug: sale-workflow

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,29 @@ stages:
 
 jobs:
   include:
+    # Test separately: sale_partner_version
     - stage: test
       env:
-        - TESTS=1 ODOO_REPO="odoo/odoo" MAKEPOT="1" EXCLUDE="sale_partner_version"
+        - TESTS=1 ODOO_REPO="odoo/odoo" MAKEPOT=1 INCLUDE="sale_partner_version"
     - stage: test
       env:
-        - TESTS=1 ODOO_REPO="OCA/OCB" EXCLUDE="sale_partner_version"
+        - TESTS=1 ODOO_REPO="OCA/OCB" INCLUDE="sale_partner_version"
+    # Test separately: sale_quotation_number
     - stage: test
       env:
-        - TESTS=1 ODOO_REPO="odoo/odoo" MAKEPOT="1" EXCLUDE="sale_partner_version"
+        - TESTS=1 ODOO_REPO="odoo/odoo" MAKEPOT=1 INCLUDE="sale_quotation_number"
     - stage: test
       env:
-        - TESTS=1 ODOO_REPO="OCA/OCB" EXCLUDE="sale_partner_version"
+        - TESTS=1 ODOO_REPO="OCA/OCB" INCLUDE="sale_quotation_number"
+    # Test all other addons together
+    - stage: test
+      env:
+        - TESTS=1 ODOO_REPO="odoo/odoo" MAKEPOT=1
+          EXCLUDE="sale_partner_version,sale_quotation_number"
+    - stage: test
+      env:
+        - TESTS=1 ODOO_REPO="OCA/OCB"
+          EXCLUDE="sale_partner_version,sale_quotation_number"
 env:
   global:
     - VERSION="14.0" TESTS="0" LINT_CHECK="0" MAKEPOT="0"

--- a/sale_isolated_quotation/__manifest__.py
+++ b/sale_isolated_quotation/__manifest__.py
@@ -7,6 +7,7 @@
     "category": "Sales",
     "website": "https://github.com/OCA/sale-workflow",
     "depends": ["sale_management"],
+    "excludes": ["sale_quotation_number"],
     "license": "AGPL-3",
     "images": [],
     "data": ["data/ir_sequence_data.xml", "views/sale_views.xml"],

--- a/sale_isolated_quotation/readme/INSTALL.rst
+++ b/sale_isolated_quotation/readme/INSTALL.rst
@@ -1,0 +1,1 @@
+NOTE: `sale_isolated_quotation` is incompatible with `sale_quotation_number`: they can't be installed together.

--- a/sale_quotation_number/__manifest__.py
+++ b/sale_quotation_number/__manifest__.py
@@ -17,5 +17,6 @@
     "application": False,
     "installable": True,
     "depends": ["sale_management"],
+    "excludes": ["sale_isolated_quotation"],
     "data": ["data/data.xml", "views/sales_config.xml"],
 }

--- a/sale_quotation_number/readme/INSTALL.rst
+++ b/sale_quotation_number/readme/INSTALL.rst
@@ -1,0 +1,1 @@
+NOTE: `sale_quotation_number` is incompatible with `sale_isolated_quotation`: they can't be installed together.


### PR DESCRIPTION
`sale_isolated_quotation` and `sale_quotation_number` are incompatible (both define a sequence with same code `sale.quotation`): they should not be installed nor tested together