### PR TITLE
[14.0][imp][sale_advance_payment] various improvements

### DIFF
--- a/sale_advance_payment/tests/test_sale_advance_payment.py
+++ b/sale_advance_payment/tests/test_sale_advance_payment.py
@@ -156,6 +156,7 @@ class TestSaleAdvancePayment(common.SavepointCase):
             .create(
                 {
                     "journal_id": self.journal_eur_bank.id,
+                    "payment_type": "inbound",
                     "amount_advance": 100,
                     "order_id": self.sale_order_1.id,
                 }
@@ -172,6 +173,7 @@ class TestSaleAdvancePayment(common.SavepointCase):
             .create(
                 {
                     "journal_id": self.journal_usd_cash.id,
+                    "payment_type": "inbound",
                     "amount_advance": 200,
                     "order_id": self.sale_order_1.id,
                 }
@@ -191,6 +193,7 @@ class TestSaleAdvancePayment(common.SavepointCase):
             .create(
                 {
                     "journal_id": self.journal_eur_cash.id,
+                    "payment_type": "inbound",
                     "amount_advance": 250,
                     "order_id": self.sale_order_1.id,
                 }
@@ -206,6 +209,7 @@ class TestSaleAdvancePayment(common.SavepointCase):
             .create(
                 {
                     "journal_id": self.journal_usd_bank.id,
+                    "payment_type": "inbound",
                     "amount_advance": 400,
                     "order_id": self.sale_order_1.id,
                 }
@@ -227,3 +231,43 @@ class TestSaleAdvancePayment(common.SavepointCase):
         payments = json.loads(invoice.invoice_outstanding_credits_debits_widget)
         result = [d["amount"] for d in payments["content"]]
         self.assertEqual(set(payment_list), set(result))
+
+    def test_sale_advance_payment_outgoing(self):
+        self.assertEqual(
+            self.sale_order_1.amount_residual,
+            3600,
+        )
+        context_payment = {
+            "active_ids": [self.sale_order_1.id],
+            "active_id": self.sale_order_1.id,
+        }
+        # Create an inbound payment of 200 USD
+        advance_payment_2 = (
+            self.env["account.voucher.wizard"]
+            .with_context(context_payment)
+            .create(
+                {
+                    "journal_id": self.journal_usd_cash.id,
+                    "payment_type": "inbound",
+                    "amount_advance": 200,
+                    "order_id": self.sale_order_1.id,
+                }
+            )
+        )
+        advance_payment_2.make_advance_payment()
+        self.assertEqual(self.sale_order_1.amount_residual, 3400)
+        # Create an outbound payment of 200 USD
+        advance_payment_2 = (
+            self.env["account.voucher.wizard"]
+            .with_context(context_payment)
+            .create(
+                {
+                    "journal_id": self.journal_usd_cash.id,
+                    "payment_type": "outbound",
+                    "amount_advance": 200,
+                    "order_id": self.sale_order_1.id,
+                }
+            )
+        )
+        advance_payment_2.make_advance_payment()
+        self.assertEqual(self.sale_order_1.amount_residual, 3600)

--- a/sale_advance_payment/tests/test_sale_advance_payment.py
+++ b/sale_advance_payment/tests/test_sale_advance_payment.py
@@ -21,13 +21,13 @@ class TestSaleAdvancePayment(common.SavepointCase):
 
         # Products
         cls.product_1 = cls.env["product.product"].create(
-            {"name": "Desk Combination", "type": "product", "invoice_policy": "order"}
+            {"name": "Desk Combination", "invoice_policy": "order"}
         )
         cls.product_2 = cls.env["product.product"].create(
-            {"name": "Conference Chair", "type": "product", "invoice_policy": "order"}
+            {"name": "Conference Chair", "invoice_policy": "order"}
         )
         cls.product_3 = cls.env["product.product"].create(
-            {"name": "Repair Services", "type": "service", "invoice_policy": "order"}
+            {"name": "Repair Services", "invoice_policy": "order"}
         )
 
         cls.tax = cls.env["account.tax"].create(

--- a/sale_advance_payment/views/sale_view.xml
+++ b/sale_advance_payment/views/sale_view.xml
@@ -11,7 +11,7 @@
                     string="Pay sale advanced"
                     type="action"
                     groups="account.group_account_invoice"
-                    attrs="{'invisible': ['|',('state', 'in', ['done','cancel']),('invoice_status', 'in', ['invoiced'])]}"
+                    attrs="{'invisible': ['|',('state', 'in', ['done','cancel'])]}"
                 />
             </button>
             <notebook position="inside">

--- a/sale_advance_payment/views/sale_view.xml
+++ b/sale_advance_payment/views/sale_view.xml
@@ -11,7 +11,7 @@
                     string="Pay sale advanced"
                     type="action"
                     groups="account.group_account_invoice"
-                    attrs="{'invisible': ['|',('state', 'in', ['done','cancel'])]}"
+                    attrs="{'invisible': [('state', 'in', ['done','cancel'])]}"
                 />
             </button>
             <notebook position="inside">

--- a/sale_advance_payment/wizard/sale_advance_payment_wzd.py
+++ b/sale_advance_payment/wizard/sale_advance_payment_wzd.py
@@ -1,7 +1,9 @@
 # Copyright 2017 Omar Castiñeira, Comunitea Servicios Tecnológicos S.L.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+
 from odoo import _, api, exceptions, fields, models
+from odoo.exceptions import UserError
 from odoo.tools import float_compare
 
 
@@ -34,12 +36,18 @@ class AccountVoucherWizard(models.TransientModel):
         "Curr. amount", readonly=True, currency_field="currency_id"
     )
     payment_ref = fields.Char("Ref.")
+    payment_type = fields.Selection(
+        [("inbound", "Inbound"), ("outbound", "Outbound")],
+        default="inbound",
+        required=True,
+    )
 
     @api.depends("journal_id")
     def _compute_get_journal_currency(self):
         for wzd in self:
             wzd.journal_currency_id = (
-                wzd.journal_id.currency_id.id or self.env.user.company_id.currency_id.id
+                wzd.journal_id.currency_id.id
+                or wzd.journal_id.company_id.currency_id.id
             )
 
     @api.constrains("amount_advance")
@@ -94,10 +102,19 @@ class AccountVoucherWizard(models.TransientModel):
 
     def _prepare_payment_vals(self, sale):
         partner_id = sale.partner_invoice_id.commercial_partner_id.id
+        if self.amount_advance < 0.0:
+            raise UserError(
+                _(
+                    "The amount to advance must always be positive. "
+                    "Please use the payment type to indicate if this "
+                    "is an inbound or an outbound payment."
+                )
+            )
+
         return {
             "date": self.date,
             "amount": self.amount_advance,
-            "payment_type": "inbound",
+            "payment_type": self.payment_type,
             "partner_type": "customer",
             "ref": self.payment_ref or sale.name,
             "journal_id": self.journal_id.id,
@@ -113,7 +130,6 @@ class AccountVoucherWizard(models.TransientModel):
         self.ensure_one()
         payment_obj = self.env["account.payment"]
         sale_obj = self.env["sale.order"]
-
         sale_ids = self.env.context.get("active_ids", [])
         if sale_ids:
             sale_id = fields.first(sale_ids)

--- a/sale_advance_payment/wizard/sale_advance_payment_wzd_view.xml
+++ b/sale_advance_payment/wizard/sale_advance_payment_wzd_view.xml
@@ -16,6 +16,7 @@
                             select="1"
                             string="Payment Method"
                         />
+                        <field name="payment_type" />
                         <field name="journal_currency_id" string="Currency" />
                         <field name="payment_ref" />
                         <field name="date" />


### PR DESCRIPTION
- Allow to make advance payments when invoice has been created.
  This is justified by the fact that users may want to create a
  payment reversal in some circumstances.
- Introduce payment type (inbound, outbound) to improve usability

Already introduced in https://github.com/OCA/sale-workflow/pull/1830/commits/a129e683309a62e067be8e6694d8f668ef1a81b5

cc @GuillemCForgeFlow @MateuGForgeFlow 