### PR TITLE
[FIX][13.0] fix recompute at package qty change

### DIFF
--- a/sale_by_packaging/models/sale_order_line.py
+++ b/sale_by_packaging/models/sale_order_line.py
@@ -129,11 +129,17 @@ class SaleOrderLine(models.Model):
                 if "product_uom" in vals
                 else self.product_uom
             )
-            packaging = self._get_product_packaging_having_multiple_qty(
-                product, quantity, uom
-            )
-            if packaging:
-                return {"product_packaging": packaging.id}
+            # Here, we ensure that no package is already set on the line.
+            # If so, it could lead to errors, since product_packaging_qty
+            # isn't updated after product_packaging has been modified.
+            # The simple way to handle that is to not modify product_packaging
+            # if one is already set.
+            if not self.product_packaging:
+                packaging = self._get_product_packaging_having_multiple_qty(
+                    product, quantity, uom
+                )
+                if packaging:
+                    return {"product_packaging": packaging.id}
             # No need to raise an error here if no packaging has been found
             #  since the error on _check_product_packaging will be raised
         return {}

--- a/sale_by_packaging/tests/__init__.py
+++ b/sale_by_packaging/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_packaging_type_can_be_sold
 from . import test_sale_only_by_packaging
+from . import test_sale_line_onchanges

--- a/sale_by_packaging/tests/common.py
+++ b/sale_by_packaging/tests/common.py
@@ -1,0 +1,91 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.tests.common import Form, SavepointCase
+
+TU_PRODUCT_QTY = 20
+PL_PRODUCT_QTY = TU_PRODUCT_QTY * 30
+
+
+class Common(SavepointCase):
+    at_install = False
+    post_install = True
+
+    @classmethod
+    def setUpClass(cls):
+        super(Common, cls).setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.setUpClassPartner()
+        cls.setUpClassProduct()
+        cls.setUpClassPackagingType()
+        cls.setUpClassPackaging()
+        cls.setUpClassSaleOrder()
+        cls.setUpClassConfig()
+
+    @classmethod
+    def setUpClassConfig(cls):
+        cls.precision = cls.env["decimal.precision"].precision_get("Product Price")
+
+    @classmethod
+    def setUpClassPartner(cls):
+        cls.partner = cls.env.ref("base.res_partner_12")
+
+    @classmethod
+    def setUpClassProduct(cls):
+        cls.product = cls.env.ref("product.product_product_9")
+
+    @classmethod
+    def setUpClassPackagingType(cls):
+        cls.packaging_type_tu = cls.env["product.packaging.type"].create(
+            {"name": "Transport Unit", "code": "TU", "sequence": 1}
+        )
+        cls.packaging_type_pl = cls.env["product.packaging.type"].create(
+            {"name": "Pallet", "code": "PL", "sequence": 2}
+        )
+        cls.packaging_type_cannot_be_sold = cls.env["product.packaging.type"].create(
+            {
+                "name": "Can not be sold",
+                "code": "CNBS",
+                "sequence": 30,
+                "can_be_sold": False,
+            }
+        )
+
+    @classmethod
+    def setUpClassPackaging(cls):
+        cls.packaging_tu = cls.env["product.packaging"].create(
+            {
+                "name": "PACKAGING TU",
+                "product_id": cls.product.id,
+                "packaging_type_id": cls.packaging_type_tu.id,
+                "qty": TU_PRODUCT_QTY,
+            }
+        )
+        cls.packaging_pl = cls.env["product.packaging"].create(
+            {
+                "name": "PACKAGING PL",
+                "product_id": cls.product.id,
+                "packaging_type_id": cls.packaging_type_pl.id,
+                "qty": PL_PRODUCT_QTY,
+            }
+        )
+        cls.packaging_cannot_be_sold = cls.env["product.packaging"].create(
+            {
+                "name": "Test packaging cannot be sold",
+                "product_id": cls.product.id,
+                "qty": 10.0,
+                "packaging_type_id": cls.packaging_type_cannot_be_sold.id,
+            }
+        )
+        cls.sellable_packagings = cls.packaging_tu | cls.packaging_pl
+
+    @classmethod
+    def setUpClassSaleOrder(cls):
+        cls.so_model = cls.env["sale.order"]
+        sale_form = Form(cls.so_model)
+        sale_form.partner_id = cls.partner
+        with sale_form.order_line.new() as line:
+            line.product_id = cls.product
+            line.product_uom = cls.product.uom_id
+        cls.order = sale_form.save()
+        cls.order_line = cls.order.order_line

--- a/sale_by_packaging/tests/test_packaging_type_can_be_sold.py
+++ b/sale_by_packaging/tests/test_packaging_type_can_be_sold.py
@@ -1,55 +1,18 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo.exceptions import ValidationError
-from odoo.tests import SavepointCase
+
+from .common import Common
 
 
-class TestPackagingTypeCanBeSold(SavepointCase):
+class TestPackagingTypeCanBeSold(Common):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.partner = cls.env.ref("base.res_partner_12")
-        cls.product = cls.env.ref("product.product_product_9")
-        cls.packaging_type_can_be_sold = cls.env["product.packaging.type"].create(
-            {"name": "Can be sold", "code": "CBS", "sequence": 20}
-        )
-        cls.packaging_type_cannot_be_sold = cls.env["product.packaging.type"].create(
-            {
-                "name": "Can not be sold",
-                "code": "CNBS",
-                "sequence": 30,
-                "can_be_sold": False,
-            }
-        )
-        cls.packaging_can_be_sold = cls.env["product.packaging"].create(
-            {
-                "name": "Test packaging can be sold",
-                "product_id": cls.product.id,
-                "qty": 5.0,
-                "packaging_type_id": cls.packaging_type_can_be_sold.id,
-            }
-        )
-        cls.packaging_cannot_be_sold = cls.env["product.packaging"].create(
-            {
-                "name": "Test packaging cannot be sold",
-                "product_id": cls.product.id,
-                "qty": 10.0,
-                "packaging_type_id": cls.packaging_type_cannot_be_sold.id,
-            }
-        )
-        cls.order = cls.env["sale.order"].create({"partner_id": cls.partner.id})
-        cls.order_line = cls.env["sale.order.line"].create(
-            {
-                "order_id": cls.order.id,
-                "product_id": cls.product.id,
-                "product_uom": cls.product.uom_id.id,
-                "product_uom_qty": 3.0,
-            }
-        )
+    def setUpClassSaleOrder(cls):
+        super().setUpClassSaleOrder()
+        cls.order_line.product_uom_qty = 3.0
 
     def test_packaging_type_can_be_sold(self):
-        self.order_line.write({"product_packaging": self.packaging_can_be_sold.id})
+        self.order_line.write({"product_packaging": self.packaging_tu.id})
         with self.assertRaises(ValidationError):
             self.order_line.write(
                 {"product_packaging": self.packaging_cannot_be_sold.id}
@@ -72,10 +35,8 @@ class TestPackagingTypeCanBeSold(SavepointCase):
         self.packaging_cannot_be_sold.can_be_sold = True
         self.order_line.write({"product_packaging": self.packaging_cannot_be_sold.id})
         # Changing the packaging type on product.packaging updates can_be_sold
-        self.packaging_can_be_sold.unlink()
-        self.packaging_cannot_be_sold.packaging_type_id = (
-            self.packaging_type_can_be_sold
-        )
+        self.sellable_packagings.unlink()
+        self.packaging_cannot_be_sold.packaging_type_id = self.packaging_type_tu
         self.packaging_cannot_be_sold.packaging_type_id = (
             self.packaging_type_cannot_be_sold
         )

--- a/sale_by_packaging/tests/test_sale_line_onchanges.py
+++ b/sale_by_packaging/tests/test_sale_line_onchanges.py
@@ -1,0 +1,24 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.tests.common import Form
+
+from .common import PL_PRODUCT_QTY, TU_PRODUCT_QTY, Common
+
+
+class TestPackaging(Common):
+    def test_compute_qties(self):
+        with Form(self.order) as so:
+            with so.order_line.edit(0) as line:
+                line.product_packaging = self.packaging_tu
+                line.product_packaging_qty = 31
+        # (20*30)+20 = 31*20 = 620
+        expected_qty = TU_PRODUCT_QTY + PL_PRODUCT_QTY
+        self.assertEqual(self.order_line.product_uom_qty, expected_qty)
+        with Form(self.order) as so:
+            with so.order_line.edit(0) as line:
+                line.product_packaging_qty = 30
+        # 20*30 = 600
+        expected_qty = PL_PRODUCT_QTY
+        self.assertEqual(self.order_line.product_uom_qty, expected_qty)
+        self.assertEqual(self.order_line.product_packaging, self.packaging_tu)

--- a/sale_by_packaging/tests/test_sale_only_by_packaging.py
+++ b/sale_by_packaging/tests/test_sale_only_by_packaging.py
@@ -1,33 +1,15 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from odoo import fields
 from odoo.exceptions import ValidationError
-from odoo.tests import Form, SavepointCase
+from odoo.tests import Form
 from odoo.tools import mute_logger
 
+from .common import Common
 
-class TestSaleProductByPackagingOnly(SavepointCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.SaleOrder = cls.env["sale.order"]
-        cls.partner = cls.env.ref("base.res_partner_12")
-        cls.product = cls.env.ref("product.product_product_9")
-        cls.packaging = cls.env["product.packaging"].create(
-            {"name": "Test packaging", "product_id": cls.product.id, "qty": 5.0}
-        )
-        cls.order = cls.env["sale.order"].create({"partner_id": cls.partner.id})
-        cls.precision = cls.env["decimal.precision"].precision_get("Product Price")
 
+class TestSaleProductByPackagingOnly(Common):
     def test_write_auto_fill_packaging(self):
-        order_line = self.env["sale.order.line"].create(
-            {
-                "order_id": self.order.id,
-                "product_id": self.product.id,
-                "product_uom": self.product.uom_id.id,
-            }
-        )
+        order_line = self.order.order_line
         self.assertFalse(order_line.product_packaging)
         self.assertFalse(order_line.product_packaging_qty)
 
@@ -39,17 +21,11 @@ class TestSaleProductByPackagingOnly(SavepointCase):
         self.assertFalse(order_line.product_packaging)
         self.assertFalse(order_line.product_packaging_qty)
 
-        order_line.write({"product_uom_qty": self.packaging.qty * 2})
+        order_line.write({"product_uom_qty": self.packaging_tu.qty * 2})
         self.assertTrue(order_line.product_packaging)
         self.assertTrue(order_line.product_packaging_qty)
-        self.assertEqual(order_line.product_packaging.name, "Test packaging")
+        self.assertEqual(order_line.product_packaging, self.packaging_tu)
         self.assertEqual(order_line.product_packaging_qty, 2)
-
-        packaging_10 = self.env["product.packaging"].create(
-            {"name": "Test packaging 10", "product_id": self.product.id, "qty": 15.0}
-        )
-        order_line.write({"product_uom_qty": packaging_10.qty * 2})
-        self.assertEqual(order_line.product_packaging.name, "Test packaging 10")
 
         with self.assertRaises(ValidationError):
             order_line.write({"product_packaging": False})
@@ -58,40 +34,33 @@ class TestSaleProductByPackagingOnly(SavepointCase):
         """Check when the packaging should be set automatically on the line
         """
         # sell_only_by_packaging is default False
-        order_line_1 = self.env["sale.order.line"].create(
-            {
-                "order_id": self.order.id,
-                "product_id": self.product.id,
-                "product_uom": self.product.uom_id.id,
-                "product_uom_qty": self.packaging.qty * 2,
-            }
-        )
-        self.assertFalse(order_line_1.product_packaging)
-        self.assertFalse(order_line_1.product_packaging_qty)
+        with Form(self.order) as so:
+            with so.order_line.new() as so_line:
+                so_line.product_id = self.product
+                so_line.product_uom_qty = self.packaging_tu.qty * 2
+        so_line = self.order.order_line[-1]
+        self.assertFalse(so_line.product_packaging)
+        self.assertFalse(so_line.product_packaging_qty)
 
-        self.product.write({"sell_only_by_packaging": True})
-        order_line_1 = self.env["sale.order.line"].create(
-            {
-                "order_id": self.order.id,
-                "product_id": self.product.id,
-                "product_uom": self.product.uom_id.id,
-                "product_uom_qty": self.packaging.qty * 2,
-            }
-        )
-        self.assertTrue(order_line_1.product_packaging)
-        self.assertTrue(order_line_1.product_packaging_qty)
-        self.assertEqual(order_line_1.product_packaging.name, "Test packaging")
-        self.assertEqual(order_line_1.product_packaging_qty, 2)
+        # If sell_only_by_packaging is set, a packaging should be automatically
+        # picked if possible
+        self.product.sell_only_by_packaging = True
+        with Form(self.order) as so:
+            with so.order_line.new() as so_line:
+                so_line.product_id = self.product
+                so_line.product_uom_qty = self.packaging_tu.qty * 2
+        so_line = self.order.order_line[-1]
+        self.assertTrue(so_line.product_packaging)
+        self.assertTrue(so_line.product_packaging_qty)
+        self.assertEqual(so_line.product_packaging, self.packaging_tu)
+        self.assertEqual(so_line.product_packaging_qty, 2)
 
+        # If qty does not match a packaging qty, an exception should be raised
         with self.assertRaises(ValidationError):
-            self.env["sale.order.line"].create(
-                {
-                    "order_id": self.order.id,
-                    "product_id": self.product.id,
-                    "product_uom": self.product.uom_id.id,
-                    "product_uom_qty": 2,
-                }
-            )
+            with Form(self.order) as so:
+                with so.order_line.new() as so_line:
+                    so_line.product_id = self.product
+                    so_line.product_uom_qty = 2
 
     @mute_logger("odoo.tests.common.onchange")
     def test_convert_packaging_qty(self):
@@ -101,13 +70,11 @@ class TestSaleProductByPackagingOnly(SavepointCase):
         :return:
         """
         self.product.sell_only_by_packaging = True
-        packaging = fields.first(self.product.packaging_ids)
+        packaging = self.packaging_tu
         # For this step, the qty is not forced on the packaging so nothing
         # should happens if the qty doesn't match with packaging multiple.
-        with Form(self.SaleOrder) as sale_order:
-            sale_order.partner_id = self.partner
-            with sale_order.order_line.new() as so_line:
-                so_line.product_id = self.product
+        with Form(self.order) as sale_order:
+            with sale_order.order_line.edit(0) as so_line:
                 so_line.product_packaging = packaging
                 so_line.product_uom_qty = 12
                 self.assertAlmostEqual(
@@ -125,34 +92,32 @@ class TestSaleProductByPackagingOnly(SavepointCase):
                 so_line.product_packaging = packaging
         # Now force the qty on the packaging
         packaging.force_sale_qty = True
-        with Form(self.SaleOrder) as sale_order:
-            sale_order.partner_id = self.partner
-            with sale_order.order_line.new() as so_line:
-                so_line.product_id = self.product
+        with Form(self.order) as sale_order:
+            with sale_order.order_line.edit(0) as so_line:
                 so_line.product_packaging = packaging
-                so_line.product_uom_qty = 12
+                so_line.product_uom_qty = 50
                 self.assertAlmostEqual(
-                    so_line.product_uom_qty, 15, places=self.precision
+                    so_line.product_uom_qty, 60, places=self.precision
                 )
-                so_line.product_uom_qty = 10
+                so_line.product_uom_qty = 40
                 self.assertAlmostEqual(
-                    so_line.product_uom_qty, 10, places=self.precision
+                    so_line.product_uom_qty, 40, places=self.precision
                 )
-                so_line.product_uom_qty = 8
+                so_line.product_uom_qty = 38
                 self.assertAlmostEqual(
-                    so_line.product_uom_qty, 10, places=self.precision
+                    so_line.product_uom_qty, 40, places=self.precision
                 )
-                so_line.product_uom_qty = 11
+                so_line.product_uom_qty = 22
                 self.assertAlmostEqual(
-                    so_line.product_uom_qty, 15, places=self.precision
+                    so_line.product_uom_qty, 40, places=self.precision
                 )
-                so_line.product_uom_qty = 208
+                so_line.product_uom_qty = 72
                 self.assertAlmostEqual(
-                    so_line.product_uom_qty, 210, places=self.precision
+                    so_line.product_uom_qty, 80, places=self.precision
                 )
                 so_line.product_uom_qty = 209.98
                 self.assertAlmostEqual(
-                    so_line.product_uom_qty, 210, places=self.precision
+                    so_line.product_uom_qty, 220, places=self.precision
                 )
 
     def test_packaging_qty_non_zero(self):
@@ -161,16 +126,9 @@ class TestSaleProductByPackagingOnly(SavepointCase):
         The packaging quantity can not be zero.
         """
         self.product.write({"sell_only_by_packaging": True})
-        order_line = self.env["sale.order.line"].create(
-            {
-                "order_id": self.order.id,
-                "product_id": self.product.id,
-                "product_uom": self.product.uom_id.id,
-                "product_uom_qty": 10,  # 2 packs
-            }
-        )
+        self.order_line.product_uom_qty = 40  # 2 packs
         with self.assertRaises(ValidationError):
-            order_line.write({"product_uom_qty": 3, "product_packaging_qty": 0})
+            self.order_line.product_packaging_qty = 0
 
     def test_onchange_qty_is_not_pack_multiple(self):
         """ Check package when qantity is not a multiple of package quantity.
@@ -179,13 +137,6 @@ class TestSaleProductByPackagingOnly(SavepointCase):
         possible package an error is raised.
         """
         self.product.write({"sell_only_by_packaging": True})
-        order_line = self.env["sale.order.line"].create(
-            {
-                "order_id": self.order.id,
-                "product_id": self.product.id,
-                "product_uom": self.product.uom_id.id,
-                "product_uom_qty": 10,  # 2 packs
-            }
-        )
+        self.order_line.product_uom_qty = 40  # 2 packs
         with self.assertRaises(ValidationError):
-            order_line.write({"product_uom_qty": 3})
+            self.order_line.product_uom_qty = 18


### PR DESCRIPTION
Let's consider this case:
A product with 2 packaging :
  - Transport Unit (TU) with qty = 20
  - Pallet (PL) with qty = 600

A sale order line with the following:
  - packaging : transport unit
  - packaging quantity : 31
  - product qty : 620

If we decrease the packaging qty from 31 to 30, then the following happens:
  - The product qty is recomputed : 620 -> 600
  - The packaging is modified : TU -> PL
  - The product qty is recomputed as `packaging.qty * line.packaging_qty` -> `600 * 30` -> `18,000`
    which is wrong, it should be 600.
  
Proposition : change the packaging only is no one is already set.