### PR TITLE
[13.0] [FIX] sale_order_lot_selection: Restrict create and edit lots from the lot field in sale order line.

### DIFF
--- a/sale_order_lot_selection/view/sale_view.xml
+++ b/sale_order_lot_selection/view/sale_view.xml
@@ -13,6 +13,7 @@
                     domain="[('product_id','=', product_id)]"
                     context="{'default_product_id': product_id}"
                     groups="stock.group_production_lot"
+                    options="{'no_create_edit': True}"
                 />
             </xpath>
             <xpath
@@ -24,6 +25,7 @@
                     domain="[('product_id','=', product_id)]"
                     context="{'default_product_id': product_id}"
                     groups="stock.group_production_lot"
+                    options="{'no_create_edit': True}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Before this change any user could crate or edit lots, and for this case in sales the only reason is to select a lot of banch of existing lots, no create one.