### PR TITLE
[13.0][FIX] Fix report expected delivery date in the past

### DIFF
--- a/sale_cutoff_time_delivery/reports/stock_picking.xml
+++ b/sale_cutoff_time_delivery/reports/stock_picking.xml
@@ -4,22 +4,11 @@
 <odoo>
     <template id="report_delivery_document" inherit_id="stock.report_delivery_document">
         <xpath expr="//div[@name='div_sched_date']" position="after">
-            <t t-set="order" t-value="o.sale_id" />
-            <div
-                t-if="order.commitment_date or order.expected_date"
-                class="col-auto mw-100 mb-2"
-            >
+            <div class="col-auto mw-100 mb-2">
                 <strong>Expected delivery date:</strong>
                 <p
-                    t-if="order.commitment_date"
                     class="m-0"
-                    t-field="order.commitment_date"
-                    t-options="{'date_only': 'True'}"
-                />
-                <p
-                    t-else=""
-                    class="m-0"
-                    t-field="order.expected_date"
+                    t-field="o.expected_delivery_date"
                     t-options="{'date_only': 'True'}"
                 />
             </div>


### PR DESCRIPTION
In some cases, SO expected_date / commitment_date are way in the past compared to the picking scheduled_date (e.g. backorders).
In such case, the expected delivery date on the report is wrong, and should be computed as:
```python
(picking.date_done or picking.scheduled_date) + picking.company_id.security_lead
``` 