### PR TITLE
[13.0] sale_discount_display_amount: fix init hook

### DIFF
--- a/sale_discount_display_amount/hooks.py
+++ b/sale_discount_display_amount/hooks.py
@@ -4,41 +4,23 @@ import logging
 
 from odoo import SUPERUSER_ID
 from odoo.api import Environment
+from odoo.tools.sql import column_exists, create_column
 
 _logger = logging.getLogger(__name__)
 
+COLUMNS = (
+    ("sale_order", "price_total_no_discount"),
+    ("sale_order", "discount_total"),
+    ("sale_order_line", "price_total_no_discount"),
+    ("sale_order_line", "discount_total"),
+)
+
 
 def pre_init_hook(cr):
-    _logger.info("Create discount columns in database")
-    # Use IF NOT EXISTS to alter table because when the module is already
-    # installed (v9.0 for example) and you migrate to this 13.0, the column
-    # already exists but the module is considered as new.
-    # So this hook is triggered and it raise an exception.
-    cr.execute(
-        """
-        ALTER TABLE sale_order
-        ADD COLUMN IF NOT EXISTS price_total_no_discount numeric;
-    """
-    )
-    cr.execute(
-        """
-        ALTER TABLE sale_order
-        ADD COLUMN IF NOT EXISTS discount_total numeric;
-    """
-    )
-    cr.execute(
-        """
-        ALTER TABLE sale_order_line
-        ADD COLUMN IF NOT EXISTS price_total_no_discount
-        numeric;
-    """
-    )
-    cr.execute(
-        """
-        ALTER TABLE sale_order_line
-        ADD COLUMN IF NOT EXISTS discount_total numeric;
-    """
-    )
+    for table, column in COLUMNS:
+        if not column_exists(cr, table, column):
+            _logger.info("Create discount column %s in database", column)
+            create_column(cr, table, column, "numeric")
 
 
 def post_init_hook(cr, registry):


### PR DESCRIPTION
Prevent failure if new columns are already in DB.

Backport of https://github.com/OCA/sale-workflow/pull/1651
Not needed in v13 because of the clause "IF NOT EXISTS" but this version is more compact and it uses a core util which annotates columns too.