### PR TITLE
[15.0][FIX] sale_order_line_date: Refactor code

### DIFF
--- a/sale_order_line_date/models/sale_order.py
+++ b/sale_order_line_date/models/sale_order.py
@@ -6,25 +6,36 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
+    @api.onchange("expected_date")
+    def _onchange_expected_date(self):
+        """
+        Every time a sale order line Delivery Date is changed,
+        this method is called.
+        """
+        res = super(SaleOrder, self)._onchange_expected_date()
+        dates_list = []
+        for line in self.order_line.filtered(
+            lambda x: x.state != "cancel"
+            and not x._is_delivery()
+            and not x.display_type
+        ):
+            if line.commitment_date:
+                dt = line.commitment_date
+                dates_list.append(dt)
+        if dates_list:
+            commitment_date = (
+                min(dates_list) if self.picking_policy == "direct" else max(dates_list)
+            )
+            self.commitment_date = fields.Datetime.to_string(commitment_date)
+        else:
+            return res
+
     @api.onchange("commitment_date")
     def _onchange_commitment_date(self):
-        """Update order lines with commitment date from sale order"""
-        result = super(SaleOrder, self)._onchange_commitment_date() or {}
-        if "warning" not in result:
-            result["value"] = {
-                "order_line": [
-                    (1, line.id, {"commitment_date": self.commitment_date})
-                    for line in self.order_line
-                    if not line.commitment_date
-                    or (
-                        self.expected_date and line.commitment_date < self.expected_date
-                    )
-                ]
-            }
-        return result
+        self._onchange_expected_date()

--- a/sale_order_line_date/models/sale_order_line.py
+++ b/sale_order_line_date/models/sale_order_line.py
@@ -6,6 +6,8 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
+from datetime import timedelta
+
 from odoo import fields, models
 
 
@@ -14,22 +16,25 @@ class SaleOrderLine(models.Model):
 
     commitment_date = fields.Datetime("Delivery Date")
 
-    def write(self, vals):
-        # Force commitment date only if all lines are on the same sale order
-        if len(self.mapped("order_id")) == 1:
-            for line in self:
-                if (
-                    not line.commitment_date
-                    and line.order_id.commitment_date
-                    and "commitment_date" not in vals
-                ):
-                    vals.update({"commitment_date": line.order_id.commitment_date})
-                    break
-        return super(SaleOrderLine, self).write(vals)
-
     def _prepare_procurement_values(self, group_id=False):
         vals = super(SaleOrderLine, self)._prepare_procurement_values(group_id)
         # has ensure_one already
         if self.commitment_date:
+            vals.update(
+                {
+                    "date_planned": self.commitment_date
+                    - timedelta(days=self.order_id.company_id.security_lead)
+                }
+            )
             vals.update({"date_deadline": self.commitment_date})
         return vals
+
+    def _expected_date(self):
+        """
+        The only intention of this method is to call
+        _onchange_expected_date() when a sale order line
+        Delivery Date is changed and SO was already confirmed.
+        """
+        res = super(SaleOrderLine, self)._expected_date()
+        self.order_id._onchange_expected_date()
+        return res

--- a/sale_order_line_date/readme/CONTRIBUTORS.rst
+++ b/sale_order_line_date/readme/CONTRIBUTORS.rst
@@ -10,3 +10,4 @@
 * Open-Net Sàrl <jae@open-net.ch>
 * Miquel Raïch <miquel.raich@forgeflow.com>
 * Moaad Bourhim <moaad.bourhim@gmail.com>
+* Bernat Puig <bernat.puig@forgeflow.com>

--- a/sale_order_line_date/readme/DESCRIPTION.rst
+++ b/sale_order_line_date/readme/DESCRIPTION.rst
@@ -1,4 +1,4 @@
 This module adds a commitment date to each sale order line and propagate it to
 stock moves and pickings.
-When the commitment date of the whole sale order is modified, the commitment date
-of the lines change to match if necessary.
+The commitment date of the whole sale order is computed based on each sale order
+line date and the sale order shipping policy. It can't be modified.

--- a/sale_order_line_date/tests/test_sale_order_line_date.py
+++ b/sale_order_line_date/tests/test_sale_order_line_date.py
@@ -19,22 +19,20 @@ class TestSaleOrderLineDates(TransactionCase):
         price = 100.0
         qty = 5
         product_id = self.env.ref("product.product_product_7")
-        today = fields.Datetime.now()
-        dt1 = today + datetime.timedelta(days=9)
-        dt2 = today + datetime.timedelta(days=10)
-        self.dt3 = today + datetime.timedelta(days=3)
-        self.sale1 = self._create_sale_order(customer, dt2)
+        self.today = fields.Datetime.now()
+        self.dt1 = self.today + datetime.timedelta(days=9)
+        self.dt2 = self.today + datetime.timedelta(days=10)
+        self.dt3 = self.today + datetime.timedelta(days=3)
+        self.sale1 = self._create_sale_order(customer, None)
         self.sale_line1 = self._create_sale_order_line(
-            self.sale1, product_id, qty, price, dt1
+            self.sale1, product_id, qty, price, None
         )
         self.sale_line2 = self._create_sale_order_line(
-            self.sale1, product_id, qty, price, dt2
+            self.sale1, product_id, qty, price, None
         )
         self.sale_line3 = self._create_sale_order_line(
             self.sale1, product_id, qty, price, None
         )
-        self.sale_line2.write({"commitment_date": dt2})
-        self.sale1.action_confirm()
 
     def _create_sale_order(self, customer, date):
         sale = self.env["sale.order"].create(
@@ -43,6 +41,7 @@ class TestSaleOrderLineDates(TransactionCase):
                 "partner_invoice_id": customer.id,
                 "partner_shipping_id": customer.id,
                 "commitment_date": date,
+                "picking_policy": "direct",
             }
         )
         return sale
@@ -60,10 +59,38 @@ class TestSaleOrderLineDates(TransactionCase):
         )
         return sale_line
 
-    def test_on_change_commitment_date(self):
-        """True when the commitment date in the sale_order_line
-        matches the commitment date in the sale order"""
+    def test_01_so_quotation_commitment_date(self):
+        """Test if commitment date is correct in SO quotation"""
+        self.assertEqual(self.sale1.commitment_date, False)
+        self.sale_line1.write({"commitment_date": self.dt3})
+        self.sale1._onchange_expected_date()
+        self.assertEqual(self.sale1.commitment_date, self.dt3)
+        self.sale_line2.write({"commitment_date": self.dt2})
+        self.sale1._onchange_expected_date()
+        self.assertEqual(self.sale1.commitment_date, self.dt3)
+        self.sale1.picking_policy = "one"
+        self.assertEqual(self.sale1.commitment_date, self.dt3)
+
+    def test_02_so_commitment_date(self):
+        """Test if commitment date is correct in SO quotation"""
+        self.sale1.action_confirm()
+        self.assertEqual(self.sale1.commitment_date, False)
+        self.sale_line1.write({"commitment_date": self.dt3})
+        self.sale1._onchange_expected_date()
+        self.assertEqual(self.sale1.commitment_date, self.dt3)
+        self.sale_line2.write({"commitment_date": self.dt2})
+        self.sale1._onchange_expected_date()
+        self.assertEqual(self.sale1.commitment_date, self.dt3)
+        self.sale1.picking_policy = "one"
+        self.assertEqual(self.sale1.commitment_date, self.dt3)
+
+    def test_03_on_change_so_commitment_date(self):
+        """Test if changing Delivery Date has repercussion in SO lines"""
+        self.sale_line1.write({"commitment_date": self.dt1})
+        self.sale_line2.write({"commitment_date": self.dt2})
+        self.sale_line3.write({"commitment_date": self.dt3})
+        self.sale1.action_confirm()
         self.sale1.write({"commitment_date": self.dt3})
-        result = self.sale1._onchange_commitment_date()
-        for line in result["value"]["order_line"]:
-            self.assertEqual(line[2]["commitment_date"], self.dt3)
+        self.assertEqual(self.sale_line1.commitment_date, self.dt1)
+        self.assertEqual(self.sale_line2.commitment_date, self.dt2)
+        self.assertEqual(self.sale_line3.commitment_date, self.dt3)


### PR DESCRIPTION
Sale order line date refactor code. 

Previous behavior:
User can't change Delivery Date from a SO. Moreover, connection between order lines Delivery Dates and their sales order Delivery Date is not coherent.

Current behavior:
- User can select different delivery dates for each order line and SO Delivery Date will be calculated taking into account shipping policy. This works in the different states of the SO.¡
- If there's no delivery dates in sales order lines, the operation will be as the standard.