### PR TITLE
[14.0][IMP] sale_order_revision: Set state=cancel in _prepare_revision_data() function.

### DIFF
--- a/sale_order_revision/models/sale_order.py
+++ b/sale_order_revision/models/sale_order.py
@@ -26,3 +26,20 @@ class SaleOrder(models.Model):
             "Order Reference and revision must be unique per Company.",
         )
     ]
+
+    def _prepare_revision_data(self, new_revision):
+        vals = super()._prepare_revision_data(new_revision)
+        vals.update({"state": "cancel"})
+        return vals
+
+    def action_view_revisions(self):
+        self.ensure_one()
+        action = self.env.ref("sale.action_orders")
+        result = action.read()[0]
+        result["domain"] = ["|", ("active", "=", False), ("active", "=", True)]
+        result["context"] = {
+            "active_test": 0,
+            "search_default_current_revision_id": self.id,
+            "default_current_revision_id": self.id,
+        }
+        return result

--- a/sale_order_revision/view/sale_order.xml
+++ b/sale_order_revision/view/sale_order.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+    <record id="view_sales_order_filter" model="ir.ui.view">
+        <field name="name">sale.order.list.select</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_sales_order_filter" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="current_revision_id" invisible="1" />
+            </field>
+        </field>
+    </record>
     <record id="view_order_form" model="ir.ui.view">
         <field name="name">sale.order.form</field>
         <field name="model">sale.order</field>
@@ -14,30 +24,28 @@
                     type="object"
                 />
             </xpath>
-            <notebook position="inside">
-                <page
-                    string="Revisions"
-                    attrs="{'invisible': ['&amp;',('has_old_revisions', '=', False), ('current_revision_id', '=', False)]}"
+            <xpath expr="//button[@name='action_view_invoice']" position="after">
+                <button
+                    name="action_view_revisions"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-file-archive-o"
+                    attrs="{'invisible': ['|', ('has_old_revisions', '=', False),('revision_count', '=', 0)]}"
                 >
                     <field
-                        name="old_revision_ids"
-                        domain="['|', ('active', '=', False), ('active', '=', True)]"
-                        context="{'active_test': 0}"
-                        attrs="{'invisible': [('has_old_revisions', '=', False)]}"
-                    >
-                        <tree>
-                            <field name="name" />
-                            <field name="create_date" string="Superseeded on" />
-                            <field name="create_uid" string="Superseeded by" />
-                            <field name="state" invisible="1" />
-                        </tree>
-                    </field>
-                    <group attrs="{'invisible': [('current_revision_id', '=', False)]}">
-                        <field name="current_revision_id" />
-                        <field name="has_old_revisions" invisible="1" />
-                    </group>
-                </page>
-            </notebook>
+                        name="revision_count"
+                        widget="statinfo"
+                        string="Prev. revisions"
+                    />
+                </button>
+            </xpath>
+            <field name="client_order_ref" position="after">
+                <field
+                    name="current_revision_id"
+                    attrs="{'invisible': [('current_revision_id', '=', False)]}"
+                />
+                <field name="has_old_revisions" invisible="1" />
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Set state=cancel in _prepare_revision_data() function.

Locked by:
- [x] `base_revision` https://github.com/OCA/server-ux/pull/449

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa