### PR TITLE
[FIX] sale_order_type: Default value check company

### DIFF
--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -25,7 +25,9 @@ class SaleOrder(models.Model):
 
     @api.model
     def _default_type_id(self):
-        return self.env["sale.order.type"].search([], limit=1)
+        return self.env["sale.order.type"].search(
+            [("company_id", "in", [self.env.company.id, False])], limit=1
+        )
 
     @api.depends("partner_id", "company_id")
     def _compute_sale_type_id(self):


### PR DESCRIPTION
This could pick an incorrect type for the order's company when creating as Superuser

Only started happening after the recent changes in https://github.com/OCA/sale-workflow/pull/1884, I assume it's due to the `check_company` added to the field
After those changes a cron job that created sale orders in multiple companies (as superuser) would end up always picking a `sale_order_type` for the 1st company by default and would error when trying to create any order for other companies

With this change in default it returns to picking an appropriate type