### PR TITLE
[14.0][FIX] sale_order_lot_selection: Avoid missing warning in the product selection.

### DIFF
--- a/sale_order_lot_selection/models/sale_order_line.py
+++ b/sale_order_lot_selection/models/sale_order_line.py
@@ -14,8 +14,9 @@ class SaleOrderLine(models.Model):
 
     @api.onchange("product_id")
     def product_id_change(self):
-        super().product_id_change()
+        res = super().product_id_change()
         self.lot_id = False
+        return res
 
     @api.onchange("product_id")
     def _onchange_product_id_set_lot_domain(self):


### PR DESCRIPTION

This call of super without a return is cause that alert of warning for product wasn't working.
After this change we ensure that return of warning or domain will apply finally