### PR TITLE
[14.0][IMP] sale_order_general_discount: apply discount product optin

### DIFF
--- a/sale_order_general_discount/__manifest__.py
+++ b/sale_order_general_discount/__manifest__.py
@@ -12,5 +12,9 @@
     "application": False,
     "installable": True,
     "depends": ["sale"],
-    "data": ["views/sale_order_view.xml", "views/res_partner_view.xml"],
+    "data": [
+        "views/product_view.xml",
+        "views/sale_order_view.xml",
+        "views/res_partner_view.xml",
+    ],
 }

--- a/sale_order_general_discount/i18n/de.po
+++ b/sale_order_general_discount/i18n/de.po
@@ -17,6 +17,12 @@ msgstr ""
 "X-Generator: Weblate 3.7.1\n"
 
 #. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product__general_discount_apply
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template__general_discount_apply
+msgid "Apply general discount"
+msgstr ""
+
+#. module: sale_order_general_discount
 #: model:ir.model,name:sale_order_general_discount.model_res_partner
 msgid "Contact"
 msgstr "Kontakt"
@@ -33,6 +39,51 @@ msgstr "Rabatt (%)"
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line__discount
 msgid "Discount (%)"
 msgstr "Rabatt (%)"
+
+#. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_res_partner__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_res_partner__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model.fields,help:sale_order_general_discount.field_product_product__general_discount_apply
+#: model:ir.model.fields,help:sale_order_general_discount.field_product_template__general_discount_apply
+msgid ""
+"If this checkbox is ticked, it means changing general discount on sale order "
+"will impact sale order lines with this related product."
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_res_partner____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model,name:sale_order_general_discount.model_product_product
+msgid "Product"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model,name:sale_order_general_discount.model_product_template
+msgid "Product Template"
+msgstr ""
 
 #. module: sale_order_general_discount
 #: model:ir.model,name:sale_order_general_discount.model_sale_order

--- a/sale_order_general_discount/i18n/es.po
+++ b/sale_order_general_discount/i18n/es.po
@@ -18,6 +18,12 @@ msgstr ""
 "X-Generator: Weblate 3.10\n"
 
 #. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product__general_discount_apply
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template__general_discount_apply
+msgid "Apply general discount"
+msgstr ""
+
+#. module: sale_order_general_discount
 #: model:ir.model,name:sale_order_general_discount.model_res_partner
 msgid "Contact"
 msgstr "Contacto"
@@ -35,6 +41,51 @@ msgid "Discount (%)"
 msgstr "Descuento (%)"
 
 #. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_res_partner__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_res_partner__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model.fields,help:sale_order_general_discount.field_product_product__general_discount_apply
+#: model:ir.model.fields,help:sale_order_general_discount.field_product_template__general_discount_apply
+msgid ""
+"If this checkbox is ticked, it means changing general discount on sale order "
+"will impact sale order lines with this related product."
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_res_partner____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model,name:sale_order_general_discount.model_product_product
+msgid "Product"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model,name:sale_order_general_discount.model_product_template
+msgid "Product Template"
+msgstr ""
+
+#. module: sale_order_general_discount
 #: model:ir.model,name:sale_order_general_discount.model_sale_order
 msgid "Sales Order"
 msgstr "Pedido de venta"
@@ -43,6 +94,3 @@ msgstr "Pedido de venta"
 #: model:ir.model,name:sale_order_general_discount.model_sale_order_line
 msgid "Sales Order Line"
 msgstr "Línea Pedido de Venta"
-
-#~ msgid "Quotation"
-#~ msgstr "Presupuesto"

--- a/sale_order_general_discount/i18n/fr.po
+++ b/sale_order_general_discount/i18n/fr.po
@@ -17,24 +17,24 @@ msgstr ""
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product__general_discount_apply
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template__general_discount_apply
 msgid "Apply general discount"
-msgstr ""
+msgstr "Appliquer la remise générale"
 
 #. module: sale_order_general_discount
 #: model:ir.model,name:sale_order_general_discount.model_res_partner
 msgid "Contact"
-msgstr ""
+msgstr "Contact"
 
 #. module: sale_order_general_discount
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_res_partner__sale_discount
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_res_users__sale_discount
 msgid "Discount"
-msgstr ""
+msgstr "Remise"
 
 #. module: sale_order_general_discount
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order__general_discount
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line__discount
 msgid "Discount (%)"
-msgstr ""
+msgstr "Remise (%)"
 
 #. module: sale_order_general_discount
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product__display_name
@@ -43,7 +43,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order__display_name
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line__display_name
 msgid "Display Name"
-msgstr ""
+msgstr "Nom affiché"
 
 #. module: sale_order_general_discount
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product__id
@@ -61,6 +61,9 @@ msgid ""
 "If this checkbox is ticked, it means changing general discount on sale order"
 " will impact sale order lines with this related product."
 msgstr ""
+"Si coché, lorsque vous modifié la remise générale sur le bon de commande"
+" la modification sera prise en compte sur les lignes de bon de commandes"
+" liées à cet article."
 
 #. module: sale_order_general_discount
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product____last_update
@@ -69,24 +72,24 @@ msgstr ""
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order____last_update
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line____last_update
 msgid "Last Modified on"
-msgstr ""
+msgstr "Dernière modification le"
 
 #. module: sale_order_general_discount
 #: model:ir.model,name:sale_order_general_discount.model_product_product
 msgid "Product"
-msgstr ""
+msgstr "Article"
 
 #. module: sale_order_general_discount
 #: model:ir.model,name:sale_order_general_discount.model_product_template
 msgid "Product Template"
-msgstr ""
+msgstr "Modèle d'article"
 
 #. module: sale_order_general_discount
 #: model:ir.model,name:sale_order_general_discount.model_sale_order
 msgid "Sales Order"
-msgstr ""
+msgstr "Bons de commande"
 
 #. module: sale_order_general_discount
 #: model:ir.model,name:sale_order_general_discount.model_sale_order_line
 msgid "Sales Order Line"
-msgstr ""
+msgstr "Ligne de bons de commande"

--- a/sale_order_general_discount/i18n/it.po
+++ b/sale_order_general_discount/i18n/it.po
@@ -17,6 +17,12 @@ msgstr ""
 "X-Generator: Weblate 3.10\n"
 
 #. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product__general_discount_apply
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template__general_discount_apply
+msgid "Apply general discount"
+msgstr ""
+
+#. module: sale_order_general_discount
 #: model:ir.model,name:sale_order_general_discount.model_res_partner
 msgid "Contact"
 msgstr "Contatto"
@@ -33,6 +39,51 @@ msgstr "Sconto (%)"
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line__discount
 msgid "Discount (%)"
 msgstr "Sconto (%)"
+
+#. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_res_partner__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_res_partner__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model.fields,help:sale_order_general_discount.field_product_product__general_discount_apply
+#: model:ir.model.fields,help:sale_order_general_discount.field_product_template__general_discount_apply
+msgid ""
+"If this checkbox is ticked, it means changing general discount on sale order "
+"will impact sale order lines with this related product."
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_res_partner____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model,name:sale_order_general_discount.model_product_product
+msgid "Product"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model,name:sale_order_general_discount.model_product_template
+msgid "Product Template"
+msgstr ""
 
 #. module: sale_order_general_discount
 #: model:ir.model,name:sale_order_general_discount.model_sale_order

--- a/sale_order_general_discount/i18n/zh_CN.po
+++ b/sale_order_general_discount/i18n/zh_CN.po
@@ -17,6 +17,12 @@ msgstr ""
 "X-Generator: Weblate 3.8\n"
 
 #. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product__general_discount_apply
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template__general_discount_apply
+msgid "Apply general discount"
+msgstr ""
+
+#. module: sale_order_general_discount
 #: model:ir.model,name:sale_order_general_discount.model_res_partner
 msgid "Contact"
 msgstr "联系人"
@@ -33,6 +39,51 @@ msgstr "折扣(%)"
 #: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line__discount
 msgid "Discount (%)"
 msgstr "折扣(%)"
+
+#. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_res_partner__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order__display_name
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_res_partner__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order__id
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model.fields,help:sale_order_general_discount.field_product_product__general_discount_apply
+#: model:ir.model.fields,help:sale_order_general_discount.field_product_template__general_discount_apply
+msgid ""
+"If this checkbox is ticked, it means changing general discount on sale order "
+"will impact sale order lines with this related product."
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_product____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_product_template____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_res_partner____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order____last_update
+#: model:ir.model.fields,field_description:sale_order_general_discount.field_sale_order_line____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model,name:sale_order_general_discount.model_product_product
+msgid "Product"
+msgstr ""
+
+#. module: sale_order_general_discount
+#: model:ir.model,name:sale_order_general_discount.model_product_template
+msgid "Product Template"
+msgstr ""
 
 #. module: sale_order_general_discount
 #: model:ir.model,name:sale_order_general_discount.model_sale_order

--- a/sale_order_general_discount/models/__init__.py
+++ b/sale_order_general_discount/models/__init__.py
@@ -1,4 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import product_product
+from . import product_template
 from . import res_partner
 from . import sale_order
 from . import sale_order_line

--- a/sale_order_general_discount/models/product_product.py
+++ b/sale_order_general_discount/models/product_product.py
@@ -1,0 +1,15 @@
+# Copyright 2021 - Pierre Verkest
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    general_discount_apply = fields.Boolean(
+        string="Apply general discount",
+        default=True,
+        required=True,
+        help="If this checkbox is ticked, it means changing general discount on sale order "
+        "will impact sale order lines with this related product.",
+    )

--- a/sale_order_general_discount/models/product_template.py
+++ b/sale_order_general_discount/models/product_template.py
@@ -1,0 +1,37 @@
+# Copyright 2021 - Pierre Verkest
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import api, fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    general_discount_apply = fields.Boolean(
+        string="Apply general discount",
+        compute="_compute_general_discount_apply",
+        inverse="_inverse_general_discount_apply",
+        search="_search_general_discount_apply",
+        help="If this checkbox is ticked, it means changing general discount on sale order "
+        "will impact sale order lines with this related product.",
+    )
+
+    def _search_general_discount_apply(self, operator, value):
+        templates = self.with_context(active_test=False).search(
+            [("product_variant_ids.general_discount_apply", operator, value)]
+        )
+        return [("id", "in", templates.ids)]
+
+    @api.depends("product_variant_ids.general_discount_apply")
+    def _compute_general_discount_apply(self):
+        self.general_discount_apply = True
+        for template in self:
+            if len(template.product_variant_ids) == 1:
+                template.general_discount_apply = (
+                    template.product_variant_ids.general_discount_apply
+                )
+
+    def _inverse_general_discount_apply(self):
+        if len(self.product_variant_ids) == 1:
+            self.product_variant_ids.general_discount_apply = (
+                self.general_discount_apply
+            )

--- a/sale_order_general_discount/models/sale_order_line.py
+++ b/sale_order_general_discount/models/sale_order_line.py
@@ -20,7 +20,9 @@ class SaleOrderLine(models.Model):
         if "discount" not in vals and "order_id" in vals:
             sale_order = self.env["sale.order"].browse(vals["order_id"])
             if sale_order.general_discount:
-                vals["discount"] = sale_order.general_discount
+                product = self.env["product.product"].browse(vals["product_id"])
+                if product.general_discount_apply:
+                    vals["discount"] = sale_order.general_discount
         return super().create(vals)
 
     @api.depends("order_id", "order_id.general_discount")
@@ -28,4 +30,14 @@ class SaleOrderLine(models.Model):
         if hasattr(super(), "_compute_discount"):
             super()._compute_discount()
         for line in self:
-            line.discount = line.order_id.general_discount
+            if line.product_id.general_discount_apply:
+                line.discount = line.order_id.general_discount
+
+    @api.onchange("product_id")
+    def _onchange_product_id(self):
+        if hasattr(super(), "_onchange_product_id"):
+            super()._onchange_product_id()
+        for line in self:
+            line.discount = 0
+            if line.product_id.general_discount_apply:
+                line.discount = line.order_id.general_discount

--- a/sale_order_general_discount/readme/DESCRIPTION.rst
+++ b/sale_order_general_discount/readme/DESCRIPTION.rst
@@ -1,4 +1,6 @@
 This module allows to set a general discount in a sales order. This general
 discount is set to each line order in the standard `discount` field.
 
-You can also set a default general discount on customers.
+You can configure:
+ * a default general discount on customers
+ * On each product define if general discount is applied

--- a/sale_order_general_discount/readme/USAGE.rst
+++ b/sale_order_general_discount/readme/USAGE.rst
@@ -2,4 +2,7 @@ To use this module, you need to:
 
 #. Create a sale order and set a discount,
    this discount will be set in all lines.
-#. Also you can set a discount in a partner.
+#. You can set a discount in a partner.
+#. On product you can define if you
+   apply general discount on sale order line
+   linked to that product

--- a/sale_order_general_discount/views/product_view.xml
+++ b/sale_order_general_discount/views/product_view.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data>
+        <record id="product_normal_form_view" model="ir.ui.view">
+            <field
+                name="name"
+            >sale_order_general_discount.product_normal_form_view</field>
+            <field name="model">product.product</field>
+            <field name="priority" eval="16" />
+            <field name="inherit_id" ref="product.product_normal_form_view" />
+            <field name="arch" type="xml">
+                <xpath expr="//group[@name='group_standard_price']" position="inside">
+                    <field name="general_discount_apply" />
+                </xpath>
+            </field>
+        </record>
+        <record id="product_template_only_form_view" model="ir.ui.view">
+            <field name="name">product.template.sale_order_general_discount.form</field>
+            <field name="model">product.template</field>
+            <field name="priority" eval="24" />
+            <field name="inherit_id" ref="product.product_template_only_form_view" />
+            <field name="arch" type="xml">
+                <xpath expr="//group[@name='group_standard_price']" position="inside">
+                    <field
+                        name="general_discount_apply"
+                        attrs="{'invisible': [('product_variant_count', '>', 1)]}"
+                    />
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</odoo>


### PR DESCRIPTION
My customer has hundred lines in sale order, he wants apply discount only on some kind of products according his business rules. As today he set general discoung and move back to zero each lines manually.

The purpose of this PR is to improve `sale_order_general_discount` module in order to add an option on product to define if the general discount should be applied on sale order lines according linked product.
 