### PR TITLE
[12.0][IMP]  sale_force_whole_invoiceability: allow forcing in done state too; fix invisibility domain

### DIFF
--- a/sale_force_whole_invoiceability/models/sale_order.py
+++ b/sale_force_whole_invoiceability/models/sale_order.py
@@ -13,7 +13,7 @@ class SaleOrder(models.Model):
             raise UserError(_(
                 "Only Sales Managers are allowed to force the lines to invoice"
             ))
-        if self.state != "sale":
+        if self.state not in ("sale", "done"):
             raise UserError(_(
                 "You can't perform this action over a sale order in this state"
             ))

--- a/sale_force_whole_invoiceability/views/sale_order_views.xml
+++ b/sale_force_whole_invoiceability/views/sale_order_views.xml
@@ -8,7 +8,7 @@
         <field name="groups_id" eval="[(4,ref('sales_team.group_sale_manager'))]"/>
         <field name="arch" type="xml">
             <button name="action_quotation_send" position="before">
-                <button name="force_lines_to_invoice_policy_order" string="Force Invoice Policy" type="object" attrs="{'invisible': [('state', 'not in', ['sale']), ('invoice_count', '>', 0)]}"/>
+                <button name="force_lines_to_invoice_policy_order" string="Force Invoice Policy" type="object" attrs="{'invisible': ['|', ('state', 'not in', ['sale', 'done']), ('invoice_count', '>', 0)]}"/>
             </button>
         </field>
     </record>


### PR DESCRIPTION
given we can configure Odoo to move sale orders to locked (`done`) [immediately](https://github.com/OCA/OCB/blob/14.0/addons/sale/models/res_config_settings.py#L10), it makes sense to show the button also in this state and allow the function to be called - we're still protected from messing up things by the check for `invoice_count`.