### PR TITLE
[10.0][IMP] sale_stock_picking_note: update picking notes if changes in the order

### DIFF
--- a/sale_stock_picking_note/models/__init__.py
+++ b/sale_stock_picking_note/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import sale_stock
+from . import stock_picking

--- a/sale_stock_picking_note/models/sale_stock.py
+++ b/sale_stock_picking_note/models/sale_stock.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Carlos Dauden - Tecnativa <carlos.dauden@tecnativa.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class SaleOrder(models.Model):
@@ -10,6 +10,15 @@ class SaleOrder(models.Model):
     picking_note = fields.Text(
         string="Picking Note",
     )
+    @api.multi
+    def write(self, vals):
+        res = super(SaleOrder, self).write(vals)
+        if vals.get('picking_note', False):
+            for rec in self:
+                stock_moves = self.env['stock.move'].search([('procurement_id.sale_line_id.order_id', '=', rec.id), ('state', 'not in', ('done', 'cancel'))])
+                for picking in stock_moves.mapped('picking_id'):
+                    picking.note = vals.get('picking_note', False)
+        return res
 
 
 class StockMove(models.Model):

--- a/sale_stock_picking_note/models/stock_picking.py
+++ b/sale_stock_picking_note/models/stock_picking.py
@@ -1,0 +1,9 @@
+# Copyright 2021 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    note = fields.Text(track_visibility="onchange")

--- a/sale_stock_picking_note/readme/USAGE.rst
+++ b/sale_stock_picking_note/readme/USAGE.rst
@@ -2,3 +2,4 @@
 #. Go to *Other information* tab and set the **Picking Note** you want to.
 #. Confirm the Sale Order and go to the created picking.
 #. The note will be available under the *Additional Info* tab.
+#. If a change is needed in the notes it will be propagated to the pickings

--- a/sale_stock_picking_note/tests/test_sale_stock_picking_note.py
+++ b/sale_stock_picking_note/tests/test_sale_stock_picking_note.py
@@ -30,3 +30,10 @@ class TestSaleStockPickingNote(common.SavepointCase):
         self.order.action_confirm()
         self.assertEqual(self.order.picking_ids[:1].note,
                          self.order.picking_note)
+
+    def test_02_sale_to_picking_note_update(self):
+        """ Update picking note from SO """
+        self.order.action_confirm()
+        self.order.picking_note = "The note is now different."
+        self.assertEqual(self.order.picking_ids[:1].note,
+                         self.order.picking_note)

--- a/sale_stock_picking_note/views/sale_order_view.xml
+++ b/sale_stock_picking_note/views/sale_order_view.xml
@@ -9,7 +9,7 @@
         <field name="arch" type="xml">
             <group name="sale_shipping" position="inside">
                 <field name="picking_note"
-                       attrs="{'readonly': [('state', 'not in', ('draft', 'sent'))]}"
+                       attrs="{'readonly': [('state', 'not in', ('draft', 'sent', 'sale'))]}"
                        placeholder="This note will be carried over to the picking."/>
             </group>
         </field>


### PR DESCRIPTION
It could happen the customer demands some special instructions after the order is confirmed, those instructions need to be communicated to the warehouse.

If this PR is accepted I will forward-port this to newer versions.

@ForgeFlow 
