### PR TITLE
[13.0][FIX] sale_order_line_input: company_id field is empty and multi-company...

### DIFF
--- a/sale_order_line_input/models/sale_order.py
+++ b/sale_order_line_input/models/sale_order.py
@@ -8,17 +8,46 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     pricelist_id = fields.Many2one(related="order_id.pricelist_id", readonly=True,)
+    force_company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Forced company",
+        compute="_compute_force_company_id",
+        readonly=False,
+        help="Technical field to force company or get it "
+        "from env user if order don't exist.",
+    )
 
-    @api.model
-    def create(self, vals):
-        if not vals.get("order_id", False):
-            sale_order = self.env["sale.order"]
-            new_so = sale_order.new({"partner_id": vals.pop("order_partner_id")})
-            for onchange_method in new_so._onchange_methods["partner_id"]:
-                onchange_method(new_so)
-            order_data = new_so._convert_to_write(new_so._cache)
-            vals["order_id"] = sale_order.create(order_data).id
-        return super().create(vals)
+    @api.depends("order_id")
+    def _compute_force_company_id(self):
+        """ Related company is not computed already when we click create new line """
+        for line in self:
+            line.force_company_id = (
+                line.order_id.company_id
+                # Is not necessary use browse here
+                or self.env.context.get("force_company")
+                or self.env.company
+            )
+
+    @api.onchange("force_company_id")
+    def _onchange_force_company_id(self):
+        """ Assign company_id because is used in domains as partner,
+            product, taxes... """
+        for line in self:
+            line.company_id = line.force_company_id
+
+    @api.onchange("order_partner_id")
+    def _onchange_order_partner_id(self):
+        """ Create order to correct compute of taxes """
+        if not self.order_partner_id or self.order_id:
+            return
+        SaleOrder = self.env["sale.order"]
+        new_so = SaleOrder.new(
+            {"partner_id": self.order_partner_id, "company_id": self.force_company_id}
+        )
+        for onchange_method in new_so._onchange_methods["partner_id"]:
+            onchange_method(new_so)
+        order_vals = new_so._convert_to_write(new_so._cache)
+        self.order_id = SaleOrder.create(order_vals)
 
     def action_sale_order_form(self):
         self.ensure_one()

--- a/sale_order_line_input/tests/test_sale_order_line_input.py
+++ b/sale_order_line_input/tests/test_sale_order_line_input.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Tecnativa - Carlos Dauden
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests import SavepointCase
+from odoo.tests import Form, SavepointCase
 
 
 class TestSaleOrderLineInput(SavepointCase):
@@ -14,16 +14,17 @@ class TestSaleOrderLineInput(SavepointCase):
         )
 
     def test_sale_order_create_and_show(self):
-        line = self.env["sale.order.line"].create(
-            {
-                "order_partner_id": self.partner.id,
-                "product_id": self.product.id,
-                "price_unit": 190.50,
-                "product_uom": self.ref("product.decimal_product_uom"),
-                "product_uom_qty": 8.0,
-                "name": "Test line description",
-            }
+        line_form = Form(
+            self.env["sale.order.line"],
+            view="sale_order_line_input.view_sales_order_line_input_tree",
         )
+        line_form.order_partner_id = self.partner
+        line_form.product_id = self.product
+        line_form.price_unit = 190.50
+        line_form.product_uom = self.env.ref("uom.product_uom_unit")
+        line_form.product_uom_qty = 8.0
+        line_form.name = "Test line description"
+        line = line_form.save()
         self.assertTrue(line.order_id)
         action_dict = line.action_sale_order_form()
         self.assertEquals(action_dict["res_id"], line.order_id.id)

--- a/sale_order_line_input/views/sale_order_line_view.xml
+++ b/sale_order_line_input/views/sale_order_line_view.xml
@@ -18,11 +18,17 @@
                 <!-- We do not display the type because we don't want the user to be bothered with that information if he has no section or note. -->
                 <field name="display_type" invisible="1" />
                 <field
+                    name="force_company_id"
+                    optional="hide"
+                    attrs="{'readonly': [('order_id', '!=', False)]}"
+                    options="{'no_create': True}"
+                />
+                <field
                     name="order_id"
                     string="Order"
                     required="0"
                     placeholder="New"
-                    domain="[('state', 'not in', ('done', 'cancel'))]"
+                    domain="[('state', 'not in', ('done', 'cancel')), ('company_id', '=', company_id)]"
                     attrs="{'readonly': [('order_id', '!=', False)]}"
                     force_save="1"
                     options='{"no_open": True, "no_create": True}'
@@ -57,7 +63,7 @@
                         'quantity': product_uom_qty,
                         'pricelist': parent.pricelist_id,
                         'uom':product_uom,
-                        'company_id': parent.company_id,
+                        'company_id': company_id,
                         'default_list_price': price_unit,
                         'default_description_sale': name
                     }"


### PR DESCRIPTION
domains don't work. Taxes empty

Before this PR only partners and products without company could be selected and the tax field was empty.

I try use several methods to set order_id (NewId) related info from sale.order.line, but when the flow returns to user browser this info is lost.

Until we find a better solution or the ORM allows it, the record will be created in an onchange, something that, as I say, is not ideal.
The only downside is that if after selecting a partner you discard the introduction of the order line, you have to delete it manually.

@Tecnativa