### PR TITLE
[14.0][TMP] fix to resolve calendar conflict with DDMRP

### DIFF
--- a/sale_delivery_date/__manifest__.py
+++ b/sale_delivery_date/__manifest__.py
@@ -20,6 +20,8 @@
         "sale_stock",
         "stock_partner_delivery_window",
         "stock_warehouse_calendar",
+        # OCA/sale-workflow
+        "sale_order_line_date",
     ],
     "data": [
         # reports

--- a/sale_delivery_date/__manifest__.py
+++ b/sale_delivery_date/__manifest__.py
@@ -15,10 +15,15 @@
     "installable": True,
     "auto_install": True,
     "depends": [
+        # core
         "delivery",
-        "partner_tz",
+        "resource",
         "sale_stock",
+        # OCA/partner-contact
+        "partner_tz",
+        # OCA/stock-logistics-workflow
         "stock_partner_delivery_window",
+        # OCA/stock-logistics-warehouse
         "stock_warehouse_calendar",
         # OCA/sale-workflow
         "sale_order_line_date",

--- a/sale_delivery_date/migrations/14.0.1.0.0/pre-migrate.py
+++ b/sale_delivery_date/migrations/14.0.1.0.0/pre-migrate.py
@@ -1,0 +1,25 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from openupgradelib import openupgrade
+except (ImportError, IOError) as err:
+    _logger.debug(err)
+
+
+def migrate_calendar2(cr):
+    model = "stock_warehouse"
+    field_names = ["calendar2_id"]
+    previous_module = "sale_warehouse_calendar"
+    new_module = "sale_delivery_date"
+    openupgrade.update_module_moved_fields(
+        cr, model, field_names, previous_module, new_module
+    )
+
+
+def migrate(cr, version):
+    migrate_calendar2(cr)

--- a/sale_delivery_date/models/__init__.py
+++ b/sale_delivery_date/models/__init__.py
@@ -2,5 +2,6 @@ from . import cutoff_time_mixin
 from . import res_partner
 from . import sale_order
 from . import sale_order_line
+from . import stock_move
 from . import stock_picking
 from . import stock_warehouse

--- a/sale_delivery_date/models/res_partner.py
+++ b/sale_delivery_date/models/res_partner.py
@@ -6,6 +6,8 @@ from odoo import _, fields, models
 from odoo.exceptions import UserError
 from odoo.tools.date_utils import date_range
 
+from odoo.addons.partner_tz.tools import tz_utils
+
 
 class ResPartner(models.Model):
     _name = "res.partner"
@@ -99,5 +101,12 @@ class ResPartner(models.Model):
                 this_weekday_start_datetime = datetime.combine(
                     this_datetime, win.get_time_window_start_time()
                 )
+                if self.tz:
+                    start_time = tz_utils.tz_to_utc_time(
+                        self.tz, this_weekday_start_datetime.time()
+                    )
+                    this_weekday_start_datetime = datetime.combine(
+                        this_weekday_start_datetime, start_time
+                    )
                 res.append(this_weekday_start_datetime)
         return res

--- a/sale_delivery_date/models/sale_order.py
+++ b/sale_delivery_date/models/sale_order.py
@@ -74,15 +74,14 @@ class SaleOrder(models.Model):
         self.ensure_one()
         return bool(self.commitment_date or self.expected_date)
 
-    def get_cutoff_time(self):
-        self.ensure_one()
-        partner = self.partner_shipping_id
+    @api.model
+    def get_cutoff_time(self, partner, warehouse):
         if (
             partner.order_delivery_cutoff_preference == "warehouse_cutoff"
-            and self.warehouse_id.apply_cutoff
+            and warehouse.apply_cutoff
         ):
-            return self.warehouse_id.get_cutoff_time()
+            return warehouse.get_cutoff_time()
         elif partner.order_delivery_cutoff_preference == "partner_cutoff":
-            return self.partner_shipping_id.get_cutoff_time()
+            return partner.get_cutoff_time()
         else:
             return {}

--- a/sale_delivery_date/models/sale_order.py
+++ b/sale_delivery_date/models/sale_order.py
@@ -26,7 +26,7 @@ class SaleOrder(models.Model):
         """Add dependencies to consider fixed delivery windows"""
         return super()._compute_expected_date()
 
-    @api.onchange("commitment_date")
+    @api.onchange("expected_date", "commitment_date")
     def _onchange_commitment_date(self):
         """Warns if commitment date is not a preferred window for delivery"""
         res = super()._onchange_commitment_date()

--- a/sale_delivery_date/models/sale_order_line.py
+++ b/sale_delivery_date/models/sale_order_line.py
@@ -12,6 +12,8 @@ from odoo.addons.partner_tz.tools import tz_utils
 
 _logger = logging.getLogger(__name__)
 
+FIND_WORKING_DAY_COUNT = 10  # To avoid infinite loops, could be increased
+
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
@@ -43,170 +45,43 @@ class SaleOrderLine(models.Model):
         The 'date_deadline' is already set to the 'commitment_date' (that should
         preferably fit the partner's time window if any).
         """
-        # 1) compute the date when the transfer should be ready to be shipped
-        date_transfer_done = res["date_deadline"] - timedelta(
-            days=self.order_id.company_id.security_lead
-        )
-        res["date_planned"] = date_transfer_done
-        # 2) Find the first date in the WH calendar (by going back in the past)
-        calendar = self.order_id.warehouse_id.calendar_id
-        if calendar:
-            res["date_planned"] = calendar.plan_days(
-                -1, res["date_planned"], compute_leaves=True
-            )
-        # 3) Apply the partner or warehouse cutoff if any
-        res["date_planned"] = self._get_date_planned_with_cutoff_time(
-            res["date_planned"]
+        warehouse = self.order_id.warehouse_id
+        partner = self.order_id.partner_id
+        __, security_lead, workload = self._get_delays()
+        worload_days = self._delay_to_days(workload)
+        # Find the first date in the WH calendar by going back in the past, if any.
+        res["date_planned"] = self._deduce_workload_and_security_lead(
+            res["date_deadline"], partner, warehouse, worload_days, security_lead
         )
         return res
 
     def _prepare_procurement_values_no_commitment_date(self, res):
         """Set 'date_planned' and 'date_deadline' if no 'commitment_date'."""
-        res["date_planned"] = (
+        customer_lead, security_lead, workload = self._get_delays()
+        workload_days = self._delay_to_days(workload)
+        date_planned = (
             self.order_id.date_order
-            + timedelta(days=self.customer_lead or 0.0)
-            - timedelta(days=self.order_id.company_id.security_lead)
+            + timedelta(days=customer_lead or 0.0)
+            - timedelta(days=security_lead)
         )
-        res["date_planned"] = self._get_date_planned_with_cutoff_time(
-            res["date_planned"]
+        partner = self.order_id.partner_shipping_id
+        warehouse = self.order_id.warehouse_id
+        calendar = warehouse.calendar_id
+        date_planned = self._apply_cutoff(date_planned, partner, warehouse)
+        date_planned = self._apply_workload(date_planned, workload_days, calendar)
+        date_deadline = self._apply_delivery_window(
+            date_planned, partner, security_lead, calendar
         )
-        res["date_planned"] = self._get_date_planned_with_warehouse_calendar(
-            res["date_planned"]
+        date_planned = self._deduce_workload_and_security_lead(
+            date_deadline, partner, warehouse, workload_days, security_lead
         )
-        res["date_deadline"] = self._get_date_deadline_with_delivery_window(
-            res["date_planned"]
-        )
-        res["date_planned"] = self._get_date_planned_from_date_deadline(
-            res["date_deadline"]
-        )
+        res.update({"date_deadline": date_deadline, "date_planned": date_planned})
         return res
 
-    def _get_date_planned_with_cutoff_time(self, date_planned, keep_same_day=False):
-        """Apply the cut-off time on a planned date
-
-        The cut-off configuration is taken on the partner if set, otherwise
-        on the warehouse.
-
-        By default, if the planned date is the same day but after the cut-off,
-        the new planned date is delayed one day later. The argument
-        keep_same_day forces keeping the same day.
-        """
-        cutoff = self.order_id.get_cutoff_time()
-        partner = self.order_id.partner_shipping_id
-        if not cutoff:
-            if not self.order_id.warehouse_id.apply_cutoff:
-                _logger.debug(
-                    "No cutoff applied on order %s as partner %s is set to use "
-                    "%s and warehouse %s doesn't apply cutoff."
-                    % (
-                        self.order_id,
-                        partner,
-                        partner.order_delivery_cutoff_preference,
-                        self.order_id.warehouse_id,
-                    )
-                )
-            else:
-                _logger.warning(
-                    "No cutoff applied on order %s. %s time not applied"
-                    "on line %s."
-                    % (self.order_id, partner.order_delivery_cutoff_preference, self)
-                )
-            return date_planned
-        new_date_planned = self._get_utc_cutoff_datetime(
-            cutoff, date_planned, keep_same_day
-        )
-        _logger.debug(
-            "%s applied on order %s. Date planned for line %s"
-            " rescheduled from %s to %s"
-            % (
-                partner.order_delivery_cutoff_preference,
-                self.order_id,
-                self,
-                date_planned,
-                new_date_planned,
-            )
-        )
-        return new_date_planned
-
-    def _get_date_planned_with_warehouse_calendar(self, date_planned):
-        """Update the date planned based on the warehouse calendar if any."""
-        calendar = self.order_id.warehouse_id.calendar_id
-        if date_planned and calendar:
-            customer_lead, security_lead, workload = self._get_delays()
-            # plan_days() expect a number of days instead of a delay
-            workload_days = self._delay_to_days(workload)
-            # Add the workload, with respect to the wh calendar
-            date_planned = calendar.plan_days(
-                workload_days, date_planned, compute_leaves=True
-            )
-        return date_planned
-
-    def _get_date_deadline_with_delivery_window(self, date_planned):
-        """Return 'date_deadline' according to customer's time windows.
-
-        This computation is called only if no commitment_date is set and
-        if the customer's delivery time preference is "time windows".
-        It will return the effective delivery date by considering the next
-        preferred delivery time window of the customer.
-        """
-        # As the 'date_planned' is the date when the work can start on the
-        # transfer, we have to add the security lead of the company to get
-        # the date indicating when the transfer will be ready to be shipped.
-        # From this date we will be able to compute the preferred delivery date
-        # of the customer.
-        date_transfer_done = date_planned + timedelta(
-            days=self.order_id.company_id.security_lead
-        )
-        date_transfer_done = self._next_working_day(date_transfer_done)
-        if self.order_id.partner_shipping_id.delivery_time_preference != "time_windows":
-            return date_transfer_done
-        # Find the first working day matching the customer's delivery time window
-        ops = self.order_id.partner_shipping_id
-        next_preferred_date = ops.next_delivery_window_start_datetime(
-            from_date=date_transfer_done
-        )
-        next_working_day = self._next_working_day(next_preferred_date)
-        count = 0
-        while next_working_day.date() != next_preferred_date.date():
-            if count > 10:  # To avoid infinite loop, could be increased
-                raise exceptions.UserError(
-                    _(
-                        "Unable to find a working day matching "
-                        "customer's delivery time window."
-                    )
-                )
-            next_preferred_date = ops.next_delivery_window_start_datetime(
-                from_date=next_working_day
-            )
-            next_working_day = self._next_working_day(next_preferred_date)
-            count += 1
-        if date_transfer_done != next_preferred_date:
-            _logger.debug(
-                "Delivery window applied for order %s. Date planned for line %s"
-                " rescheduled from %s to %s",
-                self.order_id.name,
-                self.name,
-                date_transfer_done,
-                next_preferred_date,
-            )
-            return next_preferred_date
-        else:
-            _logger.debug(
-                "Delivery window not applied for order %s. Date planned for line %s",
-                " already in delivery window",
-                self.order_id.name,
-                self.name,
-            )
-        return next_preferred_date
-
-    def _next_working_day(self, date_):
-        """Return the next working day starting from `date_`."""
-        calendar = self.order_id.warehouse_id.calendar_id
-        if calendar:
-            return calendar.plan_hours(0, date_, compute_leaves=True)
-        return date_
-
-    def _get_date_planned_from_date_deadline(self, date_deadline):
+    @api.model
+    def _deduce_workload_and_security_lead(
+        self, date_deadline, partner, warehouse, days, security_lead
+    ):
         """Return the 'date_planned' from the 'date_deadline'.
 
         Once we know the delivery date of the customer, we are able to
@@ -214,23 +89,91 @@ class SaleOrderLine(models.Model):
         account the workload, the WH calendar and the cutoff time.
         """
         # Remove the security lead from the date_deadline
-        date_planned = date_deadline - timedelta(
-            days=self.order_id.company_id.security_lead
-        )
-        calendar = self.order_id.warehouse_id.calendar_id
+        # If there's a calendar, remove 1 day until we get to a working day.
+        # The reason for that is the parcel cannot be given to the carrier
+        # on a non-working day.
+        calendar = warehouse.calendar_id
+        date_planned = date_deadline - timedelta(days=security_lead)
         if calendar:
-            __, __, workload = self._get_delays()
-            workload_days = self._delay_to_days(workload)
-            date_planned = calendar.plan_days(
-                -workload_days, date_planned, compute_leaves=True
-            )
-        return self._get_date_planned_with_cutoff_time(
-            date_planned,
-            # the correct day has already been computed, only change
-            # the cut-off time
-            keep_same_day=True,
+            next_working_day = self._next_working_day(date_planned, calendar)
+            count = 0
+            while next_working_day.date() != date_planned.date():
+                if count > FIND_WORKING_DAY_COUNT:  # To avoid infinite loop
+                    raise exceptions.UserError(
+                        _(
+                            "Unable to find a working day matching "
+                            "customer's delivery time window."
+                        )
+                    )
+                date_planned -= timedelta(days=1)
+                next_working_day = self._next_working_day(date_planned, calendar)
+                count += 1
+        # Deduce the workload, if date_planned is after the cutoff
+        date_planned_w_cutoff = self._apply_cutoff(
+            date_planned, partner, warehouse, keep_same_day=True
         )
+        if date_planned > date_planned_w_cutoff:
+            date_planned = self._apply_workload(
+                date_planned, -days, warehouse.calendar_id
+            )
+            # the correct day has already been computed, only change the cut-off time
+            return self._apply_cutoff(
+                date_planned, partner, warehouse, keep_same_day=True
+            )
+        return date_planned_w_cutoff
 
+    @api.model
+    def _apply_cutoff(self, date, partner, warehouse, keep_same_day=False):
+        cutoff = self.env["sale.order"].get_cutoff_time(partner, warehouse)
+        if not cutoff:
+            return date
+        return self._get_utc_cutoff_datetime(cutoff, date, keep_same_day)
+
+    @api.model
+    def _apply_workload(self, date, days, calendar=None):
+        if calendar:
+            return calendar.plan_days(days, date, compute_leaves=True)
+        return date
+
+    @api.model
+    def _apply_delivery_window(
+        self, date_planned, partner, security_lead, calendar=None
+    ):
+        date_done = date_planned + timedelta(days=security_lead)
+        date_done = self._next_working_day(date_done, calendar)
+        if partner.delivery_time_preference != "time_windows":
+            return date_done
+        next_preferred_date = partner.next_delivery_window_start_datetime(
+            from_date=date_done
+        )
+        next_working_day = self._next_working_day(next_preferred_date, calendar)
+        count = 0
+        while next_working_day.date() != next_preferred_date.date():
+            if count > FIND_WORKING_DAY_COUNT:  # To avoid infinite loop
+                raise exceptions.UserError(
+                    _(
+                        "Unable to find a working day matching "
+                        "customer's delivery time window."
+                    )
+                )
+            next_preferred_date = partner.next_delivery_window_start_datetime(
+                from_date=next_working_day
+            )
+            next_working_day = self._next_working_day(next_preferred_date, calendar)
+            count += 1
+        if date_done != next_preferred_date:
+            # TODO : Add logs ?
+            return next_preferred_date
+        return next_preferred_date
+
+    @api.model
+    def _next_working_day(self, date_, calendar=None):
+        """Return the next working day starting from `date_`."""
+        if calendar:
+            return calendar.plan_hours(0, date_, compute_leaves=True)
+        return date_
+
+    @api.model
     def _delay_to_days(self, number_of_days):
         """Converts a delay to a number of days."""
         return number_of_days + 1
@@ -247,14 +190,21 @@ class SaleOrderLine(models.Model):
         #   - the warehouse or partner cutoff time
         #   - the warehouse calendar
         #   - the delivery time window of the customer
+        customer_lead, security_lead, workload = self._get_delays()
         date_planned = (
             (self.order_id.date_order or fields.Datetime.now())
-            + timedelta(days=self.customer_lead or 0.0)
-            - timedelta(days=self.order_id.company_id.security_lead)
+            + timedelta(days=customer_lead or 0.0)
+            - timedelta(days=security_lead)
         )
-        date_planned = self._get_date_planned_with_cutoff_time(date_planned)
-        date_planned = self._get_date_planned_with_warehouse_calendar(date_planned)
-        expected_date = self._get_date_deadline_with_delivery_window(date_planned)
+        partner = self.order_id.partner_shipping_id
+        warehouse = self.order_id.warehouse_id
+        calendar = warehouse.calendar_id
+        workload_days = self._delay_to_days(workload)
+        date_planned = self._apply_cutoff(date_planned, partner, warehouse)
+        date_planned = self._apply_workload(date_planned, workload_days, calendar)
+        expected_date = self._apply_delivery_window(
+            date_planned, partner, security_lead, calendar
+        )
         return expected_date
 
     @api.depends("order_id.expected_date")
@@ -262,6 +212,7 @@ class SaleOrderLine(models.Model):
         """Trigger computation of qty_at_date when expected_date is updated"""
         return super()._compute_qty_at_date()
 
+    @api.model
     def _get_utc_cutoff_datetime(self, cutoff, date, keep_same_day=False):
         tz = cutoff.get("tz")
         if tz:

--- a/sale_delivery_date/models/sale_order_line.py
+++ b/sale_delivery_date/models/sale_order_line.py
@@ -87,7 +87,7 @@ class SaleOrderLine(models.Model):
         )
         partner = self.order_id.partner_shipping_id
         warehouse = self.order_id.warehouse_id
-        calendar = warehouse.calendar_id
+        calendar = warehouse.calendar2_id
         date_planned = self._apply_cutoff(date_planned, partner, warehouse)
         date_planned = self._apply_workload(date_planned, workload_days, calendar)
         date_deadline = self._apply_delivery_window(
@@ -113,7 +113,7 @@ class SaleOrderLine(models.Model):
         # If there's a calendar, remove 1 day until we get to a working day.
         # The reason for that is the parcel cannot be given to the carrier
         # on a non-working day.
-        calendar = warehouse.calendar_id
+        calendar = warehouse.calendar2_id
         date_planned = date_deadline - timedelta(days=security_lead)
         if calendar:
             next_working_day = self._next_working_day(date_planned, calendar)
@@ -135,7 +135,7 @@ class SaleOrderLine(models.Model):
         )
         if date_planned > date_planned_w_cutoff:
             date_planned = self._apply_workload(
-                date_planned, -days, warehouse.calendar_id
+                date_planned, -days, warehouse.calendar2_id
             )
             # the correct day has already been computed, only change the cut-off time
             return self._apply_cutoff(
@@ -222,7 +222,7 @@ class SaleOrderLine(models.Model):
         )
         partner = self.order_id.partner_shipping_id
         warehouse = self.order_id.warehouse_id
-        calendar = warehouse.calendar_id
+        calendar = warehouse.calendar2_id
         workload_days = self._delay_to_days(workload)
         date_planned = self._apply_cutoff(date_planned, partner, warehouse)
         date_planned = self._apply_workload(date_planned, workload_days, calendar)

--- a/sale_delivery_date/models/sale_order_line.py
+++ b/sale_delivery_date/models/sale_order_line.py
@@ -160,7 +160,10 @@ class SaleOrderLine(models.Model):
     def _apply_delivery_window(
         self, date_planned, partner, security_lead, calendar=None
     ):
-        date_done = date_planned + timedelta(days=security_lead)
+        datetime_done = date_planned + timedelta(days=security_lead)
+        # Only the date here is relevant, both to find out if this is a working day
+        # and to apply the delivery window on top of it.
+        date_done = datetime_done.replace(hour=0, minute=0, second=0, microsecond=0)
         date_done = self._next_working_day(date_done, calendar)
         if partner.delivery_time_preference != "time_windows":
             return date_done

--- a/sale_delivery_date/models/stock_move.py
+++ b/sale_delivery_date/models/stock_move.py
@@ -1,0 +1,48 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _get_delays(self):
+        self.ensure_one()
+        customer_lead = self.product_id.sale_delay
+        security_lead = self.company_id.security_lead or 0.0
+        workload = customer_lead - security_lead
+        return customer_lead, security_lead, workload
+
+    def _get_delivery_dates(self, from_date=None):
+        """Returns the delivery dates, according to the from_date arg, or now(),
+        if not set.
+        """
+        self.ensure_one()
+        if not from_date:
+            from_date = fields.Datetime.now()
+        partner = self.picking_id.partner_id
+        warehouse = self.picking_id.picking_type_id.warehouse_id
+        calendar = warehouse.calendar_id
+        customer_lead, security_lead, workload = self._get_delays()
+        sale_line_model = self.env["sale.order.line"]
+        workload_days = sale_line_model._delay_to_days(workload)
+        # Those steps are the same as in sale_order_line.py,
+        # in the `_prepare_procurement_values_no_commitment_date` method,
+        # which means that we compute both date_planned and date_deadline based
+        # on `from_date`:
+        #   1) apply cutoff (partner or warehouse cutoff, depending on the config)
+        #   2) apply the workload
+        #   3) apply partner's time window to get the date deadline
+        #   4) deduce security_lead and the workload to get the date planned
+        date_planned = sale_line_model._apply_cutoff(from_date, partner, warehouse)
+        date_planned = sale_line_model._apply_workload(
+            date_planned, workload_days, calendar
+        )
+        date_deadline = sale_line_model._apply_delivery_window(
+            date_planned, partner, security_lead, calendar
+        )
+        date_planned = sale_line_model._deduce_workload_and_security_lead(
+            date_deadline, partner, warehouse, workload_days, security_lead
+        )
+        return {"date": date_planned, "date_deadline": date_deadline}

--- a/sale_delivery_date/models/stock_move.py
+++ b/sale_delivery_date/models/stock_move.py
@@ -23,7 +23,7 @@ class StockMove(models.Model):
             from_date = fields.Datetime.now()
         partner = self.picking_id.partner_id
         warehouse = self.picking_id.picking_type_id.warehouse_id
-        calendar = warehouse.calendar_id
+        calendar = warehouse.calendar2_id
         customer_lead, security_lead, workload = self._get_delays()
         sale_line_model = self.env["sale.order.line"]
         workload_days = sale_line_model._delay_to_days(workload)

--- a/sale_delivery_date/models/stock_picking.py
+++ b/sale_delivery_date/models/stock_picking.py
@@ -58,7 +58,7 @@ class StockPicking(models.Model):
         """Compute the stock.picking status in relation to warehouse cut-off time.
 
         Possible values are:
-        -1 schedulled_date is in the past of yesterday's cutoff time
+        -1 scheduled_date is in the past of yesterday's cutoff time
          0 scheduled_date is between yesterday and today's cuttoff
          1 scheduled_date is in the future of today's cutoff time
 

--- a/sale_delivery_date/models/stock_warehouse.py
+++ b/sale_delivery_date/models/stock_warehouse.py
@@ -9,3 +9,4 @@ class StockWarehouse(models.Model):
     _inherit = ["stock.warehouse", "time.cutoff.mixin"]
 
     apply_cutoff = fields.Boolean()
+    calendar2_id = fields.Many2one("resource.calendar", string="Working Hours")

--- a/sale_delivery_date/tests/__init__.py
+++ b/sale_delivery_date/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_sale_partner_cutoff_delivery_window
 from . import test_sale_warehouse_calendar
 from . import test_sale_partner_delivery_window
 from . import test_delivery_date_in_the_past
+from . import test_backorder_date

--- a/sale_delivery_date/tests/common.py
+++ b/sale_delivery_date/tests/common.py
@@ -98,7 +98,7 @@ class Common(SavepointCase):
                 "apply_cutoff": True,
                 "cutoff_time": WAREHOUSE_CUTOFF_TIME,
                 "tz": TZ,
-                "calendar_id": cls.calendar,
+                "calendar2_id": cls.calendar,
             }
         )
 

--- a/sale_delivery_date/tests/test_backorder_date.py
+++ b/sale_delivery_date/tests/test_backorder_date.py
@@ -1,0 +1,80 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from freezegun import freeze_time
+
+from .common import Common
+
+MONDAY = "2022-04-11"
+THURSDAY = "2022-04-14"
+FRIDAY = "2022-04-15"
+# The week after
+NEXT_THURSDAY = "2022-04-21"
+NEXT_FRIDAY = "2022-04-22"
+# As per Common config, those hours are in "UTC" TZ
+BEFORE_CUTOFF_UTC = "06:00:00"
+CUTOFF_UTC = "07:00:00"
+AFTER_CUTOFF_UTC = "08:00:00"
+TIME_WINDOW_START_UTC = "06:00:00"
+MONDAY_BEFORE_CUTOFF_UTC = f"{MONDAY} {BEFORE_CUTOFF_UTC}"
+
+
+@freeze_time(MONDAY_BEFORE_CUTOFF_UTC)
+class TestBackorderDate(Common):
+    # Two cases to ensure here:
+    #   - If a backorder is created, then its delivery dates are postponed
+    #   - If we modify a SO (I.E. add lines) after it has been confirmed,
+    #     the delivery date of the picking might be reevaluated
+    # Configuration:
+    #   - partner_cutoff: 07:00:00 UTC
+    #   - wh calendar: start=07:00:00 UTC, end=15:00:00 UTC
+    #   - partner window: between 06:00:00 UTC and 16:00:00 UTC on fridays
+    # With this config, an a SO confirmed on, 2022-04-11 (monday) at 06:00:00 UTC,
+    # the first picking should have the following dates:
+    #   - date_deadline: 2022-04-15 06:00
+    #   - scheduled_date: 2022-04-14 07:00:00
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Set customer's time window to friday, so delivery is postponed by 1
+        # week, which makes it easier to test
+        cls._set_partner_time_window_to_friday(cls.customer_partner_cutoff)
+        cls.order = cls.order_partner_cutoff
+        cls.order.action_confirm()
+        cls.picking = cls.order.picking_ids
+        # Here, we want to ensure that the picking date is correctly postponed
+        cls.picking.move_type = "one"
+
+    @classmethod
+    def _get_default_products(cls):
+        return [(cls.product, 10)]
+
+    @classmethod
+    def _create_backorder(cls):
+        # Set the half as done, then confirm the picking
+        cls.picking.move_lines.quantity_done = 5.0
+        cls.picking._action_done()
+        return cls.order.picking_ids - cls.picking
+
+    def test_backorder_before_scheduled_date(self):
+        # If we want the backorder to be delivered this week, then it has to be
+        # created before monday's cutoff.
+        # If so, it will be delivered friday, at 06:00
+        with freeze_time(f"{THURSDAY} {BEFORE_CUTOFF_UTC}"):
+            backorder = self._create_backorder()
+        self.assertEqual(str(backorder.scheduled_date), f"{THURSDAY} {CUTOFF_UTC}")
+        self.assertEqual(
+            str(backorder.date_deadline), f"{FRIDAY} {TIME_WINDOW_START_UTC}"
+        )
+
+    def test_backorder_after_scheduled_date(self):
+        # If we want the backorder to be delivered this week, then it has to be
+        # created before monday's cutoff.
+        # If so, it will be delivered friday, at 06:00
+        with freeze_time(f"{THURSDAY} {AFTER_CUTOFF_UTC}"):
+            backorder = self._create_backorder()
+        self.assertEqual(str(backorder.scheduled_date), f"{NEXT_THURSDAY} {CUTOFF_UTC}")
+        self.assertEqual(
+            str(backorder.date_deadline), f"{NEXT_FRIDAY} {TIME_WINDOW_START_UTC}"
+        )

--- a/sale_delivery_date/tests/test_delivery_date_in_the_past.py
+++ b/sale_delivery_date/tests/test_delivery_date_in_the_past.py
@@ -82,6 +82,15 @@ class TestDeliveryDateInThePast(SavepointCase):
         then expected_date is still valid, since it's updated when the
         so is confirmed.
         """
+        # Parameters:
+        #   - customer_lead = 0
+        #   - security_lead = 1
+        #   - date_order = "2021-10-25 00:00" (Monday)
+        #   - partner's cutoff time at 09:00
+        #   - no partner's delivery time window
+        #   - no WH calendar
+        # Expected result:
+        #   - date_planned = "2021-10-24"
         with freeze_time("2021-10-15"):
             order = self._create_order(partner=self.customer_partner)
         with freeze_time("2021-10-25"):

--- a/sale_delivery_date/tests/test_sale_cutoff_time_delivery.py
+++ b/sale_delivery_date/tests/test_sale_cutoff_time_delivery.py
@@ -131,6 +131,7 @@ class TestSaleCutoffTimeDelivery(Common):
 
     @freeze_time(MONDAY_BEFORE_CUTOFF_TZ)
     def test_commitment_date_partner_cutoff(self):
+        # FIXME: computation of date_planned based on commitment_date not implemented
         order = self.order_partner_cutoff
         order.commitment_date = fields.Datetime.to_datetime(f"{THURSDAY} 16:00:00")
         order.action_confirm()

--- a/sale_delivery_date/tests/test_sale_cutoff_time_delivery.py
+++ b/sale_delivery_date/tests/test_sale_cutoff_time_delivery.py
@@ -32,7 +32,7 @@ class TestSaleCutoffTimeDelivery(Common):
     def setUpClassWarehouse(cls):
         super().setUpClassWarehouse()
         cls.apply_cutoff = False
-        cls.warehouse.calendar_id = False
+        cls.warehouse.calendar2_id = False
 
     @classmethod
     def setUpClassProduct(cls):

--- a/sale_delivery_date/tests/test_sale_warehouse_calendar.py
+++ b/sale_delivery_date/tests/test_sale_warehouse_calendar.py
@@ -144,6 +144,7 @@ class TestSaleOrderDates(SavepointCase):
     def test_confirm_before_cutoff_weekend_3_days_preparation(self):
         order = self._create_order(customer_lead=3)
         order.action_confirm()
+        self.assertEqual(str(order.picking_ids.date_deadline.date()), NEXT_THURSDAY)
         self.assertEqual(str(order.expected_date.date()), NEXT_THURSDAY)
         picking = order.picking_ids
         self.assertEqual(str(picking.scheduled_date.date()), NEXT_WEDNESDAY)

--- a/sale_delivery_date/tests/test_sale_warehouse_calendar.py
+++ b/sale_delivery_date/tests/test_sale_warehouse_calendar.py
@@ -76,7 +76,7 @@ class TestSaleOrderDates(SavepointCase):
             {
                 "cutoff_time": CUTOFF_TIME,
                 "apply_cutoff": True,
-                "calendar_id": cls.calendar,
+                "calendar2_id": cls.calendar,
             }
         )
 

--- a/sale_delivery_date/views/stock_warehouse.xml
+++ b/sale_delivery_date/views/stock_warehouse.xml
@@ -5,6 +5,12 @@
         <field name="model">stock.warehouse</field>
         <field name="inherit_id" ref="stock.view_warehouse" />
         <field name="arch" type="xml">
+            <field name="calendar_id" position="after">
+                <field name="calendar2_id" options="{'no_create': True}" />
+            </field>
+            <field name="calendar_id" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
             <field name="partner_id" position="after">
                 <field name="apply_cutoff" />
                 <field

--- a/sale_order_line_date/models/sale_order.py
+++ b/sale_order_line_date/models/sale_order.py
@@ -12,7 +12,7 @@ from odoo import api, models
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    @api.onchange("commitment_date")
+    @api.onchange("expected_date", "commitment_date")
     def _onchange_commitment_date(self):
         """Update order lines with commitment date from sale order"""
         result = super(SaleOrder, self)._onchange_commitment_date() or {}


### PR DESCRIPTION
There's a conflict with DDMRP regarding the usage of the
stock.warehouse's calendar_id.
This PR implements a new `calendar2_id` field (already there in v13, see
this commit https://github.com/OCA/sale-workflow/pull/1696/commits/5b0b93a126706b3f32e789b6e751099001b16bcc)
in order to temporary solve this conflict.