### PR TITLE
[12.0] FIX sale_order_revision and sale_quotation_number working together

### DIFF
--- a/sale_order_revision/models/sale_order.py
+++ b/sale_order_revision/models/sale_order.py
@@ -71,7 +71,9 @@ class SaleOrder(models.Model):
             'name': '%s-%02d' % (self.unrevisioned_name, new_rev_number),
             'old_revision_ids': [(4, self.id, False)],
         })
-        new_revision = self.copy(default_data)
+        new_revision = self.with_context(
+            skip_overwriting_order_name=True
+        ).copy(default_data)
         self.old_revision_ids.write({
             'current_revision_id': new_revision.id,
         })

--- a/sale_quotation_number/models/sale_order.py
+++ b/sale_quotation_number/models/sale_order.py
@@ -17,7 +17,10 @@ class SaleOrder(models.Model):
             company = self.env['res.company'].browse(company)
         else:
             company = self.env['res.company']._company_default_get('sale.order')
-        if not company.keep_name_so:
+        if (
+            not company.keep_name_so and
+            not self.env.context.get("skip_overwriting_order_name")
+        ):
             vals['name'] = self.env['ir.sequence'].next_by_code(
                 'sale.quotation') or '/'
         return super(SaleOrder, self).create(vals)
@@ -27,7 +30,8 @@ class SaleOrder(models.Model):
         self.ensure_one()
         if default is None:
             default = {}
-        default['name'] = '/'
+        if not self.env.context.get("skip_overwriting_order_name"):
+            default['name'] = '/'
         if self.origin and self.origin != '':
             default['origin'] = self.origin + ', ' + self.name
         else:


### PR DESCRIPTION
Fix the following steps:

 - Install sale_order_revision and sale_quotation_number
 - Create quotation SQ01
 - Cancel quotation
 - New revision

Observed: quotation SQ01 is created

Desired: quotation SQ01-01 is created
