### PR TITLE
[14.0][IMP] sale_order_qty_change_no_recompute: Add context in test to prevent onchange quantity and some possible related error in another addons

### DIFF
--- a/sale_order_qty_change_no_recompute/models/sale_order.py
+++ b/sale_order_qty_change_no_recompute/models/sale_order.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import models
+from odoo.tools import config
 
 
 class SaleOrderLine(models.Model):
@@ -15,7 +16,11 @@ class SaleOrderLine(models.Model):
         property, and thus it can't be inherited due to the conflict of
         inheritance between Python and Odoo ORM, so we can consider this as a HACK.
         """
-        if field_name == "product_uom_qty":
+        ctx = self.env.context
+        if field_name == "product_uom_qty" and (
+            not config["test_enable"]
+            or (config["test_enable"] and ctx.get("prevent_onchange_quantity", False))
+        ):
             cls = type(self)
             for method in self._onchange_methods.get(field_name, ()):
                 if method == cls.product_uom_change:

--- a/sale_order_qty_change_no_recompute/tests/test_sale_order_qty_change.py
+++ b/sale_order_qty_change_no_recompute/tests/test_sale_order_qty_change.py
@@ -14,7 +14,9 @@ class TestSaleOrderQtyChange(SavepointCase):
             {"name": "Test Product 2", "list_price": 30.00, "taxes_id": False}
         )
         pricelist = cls.env["product.pricelist"].create({"name": "Test pricelist"})
-        sale_form = Form(cls.env["sale.order"])
+        sale_form = Form(
+            cls.env["sale.order"].with_context(prevent_onchange_quantity=True)
+        )
         sale_form.partner_id = cls.env.ref("base.res_partner_12")
         sale_form.pricelist_id = pricelist
         with sale_form.order_line.new() as cls.line_form:


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/sale-workflow/pull/1712

Add context in test to prevent onchange quantity and some possible related error in another addons.

Please @pedrobaeza and @chienandalu  can you review it?

@Tecnativa TT31537