### PR TITLE
[13.0] [FIX] sale_order_lot_selection: Adjust problems with reservetion for the qty using a lot.

### DIFF
--- a/sale_order_lot_selection/models/stock.py
+++ b/sale_order_lot_selection/models/stock.py
@@ -14,7 +14,10 @@ class StockMove(models.Model):
         owner_id=None,
         strict=True,
     ):
-        if self._context.get("sol_lot_id"):
+        if (
+            self.sale_line_id.lot_id
+            and available_quantity >= self.sale_line_id.product_uom_qty
+        ):
             lot_id = self.sale_line_id.lot_id
         return super()._update_reserved_quantity(
             need,
@@ -30,6 +33,12 @@ class StockMove(models.Model):
         vals = super()._prepare_move_line_vals(
             quantity=quantity, reserved_quant=reserved_quant
         )
-        if reserved_quant and self.sale_line_id.lot_id:
-            vals["lot_id"] = self.sale_line_id.lot_id.id
+        lot = self.sale_line_id.lot_id
+        if (
+            reserved_quant
+            and reserved_quant.lot_id
+            and lot
+            and reserved_quant.lot_id == lot
+        ):
+            vals["lot_id"] = lot.id
         return vals


### PR DESCRIPTION
In some case you don't have enought qty in one lot for cover the initial demand the system reserved for the all the quants the qtty to complete the initial demand, but the asignation in the smls are
completed with the lot chossing in the sale order line. This inconsit produce a lot a problems with the units reserved and you cannnot cancel the all reservation.
To solve this situation i propose this PR to ensure that Lot in the sol is use for the qty that may have and  if you could use others lots with quantity to complete if it's posible by the qty avaliable the inicial demand.