### PR TITLE
[12.0][FIX] sale_order_line_date depends on sale_stock

### DIFF
--- a/sale_order_line_date/__manifest__.py
+++ b/sale_order_line_date/__manifest__.py
@@ -18,7 +18,7 @@
     "category": "Sale",
     "license": "AGPL-3",
     "depends": [
-        "sale",
+        "sale_stock",
     ],
     "data": [
         "views/sale_order_view.xml",


### PR DESCRIPTION
Fixes #1705 
n.b. in v. 14.0 is already done