### PR TITLE
[12,0] [FIX] Fixed delivery_state when the sale_order is in the state "sent"

### DIFF
--- a/sale_delivery_state/models/sale_order.py
+++ b/sale_delivery_state/models/sale_order.py
@@ -67,7 +67,7 @@ class SaleOrder(models.Model):
                  'state', 'force_delivery_state')
     def _compute_delivery_state(self):
         for order in self:
-            if order.state in ('draft', 'cancel'):
+            if order.state in ('draft', 'sent', 'cancel'):
                 order.delivery_state = 'no'
             elif (order.force_delivery_state or
                   order._all_qty_delivered()):


### PR DESCRIPTION
When the sale_order switches to the state "sent", the delivery_state becomes "unprocessed". 
This is not correct, because it's still a price quotation.

Now, by adding "sent" to the list of the states in which the delivery_state should be 'no', only when the sale_order is confirmed the delivery_state assumes value "unprocessed".