### PR TITLE
[14.0][FW] sale_automatic_workflow: port from 12.0/13.0

### DIFF
--- a/sale_automatic_workflow/README.rst
+++ b/sale_automatic_workflow/README.rst
@@ -41,6 +41,7 @@ A workflow can:
 - Apply automatic actions:
 
   * Validate the order (only if paid, always, never)
+  * Send order confirmation mail (only when order confirmed)
   * Create an invoice
   * Validate the invoice
   * Confirm the picking

--- a/sale_automatic_workflow/data/automatic_workflow_data.xml
+++ b/sale_automatic_workflow/data/automatic_workflow_data.xml
@@ -46,6 +46,7 @@
         <field name="name">Automatic</field>
         <field name="picking_policy">one</field>
         <field name="validate_order" eval="1" />
+        <field name="send_order_confirmation_mail" eval="1" />
         <field name="order_filter_id" eval="automatic_workflow_order_filter" />
         <field name="create_invoice" eval="1" />
         <field

--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -25,16 +25,6 @@ def savepoint(cr):
         _logger.exception("Error during an automatic workflow action.")
 
 
-@contextmanager
-def force_company(env, company_id):
-    user_company = env.user.company_id
-    env.user.update({"company_id": company_id})
-    try:
-        yield
-    finally:
-        env.user.update({"company_id": user_company})
-
-
 class AutomaticWorkflowJob(models.Model):
     """Scheduler that will play automatically the validation of
     invoices, pickings..."""

--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -44,6 +44,20 @@ class AutomaticWorkflowJob(models.Model):
         sale.action_confirm()
         return "{} {} confirmed successfully".format(sale.display_name, sale)
 
+    def _do_send_order_confirmation_mail(self, sale):
+        """Send order confirmation mail, while filtering to make sure the order is
+        confirmed with _do_validate_sale_order() function"""
+        if not self.env["sale.order"].search_count(
+            [("id", "=", sale.id), ("state", "=", "sale")]
+        ):
+            return "{} {} job bypassed".format(sale.display_name, sale)
+        if sale.user_id:
+            sale = sale.with_user(sale.user_id)
+        sale._send_order_confirmation_mail()
+        return "{} {} send order confirmation mail successfully".format(
+            sale.display_name, sale
+        )
+
     @api.model
     def _validate_sale_orders(self, order_filter):
         sale_obj = self.env["sale.order"]
@@ -54,6 +68,8 @@ class AutomaticWorkflowJob(models.Model):
                 self._do_validate_sale_order(
                     sale.with_company(sale.company_id), order_filter
                 )
+                if self.env.context.get("send_order_confirmation_mail"):
+                    self._do_send_order_confirmation_mail(sale)
 
     def _do_create_invoice(self, sale, domain_filter):
         """Create an invoice for a sales order, filter ensure no duplication"""
@@ -170,7 +186,9 @@ class AutomaticWorkflowJob(models.Model):
     def run_with_workflow(self, sale_workflow):
         workflow_domain = [("workflow_process_id", "=", sale_workflow.id)]
         if sale_workflow.validate_order:
-            self._validate_sale_orders(
+            self.with_context(
+                send_order_confirmation_mail=sale_workflow.send_order_confirmation_mail
+            )._validate_sale_orders(
                 safe_eval(sale_workflow.order_filter_id.domain) + workflow_domain
             )
         if sale_workflow.validate_picking:

--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -160,7 +160,7 @@ class AutomaticWorkflowJob(models.Model):
         )
         return {
             "reconciled_invoice_ids": [(6, 0, invoice.ids)],
-            "amount": invoice.residual,
+            "amount": invoice.amount_residual,
             "partner_id": invoice.partner_id.id,
             "partner_type": partner_type,
             "date": fields.Date.context_today(self),

--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -6,7 +6,7 @@
 import logging
 from contextlib import contextmanager
 
-from odoo import api, models
+from odoo import api, fields, models
 from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
@@ -136,6 +136,36 @@ class AutomaticWorkflowJob(models.Model):
             with savepoint(self.env.cr):
                 self._do_sale_done(sale.with_company(sale.company_id), sale_done_filter)
 
+    def _prepare_dict_account_payment(self, invoice):
+        partner_type = (
+            invoice.move_type in ("out_invoice", "out_refund")
+            and "customer"
+            or "supplier"
+        )
+        return {
+            "reconciled_invoice_ids": [(6, 0, invoice.ids)],
+            "amount": invoice.residual,
+            "partner_id": invoice.partner_id.id,
+            "partner_type": partner_type,
+            "date": fields.Date.context_today(self),
+        }
+
+    @api.model
+    def _register_payments(self, payment_filter):
+        invoice_obj = self.env["account.move"]
+        invoices = invoice_obj.search(payment_filter)
+        _logger.debug("Invoices to Register Payment: %s", invoices.ids)
+        for invoice in invoices:
+            self._register_payment_invoice(invoice)
+        return
+
+    def _register_payment_invoice(self, invoice):
+        with savepoint(self.env.cr):
+            payment = self.env["account.payment"].create(
+                self._prepare_dict_account_payment(invoice)
+            )
+            payment.action_post()
+
     @api.model
     def run_with_workflow(self, sale_workflow):
         workflow_domain = [("workflow_process_id", "=", sale_workflow.id)]
@@ -160,6 +190,11 @@ class AutomaticWorkflowJob(models.Model):
         if sale_workflow.sale_done:
             self._sale_done(
                 safe_eval(sale_workflow.sale_done_filter_id.domain) + workflow_domain
+            )
+
+        if sale_workflow.register_payment:
+            self._register_payments(
+                safe_eval(sale_workflow.payment_filter_id.domain) + workflow_domain
             )
 
     @api.model

--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -182,6 +182,17 @@ class AutomaticWorkflowJob(models.Model):
             )
             payment.action_post()
 
+            domain = [
+                ("account_internal_type", "in", ("receivable", "payable")),
+                ("reconciled", "=", False),
+            ]
+            payment_lines = payment.line_ids.filtered_domain(domain)
+            lines = invoice.line_ids
+            for account in payment_lines.account_id:
+                (payment_lines + lines).filtered_domain(
+                    [("account_id", "=", account.id), ("reconciled", "=", False)]
+                ).reconcile()
+
     @api.model
     def run_with_workflow(self, sale_workflow):
         workflow_domain = [("workflow_process_id", "=", sale_workflow.id)]

--- a/sale_automatic_workflow/models/sale_workflow_process.py
+++ b/sale_automatic_workflow/models/sale_workflow_process.py
@@ -41,6 +41,11 @@ class SaleWorkflowProcess(models.Model):
         default="direct",
     )
     validate_order = fields.Boolean()
+    send_order_confirmation_mail = fields.Boolean(
+        string="Send order confirmation mail",
+        help="When checked, after order confirmation, a confirmation email will be "
+        "sent (if not already sent).",
+    )
     order_filter_domain = fields.Text(
         string="Order Filter Domain", related="order_filter_id.domain"
     )

--- a/sale_automatic_workflow/models/sale_workflow_process.py
+++ b/sale_automatic_workflow/models/sale_workflow_process.py
@@ -27,6 +27,10 @@ class SaleWorkflowProcess(models.Model):
             return record
         return self.env["ir.filters"].browse()
 
+    @api.model
+    def _default_payment_filter_id(self):
+        return self.env["ir.filters"].browse()
+
     name = fields.Char()
     picking_policy = fields.Selection(
         selection=[
@@ -114,4 +118,14 @@ class SaleWorkflowProcess(models.Model):
         default=lambda self: self._default_filter(
             "sale_automatic_workflow.automatic_workflow_sale_done_filter"
         ),
+    )
+    payment_filter_id = fields.Many2one(
+        comodel_name="ir.filters",
+        string="Register Payment Invoice Filter",
+        default=lambda x: x._default_payment_filter_id(),
+    )
+    register_payment = fields.Boolean(string="Register Payment")
+    payment_filter_domain = fields.Text(
+        string="Payment Filter Domain",
+        related="payment_filter_id.domain",
     )

--- a/sale_automatic_workflow/readme/DESCRIPTION.rst
+++ b/sale_automatic_workflow/readme/DESCRIPTION.rst
@@ -14,6 +14,7 @@ A workflow can:
 - Apply automatic actions:
 
   * Validate the order (only if paid, always, never)
+  * Send order confirmation mail (only when order confirmed)
   * Create an invoice
   * Validate the invoice
   * Confirm the picking

--- a/sale_automatic_workflow/static/description/index.html
+++ b/sale_automatic_workflow/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Sale Automatic Workflow</title>
 <style type="text/css">
 
@@ -382,6 +382,7 @@ orders.</p>
 </li>
 <li>Apply automatic actions:<ul>
 <li>Validate the order (only if paid, always, never)</li>
+<li>Send order confirmation mail (only when order confirmed)</li>
 <li>Create an invoice</li>
 <li>Validate the invoice</li>
 <li>Confirm the picking</li>

--- a/sale_automatic_workflow/tests/test_automatic_workflow.py
+++ b/sale_automatic_workflow/tests/test_automatic_workflow.py
@@ -13,6 +13,19 @@ from .common import TestAutomaticWorkflowMixin, TestCommon
 
 @tagged("post_install", "-at_install")
 class TestAutomaticWorkflow(TestCommon, TestAutomaticWorkflowMixin):
+    def setUp(self):
+        super().setUp()
+        self.env = self.env(
+            context=dict(
+                self.env.context,
+                tracking_disable=True,
+                # Compatibility with sale_automatic_workflow_job: even if
+                # the module is installed, ensure we don't delay a job.
+                # Thus, we test the usual flow.
+                _job_force_sync=True,
+            )
+        )
+
     def test_full_automatic(self):
         workflow = self.create_full_automatic()
         sale = self.create_sale_order(workflow)

--- a/sale_automatic_workflow/tests/test_automatic_workflow.py
+++ b/sale_automatic_workflow/tests/test_automatic_workflow.py
@@ -148,3 +148,23 @@ class TestAutomaticWorkflow(TestCommon, TestAutomaticWorkflowMixin):
         self.assertTrue(sale.invoice_ids)
         invoice = sale.invoice_ids
         self.assertEqual(invoice.journal_id.id, new_sale_journal.id)
+
+    def test_automatic_sale_order_confirmation_mail(self):
+        workflow = self.create_full_automatic()
+        workflow.send_order_confirmation_mail = True
+        sale = self.create_sale_order(workflow)
+        sale._onchange_workflow_process_id()
+        previous_message_ids = sale.message_ids
+        self.run_job()
+        self.assertEqual(sale.state, "sale")
+        new_messages = self.env["mail.message"].search(
+            [
+                ("id", "in", sale.message_ids.ids),
+                ("id", "not in", previous_message_ids.ids),
+            ]
+        )
+        self.assertTrue(
+            new_messages.filtered(
+                lambda x: x.subtype_id == self.env.ref("mail.mt_comment")
+            )
+        )

--- a/sale_automatic_workflow/tests/test_automatic_workflow.py
+++ b/sale_automatic_workflow/tests/test_automatic_workflow.py
@@ -1,11 +1,11 @@
 # Copyright 2014 Camptocamp SA (author: Guewen Baconnier)
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from datetime import timedelta
 
-import mock
-
 from odoo import fields
+from odoo.exceptions import UserError
 from odoo.tests import tagged
 
 from .common import TestAutomaticWorkflowMixin, TestCommon
@@ -75,19 +75,13 @@ class TestAutomaticWorkflow(TestCommon, TestAutomaticWorkflowMixin):
         self.assertFalse(workflow.invoice_service_delivery)
         self.assertEqual(line.qty_delivered_method, "stock_move")
         self.assertEqual(line.qty_delivered, 0.0)
-        # `_create_invoices` is already tested in `sale` module.
-        # Make sure this addon works properly in regards to it.
-        mock_path = "odoo.addons.sale.models.sale.SaleOrder._create_invoices"
-        with mock.patch(mock_path) as mocked:
+        with self.assertRaises(UserError):
             sale._create_invoices()
-            mocked.assert_called()
         self.assertEqual(line.qty_delivered, 0.0)
-
         workflow.invoice_service_delivery = True
+        sale.state = "done"
         line.qty_delivered_method = "manual"
-        with mock.patch(mock_path) as mocked:
-            sale._create_invoices()
-            mocked.assert_called()
+        sale._create_invoices()
         self.assertEqual(line.qty_delivered, 1.0)
 
     def test_invoice_from_picking_with_service_product(self):

--- a/sale_automatic_workflow/tests/test_multicompany.py
+++ b/sale_automatic_workflow/tests/test_multicompany.py
@@ -8,6 +8,9 @@ from .common import TestCommon
 
 @tagged("post_install", "-at_install")
 class TestMultiCompany(TestCommon):
+    def setUp(self):
+        super().setUp()
+
     @classmethod
     def create_company(cls, values):
         return cls.env["res.company"].create(values)
@@ -21,6 +24,16 @@ class TestMultiCompany(TestCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                tracking_disable=True,
+                # Compatibility with sale_automatic_workflow_job: even if
+                # the module is installed, ensure we don't delay a job.
+                # Thus, we test the usual flow.
+                _job_force_sync=True,
+            )
+        )
         coa = cls.env.user.company_id.chart_template_id
         cls.company_fr = cls.create_company(
             {

--- a/sale_automatic_workflow/views/sale_workflow_process_view.xml
+++ b/sale_automatic_workflow/views/sale_workflow_process_view.xml
@@ -126,6 +126,32 @@
                             />
                         </div>
                     </div>
+                    <field name="register_payment" />
+                    <label
+                        for="payment_filter_id"
+                        attrs="{'required':[('register_payment','=',True)], 'invisible':[('register_payment','!=',True)]}"
+                    />
+                    <div
+                        attrs="{'required':[('register_payment','=',True)], 'invisible':[('register_payment','!=',True)]}"
+                    >
+                        <field
+                            name="payment_filter_domain"
+                            widget="domain"
+                            attrs="{'invisible': [('payment_filter_id', '=', False)]}"
+                            options="{'model': 'account.move'}"
+                        />
+                        <div class="oe_edit_only oe_inline">
+                            Set selection based on a search filter:
+                            <field
+                                name="payment_filter_id"
+                                domain="[('model_id', '=', 'account.move')]"
+                                class="oe_inline"
+                                context="{'default_model_id': 'account.move', 'default_active': False, 'active_test': False}"
+                                can_create="true"
+                                can_write="true"
+                            />
+                        </div>
+                    </div>
                     <field name="sale_done" />
                     <label
                         for="sale_done_filter_id"
@@ -178,6 +204,7 @@
                 <field name="validate_order" />
                 <field name="validate_picking" />
                 <field name="validate_invoice" />
+                <field name="register_payment" />
                 <field name="invoice_date_is_order_date" />
             </tree>
         </field>

--- a/sale_automatic_workflow/views/sale_workflow_process_view.xml
+++ b/sale_automatic_workflow/views/sale_workflow_process_view.xml
@@ -45,6 +45,7 @@
                             />
                         </div>
                     </div>
+                    <field name="send_order_confirmation_mail" colspan="4" />
                     <field name="validate_picking" />
                     <label
                         for="picking_filter_id"


### PR DESCRIPTION
 Port PRs from 12.0/13.0 to 14.0

- https://github.com/OCA/sale-workflow/pull/1167
- https://github.com/OCA/sale-workflow/pull/1337
- https://github.com/OCA/sale-workflow/pull/1526
- https://github.com/OCA/sale-workflow/pull/1576
- https://github.com/OCA/sale-workflow/pull/1673/commits/4e4359066270dbea0edd01e02029a1687a8484dd
- https://github.com/OCA/sale-workflow/pull/1677
- https://github.com/OCA/sale-workflow/pull/1782

This commit to fix tests case for module `sale_automatic_workflow_payment_mode`: https://github.com/OCA/sale-workflow/pull/1789/commits/ad999eb5ad3861322ae6728c5bbec63d780ecaf5