### PR TITLE
[13.0][IMP] change development_status

### DIFF
--- a/sale_by_packaging/__manifest__.py
+++ b/sale_by_packaging/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Sale By Packaging",
     "summary": "Manage sale of packaging",
     "version": "13.0.1.5.2",
-    "development_status": "Alpha",
+    "development_status": "Production/Stable",
     "category": "Warehouse Management",
     "website": "https://github.com/OCA/sale-workflow",
     "author": "Camptocamp, Odoo Community Association (OCA)",

--- a/sale_order_line_packaging_qty/__manifest__.py
+++ b/sale_order_line_packaging_qty/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Sale Order Line Packaging Quantity",
     "summary": "Define quantities according to product packaging on sale order lines",
     "version": "13.0.1.2.2",
-    "development_status": "Alpha",
+    "development_status": "Production/Stable",
     "category": "Warehouse Management",
     "website": "https://github.com/OCA/sale-workflow",
     "author": "Camptocamp, Odoo Community Association (OCA)",


### PR DESCRIPTION
Upgrade `development_status` of these modules:
- `sale_order_line_packaging_qty`;
- `sale_by_packaging`.

Because this status wasn't updated for 2 years and we use it in production. IMO these could be upgraded to `"Production/Stable"`