### PR TITLE
[FIX] sale_order_type: When creating a sale order, the "Type of order" changes.

### DIFF
--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -31,20 +31,21 @@ class SaleOrder(models.Model):
 
     @api.depends("partner_id", "company_id")
     def _compute_sale_type_id(self):
-        for record in self:
-            if not record.partner_id:
-                record.type_id = self.env["sale.order.type"].search(
-                    [("company_id", "in", [self.env.company.id, False])], limit=1
-                )
-            else:
-                sale_type = (
-                    record.partner_id.with_company(record.company_id).sale_type
-                    or record.partner_id.commercial_partner_id.with_company(
-                        record.company_id
-                    ).sale_type
-                )
-                if sale_type:
-                    record.type_id = sale_type
+        if 'compute_sale_type_id' not in self.env.context:
+            for record in self:
+                if not record.partner_id:
+                    record.type_id = self.env["sale.order.type"].search(
+                        [("company_id", "in", [self.env.company.id, False])],
+                        limit=1)
+                else:
+                    sale_type = (
+                        record.partner_id.with_company(
+                            record.company_id).sale_type or
+                        record.partner_id.commercial_partner_id.with_company(
+                            record.company_id).sale_type
+                    )
+                    if sale_type:
+                        record.type_id = sale_type
 
     @api.onchange("type_id")
     def onchange_type_id(self):
@@ -79,7 +80,8 @@ class SaleOrder(models.Model):
                 vals["name"] = sale_type.sequence_id.next_by_id(
                     sequence_date=vals.get("date_order")
                 )
-        return super(SaleOrder, self).create(vals)
+        return super(SaleOrder, self.with_context(
+            compute_sale_type_id=False)).create(vals)
 
     def write(self, vals):
         """A sale type could have a different order sequence, so we could


### PR DESCRIPTION
When creating the sale order, the selected sale order type changes.
1.- When selecting a customer in the sale order, it brings me the type of sale order defined in the customer, to the sales order. 
2.- I change the sales order type, and save the new sales order.
3.- The error is that AFTER EXECUTING the CREATE function of the sales order, the "_compute_sale_type_id" function is EXECUTED, in the pyhton file "sale_order.py", of the "sale_order_type" module, and the sales order is given the sales order type defined in the customer.

@anajuaristi was talking about this bug here https://github.com/OCA/sale-workflow/issues/1852 