### PR TITLE
[13.0][FIX] sale_order_invoicing_finished_task: Wrong value task_new_project...

### DIFF
--- a/sale_order_invoicing_finished_task/models/sale_order.py
+++ b/sale_order_invoicing_finished_task/models/sale_order.py
@@ -42,7 +42,7 @@ class SaleOrderLine(models.Model):
                 x.product_id.type == "service"
                 and x.product_id.invoicing_finished_task
                 and x.product_id.service_tracking
-                in ["task_global_project", "task_new_project"]
+                in ["task_global_project", "task_in_project"]
                 and not all(x.task_ids.mapped("invoiceable"))
             )
         )

--- a/sale_order_invoicing_finished_task/views/product_view.xml
+++ b/sale_order_invoicing_finished_task/views/product_view.xml
@@ -9,7 +9,7 @@
             <field name="project_id" position="before">
                 <field
                     name="invoicing_finished_task"
-                    attrs="{'invisible':['|', ('type','!=','service'), ('service_tracking', 'not in', ['task_global_project', 'task_new_project'])]}"
+                    attrs="{'invisible':['|', ('type','!=','service'), ('service_tracking', 'not in', ['task_global_project', 'task_in_project'])]}"
                 />
             </field>
         </field>


### PR DESCRIPTION
... instead of task_in_project in tests

New value in v13 and don't changed in sale_order_invoicing_finished_task migration:
https://github.com/odoo/odoo/blob/e7543a59dc7dbfb26d5f4f220462cf2ea501348e/addons/sale_timesheet/models/product.py#L22

@Tecnativa
ping @joao-p-marques @sergio-teruel 