### PR TITLE
[14.0][PORT] sale_delivery_date: Fix report expected delivery date in the past

### DIFF
--- a/sale_delivery_date/models/stock_picking.py
+++ b/sale_delivery_date/models/stock_picking.py
@@ -20,6 +20,38 @@ class StockPicking(models.Model):
         search="_search_cutoff_time_diff",
         store=False,
     )
+    expected_delivery_date = fields.Datetime(compute="_compute_expected_delivery_date")
+
+    def _compute_expected_delivery_date(self):
+        """Computes the expected delivery date.
+
+        In some cases, the order expected_date and commitment_date
+        can be in the past.
+        e.g. when the current picking is a backorder.
+        Also, we can have pickings that should be considered as backorders
+        but where backorder_id is not set.
+        e.g. If lines are added to a SO after it has been validated.
+        In such case, we do not want to display those dates that are
+        not valid for the current picking, and set the delivery_date
+        as date_done + company.security_lead.
+        We still try to keep this priority:
+            commitment_date > expected_date > date_done > scheduled_date
+        """
+        today = fields.Date.today()
+        for record in self:
+            delivery_date = False
+            commitment_date = record.sale_id.commitment_date
+            if commitment_date and commitment_date.date() >= today:
+                delivery_date = commitment_date
+            if not delivery_date:
+                expected_date = record.sale_id.expected_date
+                if expected_date and expected_date.date() >= today:
+                    delivery_date = expected_date
+            if not delivery_date:
+                date_done = record.date_done or record.scheduled_date
+                security_lead = record.company_id.security_lead
+                delivery_date = fields.Datetime.add(date_done, days=security_lead)
+            record.expected_delivery_date = delivery_date
 
     @api.depends("location_id")
     def _compute_cutoff_time_diff(self):

--- a/sale_delivery_date/reports/stock_picking.xml
+++ b/sale_delivery_date/reports/stock_picking.xml
@@ -4,22 +4,11 @@
 <odoo>
     <template id="report_delivery_document" inherit_id="stock.report_delivery_document">
         <xpath expr="//div[@name='div_sched_date']" position="after">
-            <t t-set="order" t-value="o.sale_id" />
-            <div
-                t-if="order.commitment_date or order.expected_date"
-                class="col-auto mw-100 mb-2"
-            >
+            <div class="col-auto mw-100 mb-2">
                 <strong>Expected delivery date:</strong>
                 <p
-                    t-if="order.commitment_date"
                     class="m-0"
-                    t-field="order.commitment_date"
-                    t-options="{'date_only': 'True'}"
-                />
-                <p
-                    t-else=""
-                    class="m-0"
-                    t-field="order.expected_date"
+                    t-field="o.expected_delivery_date"
                     t-options="{'date_only': 'True'}"
                 />
             </div>

--- a/sale_delivery_date/tests/__init__.py
+++ b/sale_delivery_date/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_sale_cutoff_time_delivery
 from . import test_sale_partner_cutoff_delivery_window
 from . import test_sale_warehouse_calendar
 from . import test_sale_partner_delivery_window
+from . import test_delivery_date_in_the_past

--- a/sale_delivery_date/tests/test_delivery_date_in_the_past.py
+++ b/sale_delivery_date/tests/test_delivery_date_in_the_past.py
@@ -1,0 +1,127 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from datetime import timedelta
+
+from freezegun import freeze_time
+
+from odoo.tests import SavepointCase
+
+
+class TestDeliveryDateInThePast(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.customer_partner = cls.env["res.partner"].create(
+            {
+                "name": "Partner cutoff",
+                "order_delivery_cutoff_preference": "partner_cutoff",
+                "cutoff_time": 9.0,
+            }
+        )
+        cls.customer_warehouse = cls.env["res.partner"].create(
+            {
+                "name": "Partner warehouse cutoff",
+                "order_delivery_cutoff_preference": "warehouse_cutoff",
+                "cutoff_time": 9.0,
+            }
+        )
+
+        company = cls.env.ref("base.main_company")
+        # the global lead time will always plan 1 day before
+        company.write({"security_lead": 1.00})
+
+        cls.warehouse = cls.env.ref("stock.warehouse0")
+        cls.warehouse.write({"apply_cutoff": True, "cutoff_time": 10.0})
+        cls.product = cls.env.ref("product.product_product_9")
+
+    def _create_order(self, partner=None):
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": partner.id,
+                "partner_shipping_id": partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product.name,
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1,
+                            "product_uom": self.product.uom_id.id,
+                            "price_unit": self.product.list_price,
+                        },
+                    )
+                ],
+            }
+        )
+        return order
+
+    def test_delivery_date_as_commitment_date(self):
+        """Commitment date should be used as expected_delivery_date if
+        set and not in the past"""
+        with freeze_time("2021-10-15"):
+            order = self._create_order(partner=self.customer_partner)
+            order.commitment_date = "2021-10-20 09:00:00"
+            order.action_confirm()
+            picking = order.picking_ids
+            self.assertEqual(picking.expected_delivery_date, order.commitment_date)
+
+    def test_delivery_date_as_expected_date(self):
+        """Expected date should be used if commitment_date isn't set and
+        expected date is set but is not in the past.
+        """
+        with freeze_time("2021-10-15"):
+            order = self._create_order(partner=self.customer_partner)
+            order.action_confirm()
+            picking = order.picking_ids
+            self.assertEqual(picking.expected_delivery_date, order.expected_date)
+
+    def test_delivery_date_as_late_confirm_expected_date(self):
+        """If so has been confirmed late and there's no commitment_date,
+        then expected_date is still valid, since it's updated when the
+        so is confirmed.
+        """
+        with freeze_time("2021-10-15"):
+            order = self._create_order(partner=self.customer_partner)
+        with freeze_time("2021-10-25"):
+            order.action_confirm()
+            picking = order.picking_ids
+            self.assertEqual(str(order.expected_date.date()), "2021-10-25")
+            self.assertEqual(str(picking.scheduled_date.date()), "2021-10-24")
+            self.assertEqual(picking.expected_delivery_date, order.expected_date)
+
+    def test_delivery_date_as_late_scheduled_date(self):
+        """Scheduled date should be used if both commitment_date and
+        expected date are in the past, and if the picking is not done.
+        """
+        with freeze_time("2021-10-15"):
+            order = self._create_order(partner=self.customer_partner)
+            order.action_confirm()
+        picking = order.picking_ids
+        self.assertEqual(str(picking.scheduled_date.date()), "2021-10-14")
+        with freeze_time("2021-10-25"):
+            # picking is handled late, order.commitment_date and
+            # order.expected_date are outdated.
+            # expected_delivery_date is scheduled_date + security_lead
+            td_security_lead = timedelta(days=picking.company_id.security_lead)
+            expected_datetime = picking.scheduled_date + td_security_lead
+            self.assertEqual(picking.expected_delivery_date, expected_datetime)
+
+    def test_delivery_date_as_date_done(self):
+        """Date done should be used if both commitment_date and
+        expected date are in the past, and if the picking is done.
+        """
+        with freeze_time("2021-10-15"):
+            order = self._create_order(partner=self.customer_partner)
+            order.action_confirm()
+            picking = order.picking_ids
+        # Once picking has been set to done, the expected_delivery_date
+        # is the picking's date done + security_lead and should never change
+        td_security_lead = timedelta(days=picking.company_id.security_lead)
+        with freeze_time("2021-10-20"):
+            picking._action_done()
+            expected_datetime = picking.date_done + td_security_lead
+            self.assertEqual(picking.expected_delivery_date, expected_datetime)
+        with freeze_time("2021-10-30"):
+            self.assertEqual(picking.expected_delivery_date, expected_datetime)


### PR DESCRIPTION
FW port of https://github.com/OCA/sale-workflow/pull/1760/files

In some cases, SO expected_date / commitment_date are way in the past
compared to the picking scheduled_date (e.g. backorders).
In such case, the expected delivery date on the report is wrong,
and should be computed as:

```python
(picking.date_done or picking.scheduled_date) + picking.company_id.security_lead
```