### PR TITLE
[14.0][FIX] sale_order_line_date: Fix for same behaviour as v13

### DIFF
--- a/sale_order_line_date/models/sale_order.py
+++ b/sale_order_line_date/models/sale_order.py
@@ -17,14 +17,9 @@ class SaleOrder(models.Model):
         """Update order lines with commitment date from sale order"""
         result = super(SaleOrder, self)._onchange_commitment_date() or {}
         if "warning" not in result:
-            result["value"] = {
-                "order_line": [
-                    (1, line.id, {"commitment_date": self.commitment_date})
-                    for line in self.order_line
-                    if not line.commitment_date
-                    or (
-                        self.expected_date and line.commitment_date < self.expected_date
-                    )
-                ]
-            }
+            for line in self.order_line:
+                if not line.commitment_date or (
+                    self.expected_date and line.commitment_date < self.expected_date
+                ):
+                    line.commitment_date = self.commitment_date
         return result

--- a/sale_order_line_date/models/sale_order_line.py
+++ b/sale_order_line_date/models/sale_order_line.py
@@ -6,6 +6,8 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
+from datetime import timedelta
+
 from odoo import fields, models
 
 
@@ -14,22 +16,15 @@ class SaleOrderLine(models.Model):
 
     commitment_date = fields.Datetime("Delivery Date")
 
-    def write(self, vals):
-        # Force commitment date only if all lines are on the same sale order
-        if len(self.mapped("order_id")) == 1:
-            for line in self:
-                if (
-                    not line.commitment_date
-                    and line.order_id.commitment_date
-                    and "commitment_date" not in vals
-                ):
-                    vals.update({"commitment_date": line.order_id.commitment_date})
-                    break
-        return super(SaleOrderLine, self).write(vals)
-
     def _prepare_procurement_values(self, group_id=False):
         vals = super(SaleOrderLine, self)._prepare_procurement_values(group_id)
         # has ensure_one already
         if self.commitment_date:
-            vals.update({"date_deadline": self.commitment_date})
+            vals.update(
+                {
+                    "date_planned": self.commitment_date
+                    - timedelta(days=self.order_id.company_id.security_lead),
+                    "date_deadline": self.commitment_date,
+                }
+            )
         return vals

--- a/sale_order_line_date/tests/test_sale_order_line_date.py
+++ b/sale_order_line_date/tests/test_sale_order_line_date.py
@@ -20,21 +20,29 @@ class TestSaleOrderLineDates(TransactionCase):
         qty = 5
         product_id = self.env.ref("product.product_product_7")
         today = fields.Datetime.now()
-        dt1 = today + datetime.timedelta(days=9)
-        dt2 = today + datetime.timedelta(days=10)
+        self.dt1 = today + datetime.timedelta(days=9)
+        self.dt2 = today + datetime.timedelta(days=10)
         self.dt3 = today + datetime.timedelta(days=3)
-        self.sale1 = self._create_sale_order(customer, dt2)
+        self.sale1 = self._create_sale_order(customer, self.dt2)
         self.sale_line1 = self._create_sale_order_line(
-            self.sale1, product_id, qty, price, dt1
+            self.sale1, product_id, qty, price, self.dt1
         )
         self.sale_line2 = self._create_sale_order_line(
-            self.sale1, product_id, qty, price, dt2
+            self.sale1, product_id, qty, price, self.dt2
         )
         self.sale_line3 = self._create_sale_order_line(
             self.sale1, product_id, qty, price, None
         )
-        self.sale_line2.write({"commitment_date": dt2})
-        self.sale1.action_confirm()
+        self.sale2 = self._create_sale_order(customer, self.dt2)
+        self.sale_line4 = self._create_sale_order_line(
+            self.sale2, product_id, qty, price, self.dt3
+        )
+        self.sale_line5 = self._create_sale_order_line(
+            self.sale2, product_id, qty, price, self.dt2
+        )
+        self.sale_line6 = self._create_sale_order_line(
+            self.sale2, product_id, qty, price, self.dt1
+        )
 
     def _create_sale_order(self, customer, date):
         sale = self.env["sale.order"].create(
@@ -42,6 +50,7 @@ class TestSaleOrderLineDates(TransactionCase):
                 "partner_id": customer.id,
                 "partner_invoice_id": customer.id,
                 "partner_shipping_id": customer.id,
+                "picking_policy": "direct",
                 "commitment_date": date,
             }
         )
@@ -61,9 +70,34 @@ class TestSaleOrderLineDates(TransactionCase):
         return sale_line
 
     def test_on_change_commitment_date(self):
-        """True when the commitment date in the sale_order_line
-        matches the commitment date in the sale order"""
-        self.sale1.write({"commitment_date": self.dt3})
-        result = self.sale1._onchange_commitment_date()
-        for line in result["value"]["order_line"]:
-            self.assertEqual(line[2]["commitment_date"], self.dt3)
+        """True when the commitment date in the sale_order_line was empty
+        and after matches with the commitment date in the sale order"""
+        self.assertEqual(self.sale_line3.commitment_date, False)
+        self.sale1._onchange_commitment_date()
+        self.assertEqual(self.sale_line3.commitment_date, self.dt2)
+
+    def test_shipping_policies(self):
+        """Test if dates are propagated correctly taking into
+        account Shipping Policy"""
+        self.sale1.action_confirm()
+        picking = self.sale1.picking_ids
+        self.assertEqual(len(picking), 1)
+        self.assertEqual(picking.scheduled_date, self.dt1)
+        self.assertEqual(picking.date_deadline, self.dt1)
+        self.sale2.picking_policy = "one"
+        self.sale2.action_confirm()
+        picking = self.sale2.picking_ids
+        self.assertEqual(len(picking), 1)
+        self.assertEqual(picking.scheduled_date, self.dt2)
+        self.assertEqual(picking.date_deadline, self.dt2)
+
+    def test_line_commitment_date_picking_propagation(self):
+        """Test if dates are propagated correctly in stock moves"""
+        self.sale1.write({"commitment_date": self.dt1})
+        self.sale1._onchange_commitment_date()
+        self.sale1.action_confirm()
+        scheduled_dates = self.sale1.picking_ids.move_lines.mapped("date")
+        deadline_dates = self.sale1.picking_ids.move_lines.mapped("date_deadline")
+        self.assertEqual(scheduled_dates, deadline_dates)
+        commitment_dates = self.sale1.order_line.mapped("commitment_date")
+        self.assertEqual(commitment_dates, deadline_dates)

--- a/sale_order_line_date/tests/test_sale_order_line_date.py
+++ b/sale_order_line_date/tests/test_sale_order_line_date.py
@@ -1,7 +1,7 @@
 # © 2016 OdooMRP team
 # © 2016 AvanzOSC
 # © 2016 Serv. Tecnol. Avanzados - Pedro M. Baeza
-# © 2016 ForgeFlow S.L. (https://forgeflow.com)
+# © 2016-22 ForgeFlow S.L. (https://forgeflow.com)
 # Copyright 2017 Serpent Consulting Services Pvt. Ltd.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
@@ -16,6 +16,9 @@ class TestSaleOrderLineDates(TransactionCase):
         """Setup a Sale Order with 4 lines."""
         super(TestSaleOrderLineDates, self).setUp()
         customer = self.env.ref("base.res_partner_3")
+        self.company = self.env.ref("base.main_company")
+        self.company.security_lead = 1
+
         price = 100.0
         qty = 5
         product_id = self.env.ref("product.product_product_7")
@@ -69,35 +72,85 @@ class TestSaleOrderLineDates(TransactionCase):
         )
         return sale_line
 
+    def _assert_equal_dates(self, date1, date2):
+        if isinstance(date1, datetime.datetime):
+            date1 = date1.date()
+        if isinstance(date2, datetime.datetime):
+            date2 = date2.date()
+        self.assertEqual(date1, date2)
+
     def test_on_change_commitment_date(self):
         """True when the commitment date in the sale_order_line was empty
         and after matches with the commitment date in the sale order"""
         self.assertEqual(self.sale_line3.commitment_date, False)
         self.sale1._onchange_commitment_date()
-        self.assertEqual(self.sale_line3.commitment_date, self.dt2)
+        self._assert_equal_dates(self.sale_line3.commitment_date, self.dt2)
 
     def test_shipping_policies(self):
         """Test if dates are propagated correctly taking into
         account Shipping Policy"""
+        self.assertEqual(self.sale2.picking_policy, "direct")
         self.sale1.action_confirm()
         picking = self.sale1.picking_ids
         self.assertEqual(len(picking), 1)
-        self.assertEqual(picking.scheduled_date, self.dt1)
+        # it should be the earliest (3 line commitment_date is not set) -> dt1
+        self.assertEqual(picking.scheduled_date, self.dt1 - datetime.timedelta(days=1))
         self.assertEqual(picking.date_deadline, self.dt1)
         self.sale2.picking_policy = "one"
         self.sale2.action_confirm()
         picking = self.sale2.picking_ids
         self.assertEqual(len(picking), 1)
-        self.assertEqual(picking.scheduled_date, self.dt2)
+        # It should be the latest -> dt2
+        self.assertEqual(picking.scheduled_date, self.dt2 - datetime.timedelta(days=1))
         self.assertEqual(picking.date_deadline, self.dt2)
+        # security_lead 1 day.
+        self._assert_equal_dates(
+            self.sale_line4.commitment_date - datetime.timedelta(days=1),
+            self.sale_line4.move_ids.date,
+        )
+        self._assert_equal_dates(
+            self.sale_line4.commitment_date, self.sale_line4.move_ids.date_deadline
+        )
+        self._assert_equal_dates(
+            self.sale_line5.commitment_date - datetime.timedelta(days=1),
+            self.sale_line5.move_ids.date,
+        )
+        self._assert_equal_dates(
+            self.sale_line5.commitment_date, self.sale_line5.move_ids.date_deadline
+        )
+        self._assert_equal_dates(
+            self.sale_line6.commitment_date - datetime.timedelta(days=1),
+            self.sale_line6.move_ids.date,
+        )
+        self._assert_equal_dates(
+            self.sale_line6.commitment_date, self.sale_line6.move_ids.date_deadline
+        )
 
     def test_line_commitment_date_picking_propagation(self):
         """Test if dates are propagated correctly in stock moves"""
         self.sale1.write({"commitment_date": self.dt1})
         self.sale1._onchange_commitment_date()
+        self._assert_equal_dates(self.sale_line3.commitment_date, self.dt1)
         self.sale1.action_confirm()
-        scheduled_dates = self.sale1.picking_ids.move_lines.mapped("date")
-        deadline_dates = self.sale1.picking_ids.move_lines.mapped("date_deadline")
-        self.assertEqual(scheduled_dates, deadline_dates)
-        commitment_dates = self.sale1.order_line.mapped("commitment_date")
-        self.assertEqual(commitment_dates, deadline_dates)
+        # security_lead 1 day.
+        self._assert_equal_dates(
+            self.sale_line1.commitment_date - datetime.timedelta(days=1),
+            self.sale_line1.move_ids.date,
+        )
+        self._assert_equal_dates(
+            self.sale_line1.commitment_date, self.sale_line1.move_ids.date_deadline
+        )
+        self._assert_equal_dates(
+            self.sale_line2.commitment_date - datetime.timedelta(days=1),
+            self.sale_line2.move_ids.date,
+        )
+        self._assert_equal_dates(
+            self.sale_line2.commitment_date, self.sale_line2.move_ids.date_deadline
+        )
+        self._assert_equal_dates(
+            self.sale_line3.commitment_date - datetime.timedelta(days=1),
+            self.sale_line3.move_ids.date,
+        )
+        self._assert_equal_dates(
+            self.sale_line3.commitment_date, self.sale_line3.move_ids.date_deadline
+        )


### PR DESCRIPTION
This fix pretends to follow with the same behaviour of the module as in v13.  Actual changes are the following:
- Add the correct propagation of the scheduled date for stock moves in SO confimation.
- Change test as it was outdated.

After this PR, another one will be created to improve some parts. If we are using sale_order_line_date to determine dates for sale_order it should be computed based on sale_order_line_dates and shipping policy.