### PR TITLE
[FIX] duplicate sale.order need to have 'New' as default name

### DIFF
--- a/sale_order_revision/models/sale_order.py
+++ b/sale_order_revision/models/sale_order.py
@@ -47,9 +47,9 @@ class SaleOrder(models.Model):
     def copy(self, default=None):
         if default is None:
             default = {}
-        if default.get("name", "/") == "/":
+        if default.get("name", _("New")) == _("New"):
             seq = self.env["ir.sequence"]
-            default["name"] = seq.next_by_code("sale.order") or "/"
+            default["name"] = seq.next_by_code("sale.order") or _("New")
             default["revision_number"] = 0
             default["unrevisioned_name"] = default["name"]
         return super(SaleOrder, self).copy(default=default)
@@ -75,9 +75,9 @@ class SaleOrder(models.Model):
     @api.model
     def create(self, values):
         if "unrevisioned_name" not in values:
-            if values.get("name", "/") == "/":
+            if values.get("name", _("New")) == _("New"):
                 seq = self.env["ir.sequence"]
-                values["name"] = seq.next_by_code("sale.order") or "/"
+                values["name"] = seq.next_by_code("sale.order") or _("New")
             values["unrevisioned_name"] = values["name"]
         return super(SaleOrder, self).create(values)
 

--- a/sale_quotation_number/models/sale_order.py
+++ b/sale_quotation_number/models/sale_order.py
@@ -4,7 +4,7 @@
 # © 2020 Manuel Regidor  <manuel.regidor@sygel.es>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
-from odoo import api, models
+from odoo import _, api, models
 
 
 class SaleOrder(models.Model):
@@ -25,7 +25,7 @@ class SaleOrder(models.Model):
         self.ensure_one()
         if default is None:
             default = {}
-        default["name"] = "/"
+        default["name"] = _("New")
         if self.origin and self.origin != "":
             default["origin"] = self.origin + ", " + self.name
         else:


### PR DESCRIPTION
When copy a sale order, new order should have new number, this is done by passing 'New' value à default name for a sale.order.
This is the case in sale_order_revision too.

This Merge request should fix the red status of travis for the sale-workflow repo