### PR TITLE
[14.0][ADD] sale_automatic_workflow_ignore_exception

### DIFF
--- a/sale_automatic_workflow_ignore_exception/__init__.py
+++ b/sale_automatic_workflow_ignore_exception/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_automatic_workflow_ignore_exception/__manifest__.py
+++ b/sale_automatic_workflow_ignore_exception/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+{
+    "name": "Sale automatic workflow ignore exception",
+    "version": "14.0.1.0.0",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "category": "Sale",
+    "depends": [
+        # oca/sale-workflow
+        "sale_automatic_workflow",
+        "sale_exception",
+    ],
+    "website": "https://github.com/OCA/sale-workflow",
+    "data": [
+        # Views
+        "views/sale_workflow_process.xml",
+    ],
+}

--- a/sale_automatic_workflow_ignore_exception/i18n/fr.po
+++ b/sale_automatic_workflow_ignore_exception/i18n/fr.po
@@ -1,0 +1,59 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale_automatic_workflow_ignore_exception
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-01-17 11:00+0000\n"
+"PO-Revision-Date: 2022-01-17 11:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sale_automatic_workflow_ignore_exception
+#: model:ir.model.fields,field_description:sale_automatic_workflow_ignore_exception.field_automatic_workflow_job__display_name
+#: model:ir.model.fields,field_description:sale_automatic_workflow_ignore_exception.field_sale_order__display_name
+#: model:ir.model.fields,field_description:sale_automatic_workflow_ignore_exception.field_sale_workflow_process__display_name
+msgid "Display Name"
+msgstr "Afficher le nom"
+
+#. module: sale_automatic_workflow_ignore_exception
+#: model:ir.model.fields,field_description:sale_automatic_workflow_ignore_exception.field_automatic_workflow_job__id
+#: model:ir.model.fields,field_description:sale_automatic_workflow_ignore_exception.field_sale_order__id
+#: model:ir.model.fields,field_description:sale_automatic_workflow_ignore_exception.field_sale_workflow_process__id
+msgid "ID"
+msgstr ""
+
+#. module: sale_automatic_workflow_ignore_exception
+#: model:ir.model.fields,field_description:sale_automatic_workflow_ignore_exception.field_sale_workflow_process__ignore_exception_when_confirm
+msgid "Ignore Exception When Confirm"
+msgstr "Ignorer les restrictions de vente pour confirmer les commandes"
+
+#. module: sale_automatic_workflow_ignore_exception
+#: model:ir.model.fields,field_description:sale_automatic_workflow_ignore_exception.field_automatic_workflow_job____last_update
+#: model:ir.model.fields,field_description:sale_automatic_workflow_ignore_exception.field_sale_order____last_update
+#: model:ir.model.fields,field_description:sale_automatic_workflow_ignore_exception.field_sale_workflow_process____last_update
+msgid "Last Modified on"
+msgstr "Dernière modification le"
+
+#. module: sale_automatic_workflow_ignore_exception
+#: model:ir.model,name:sale_automatic_workflow_ignore_exception.model_sale_workflow_process
+msgid "Sale Workflow Process"
+msgstr "Flux automatique de vente"
+
+#. module: sale_automatic_workflow_ignore_exception
+#: model:ir.model,name:sale_automatic_workflow_ignore_exception.model_sale_order
+msgid "Sales Order"
+msgstr "Bon de commande"
+
+#. module: sale_automatic_workflow_ignore_exception
+#: model:ir.model,name:sale_automatic_workflow_ignore_exception.model_automatic_workflow_job
+msgid ""
+"Scheduler that will play automatically the validation of invoices, "
+"pickings..."
+msgstr ""

--- a/sale_automatic_workflow_ignore_exception/models/__init__.py
+++ b/sale_automatic_workflow_ignore_exception/models/__init__.py
@@ -1,0 +1,3 @@
+from . import automatic_workflow_job
+from . import sale_order
+from . import sale_workflow_process

--- a/sale_automatic_workflow_ignore_exception/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow_ignore_exception/models/automatic_workflow_job.py
@@ -1,0 +1,14 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AutomaticWorkflowJob(models.Model):
+
+    _inherit = "automatic.workflow.job"
+
+    def _do_validate_sale_order(self, sale, domain_filter):
+        if sale.workflow_process_id.ignore_exception_when_confirm:
+            sale = sale.with_context(ignore_exception_when_confirm=True)
+        return super()._do_validate_sale_order(sale, domain_filter)

--- a/sale_automatic_workflow_ignore_exception/models/sale_order.py
+++ b/sale_automatic_workflow_ignore_exception/models/sale_order.py
@@ -1,0 +1,14 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SaleOrder(models.Model):
+
+    _inherit = "sale.order"
+
+    def action_confirm(self):
+        if self.env.context.get("ignore_exception_when_confirm"):
+            self.write({"ignore_exception": True})
+        return super().action_confirm()

--- a/sale_automatic_workflow_ignore_exception/models/sale_workflow_process.py
+++ b/sale_automatic_workflow_ignore_exception/models/sale_workflow_process.py
@@ -1,0 +1,11 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class SaleWorkflowProcess(models.Model):
+
+    _inherit = "sale.workflow.process"
+
+    ignore_exception_when_confirm = fields.Boolean()

--- a/sale_automatic_workflow_ignore_exception/readme/CONTRIBUTORS.rst
+++ b/sale_automatic_workflow_ignore_exception/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Camptocamp
+* Julien Coux <julien.coux@camptocamp.com>

--- a/sale_automatic_workflow_ignore_exception/readme/DESCRIPTION.rst
+++ b/sale_automatic_workflow_ignore_exception/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+With this module,
+you can ignore sale exceptions when validate sale with sale automatic workflow.

--- a/sale_automatic_workflow_ignore_exception/tests/__init__.py
+++ b/sale_automatic_workflow_ignore_exception/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_automatic_workflow_ignore_exception

--- a/sale_automatic_workflow_ignore_exception/tests/test_automatic_workflow_ignore_exception.py
+++ b/sale_automatic_workflow_ignore_exception/tests/test_automatic_workflow_ignore_exception.py
@@ -1,0 +1,52 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo.addons.sale_automatic_workflow.tests.common import (
+    TestAutomaticWorkflowMixin,
+    TestCommon,
+)
+
+
+class TestAutomaticWorkflowIgnoreException(TestCommon, TestAutomaticWorkflowMixin):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        exception = cls.env.ref("sale_exception.excep_no_zip").sudo()
+        exception.active = True
+
+    def _get_override_workflow_values(self, ignore_exception):
+        return {
+            "validate_picking": False,
+            "create_invoice": False,
+            "validate_invoice": False,
+            "ignore_exception_when_confirm": ignore_exception,
+        }
+
+    def _test_common_and_return_sale(self, ignore_exception):
+        workflow_override = self._get_override_workflow_values(
+            ignore_exception=ignore_exception
+        )
+        workflow = self.create_full_automatic(workflow_override)
+        sale = self.create_sale_order(workflow)
+
+        self.assertEqual(sale.state, "draft")
+        self.assertEqual(sale.ignore_exception, False)
+        self.assertEqual(sale.workflow_process_id, workflow)
+
+        with self.cr.savepoint():  # To avoid cache problems
+            self.run_job()
+
+        return sale
+
+    def test_automatic_with_ignore_exception(self):
+        sale = self._test_common_and_return_sale(ignore_exception=True)
+
+        self.assertEqual(sale.state, "sale")
+        self.assertEqual(sale.ignore_exception, True)
+
+    def test_automatic_without_ignore_exception(self):
+        sale = self._test_common_and_return_sale(ignore_exception=False)
+
+        self.assertEqual(sale.state, "draft")
+        self.assertEqual(sale.ignore_exception, False)

--- a/sale_automatic_workflow_ignore_exception/views/sale_workflow_process.xml
+++ b/sale_automatic_workflow_ignore_exception/views/sale_workflow_process.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    # Copyright 2022 Camptocamp SA
+    # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+
+    <record id="sale_workflow_process_view_form" model="ir.ui.view">
+        <field name="model">sale.workflow.process</field>
+        <field
+            name="inherit_id"
+            ref="sale_automatic_workflow.sale_workflow_process_view_form"
+        />
+        <field name="arch" type="xml">
+
+            <field name="send_order_confirmation_mail" position="before">
+                <div attrs="{'invisible':[('validate_order','!=',True)]}" colspan="4">
+                    <label for="ignore_exception_when_confirm" />
+                    <field name="ignore_exception_when_confirm" nolabel="True" />
+                </div>
+            </field>
+
+        </field>
+    </record>
+
+</odoo>

--- a/setup/sale_automatic_workflow_ignore_exception/odoo/addons/sale_automatic_workflow_ignore_exception
+++ b/setup/sale_automatic_workflow_ignore_exception/odoo/addons/sale_automatic_workflow_ignore_exception
@@ -1,0 +1,1 @@
+../../../../sale_automatic_workflow_ignore_exception

--- a/setup/sale_automatic_workflow_ignore_exception/setup.py
+++ b/setup/sale_automatic_workflow_ignore_exception/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
With this module,
you can ignore sale exceptions when validate sale with sale automatic workflow.