### PR TITLE
[FIX] sale_automatic_workflow_payment_mode: not register payment when no fixed journal

### DIFF
--- a/sale_automatic_workflow_payment_mode/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow_payment_mode/models/automatic_workflow_job.py
@@ -28,4 +28,5 @@ class AutomaticWorkflowJob(models.Model):
                 invoice.id,
                 invoice.payment_mode_id.id,
             )
+            return
         return super()._register_payment_invoice(invoice)


### PR DESCRIPTION
This PR fix bug when `fixed_journal_id `is null