### PR TITLE
[FIX] sale_product_set: fixed issue with wizard lines delete

### DIFF
--- a/sale_product_set/README.rst
+++ b/sale_product_set/README.rst
@@ -98,6 +98,7 @@ Contributors
 * Souheil Bejaoui <souheil.bejaoui@acsone.eu>
 * Adria Gil Sorribes <adria.gil@forgeflow.com>
 * Phuc (Tran Thanh) <phuc@trobz.com>
+* Mantas Šniukas <mantas@vialaurea.lt>
 
 Other credits
 ~~~~~~~~~~~~~

--- a/sale_product_set/tests/test_product_set.py
+++ b/sale_product_set/tests/test_product_set.py
@@ -166,3 +166,12 @@ class TestProductSet(common.SavepointCase):
         )
         order_line.ensure_one()
         self.assertEqual(order_line.discount, set_line.discount)
+
+    def test_product_set_delete_in_wizard(self):
+        products = self.so.order_line.product_id
+        wizard = self._get_wiz()
+        wizard.write({"product_set_line_ids": [(3, wizard.product_set_line_ids[0].id)]})
+        products |= wizard.product_set_line_ids.product_id
+        wizard.add_set()
+        self.assertEqual(products, self.so.order_line.product_id)
+        self.assertEqual(len(self.so.order_line), 3)

--- a/sale_product_set/wizard/product_set_add.py
+++ b/sale_product_set/wizard/product_set_add.py
@@ -25,8 +25,9 @@ class ProductSetAdd(models.TransientModel):
     )
     product_set_line_ids = fields.Many2many(
         "product.set.line",
-        "Product set lines",
+        string="Product set lines",
         required=True,
+        store=True,
         ondelete="cascade",
         compute="_compute_product_set_line_ids",
         readonly=False,


### PR DESCRIPTION
Issue: [#1817](https://github.com/OCA/sale-workflow/issues/1817)

Previously deleted line in wizard was not capable because of `compute` method. `Compute` method is generating from new one after you press `Add set` button in wizard. And all your changes in lines, isn't affected. So added `store=True` and it fix for now one.