### PR TITLE
[13.0][IMP] sale_partner_selectable_option: Improve sale button in contact form to show only if "Selectable in orders" is checked.

### DIFF
--- a/sale_partner_selectable_option/views/res_partner_view.xml
+++ b/sale_partner_selectable_option/views/res_partner_view.xml
@@ -11,4 +11,19 @@
             </group>
         </field>
     </record>
+    <record id="res_partner_view_buttons" model="ir.ui.view">
+        <field name="name">res.partner.view.buttons</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="sale.res_partner_view_buttons" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//button[@name='%(sale.act_res_partner_2_sale_order)d']"
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'invisible': [('sale_selectable', '=', False)]}</attribute>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Improve sale button in contact form to show only if "Selectable in orders" is checked.

Please @ernestotejeda and @pedrobaeza can you review it?

@Tecnativa TT33933