### PR TITLE
[13.0][FIX] sale_product_set: fix sequence during set_apply on SO.

### DIFF
--- a/sale_product_set/wizard/product_set_add.py
+++ b/sale_product_set/wizard/product_set_add.py
@@ -95,16 +95,14 @@ class ProductSetAdd(models.TransientModel):
     def _prepare_order_lines(self):
         max_sequence = self._get_max_sequence()
         order_lines = []
-        for set_line in self._get_lines():
-            order_lines.append(
-                (
-                    0,
-                    0,
-                    self.prepare_sale_order_line_data(
-                        set_line, max_sequence=max_sequence
-                    ),
-                )
-            )
+        for seq, set_line in enumerate(self._get_lines(), start=1):
+            values = self.prepare_sale_order_line_data(set_line)
+            # When we play with sequence widget on a set of product,
+            # it's possible to have a negative sequence.
+            # In this case, the line is not added at the correct place.
+            # So we have to force it with the order of the line.
+            values.update({"sequence": max_sequence + seq})
+            order_lines.append((0, 0, values))
         return order_lines
 
     def _get_max_sequence(self):


### PR DESCRIPTION
If the user plays too much with sequences on the product set, it's possible to have some negative sequences.
But when the set is applied on the SO negative sequences are added to max_sequence. As the sequence is < 0 it adds the product 'in the middle' of the SO instead of let grouped every product's set.