### PR TITLE
[13.0][FIX] sale_order_line_input: The field customer does not exist

### DIFF
--- a/sale_order_line_input/views/sale_order_line_view.xml
+++ b/sale_order_line_input/views/sale_order_line_view.xml
@@ -36,8 +36,7 @@
                 />
                 <field
                     name="order_partner_id"
-                    domain="[('customer','=',True)]"
-                    context="{'search_default_customer':1, 'show_address': 1}"
+                    context="{'res_partner_search_mode': 'customer', 'default_is_company': True, 'default_customer_rank': 1}"
                     options='{"always_reload": True}'
                     required="1"
                     attrs="{'readonly': [('order_partner_id', '!=', False), ('order_id', '!=', False)]}"


### PR DESCRIPTION
Since v13 the `customer` field on `res.partner` model has been disappeared, so when we try to add a value on the field order_partner_id we get an error.

ping @pedrobaeza @carlosdauden 

@Tecnativa TT31586