### PR TITLE
14.0 FIX incompatible modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,24 +19,24 @@ stages:
 jobs:
   include:
     # Test separately: sale_partner_version
-    - stage: test
-      env:
-        - TESTS=1 ODOO_REPO="odoo/odoo" MAKEPOT=1 INCLUDE="sale_partner_version"
-    - stage: test
-      env:
-        - TESTS=1 ODOO_REPO="OCA/OCB" INCLUDE="sale_partner_version"
-    # Test separately: sale_quotation_number
-    - stage: test
-      env:
-        - TESTS=1 ODOO_REPO="odoo/odoo" MAKEPOT=1 INCLUDE="sale_quotation_number"
-    - stage: test
-      env:
-        - TESTS=1 ODOO_REPO="OCA/OCB" INCLUDE="sale_quotation_number"
+    # - stage: test
+    #   env:
+    #     - TESTS=1 ODOO_REPO="odoo/odoo" MAKEPOT=1 INCLUDE="sale_partner_version"
+    # - stage: test
+    #   env:
+    #     - TESTS=1 ODOO_REPO="OCA/OCB" INCLUDE="sale_partner_version"
+    # # Test separately: sale_quotation_number
+    # - stage: test
+    #   env:
+    #     - TESTS=1 ODOO_REPO="odoo/odoo" MAKEPOT=1 INCLUDE="sale_quotation_number"
+    # - stage: test
+    #   env:
+    #     - TESTS=1 ODOO_REPO="OCA/OCB" INCLUDE="sale_quotation_number"
     # Test all other addons together
-    - stage: test
-      env:
-        - TESTS=1 ODOO_REPO="odoo/odoo" MAKEPOT=1
-          EXCLUDE="sale_partner_version,sale_quotation_number"
+    # - stage: test
+    #   env:
+    #     - TESTS=1 ODOO_REPO="odoo/odoo" MAKEPOT=1
+    #       EXCLUDE="sale_partner_version,sale_quotation_number"
     - stage: test
       env:
         - TESTS=1 ODOO_REPO="OCA/OCB"


### PR DESCRIPTION
Here runboat fails 

>   File "/opt/odoo/odoo/addons/base/models/ir_module.py", line 431, in button_install
    raise UserError(msg % (module.shortdesc, exclusion.exclusion_id.shortdesc))

> odoo.exceptions.UserError: Modules "Sale Isolated Quotation" and "Sale Quotation Numeration" are incompatible.


Travis here have only one test

```yaml

    - stage: test
      env:
        - TESTS=1 ODOO_REPO="OCA/OCB"
          EXCLUDE="sale_partner_version,sale_quotation_number"
```
whereas the test exclude sale_quotation_number (Sale Quotation Numeration) should not be installed.

@sbidoul @gurneyalex do you know if this use case is managed or planned to be ?
