### PR TITLE
[13.0][FIX] clean code and fix cutoff tz issues

### DIFF
--- a/sale_cutoff_time_delivery/models/sale_order.py
+++ b/sale_cutoff_time_delivery/models/sale_order.py
@@ -151,13 +151,9 @@ class SaleOrderLine(models.Model):
                 hour=cutoff.get("hour"), minute=cutoff.get("minute"), second=0
             )
         if date <= utc_cutoff_datetime or keep_same_day:
-            # Postpone delivery for date planned before cutoff to cutoff time
-            return date.replace(
-                hour=utc_cutoff_datetime.hour,
-                minute=utc_cutoff_datetime.minute,
-                second=0,
-            )
-        # Postpone delivery for order confirmed after cutoff to day after
-        return date.replace(
-            hour=utc_cutoff_datetime.hour, minute=utc_cutoff_datetime.minute, second=0,
-        ) + timedelta(days=1)
+            # Postpone delivery to today's cutoff
+            new_date = utc_cutoff_datetime
+        else:
+            # Postpone delivery to the next cutoff
+            new_date = utc_cutoff_datetime + timedelta(days=1)
+        return new_date


### PR DESCRIPTION
**Issue:**
Sometimes, there could be a gap between the date and the cutoff date when dealing with hours near midnight, depending on the TZ.

I.E.:
  - `UTC hour = 00:30` with `warehouse TZ = UTC-2`
  - `UTC hour = 23:30` with `warehouse TZ = UTC+2`
In such case we were just modifying the original date `hour` and `minutes` with the cutoff ones, which led to errors.

**solution:**
Since the goal of this module is to apply today's cutoff datetime or tomorrow's cutoff datetime, then better replacing the date with it, instead of picking its hour/minute.