### PR TITLE
[14.0][ADD] sale_delivery_date

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# generated from manifests external_dependencies
+openupgradelib

--- a/sale_delivery_date/README.rst
+++ b/sale_delivery_date/README.rst
@@ -1,0 +1,1 @@
+wait 4 the bot

--- a/sale_delivery_date/__init__.py
+++ b/sale_delivery_date/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from .hooks import pre_init_hook

--- a/sale_delivery_date/__manifest__.py
+++ b/sale_delivery_date/__manifest__.py
@@ -1,0 +1,37 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+{
+    "name": "Sale Delivery Date",
+    "summary": (
+        "Postpones delivery dates based on customer preferences, "
+        "and/or warehouse configuration."
+    ),
+    "version": "14.0.1.0.0",
+    "category": "Sales",
+    "website": "https://github.com/OCA/sale-workflow",
+    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "maintainers": ["mmequignon"],
+    "license": "AGPL-3",
+    "installable": True,
+    "auto_install": True,
+    "depends": [
+        "delivery",
+        "partner_tz",
+        "sale_stock",
+        "stock_partner_delivery_window",
+        "stock_warehouse_calendar",
+    ],
+    "data": [
+        # reports
+        "reports/sale_order.xml",
+        "reports/stock_picking.xml",
+        # views
+        "views/res_partner.xml",
+        "views/stock_picking.xml",
+        "views/stock_warehouse.xml",
+    ],
+    "external_dependencies": {
+        "python": ["openupgradelib"],
+    },
+    "pre_init_hook": "pre_init_hook",
+}

--- a/sale_delivery_date/hooks.py
+++ b/sale_delivery_date/hooks.py
@@ -1,0 +1,38 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+import logging
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from openupgradelib import openupgrade
+except (ImportError, IOError) as err:
+    _logger.debug(err)
+
+
+MERGED_MODULE_NAMES = (
+    "sale_warehouse_calendar",
+    "sale_cutoff_time_delivery",
+    "sale_partner_delivery_window",
+    "sale_partner_cutoff_delivery_window",
+)
+
+
+def pre_init_hook(cr):
+    """Since 4 modules (sale_warehouse_calendar, sale_cutoff_time_delivery,
+    sale_partner_delivery_window, sale_partner_cutoff_delivery_window)
+    are merged into this one, we have to set the previous modules as
+    uninstalled, as well as we need to update the module names in ir_model_data
+    """
+    query_installed = """
+        SELECT id FROM ir_module_module
+        WHERE name IN %s and state IN ('installed', 'to upgrade')
+    """
+    cr.execute(query_installed, (MERGED_MODULE_NAMES,))
+    modules_installed = any(row[0] for row in cr.fetchall())
+    if modules_installed:
+        modules_to_merge = [
+            (merged_module_name, "sale_delivery_date")
+            for merged_module_name in MERGED_MODULE_NAMES
+        ]
+        openupgrade.update_module_names(cr, modules_to_merge, merge_modules=True)

--- a/sale_delivery_date/models/__init__.py
+++ b/sale_delivery_date/models/__init__.py
@@ -1,0 +1,6 @@
+from . import cutoff_time_mixin
+from . import res_partner
+from . import sale_order
+from . import sale_order_line
+from . import stock_picking
+from . import stock_warehouse

--- a/sale_delivery_date/models/cutoff_time_mixin.py
+++ b/sale_delivery_date/models/cutoff_time_mixin.py
@@ -1,0 +1,45 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+import math
+from datetime import time
+
+from odoo import api, fields, models
+
+from odoo.addons.base.models.res_partner import _tz_get
+
+
+class TimeCutoffMixin(models.AbstractModel):
+
+    _name = "time.cutoff.mixin"
+    _description = "Time Cut-off Mixin"
+
+    cutoff_time = fields.Float()
+    tz = fields.Selection(_tz_get, string="Timezone")
+
+    def get_cutoff_time(self):
+        hour, minute = self._get_hour_min_from_value(self.cutoff_time)
+        return {
+            "hour": hour,
+            "minute": minute,
+            "tz": self.tz,
+        }
+
+    @api.model
+    def _get_hour_min_from_value(self, value):
+        hour = math.floor(value)
+        minute = round((value % 1) * 60)
+        if minute == 60:
+            minute = 0
+            hour += 1
+        return hour, minute
+
+    @api.model
+    def float_to_time_repr(self, value):
+        pattern = "%02d:%02d"
+        hour, minute = self._get_hour_min_from_value(value)
+        return pattern % (hour, minute)
+
+    @api.model
+    def float_to_time(self, value):
+        hour, minute = self._get_hour_min_from_value(value)
+        return time(hour=hour, minute=minute)

--- a/sale_delivery_date/models/res_partner.py
+++ b/sale_delivery_date/models/res_partner.py
@@ -1,0 +1,103 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from datetime import datetime, timedelta
+
+from odoo import _, fields, models
+from odoo.exceptions import UserError
+from odoo.tools.date_utils import date_range
+
+
+class ResPartner(models.Model):
+    _name = "res.partner"
+    _inherit = ["res.partner", "time.cutoff.mixin"]
+
+    order_delivery_cutoff_preference = fields.Selection(
+        [
+            ("warehouse_cutoff", "Use global (warehouse) cutoff time"),
+            ("partner_cutoff", "Use partner's cutoff time"),
+        ],
+        string="Delivery orders cutoff preference",
+        default="warehouse_cutoff",
+        help="Define the cutoff time for delivery orders:\n\n"
+        "* Use global (warehouse) cutoff time: Delivery order for sale orders"
+        " will be postponed to the next warehouse cutoff time\n"
+        "* Use partner's cutoff time: Delivery order for sale orders"
+        " will be postponed to the next partner's cutoff time\n\n"
+        "Example: If cutoff is set to 09:00, any sale order confirmed before "
+        "09:00 will have its delivery order postponed to 09:00, and any sale "
+        "order confirmed after 09:00 will have its delivery order postponed "
+        "to 09:00 on the following day.",
+    )
+
+    def next_delivery_window_start_datetime(self, from_date=None, timedelta_days=None):
+        """Get next starting datetime in a preferred delivery window.
+
+        If from_date is already in a delivery window, from_date is "the next"
+
+        :param from_date: Datetime object (Leave empty to use now())
+        :param timedelta_days: Number of days to use in the computation
+                               (Leave empty to use 7 days or 1 week)
+        :return: Datetime object
+        """
+        self.ensure_one()
+        if not from_date:
+            from_date = datetime.now()
+        if self.is_in_delivery_window(from_date):
+            return from_date
+        if timedelta_days is None:
+            timedelta_days = 7
+        if self.delivery_time_preference == "workdays":
+            datetime_windows = self.get_next_workdays_datetime(
+                from_date, from_date + timedelta(days=timedelta_days)
+            )
+        else:
+            datetime_windows = self.get_next_windows_start_datetime(
+                from_date, from_date + timedelta(days=timedelta_days)
+            )
+        for dwin_start in datetime_windows:
+            if dwin_start >= from_date:
+                return dwin_start
+        raise UserError(
+            _("Something went wrong trying to find next delivery window. Date: %s")
+            % str(from_date)
+        )
+
+    def get_next_workdays_datetime(self, from_datetime, to_datetime):
+        """Returns all the delivery windows in the provided date range.
+
+        :param from_datetime: Datetime object
+        :param to_datetime: Datetime object
+        :return: List of Datetime objects
+        """
+        dates = date_range(from_datetime, to_datetime, timedelta(days=1))
+        return [date for date in dates if date.weekday() < 5]
+
+    def get_next_windows_start_datetime(self, from_datetime, to_datetime):
+        """Get all delivery windows start time.
+
+        Range from from_datetime weekday to to_datetime weekday.
+
+        Note result can include a start datetime that is before from_datetime
+        on the from_datetime weekday
+
+        :param from_datetime: Datetime object
+        :param to_datetime: Datetime object
+        :return: List of Datetime objects
+        """
+        res = list()
+        for this_datetime in date_range(from_datetime, to_datetime, timedelta(days=1)):
+            this_weekday_number = this_datetime.weekday()
+            this_weekday = self.env["time.weekday"].search(
+                [("name", "=", this_weekday_number)], limit=1
+            )
+            # Sort by start time to ensure the window we'll find will be the first
+            # one for the weekday
+            this_weekday_windows = self.delivery_time_window_ids.filtered(
+                lambda w: this_weekday in w.time_window_weekday_ids
+            ).sorted("time_window_start")
+            for win in this_weekday_windows:
+                this_weekday_start_datetime = datetime.combine(
+                    this_datetime, win.get_time_window_start_time()
+                )
+                res.append(this_weekday_start_datetime)
+        return res

--- a/sale_delivery_date/models/sale_order.py
+++ b/sale_delivery_date/models/sale_order.py
@@ -1,0 +1,88 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import _, api, fields, models
+from odoo.tools.misc import format_datetime
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    display_expected_date_ok = fields.Boolean(
+        string="Display Expected Date Ok",
+        compute="_compute_display_expected_date_ok",
+    )
+
+    @api.depends(
+        "partner_shipping_id.delivery_time_preference",
+        "partner_shipping_id.delivery_time_window_ids",
+        "partner_shipping_id.delivery_time_window_ids.time_window_start",
+        "partner_shipping_id.delivery_time_window_ids.time_window_end",
+        "partner_shipping_id.delivery_time_window_ids.time_window_weekday_ids",
+        "partner_shipping_id.order_delivery_cutoff_preference",
+        "partner_shipping_id.cutoff_time",
+    )
+    def _compute_expected_date(self):
+        """Add dependencies to consider fixed delivery windows"""
+        return super()._compute_expected_date()
+
+    @api.onchange("commitment_date")
+    def _onchange_commitment_date(self):
+        """Warns if commitment date is not a preferred window for delivery"""
+        res = super()._onchange_commitment_date()
+        if res and "warning" in res:
+            return res
+        ps = self.partner_shipping_id
+        if ps and self.commitment_date and ps.delivery_time_preference != "anytime":
+            if not ps.is_in_delivery_window(self.commitment_date):
+                return {"warning": self._commitment_date_no_delivery_window_match_msg()}
+
+    def _commitment_date_no_delivery_window_match_msg(self):
+        ps = self.partner_shipping_id
+        commitment_date = self.commitment_date
+        if ps.delivery_time_preference == "workdays":
+            message = _(
+                "The delivery date is {} ({}), but the partner is "
+                "set to prefer deliveries on working days."
+            ).format(commitment_date, commitment_date.strftime("%A"))
+        else:
+            windows = ps.get_delivery_windows().get(ps.id)
+            message = _(
+                "The delivery date is %s, but the shipping "
+                "partner is set to prefer deliveries on following "
+                "time windows:\n%s"
+            ) % (
+                format_datetime(self.env, self.commitment_date),
+                "\n".join(["  * %s" % w.display_name for w in windows]),
+            )
+        return {
+            "title": _(
+                "Commitment date does not match shipping "
+                "partner's Delivery time schedule preference."
+            ),
+            "message": message,
+        }
+
+    @api.depends("commitment_date", "expected_date")
+    def _compute_display_expected_date_ok(self):
+        for record in self:
+            record.display_expected_date_ok = record._get_display_expected_date_ok()
+
+    def _get_display_expected_date_ok(self):
+        """Conditions to display the expected date on the so report."""
+        # display_expected_date_ok is True date is set
+        self.ensure_one()
+        return bool(self.commitment_date or self.expected_date)
+
+    def get_cutoff_time(self):
+        self.ensure_one()
+        partner = self.partner_shipping_id
+        if (
+            partner.order_delivery_cutoff_preference == "warehouse_cutoff"
+            and self.warehouse_id.apply_cutoff
+        ):
+            return self.warehouse_id.get_cutoff_time()
+        elif partner.order_delivery_cutoff_preference == "partner_cutoff":
+            return self.partner_shipping_id.get_cutoff_time()
+        else:
+            return {}

--- a/sale_delivery_date/models/sale_order_line.py
+++ b/sale_delivery_date/models/sale_order_line.py
@@ -1,0 +1,251 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+import logging
+from datetime import datetime, time, timedelta
+
+import pytz
+
+from odoo import api, fields, models
+
+from odoo.addons.partner_tz.tools import tz_utils
+
+_logger = logging.getLogger(__name__)
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _prepare_procurement_values(self, group_id=False):
+        res = super()._prepare_procurement_values(group_id=group_id)
+        res = self._cutoff_time_delivery_prepare_procurement_values(res)
+        res = self._warehouse_calendar_prepare_procurement_values(res)
+        res = self._delivery_window_prepare_procurement_values(res)
+        return res
+
+    def _cutoff_time_delivery_prepare_procurement_values(self, res):
+        date_planned = res.get("date_planned")
+        if not date_planned:
+            return res
+        new_date_planned = self._prepare_procurement_values_cutoff_time(
+            fields.Datetime.to_datetime(date_planned),
+            # if we have a commitment date, even if we are too late, respect
+            # the original planned date (but change the time), the transfer
+            # will be considered as "late"
+            keep_same_day=bool(self.order_id.commitment_date),
+        )
+        if new_date_planned:
+            res["date_planned"] = new_date_planned
+        return res
+
+    def _warehouse_calendar_prepare_procurement_values(self, res):
+        date_planned = res.get("date_planned")
+        calendar = self.order_id.warehouse_id.calendar_id
+        if date_planned and calendar:
+            customer_lead, security_lead, workload = self._get_delays()
+            # plan_days() expect a number of days instead of a delay
+            workload_days = self._delay_to_days(workload)
+            td_workload = timedelta(days=workload)
+            # Remove the workload that has been added by odoo
+            date_planned -= td_workload
+            # Add the workload, with respect to the wh calendar
+            res["date_planned"] = calendar.plan_days(
+                workload_days, date_planned, compute_leaves=True
+            )
+        return res
+
+    def _delivery_window_prepare_procurement_values(self, res):
+        date_planned = res.get("date_planned")
+        if not date_planned:
+            return res
+        new_date_planned = self._prepare_procurement_values_time_windows(
+            fields.Datetime.to_datetime(date_planned)
+        )
+        if new_date_planned:
+            res["date_planned"] = new_date_planned
+        return res
+
+    def _prepare_procurement_values_time_windows(self, date_planned):
+        # ORIGINAL
+        if (
+            self.order_id.partner_shipping_id.delivery_time_preference != "time_windows"
+            # if a commitment_date is set we don't change the result as lead
+            # time and delivery windows must have been considered
+            or self.order_id.commitment_date
+        ):
+            _logger.debug(
+                "Commitment date set on order %s. Delivery window not applied "
+                "on line.",
+                self.order_id.name,
+            )
+            return
+        # If no commitment date is set, we must consider next preferred delivery
+        #  window to postpone date_planned
+
+        # Remove security lead time to ensure the delivery date (and not the
+        # date planned of the picking) will match delivery windows
+        date_planned_without_sec_lead = date_planned + timedelta(
+            days=self.order_id.company_id.security_lead
+        )
+        ops = self.order_id.partner_shipping_id
+        next_preferred_date = ops.next_delivery_window_start_datetime(
+            from_date=date_planned_without_sec_lead
+        )
+        # Add back security lead time
+        next_preferred_date_with_sec_lead = next_preferred_date - timedelta(
+            days=self.order_id.company_id.security_lead
+        )
+        if date_planned != next_preferred_date_with_sec_lead:
+            _logger.debug(
+                "Delivery window applied for order %s. Date planned for line %s"
+                " rescheduled from %s to %s",
+                self.order_id.name,
+                self.name,
+                date_planned,
+                next_preferred_date_with_sec_lead,
+            )
+            # if we have a new datetime proposed by a delivery time window,
+            # apply the warehouse/partner cutoff time
+            cutoff_datetime = self._prepare_procurement_values_cutoff_time(
+                next_preferred_date_with_sec_lead,
+                # the correct day has already been computed, only change
+                # the cut-off time
+                keep_same_day=True,
+            )
+            if cutoff_datetime:
+                return cutoff_datetime
+            return next_preferred_date_with_sec_lead
+        else:
+            _logger.debug(
+                "Delivery window not applied for order %s. Date planned for line %s",
+                " already in delivery window",
+                self.order_id.name,
+                self.name,
+            )
+        return
+
+    def _delay_to_days(self, number_of_days):
+        """Converts a delay to a number of days."""
+        return number_of_days + 1
+
+    def _get_delays(self):
+        # customer_lead is security_lead + workload, as explained on the field
+        customer_lead = self.customer_lead or 0.0
+        security_lead = self.company_id.security_lead or 0.0
+        workload = customer_lead - security_lead
+        return customer_lead, security_lead, workload
+
+    def _expected_date(self):
+        # Computes the expected date with respect to the WH calendar, if any.
+        expected_date = super()._expected_date()
+        expected_date = self._cutoff_time_delivery_expected_date(expected_date)
+        expected_date = self._warehouse_calendar_expected_date(expected_date)
+        expected_date = self._delivery_window_expected_date(expected_date)
+        return expected_date
+
+    def _warehouse_calendar_expected_date(self, expected_date):
+        calendar = self.order_id.warehouse_id.calendar_id
+        if calendar:
+            customer_lead, security_lead, workload = self._get_delays()
+            td_customer_lead = timedelta(days=customer_lead)
+            td_security_lead = timedelta(days=security_lead)
+            # plan_days() expect a number of days instead of a delay
+            workload_days = self._delay_to_days(workload)
+            # Remove customer_lead added to order_date in sale_stock
+            expected_date -= td_customer_lead
+            # Add the workload, with respect to the wh calendar
+            expected_date = calendar.plan_days(
+                workload_days, expected_date, compute_leaves=True
+            )
+            # add back the security lead
+            expected_date += td_security_lead
+        return expected_date
+
+    def _delivery_window_expected_date(self, expected_date):
+        partner = self.order_id.partner_shipping_id
+        if not partner or partner.delivery_time_preference == "anytime":
+            return expected_date
+        return partner.next_delivery_window_start_datetime(from_date=expected_date)
+
+    @api.depends("order_id.expected_date")
+    def _compute_qty_at_date(self):
+        """Trigger computation of qty_at_date when expected_date is updated"""
+        return super()._compute_qty_at_date()
+
+    def _prepare_procurement_values_cutoff_time(
+        self, date_planned, keep_same_day=False
+    ):
+        """Apply the cut-off time on a planned date
+
+        The cut-off configuration is taken on the partner if set, otherwise
+        on the warehouse.
+
+        By default, if the planned date is the same day but after the cut-off,
+        the new planned date is delayed one day later. The argument
+        keep_same_day forces keeping the same day.
+        """
+        cutoff = self.order_id.get_cutoff_time()
+        partner = self.order_id.partner_shipping_id
+        if not cutoff:
+            if not self.order_id.warehouse_id.apply_cutoff:
+                _logger.debug(
+                    "No cutoff applied on order %s as partner %s is set to use "
+                    "%s and warehouse %s doesn't apply cutoff."
+                    % (
+                        self.order_id,
+                        partner,
+                        partner.order_delivery_cutoff_preference,
+                        self.order_id.warehouse_id,
+                    )
+                )
+            else:
+                _logger.warning(
+                    "No cutoff applied on order %s. %s time not applied"
+                    "on line %s."
+                    % (self.order_id, partner.order_delivery_cutoff_preference, self)
+                )
+            return
+        new_date_planned = self._get_utc_cutoff_datetime(
+            cutoff, date_planned, keep_same_day
+        )
+        _logger.debug(
+            "%s applied on order %s. Date planned for line %s"
+            " rescheduled from %s to %s"
+            % (
+                partner.order_delivery_cutoff_preference,
+                self.order_id,
+                self,
+                date_planned,
+                new_date_planned,
+            )
+        )
+        return new_date_planned
+
+    def _cutoff_time_delivery_expected_date(self, expected_date):
+        cutoff = self.order_id.get_cutoff_time()
+        if not cutoff:
+            return expected_date
+        return self._get_utc_cutoff_datetime(cutoff, expected_date)
+
+    def _get_utc_cutoff_datetime(self, cutoff, date, keep_same_day=False):
+        tz = cutoff.get("tz")
+        if tz:
+            cutoff_time = time(hour=cutoff.get("hour"), minute=cutoff.get("minute"))
+            # Convert here to naive datetime in UTC
+            tz_loc = pytz.timezone(tz)
+            tz_date = date.astimezone(tz_loc)
+            tz_cutoff_datetime = datetime.combine(tz_date, cutoff_time)
+            utc_cutoff_datetime = tz_utils.tz_to_utc_naive_datetime(
+                tz_loc, tz_cutoff_datetime
+            )
+        else:
+            utc_cutoff_datetime = date.replace(
+                hour=cutoff.get("hour"), minute=cutoff.get("minute"), second=0
+            )
+        if date <= utc_cutoff_datetime or keep_same_day:
+            # Postpone delivery to today's cutoff
+            new_date = utc_cutoff_datetime
+        else:
+            # Postpone delivery to tomorrow's cutoff
+            new_date = utc_cutoff_datetime + timedelta(days=1)
+        return new_date

--- a/sale_delivery_date/models/stock_picking.py
+++ b/sale_delivery_date/models/stock_picking.py
@@ -1,0 +1,118 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from datetime import timedelta
+
+from psycopg2 import sql
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    cutoff_time_hms = fields.Char(
+        compute="_compute_cutoff_time_hms", store=True, default="00:00"
+    )
+    cutoff_time_diff = fields.Integer(
+        compute="_compute_cutoff_time_diff",
+        search="_search_cutoff_time_diff",
+        store=False,
+    )
+
+    @api.depends("location_id")
+    def _compute_cutoff_time_diff(self):
+        """Compute the stock.picking status in relation to warehouse cut-off time.
+
+        Possible values are:
+        -1 schedulled_date is in the past of yesterday's cutoff time
+         0 scheduled_date is between yesterday and today's cuttoff
+         1 scheduled_date is in the future of today's cutoff time
+
+        """
+        for record in self:
+            warehouse = record.location_id.get_warehouse()
+            hour, minute = warehouse._get_hour_min_from_value(warehouse.cutoff_time)
+            today_cutoff = fields.Datetime.now().replace(
+                hour=hour, minute=minute, second=0
+            )
+            yesterday_cutoff = fields.Datetime.subtract(today_cutoff, days=1)
+            if record.scheduled_date < yesterday_cutoff:
+                record.cutoff_time_diff = -1
+            elif record.scheduled_date > today_cutoff:
+                record.cutoff_time_diff = 1
+            else:
+                record.cutoff_time_diff = 0
+
+    def _search_cutoff_time_diff(self, operator, value):
+        if operator not in ("=", "!="):
+            raise UserError(_("Unsupported search operator %s") % (operator,))
+        today = fields.Datetime.now()
+        yesterday = fields.Datetime.subtract(today, days=1)
+        params = {
+            "yesterday": fields.Date.to_string(yesterday),
+            "today": fields.Date.to_string(today),
+        }
+        if value == -1:
+            where = """
+                scheduled_date < date(%(yesterday)s) + CAST(cutoff_time_hms AS Time)
+            """
+        elif value == 0:
+            where = """
+                scheduled_date >= date(%(yesterday)s) + CAST(cutoff_time_hms AS Time)
+                AND
+                scheduled_date <= date(%(today)s) + CAST(cutoff_time_hms AS Time)
+            """
+        elif value == 1:
+            where = """
+                scheduled_date > date(%(today)s) + CAST(cutoff_time_hms AS Time)
+            """
+        query = "SELECT id FROM stock_picking WHERE {}"
+        # Disabling pylint because this is correct according to the doc
+        # https://www.psycopg.org/docs/sql.html#module-psycopg2.sql
+        self.env.cr.execute(  # pylint: disable=E8103
+            sql.SQL(query).format(sql.SQL(where)), params
+        )
+        rows = self.env.cr.fetchall()
+        picking_ids = [row[0] for row in rows]
+        if operator == "=":
+            new_operator = "in"
+        else:
+            new_operator = "not in"
+        return [("id", new_operator, picking_ids)]
+
+    @api.depends("location_id")
+    def _compute_cutoff_time_hms(self):
+        """Keep the time of the cutoff for the related warehouse
+
+        In the format HH:MM which Postgres translate easily in Time format
+        There is a limitation here if the cutoff time change on the warehouse
+        record, it will not be propagated (But should not happen often).
+        """
+        for record in self:
+            wh = record.location_id.get_warehouse()
+            record.cutoff_time_hms = wh.float_to_time_repr(wh.cutoff_time)
+
+    def _planned_delivery_date(self):
+        res = super()._planned_delivery_date()
+        sec_lead_time = self.company_id.security_lead
+        if sec_lead_time:
+            res += timedelta(days=sec_lead_time)
+        return self.scheduled_date
+
+    @api.onchange("scheduled_date")
+    def _onchange_scheduled_date(self):
+        res = super()._onchange_scheduled_date()
+        if res and "warning" in res:
+            sec_lead_time = self.company_id.security_lead
+            if sec_lead_time:
+                res["warning"]["message"] += (
+                    _(
+                        "\nConsidering the security lead time of %s days defined on "
+                        "the company, the delivery will not match the partner time"
+                        "windows preference."
+                    )
+                    % sec_lead_time
+                )
+        return res

--- a/sale_delivery_date/models/stock_warehouse.py
+++ b/sale_delivery_date/models/stock_warehouse.py
@@ -1,0 +1,11 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class StockWarehouse(models.Model):
+    _name = "stock.warehouse"
+    _inherit = ["stock.warehouse", "time.cutoff.mixin"]
+
+    apply_cutoff = fields.Boolean()

--- a/sale_delivery_date/readme/CONTRIBUTORS.rst
+++ b/sale_delivery_date/readme/CONTRIBUTORS.rst
@@ -1,0 +1,4 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Simone Orsi <simahawk@gmail.com>
+* Matthieu Méquignon <matthieu.mequignon@camptocamp.com>

--- a/sale_delivery_date/readme/DESCRIPTION.rst
+++ b/sale_delivery_date/readme/DESCRIPTION.rst
@@ -1,0 +1,20 @@
+Cutoff
+------
+
+Potpone order preparation by 1 day if it has been validated after
+the partner or the warehouse cutoff.
+
+This can be bypassed if commitment date is set.
+
+
+Warehouse Calendar
+------------------
+
+Postpone delivery according to the warehouse calendar, if any.
+
+
+Partner delivery window
+-----------------------
+
+Allows to define scheduling preference for delivery orders on customers,
+in order to select possible delivery windows to postpone deliveries to.

--- a/sale_delivery_date/readme/ROADMAP.rst
+++ b/sale_delivery_date/readme/ROADMAP.rst
@@ -1,0 +1,15 @@
+The following modules (available in 13.0) has been merged into this module:
+ - sale_warehouse_calendar
+ - sale_cutoff_time_delivery
+ - sale_partner_delivery_window
+ - sale_partner_cutoff_delivery_window
+
+The reason for that is that `sale_warehouse_calendar` overrides have to be
+executed between `sale_cutoff_time_delivery` and `sale_partner_delivery_window`,
+and there's no other clean way to do that.
+
+However, there's still a few things to deal with:
+ - Clean tests
+ - Clean code
+ - Use TZ where it is not the case
+ - Use calendar instead of time windows when delivery preference is `working days`

--- a/sale_delivery_date/readme/USAGE.rst
+++ b/sale_delivery_date/readme/USAGE.rst
@@ -1,0 +1,17 @@
+To use this, you have to configure a few things:
+
+- You may configure the cutoff by either:
+
+  - setting the order cutoff preference to `warehouse_cutoff`,
+    in order to use the warehouse cutoff.
+  - setting the order cutoff preference to `partner_cutoff`,
+    in order to use the partner cutoff.
+
+- By default, customer's delivery window is set to `anytime` (default odoo behavior).
+  It can also be set to `working days` or `time window`.
+  If the latter is chosen, then time windows will have to be configured on the
+  customer.
+
+- By default, warehouse working hours aren't taken into account
+  when computing the scheduled date. If you want to use this feature, just
+  add a calendar on the warehouse, and enable the `apply cutoff` option.

--- a/sale_delivery_date/reports/sale_order.xml
+++ b/sale_delivery_date/reports/sale_order.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template
+        id="report_saleorder_document"
+        inherit_id="sale.report_saleorder_document"
+    >
+        <xpath expr="//p[@t-field='doc.validity_date']/.." position="after">
+            <div t-if="doc.display_expected_date_ok" class="col-auto mw-100 mb-2">
+                <strong>Expected delivery date:</strong>
+                <p
+                    t-if="doc.commitment_date"
+                    class="m-0"
+                    t-field="doc.commitment_date"
+                    t-options="{'date_only': 'True'}"
+                />
+                <p
+                    t-else=""
+                    class="m-0"
+                    t-field="doc.expected_date"
+                    t-options="{'date_only': 'True'}"
+                />
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/sale_delivery_date/reports/stock_picking.xml
+++ b/sale_delivery_date/reports/stock_picking.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <template id="report_delivery_document" inherit_id="stock.report_delivery_document">
+        <xpath expr="//div[@name='div_sched_date']" position="after">
+            <t t-set="order" t-value="o.sale_id" />
+            <div
+                t-if="order.commitment_date or order.expected_date"
+                class="col-auto mw-100 mb-2"
+            >
+                <strong>Expected delivery date:</strong>
+                <p
+                    t-if="order.commitment_date"
+                    class="m-0"
+                    t-field="order.commitment_date"
+                    t-options="{'date_only': 'True'}"
+                />
+                <p
+                    t-else=""
+                    class="m-0"
+                    t-field="order.expected_date"
+                    t-options="{'date_only': 'True'}"
+                />
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/sale_delivery_date/tests/__init__.py
+++ b/sale_delivery_date/tests/__init__.py
@@ -1,0 +1,6 @@
+from . import test_integration
+from . import test_reports
+from . import test_sale_cutoff_time_delivery
+from . import test_sale_partner_cutoff_delivery_window
+from . import test_sale_warehouse_calendar
+from . import test_sale_partner_delivery_window

--- a/sale_delivery_date/tests/common.py
+++ b/sale_delivery_date/tests/common.py
@@ -1,0 +1,168 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.tests.common import Form, SavepointCase
+from odoo.tools import mute_logger
+
+PARTNER_CUTOFF_TIME = 9.0
+WAREHOUSE_CUTOFF_TIME = 10.0
+TZ = "Europe/Paris"
+
+
+class Common(SavepointCase):
+    """Common test class providing helpful methods when writing tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.setUpClassCompany()
+        cls.setUpClassPartner()
+        cls.setUpClassProduct()
+        cls.setUpClassCommon()
+        cls.setUpClassCalendar()
+        cls.setUpClassWarehouse()
+        cls.setUpClassOrder()
+
+    @classmethod
+    def setUpClassCompany(cls):
+        cls.company = cls.env.ref("base.main_company")
+        report_layout = cls.env.ref("web.external_layout_standard")
+        paperformat_a4 = cls.env.ref("base.paperformat_euro")
+        cls.company.write(
+            {
+                # the global lead time will always plan 1 day before
+                "security_lead": 1.00,
+                "external_report_layout_id": report_layout.id,
+                "paperformat_id": paperformat_a4.id,
+            }
+        )
+
+    @classmethod
+    def setUpClassPartner(cls):
+        cls.customer_partner_cutoff = cls.env["res.partner"].create(
+            {
+                "name": "Partner cutoff",
+                "order_delivery_cutoff_preference": "partner_cutoff",
+                "tz": TZ,
+                "cutoff_time": PARTNER_CUTOFF_TIME,
+            }
+        )
+        cls.customer_warehouse_cutoff = cls.env["res.partner"].create(
+            {
+                "name": "Partner warehouse cutoff",
+                "order_delivery_cutoff_preference": "warehouse_cutoff",
+                "tz": TZ,
+            }
+        )
+        cls.customers = cls.customer_partner_cutoff | cls.customer_warehouse_cutoff
+
+    @classmethod
+    def setUpClassOrder(cls):
+        products = cls._get_default_products()
+        cls.order_partner_cutoff = cls._create_sale_order(
+            cls.customer_partner_cutoff, products
+        )
+        cls.order_warehouse_cutoff = cls._create_sale_order(
+            cls.customer_warehouse_cutoff, products
+        )
+
+    @classmethod
+    def setUpClassCalendar(cls):
+        name = "40 Hours"
+        attendances = [(9, 17, i) for i in range(5)]
+        cls.calendar = cls.env["resource.calendar"].create(
+            {
+                "name": name,
+                "attendance_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "%s_%d" % (name, index),
+                            "hour_from": att[0],
+                            "hour_to": att[1],
+                            "dayofweek": str(att[2]),
+                        },
+                    )
+                    for index, att in enumerate(attendances)
+                ],
+            }
+        )
+
+    @classmethod
+    def setUpClassWarehouse(cls):
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.warehouse.write(
+            {
+                "apply_cutoff": True,
+                "cutoff_time": WAREHOUSE_CUTOFF_TIME,
+                "tz": TZ,
+                "calendar_id": cls.calendar,
+            }
+        )
+
+    @classmethod
+    def setUpClassProduct(cls):
+        cls.product = cls.env.ref("product.product_product_9")
+        cls.product.sale_delay = 1
+
+    @classmethod
+    def setUpClassCommon(cls):
+        cls.carrier = cls.env.ref("delivery.delivery_carrier")
+
+    @classmethod
+    def _get_default_products(cls):
+        return [(cls.product, 1)]
+
+    @classmethod
+    def _create_sale_order(cls, partner, products, partner_shipping=None):
+        """Create a sale order for the given `partner`.
+
+        - `products` is a list of tuples `[(product, qty), ...]`
+        - `partner_shipping` is an optional delivery address
+        """
+        sale_form = Form(cls.env["sale.order"])
+        sale_form.partner_id = partner
+        if partner_shipping:
+            sale_form.partner_shipping_id = partner_shipping
+        with mute_logger("odoo.tests.common.onchange"):
+            for product, qty in products:
+                with sale_form.order_line.new() as line:
+                    line.product_id = product
+                    line.product_uom_qty = qty
+        return sale_form.save()
+
+    @classmethod
+    def _add_shipping_on_sale_order(cls, order):
+        delivery_wizard = Form(
+            cls.env["choose.delivery.carrier"].with_context(
+                {
+                    "default_order_id": order.id,
+                    "default_carrier_id": cls.carrier.id,
+                }
+            )
+        )
+        choose_delivery_carrier = delivery_wizard.save()
+        choose_delivery_carrier.button_confirm()
+
+    @classmethod
+    def _set_partner_time_window_to_friday(cls, partner):
+        weekday_friday = cls.env.ref("base_time_window.time_weekday_friday")
+        partner.write(
+            {
+                "delivery_time_preference": "time_windows",
+                "delivery_time_window_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "tz": TZ,
+                            "time_window_start": 8,
+                            "time_window_end": 18,
+                            "time_window_weekday_ids": [(6, 0, weekday_friday.ids)],
+                        },
+                    )
+                ],
+            }
+        )

--- a/sale_delivery_date/tests/test_integration.py
+++ b/sale_delivery_date/tests/test_integration.py
@@ -1,0 +1,85 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from freezegun import freeze_time
+
+from .common import Common
+
+BEFORE_CUTOFF = "07:30:00"
+AFTER_CUTOFF = "08:30:00"
+THURSDAY = "2021-08-19"
+FRIDAY = "2021-08-20"
+SATURDAY = "2021-08-21"
+SUNDAY = "2021-08-22"
+NEXT_MONDAY = "2021-08-23"
+NEXT_TUESDAY = "2021-08-24"
+NEXT_THURSDAY = "2021-08-26"
+NEXT_FRIDAY = "2021-08-27"
+# NOTE: the following dates are UTC, with 'Europe/Paris' we are GMT+2
+THURSDAY_BEFORE_CUTOFF = f"{THURSDAY} {BEFORE_CUTOFF}"
+THURSDAY_AFTER_CUTOFF = f"{THURSDAY} {AFTER_CUTOFF}"
+FRIDAY_BEFORE_CUTOFF = f"{FRIDAY} {BEFORE_CUTOFF}"
+FRIDAY_AFTER_CUTOFF = f"{FRIDAY} {AFTER_CUTOFF}"
+
+
+class TestSaleDeliveryDate(Common):
+    @classmethod
+    def setUpClassPartner(cls):
+        super().setUpClassPartner()
+        cls.customer_warehouse_cutoff.delivery_time_preference = "workdays"
+
+    @freeze_time(THURSDAY_AFTER_CUTOFF)
+    def test_order_on_thursday_after_cutoff_to_deliver_on_workdays(self):
+        """Order confirmed after cut-off time on Thursday to deliver on workdays."""
+        order = self.order_warehouse_cutoff
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(picking.scheduled_date.date()), FRIDAY)
+        self.assertEqual(str(order.expected_date.date()), NEXT_MONDAY)
+
+    @freeze_time(THURSDAY_BEFORE_CUTOFF)
+    def test_order_on_thursday_before_cutoff_to_deliver_on_workdays(self):
+        """Order confirmed before cut-off time on Thursday to deliver on workdays."""
+        order = self.order_warehouse_cutoff
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(picking.scheduled_date.date()), THURSDAY)
+        self.assertEqual(str(order.expected_date.date()), FRIDAY)
+
+    @freeze_time(FRIDAY_AFTER_CUTOFF)
+    def test_order_on_friday_after_cutoff_to_deliver_on_workdays(self):
+        """Order confirmed after cut-off time on Friday to deliver on workdays."""
+        order = self.order_warehouse_cutoff
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(order.expected_date.date()), NEXT_TUESDAY)
+        self.assertEqual(str(picking.scheduled_date.date()), NEXT_MONDAY)
+
+    @freeze_time(FRIDAY_BEFORE_CUTOFF)
+    def test_order_on_friday_before_cutoff_to_deliver_on_workdays(self):
+        """Order confirmed before cut-off time on Friday to deliver on workdays."""
+        order = self.order_warehouse_cutoff
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(picking.scheduled_date.date()), FRIDAY)
+        self.assertEqual(str(order.expected_date.date()), NEXT_MONDAY)
+
+    @freeze_time(FRIDAY_AFTER_CUTOFF)
+    def test_order_on_friday_after_cutoff_to_deliver_on_friday(self):
+        """Order confirmed after cut-off time on Friday to deliver on friday."""
+        self._set_partner_time_window_to_friday(self.customer_warehouse_cutoff)
+        order = self.order_warehouse_cutoff
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(picking.scheduled_date.date()), NEXT_THURSDAY)
+        self.assertEqual(str(order.expected_date.date()), NEXT_FRIDAY)
+
+    @freeze_time(FRIDAY_BEFORE_CUTOFF)
+    def test_order_on_friday_before_cutoff_to_deliver_on_friday(self):
+        """Order confirmed before cut-off time on Friday to deliver on friday."""
+        self._set_partner_time_window_to_friday(self.customer_warehouse_cutoff)
+        order = self.order_warehouse_cutoff
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(picking.scheduled_date.date()), NEXT_THURSDAY)
+        self.assertEqual(str(order.expected_date.date()), NEXT_FRIDAY)

--- a/sale_delivery_date/tests/test_reports.py
+++ b/sale_delivery_date/tests/test_reports.py
@@ -1,0 +1,24 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from .common import Common
+
+
+class TestReports(Common):
+    @classmethod
+    def _get_report_data(cls, report):
+        return {"report_type": report.report_type}
+
+    def test_reports(self):
+        # One of those should raise an exception is anything wrong occurs
+        order = self.order_partner_cutoff
+        order.action_confirm()
+        sale_report = self.env.ref("sale.action_report_saleorder")
+        content, _ = sale_report._render(
+            order.ids, data=self._get_report_data(sale_report)
+        )
+        picking = order.picking_ids
+        picking_report = self.env.ref("stock.action_report_delivery")
+        content, _ = picking_report._render(
+            picking.ids, data=self._get_report_data(picking_report)
+        )

--- a/sale_delivery_date/tests/test_sale_cutoff_time_delivery.py
+++ b/sale_delivery_date/tests/test_sale_cutoff_time_delivery.py
@@ -1,0 +1,138 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from freezegun import freeze_time
+
+from odoo import fields
+
+from .common import Common
+
+BEFORE_WH_CUTOFF = "09:30:00"
+AFTER_WH_CUTOFF = "10:30:00"
+BEFORE_PARTNER_CUTOFF = "08:30:00"
+AFTER_PARTNER_CUTOFF = "09:30:00"
+BEFORE_CUTOFF_TZ = "00:30:00"
+AFTER_CUTOFF_TZ = "23:30:00"
+MONDAY = "2021-10-04"
+TUESDAY = "2021-10-05"
+WEDNESDAY = "2021-10-06"
+THURSDAY = "2021-10-07"
+# NOTE
+MONDAY_BEFORE_WH_CUTOFF = f"{MONDAY} {BEFORE_WH_CUTOFF}"
+MONDAY_AFTER_WH_CUTOFF = f"{MONDAY} {AFTER_WH_CUTOFF}"
+MONDAY_BEFORE_PARTNER_CUTOFF = f"{MONDAY} {BEFORE_PARTNER_CUTOFF}"
+MONDAY_AFTER_PARTNER_CUTOFF = f"{MONDAY} {AFTER_PARTNER_CUTOFF}"
+# NOTE: the following dates are UTC, with 'Europe/Paris' we are GMT+2
+MONDAY_BEFORE_CUTOFF_TZ = f"{MONDAY} {BEFORE_CUTOFF_TZ}"
+MONDAY_AFTER_CUTOFF_TZ = f"{MONDAY} {AFTER_CUTOFF_TZ}"
+
+
+class TestSaleCutoffTimeDelivery(Common):
+    @classmethod
+    def setUpClassWarehouse(cls):
+        super().setUpClassWarehouse()
+        cls.apply_cutoff = False
+        cls.warehouse.calendar_id = False
+
+    @classmethod
+    def setUpClassProduct(cls):
+        super().setUpClassProduct()
+        cls.product.sale_delay = 1.0
+
+    @classmethod
+    def setUpClassCompany(cls):
+        super().setUpClassCompany()
+        cls.company.security_lead = 1.0
+
+    @classmethod
+    def _disable_tz(cls):
+        cls.warehouse.tz = False
+        cls.customers.tz = False
+
+    @freeze_time(MONDAY_BEFORE_PARTNER_CUTOFF)
+    def test_before_partner_cutoff(self):
+        self._disable_tz()
+        order = self.order_partner_cutoff
+        self.assertEqual(str(order.expected_date.date()), TUESDAY)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(picking.scheduled_date.date()), MONDAY)
+
+    @freeze_time(MONDAY_BEFORE_WH_CUTOFF)
+    def test_before_warehouse_cutoff(self):
+        self._disable_tz()
+        order = self.order_warehouse_cutoff
+        self.assertEqual(str(order.expected_date.date()), TUESDAY)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(picking.scheduled_date.date()), MONDAY)
+
+    @freeze_time(MONDAY_AFTER_PARTNER_CUTOFF)
+    def test_after_partner_cutoff(self):
+        """If order is confirmed after partner cutoff,
+        delivery is postponed by 1 day.
+        """
+        self._disable_tz()
+        order = self.order_partner_cutoff
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(order.expected_date.date()), WEDNESDAY)
+        self.assertEqual(str(picking.scheduled_date.date()), TUESDAY)
+
+    @freeze_time(MONDAY_AFTER_WH_CUTOFF)
+    def test_after_warehouse_cutoff(self):
+        """If order is confirmed after partner cutoff,
+        delivery is postponed by 1 day
+        """
+        self._disable_tz()
+        order = self.order_warehouse_cutoff
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(order.expected_date.date()), WEDNESDAY)
+        self.assertEqual(str(picking.scheduled_date.date()), TUESDAY)
+
+    @freeze_time(MONDAY_BEFORE_CUTOFF_TZ)
+    def test_before_partner_cutoff_tz(self):
+        order = self.order_partner_cutoff
+        self.assertEqual(str(order.expected_date.date()), TUESDAY)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(picking.scheduled_date.date()), MONDAY)
+
+    @freeze_time(MONDAY_BEFORE_CUTOFF_TZ)
+    def test_before_warehouse_cutoff_tz(self):
+        order = self.order_warehouse_cutoff
+        self.assertEqual(str(order.expected_date.date()), TUESDAY)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(picking.scheduled_date.date()), MONDAY)
+
+    @freeze_time(MONDAY_AFTER_CUTOFF_TZ)
+    def test_after_partner_cutoff_tz(self):
+        """If order is confirmed after partner cutoff,
+        delivery is postponed by 1 day.
+        """
+        order = self.order_partner_cutoff
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(order.expected_date.date()), WEDNESDAY)
+        self.assertEqual(str(picking.scheduled_date.date()), TUESDAY)
+
+    @freeze_time(MONDAY_AFTER_CUTOFF_TZ)
+    def test_after_warehouse_cutoff_tz(self):
+        """If order is confirmed after partner cutoff,
+        delivery is postponed by 1 day
+        """
+        order = self.order_warehouse_cutoff
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(order.expected_date.date()), WEDNESDAY)
+        self.assertEqual(str(picking.scheduled_date.date()), TUESDAY)
+
+    @freeze_time(MONDAY_BEFORE_CUTOFF_TZ)
+    def test_commitment_date_partner_cutoff(self):
+        order = self.order_partner_cutoff
+        order.commitment_date = fields.Datetime.to_datetime(f"{THURSDAY} 16:00:00")
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(picking.scheduled_date), f"{WEDNESDAY} 07:00:00")

--- a/sale_delivery_date/tests/test_sale_partner_cutoff_delivery_window.py
+++ b/sale_delivery_date/tests/test_sale_partner_cutoff_delivery_window.py
@@ -1,0 +1,363 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from freezegun import freeze_time
+
+from odoo import fields
+from odoo.tests import SavepointCase
+
+
+class TestSaleCutoffDeliveryWindow(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.customer_partner = cls.env["res.partner"].create(
+            {
+                "name": "Partner cutoff",
+                "order_delivery_cutoff_preference": "partner_cutoff",
+                "cutoff_time": 9.0,
+                "delivery_time_preference": "time_windows",
+                "delivery_time_window_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "time_window_start": 8.0,
+                            "time_window_end": 18.00,
+                            "time_window_weekday_ids": [
+                                (
+                                    6,
+                                    0,
+                                    [
+                                        cls.env.ref(
+                                            "base_time_window.time_weekday_monday"
+                                        ).id,
+                                        cls.env.ref(
+                                            "base_time_window.time_weekday_friday"
+                                        ).id,
+                                    ],
+                                )
+                            ],
+                        },
+                    )
+                ],
+            }
+        )
+        cls.customer_warehouse = cls.env["res.partner"].create(
+            {
+                "name": "Partner warehouse cutoff",
+                "order_delivery_cutoff_preference": "warehouse_cutoff",
+                "cutoff_time": 9.0,
+                "delivery_time_preference": "time_windows",
+                "delivery_time_window_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "time_window_start": 8.0,
+                            "time_window_end": 18.00,
+                            "time_window_weekday_ids": [
+                                (
+                                    6,
+                                    0,
+                                    [
+                                        cls.env.ref(
+                                            "base_time_window.time_weekday_monday"
+                                        ).id,
+                                        cls.env.ref(
+                                            "base_time_window.time_weekday_friday"
+                                        ).id,
+                                    ],
+                                )
+                            ],
+                        },
+                    )
+                ],
+            }
+        )
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.warehouse.write({"apply_cutoff": True, "cutoff_time": 10.0})
+        cls.product = cls.env.ref("product.product_product_9")
+
+    def _create_order(self, partner=None):
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": partner.id,
+                "partner_shipping_id": partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product.name,
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1,
+                            "product_uom": self.product.uom_id.id,
+                            "price_unit": self.product.list_price,
+                        },
+                    )
+                ],
+            }
+        )
+        # Play onchange manually to ensure customer_lead is set on the line
+        order.order_line._onchange_product_id_set_customer_lead()
+        return order
+
+    @freeze_time("2020-03-26 18:00:00")  # thursday evening
+    def test_after_cutoff_preferred_weekday(self):
+        # After partner cutoff
+        order = self._create_order(partner=self.customer_partner)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-27 09:00:00")
+        )
+        # Before warehouse cutoff
+        order = self._create_order(partner=self.customer_warehouse)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-27 10:00:00")
+        )
+
+    @freeze_time("2020-03-27 08:00:00")  # friday morning
+    def test_before_cutoff_preferred_weekday(self):
+        # Before partner cutoff
+        order = self._create_order(partner=self.customer_partner)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-27 09:00:00")
+        )
+        # Before warehouse cutoff
+        order = self._create_order(partner=self.customer_warehouse)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-27 10:00:00")
+        )
+
+    @freeze_time("2020-03-27 18:00:00")  # friday evening
+    def test_after_cutoff_other_weekday(self):
+        # After partner cutoff
+        order = self._create_order(partner=self.customer_partner)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-30 09:00:00")
+        )
+        # After warehouse cutoff
+        order = self._create_order(partner=self.customer_warehouse)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-30 10:00:00")
+        )
+
+    @freeze_time("2020-03-28 08:00:00")  # saturday morning
+    def test_before_cutoff_other_weekday(self):
+        # Before partner cutoff
+        order = self._create_order(partner=self.customer_partner)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-30 09:00:00")
+        )
+        # Before warehouse cutoff
+        order = self._create_order(partner=self.customer_warehouse)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-30 10:00:00")
+        )
+
+    @freeze_time("2020-03-23 08:00:00")  # monday morning
+    def test_before_cutoff_lead_time_preferred_weekday(self):
+        self.product.sale_delay = 4
+        # Before partner cutoff
+        order = self._create_order(partner=self.customer_partner)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-27 09:00:00")
+        )
+        # Before partner cutoff
+        order = self._create_order(partner=self.customer_warehouse)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-27 10:00:00")
+        )
+
+    @freeze_time("2020-03-23 18:00:00")  # monday evening
+    def test_after_cutoff_lead_time_preferred_weekday(self):
+        # THIS IS PROBABLY THE MOST IMPORTANT TEST HERE:
+        #  This test ensures that cutoff is applied before delivery window
+        #  because both sale_cutoff_time_delivery and sale_weekday_delivery
+        #  override _get_procurement_values.
+        # Also, at the beginning both modules had the same dependency and it
+        #  did seem to work because sale_cutoff_time_delivery is alphabetically
+        #  before sale_partner_delivery_window /!\
+        #  Anyway, here we want the computation to happen as follows:
+        #  confirmation time: 2020-03-23 18:00:00
+        #  application of lead time: 2020-03-27 18:00:00
+        #  application of cutoff: 2020-03-28 09:00:00
+        #  application of weekday: 2020-03-30 08:00:00
+        # what matches both cutoff and delivery window preference
+
+        # If somehow the MRO of _prepare_procurement_values is WRONG we'd have:
+        #  confirmation time: 2020-03-23 18:00:00
+        #  application of lead time: 2020-03-27 18:00:00
+        #  application of weekday: 2020-03-27 18:00:00
+        #  application of cutoff: 2020-03-28 09:00:00
+        # what doesn't match the delivery window preference!
+        self.product.sale_delay = 4
+        # Before partner cutoff
+        order = self._create_order(partner=self.customer_partner)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-30 09:00:00")
+        )
+        # Before partner cutoff
+        order = self._create_order(partner=self.customer_warehouse)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-30 10:00:00")
+        )
+
+    @freeze_time("2020-03-24 08:00:00")  # tuesday morning
+    def test_before_cutoff_lead_time_other_weekday(self):
+        self.product.sale_delay = 4
+        # Before partner cutoff
+        order = self._create_order(partner=self.customer_partner)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-30 09:00:00")
+        )
+        # Before partner cutoff
+        order = self._create_order(partner=self.customer_warehouse)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-30 10:00:00")
+        )
+
+    @freeze_time("2020-03-24 18:00:00")  # tuesday evening
+    def test_after_cutoff_lead_time_other_weekday(self):
+        self.product.sale_delay = 4
+        # Before partner cutoff
+        order = self._create_order(partner=self.customer_partner)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-30 09:00:00")
+        )
+        # Before partner cutoff
+        order = self._create_order(partner=self.customer_warehouse)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-30 10:00:00")
+        )
+
+    @freeze_time("2020-03-24 18:00:00")  # tuesday evening
+    def test_partner_time_window_outside_cutoff_no_partner_cutoff(self):
+        """Partner with a delivery time window not within cutoff
+
+        And the partner has no cutoff. The cutoff of the warehouse must be applied.
+        The expected time should not default to the delivery time window but to the
+        warehouse cutoff.
+        """
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Partner cutoff",
+                "order_delivery_cutoff_preference": "partner_cutoff",
+                "cutoff_time": 9.0,
+                "delivery_time_preference": "time_windows",
+                "delivery_time_window_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "time_window_start": 14.0,
+                            "time_window_end": 15.00,
+                            "time_window_weekday_ids": [
+                                (
+                                    6,
+                                    0,
+                                    [
+                                        self.env.ref(
+                                            "base_time_window.time_weekday_monday"
+                                        ).id,
+                                        self.env.ref(
+                                            "base_time_window.time_weekday_friday"
+                                        ).id,
+                                    ],
+                                )
+                            ],
+                        },
+                    )
+                ],
+            }
+        )
+
+        self.product.sale_delay = 4
+        # Before partner cutoff
+        order = self._create_order(partner=partner)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-30 09:00:00")
+        )
+
+    @freeze_time("2020-03-24 18:00:00")  # tuesday evening
+    def test_partner_time_window_outside_cutoff_commitment_date(self):
+        """Partner with a delivery time window not within cutoff
+
+        And we set a commitment date on the sales order.
+        """
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Partner cutoff",
+                "order_delivery_cutoff_preference": "partner_cutoff",
+                "cutoff_time": 9.0,
+                "delivery_time_preference": "time_windows",
+                "delivery_time_window_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "time_window_start": 14.0,
+                            "time_window_end": 15.00,
+                            "time_window_weekday_ids": [
+                                (
+                                    6,
+                                    0,
+                                    [
+                                        self.env.ref(
+                                            "base_time_window.time_weekday_monday"
+                                        ).id,
+                                        self.env.ref(
+                                            "base_time_window.time_weekday_friday"
+                                        ).id,
+                                    ],
+                                )
+                            ],
+                        },
+                    )
+                ],
+            }
+        )
+
+        self.product.sale_delay = 4
+        # Before partner cutoff
+        order = self._create_order(partner=partner)
+        order.commitment_date = fields.Datetime.to_datetime("2020-04-03 15:00:00")
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-04-03 09:00:00")
+        )

--- a/sale_delivery_date/tests/test_sale_partner_delivery_window.py
+++ b/sale_delivery_date/tests/test_sale_partner_delivery_window.py
@@ -1,0 +1,212 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from freezegun import freeze_time
+
+from odoo import fields
+from odoo.tests import SavepointCase
+
+
+class TestSaleDeliveryWindow(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.customer = cls.env["res.partner"].create(
+            {"name": "ACME", "delivery_time_preference": "anytime"}
+        )
+        cls.customer_shipping = cls.env["res.partner"].create(
+            {
+                "name": "Delivery address",
+                "parent_id": cls.customer.id,
+                "delivery_time_preference": "time_windows",
+                "delivery_time_window_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "time_window_start": 8.0,
+                            "time_window_end": 18.00,
+                            "time_window_weekday_ids": [
+                                (
+                                    6,
+                                    0,
+                                    [
+                                        cls.env.ref(
+                                            "base_time_window.time_weekday_thursday"
+                                        ).id,
+                                        cls.env.ref(
+                                            "base_time_window.time_weekday_saturday"
+                                        ).id,
+                                    ],
+                                )
+                            ],
+                        },
+                    )
+                ],
+            }
+        )
+        cls.product = cls.env.ref("product.product_product_9")
+
+    def _create_order(self):
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "partner_shipping_id": self.customer_shipping.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product.name,
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1,
+                            "product_uom": self.product.uom_id.id,
+                            "price_unit": self.product.list_price,
+                        },
+                    )
+                ],
+            }
+        )
+        # Play onchange manually to ensure customer_lead is set on the line
+        order.order_line._onchange_product_id_set_customer_lead()
+        return order
+
+    @freeze_time("2020-03-24")  # Tuesday
+    def test_delivery_schedule_expected_date(self):
+        order = self._create_order()
+        # We're tuesday and next delivery window is thursday
+        self.assertEqual(
+            order.expected_date, fields.Datetime.to_datetime("2020-03-26 08:00:00")
+        )
+        # Ensure product customer lead time is considered
+        # We're tuesday so + 3 days is friday, and next delivery window
+        #  is saturday 2020-03-28
+        self.product.sale_delay = 3
+        order_2 = self._create_order()
+        self.assertEqual(
+            order_2.expected_date, fields.Datetime.to_datetime("2020-03-28 08:00:00")
+        )
+        # Change the customer lead time directly on the line must also be
+        #  considered
+        # We're tuesday so + 5 days is sunday, and next delivery window
+        #  is thursday 2020-04-02
+        order_2.order_line.customer_lead = 5
+        self.assertEqual(
+            order_2.expected_date, fields.Datetime.to_datetime("2020-04-02 08:00:00")
+        )
+
+    @freeze_time("2020-03-24")  # Tuesday
+    def test_onchange_warnings(self):
+        # Test warning on sale.order
+        order = self._create_order()
+        # Set to friday
+        order.commitment_date = "2020-03-27 08:00:00"
+        onchange_res = order._onchange_commitment_date()
+        self.assertEqual(
+            onchange_res["warning"],
+            order._commitment_date_no_delivery_window_match_msg(),
+        )
+        # Set to saturday (preferred)
+        order.commitment_date = "2020-03-28 08:00:00"
+        onchange_res = order._onchange_commitment_date()
+        self.assertIsNone(onchange_res)
+        # Test warning on stock.picking
+        order.action_confirm()
+        picking = order.picking_ids
+        # Set to friday
+        picking.scheduled_date = "2020-03-27 08:00:00"
+        onchange_res = picking._onchange_scheduled_date()
+        self.assertEqual(
+            onchange_res["warning"],
+            picking._scheduled_date_no_delivery_window_match_msg(),
+        )
+        # Set to saturday (preferred)
+        picking.scheduled_date = "2020-03-28 08:00:00"
+        onchange_res = picking._onchange_scheduled_date()
+        self.assertIsNone(onchange_res)
+
+    @freeze_time("2020-03-24 01:00:00")  # Tuesday
+    def test_prepare_procurement_values(self):
+        # Without setting a commitment date, picking is scheduled for next
+        #  preferred delivery window start time
+        order = self._create_order()
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-26 08:00:00")
+        )
+        # As long as we're not in a window, picking is scheduled for next
+        #  preferred delivery window start time
+        with freeze_time("2020-03-24 09:00:00"):
+            order_2 = self._create_order()
+            order_2.action_confirm()
+            picking_2 = order_2.picking_ids
+            self.assertEqual(
+                picking_2.scheduled_date,
+                fields.Datetime.to_datetime("2020-03-26 08:00:00"),
+            )
+        self.customer_shipping.delivery_time_window_ids.write(
+            {
+                "time_window_weekday_ids": [
+                    (6, 0, [self.env.ref("base_time_window.time_weekday_thursday").id])
+                ]
+            }
+        )
+        # If we're before a window, picking is postponed to this window
+        with freeze_time("2020-03-26 06:00:00"):
+            order_3 = self._create_order()
+            order_3.action_confirm()
+            picking_3 = order_3.picking_ids
+            self.assertEqual(
+                picking_3.scheduled_date,
+                fields.Datetime.to_datetime("2020-03-26 08:00:00"),
+            )
+        # If we're already in a window, picking is not postponed
+        with freeze_time("2020-03-26 12:00:00"):
+            order_3 = self._create_order()
+            order_3.action_confirm()
+            picking_3 = order_3.picking_ids
+            self.assertEqual(
+                picking_3.scheduled_date,
+                fields.Datetime.to_datetime("2020-03-26 12:00:00"),
+            )
+        # If we're after delivery window on the only preferred weekday, picking
+        # is postponed to next week
+        with freeze_time("2020-03-26 20:00:00"):
+            order_3 = self._create_order()
+            order_3.action_confirm()
+            picking_3 = order_3.picking_ids
+            self.assertEqual(
+                picking_3.scheduled_date,
+                fields.Datetime.to_datetime("2020-04-02 08:00:00"),
+            )
+        # If we introduce a security lead time at company level, it must be
+        #  considered to compute delivery date and schedule picking accordingly
+        self.env.user.company_id.security_lead = 4
+        with freeze_time("2020-03-26 20:00:00"):
+            order_3 = self._create_order()
+            order_3.action_confirm()
+            picking_3 = order_3.picking_ids
+            self.assertEqual(
+                picking_3.scheduled_date,
+                fields.Datetime.to_datetime("2020-03-29 08:00:00"),
+            )
+
+    @freeze_time("2020-03-24 01:00:00")  # Tuesday
+    def test_prepare_procurement_values_commitment(self):
+        # Using a commitment date on a preferred weekday is perfectly fine
+        order = self._create_order()
+        order.commitment_date = "2020-03-28 10:00:00"
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(
+            picking.scheduled_date, fields.Datetime.to_datetime("2020-03-28 10:00:00")
+        )
+        # Using a commitment date on an weekday not preferred is still allowed
+        order_2 = self._create_order()
+        order_2.commitment_date = "2020-03-30 06:00:00"
+        order_2.action_confirm()
+        picking_2 = order_2.picking_ids
+        self.assertEqual(
+            picking_2.scheduled_date, fields.Datetime.to_datetime("2020-03-30 06:00:00")
+        )

--- a/sale_delivery_date/tests/test_sale_warehouse_calendar.py
+++ b/sale_delivery_date/tests/test_sale_warehouse_calendar.py
@@ -1,0 +1,149 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from freezegun import freeze_time
+
+from odoo.tests.common import SavepointCase
+
+WORKING_DAYS = list(range(5))  # working days are from monday to friday included
+CUTOFF_TIME = 8.0  # cutoff time will be set at 8 a.m.
+
+FRIDAY = "2021-08-13"
+SATURDAY = "2021-08-14"
+NEXT_MONDAY = "2021-08-16"
+NEXT_TUESDAY = "2021-08-17"
+NEXT_WEDNESDAY = "2021-08-18"
+NEXT_THURSDAY = "2021-08-19"
+FRIDAY_BEFORE_CUTOFF = "2021-08-13 07:00:00"
+FRIDAY_AFTER_CUTOFF = "2021-08-13 09:00:00"
+SATURDAY_BEFORE_CUTOFF = "2021-08-14 07:00:00"
+SATURDAY_AFTER_CUTOFF = "2021-08-15 09:00:00"
+
+
+class TestSaleOrderDates(SavepointCase):
+    at_install = False
+    post_install = True
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestSaleOrderDates, cls).setUpClass()
+        cls.env = cls.env(
+            context=dict(cls.env.context, tracking_disable=True, tz="UTC")
+        )
+        cls.setupClassCompany()
+        cls.setUpClassCalendar()
+        cls.setUpClassWarehouse()
+        cls.setUpClassPartner()
+        cls.setUpClassProduct()
+
+    @classmethod
+    def _define_calendar(cls, name, attendances):
+        return cls.env["resource.calendar"].create(
+            {
+                "name": name,
+                "attendance_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "%s_%d" % (name, index),
+                            "hour_from": att[0],
+                            "hour_to": att[1],
+                            "dayofweek": str(att[2]),
+                        },
+                    )
+                    for index, att in enumerate(attendances)
+                ],
+            }
+        )
+
+    @classmethod
+    def setupClassCompany(cls):
+        cls.company = cls.env.user.company_id
+        cls.company.security_lead = 1
+
+    @classmethod
+    def setUpClassCalendar(cls):
+        cls.calendar = cls._define_calendar(
+            "40 Hours",
+            [(8, 16, i) for i in range(5)],
+        )
+
+    @classmethod
+    def setUpClassWarehouse(cls):
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.warehouse.write(
+            {
+                "cutoff_time": CUTOFF_TIME,
+                "apply_cutoff": True,
+                "calendar_id": cls.calendar,
+            }
+        )
+
+    @classmethod
+    def setUpClassPartner(cls):
+        cls.customer = cls.env.ref("base.res_partner_12")
+        cls.customer.order_delivery_cutoff_preference = "warehouse_cutoff"
+        cls.customer.delivery_time_preference = "workdays"
+
+    @classmethod
+    def setUpClassProduct(cls):
+        cls.product = cls.env.ref("product.product_product_3")
+
+    def _create_order(self, customer_lead=1):
+        order = self.env["sale.order"].create(
+            {"partner_id": self.customer.id, "warehouse_id": self.warehouse.id}
+        )
+        self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 1,
+                "customer_lead": customer_lead,
+            }
+        )
+        return order
+
+    @freeze_time(FRIDAY_BEFORE_CUTOFF)
+    def test_confirm_before_cutoff_last_weekday(self):
+        # - preparation is friday since sale_cutoff_time_delivery,
+        #   has not postponed the delivery
+        # - friday is compatible with the warehouse calendar.
+        # - customer is only avaiable on weekdays
+        # - delivery should be done on monday
+        order = self._create_order()
+        order.action_confirm()
+        self.assertEqual(str(order.expected_date.date()), NEXT_MONDAY)
+        picking = order.picking_ids
+        self.assertEqual(str(picking.scheduled_date.date()), FRIDAY)
+
+    @freeze_time(FRIDAY_AFTER_CUTOFF)
+    def test_confirm_after_cutoff_last_weekday(self):
+        # - preparation is delayed by 1 day (sale_cutoff_time_delivery)
+        # - preparation is postponned to monday (stock_warehouse_calendar)
+        # - delivery should be done on tuesday
+        order = self._create_order()
+        order.action_confirm()
+        self.assertEqual(str(order.expected_date.date()), NEXT_TUESDAY)
+        picking = order.picking_ids
+        self.assertEqual(str(picking.scheduled_date.date()), NEXT_MONDAY)
+
+    @freeze_time(FRIDAY_BEFORE_CUTOFF)
+    def test_confirm_before_cutoff_last_weekday_3_days_preparation(self):
+        # initial expected_date NEXT_MONDAY
+        # - preparation isn't delayed by sale_cutoff_time_delivery
+        # - preparation is postponned to TUESDAY by sale_warehouse_calendar
+        # - delivery should be done on NEXT_WEDNESDAY
+        order = self._create_order(customer_lead=3)
+        order.action_confirm()
+        self.assertEqual(str(order.expected_date.date()), NEXT_WEDNESDAY)
+        picking = order.picking_ids
+        self.assertEqual(str(picking.scheduled_date.date()), NEXT_TUESDAY)
+
+    @freeze_time(SATURDAY_BEFORE_CUTOFF)
+    def test_confirm_before_cutoff_weekend_3_days_preparation(self):
+        order = self._create_order(customer_lead=3)
+        order.action_confirm()
+        self.assertEqual(str(order.expected_date.date()), NEXT_THURSDAY)
+        picking = order.picking_ids
+        self.assertEqual(str(picking.scheduled_date.date()), NEXT_WEDNESDAY)

--- a/sale_delivery_date/views/res_partner.xml
+++ b/sale_delivery_date/views/res_partner.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_partner_form_inherit" model="ir.ui.view">
+        <field name="name">res.partner.form.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//page[@name='sales_purchases']//group[@name='sale']"
+                position="inside"
+            >
+                <field name="order_delivery_cutoff_preference" />
+                <field
+                    name="cutoff_time"
+                    attrs="{'invisible': [('order_delivery_cutoff_preference', '!=', 'partner_cutoff')]}"
+                    widget="float_time"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_delivery_date/views/stock_picking.xml
+++ b/sale_delivery_date/views/stock_picking.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_picking_cutoff_search" model="ir.ui.view">
+        <field name="name">stock.picking.cutoff.search</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock.view_picking_internal_search" />
+        <field name="arch" type="xml">
+            <filter name="activities_exception" position="after">
+                <separator />
+                <filter
+                    string="Before today's cut-off"
+                    name="before_today_cutoff"
+                    domain="[('cutoff_time_diff', '=', -1)]"
+                />
+                <filter
+                    string="Inside today's cut-off"
+                    name="inside_today_cutoff"
+                    domain="[('cutoff_time_diff', '=', 0)]"
+                />
+                <filter
+                    string="After today's cut-off"
+                    name="after_today_cutoff"
+                    domain="[('cutoff_time_diff', '=', 1)]"
+                />
+            </filter>
+        </field>
+    </record>
+</odoo>

--- a/sale_delivery_date/views/stock_warehouse.xml
+++ b/sale_delivery_date/views/stock_warehouse.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_warehouse_inherit" model="ir.ui.view">
+        <field name="name">stock.warehouse.inherit</field>
+        <field name="model">stock.warehouse</field>
+        <field name="inherit_id" ref="stock.view_warehouse" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="apply_cutoff" />
+                <field
+                    name="cutoff_time"
+                    attrs="{'invisible': [('apply_cutoff', '!=', True)]}"
+                    widget="float_time"
+                />
+                <field
+                    name="tz"
+                    attrs="{'invisible': [('apply_cutoff', '!=', True)]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/setup/sale_delivery_date/odoo/addons/sale_delivery_date
+++ b/setup/sale_delivery_date/odoo/addons/sale_delivery_date
@@ -1,0 +1,1 @@
+../../../../sale_delivery_date

--- a/setup/sale_delivery_date/setup.py
+++ b/setup/sale_delivery_date/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Description
===========

Cutoff
------

Potpone order preparation by 1 day if it has been validated after
the partner or the warehouse cutoff.

This can be bypassed if commitment date is set.


Warehouse Calendar
------------------

Postpone delivery according to the warehouse calendar, if any.


Partner delivery window
-----------------------

Allows to define scheduling preference for delivery orders on customers,
in order to select possible delivery windows to postpone deliveries to.

Roadmap
=======

The following modules (available in 13.0) has been merged into this module:
- sale_warehouse_calendar
- sale_cutoff_time_delivery
- sale_partner_delivery_window
- sale_partner_cutoff_delivery_window

The reason for that is that `sale_warehouse_calendar` overrides have to be
executed between `sale_cutoff_time_delivery` and `sale_partner_delivery_window`,
and there's no other clean way to do that.

However, there's still a few things to deal with:
- Clean tests
- Clean code
- Use TZ where it is not the case
- Use calendar instead of time windows
  when delivery preference is `working days`

supersedes:
- https://github.com/OCA/sale-workflow/pull/1414
- https://github.com/OCA/sale-workflow/pull/1403
- https://github.com/OCA/sale-workflow/pull/1413

Also includes https://github.com/OCA/sale-workflow/pull/1696 and https://github.com/OCA/sale-workflow/pull/1720