### PR TITLE
[IMP][PERF] sale_coupon_multi_currency

### DIFF
--- a/sale_coupon_multi_currency/models/sale_coupon_program.py
+++ b/sale_coupon_multi_currency/models/sale_coupon_program.py
@@ -16,6 +16,7 @@ class SaleCouponProgram(models.Model):
         related=None,
         compute="_compute_currency_id",
         inverse="_inverse_currency_id",
+        store=True,
     )
     currency_custom_id = fields.Many2one("res.currency", "Custom Currency")
 


### PR DESCRIPTION
On a loaded database, the computed field currency_id created by this
module is having a measurable performance impact when the
_compute_program_amount method is called.

This PR makes the computed field stored, in order to avoid recomputing
it too often. On the customer instance I'm testing this, I'm saving 60%
of the execution time of _compute_program_amount with this patch
applied.