### PR TITLE
[14.0][IMP] sale_order_type: add sale order type to sales and invoice analysis reports

### DIFF
--- a/sale_order_type/__init__.py
+++ b/sale_order_type/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models
+from . import reports
 from . import wizards

--- a/sale_order_type/__manifest__.py
+++ b/sale_order_type/__manifest__.py
@@ -28,6 +28,8 @@
         "views/account_move_views.xml",
         "views/res_partner_view.xml",
         "data/default_type.xml",
+        "reports/account_invoice_report_view.xml",
+        "reports/sale_report_view.xml",
     ],
     "installable": True,
 }

--- a/sale_order_type/reports/__init__.py
+++ b/sale_order_type/reports/__init__.py
@@ -1,0 +1,4 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import account_invoice_report
+from . import sale_report

--- a/sale_order_type/reports/account_invoice_report.py
+++ b/sale_order_type/reports/account_invoice_report.py
@@ -1,0 +1,19 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class AccountInvoiceReport(models.Model):
+    _inherit = "account.invoice.report"
+
+    sale_type_id = fields.Many2one(
+        comodel_name="sale.order.type",
+        string="Sale Order Type",
+    )
+
+    def _select(self):
+        select_str = super()._select()
+        select_str += """
+            , move.sale_type_id as sale_type_id
+            """
+        return select_str

--- a/sale_order_type/reports/account_invoice_report_view.xml
+++ b/sale_order_type/reports/account_invoice_report_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_account_invoice_report_search" model="ir.ui.view">
+        <field name="inherit_id" ref="account.view_account_invoice_report_search" />
+        <field name="model">account.invoice.report</field>
+        <field name="arch" type="xml">
+            <filter name="user" position="before">
+                <filter
+                    string="Sale Order Type"
+                    name="sale_order_type"
+                    context="{'group_by':'sale_type_id'}"
+                />
+            </filter>
+        </field>
+    </record>
+
+</odoo>

--- a/sale_order_type/reports/sale_report.py
+++ b/sale_order_type/reports/sale_report.py
@@ -1,0 +1,19 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SaleReport(models.Model):
+    _inherit = "sale.report"
+
+    type_id = fields.Many2one(
+        comodel_name="sale.order.type",
+        string="Type",
+    )
+
+    # flake8: noqa
+    # pylint:disable=dangerous-default-value
+    def _query(self, with_clause="", fields={}, groupby="", from_clause=""):
+        fields["type_id"] = ", s.type_id as type_id"
+        groupby += ", s.type_id"
+        return super(SaleReport, self)._query(with_clause, fields, groupby, from_clause)

--- a/sale_order_type/reports/sale_report_view.xml
+++ b/sale_order_type/reports/sale_report_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_order_product_search" model="ir.ui.view">
+        <field name="inherit_id" ref="sale.view_order_product_search" />
+        <field name="model">sale.report</field>
+        <field name="arch" type="xml">
+            <filter name="User" position="before">
+                <filter
+                    string="Sale Order Type"
+                    name="sale_order_type"
+                    context="{'group_by':'type_id'}"
+                />
+            </filter>
+        </field>
+    </record>
+
+</odoo>

--- a/sale_order_type/tests/__init__.py
+++ b/sale_order_type/tests/__init__.py
@@ -1,3 +1,5 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from . import test_account_invoice_report
+from . import test_sale_order_report
 from . import test_sale_order_type

--- a/sale_order_type/tests/test_account_invoice_report.py
+++ b/sale_order_type/tests/test_account_invoice_report.py
@@ -1,0 +1,59 @@
+from odoo import fields
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("post_install", "-at_install")
+class TestAccountInvoiceReport(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.sale_order_types = cls.env["sale.order.type"].create(
+            [
+                {
+                    "name": "Normal Order",
+                },
+                {
+                    "name": "Special Order",
+                },
+            ]
+        )
+
+        cls.invoices = cls.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": cls.partner_a.id,
+                "invoice_date": fields.Date.from_string("2021-01-01"),
+                "sale_type_id": cls.sale_order_types[0].id,  # Normal Order
+                "currency_id": cls.currency_data["currency"].id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        None,
+                        {
+                            "product_id": cls.product_a.id,
+                            "quantity": 3,
+                            "price_unit": 750,
+                        },
+                    ),
+                    (
+                        0,
+                        None,
+                        {
+                            "product_id": cls.product_a.id,
+                            "quantity": 1,
+                            "price_unit": 3000,
+                        },
+                    ),
+                ],
+            }
+        )
+
+    def test_invoice_report_sale_order_type(self):
+        self.env["account.invoice.report"].read_group(
+            domain=[],
+            fields=["product_id, quantity, sale_type_id"],
+            groupby="sale_type_id",
+        )

--- a/sale_order_type/tests/test_sale_order_report.py
+++ b/sale_order_type/tests/test_sale_order_report.py
@@ -1,0 +1,55 @@
+from odoo.tests import tagged
+
+from odoo.addons.sale.tests.common import TestSaleCommon
+
+
+@tagged("post_install", "-at_install")
+class TestSaleReport(TestSaleCommon):
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.sale_order_types = cls.env["sale.order.type"].create(
+            [
+                {
+                    "name": "Normal Order",
+                },
+                {
+                    "name": "Special Order",
+                },
+            ]
+        )
+
+        # Create the SO with one order line
+        cls.sale_order = (
+            cls.env["sale.order"]
+            .with_context(tracking_disable=True)
+            .create(
+                {
+                    "partner_id": cls.partner_a.id,
+                    "partner_invoice_id": cls.partner_a.id,
+                    "partner_shipping_id": cls.partner_a.id,
+                    "pricelist_id": cls.company_data["default_pricelist"].id,
+                    "type_id": cls.sale_order_types[0].id,  # Normal Order
+                }
+            )
+        )
+        SaleOrderLine = cls.env["sale.order.line"].with_context(tracking_disable=True)
+        cls.sol_prod_order = SaleOrderLine.create(
+            {
+                "name": cls.company_data["product_order_no"].name,
+                "product_id": cls.company_data["product_order_no"].id,
+                "product_uom_qty": 5,
+                "product_uom": cls.company_data["product_order_no"].uom_id.id,
+                "price_unit": cls.company_data["product_order_no"].list_price,
+                "order_id": cls.sale_order.id,
+                "tax_id": False,
+            }
+        )
+
+    def test_sale_report_sale_order_type(self):
+        self.env["sale.report"].read_group(
+            domain=[],
+            fields=["product_id, quantity, type_id"],
+            groupby="type_id",
+        )


### PR DESCRIPTION
- add sale order type field to account invoice and sale order report
- add sale order type as group filter to account invoice report and sale order report view (pivot,graph)

![grafik](https://user-images.githubusercontent.com/226753/128627192-f1c69e4c-f15d-46aa-bd87-ae8f64ef9065.png)

![grafik](https://user-images.githubusercontent.com/226753/128627208-9e065ee6-546a-4de7-8e19-a3861e1f05e2.png)
