### PR TITLE
[14.0][FIX] sale_order_lot_selection: add company ctx

### DIFF
--- a/sale_order_lot_selection/view/sale_view.xml
+++ b/sale_order_lot_selection/view/sale_view.xml
@@ -11,7 +11,7 @@
                 <field
                     name="lot_id"
                     domain="[('product_id','=', product_id)]"
-                    context="{'default_product_id': product_id}"
+                    context="{'default_product_id': product_id, 'default_company_id': parent.company_id}"
                     groups="stock.group_production_lot"
                 />
             </xpath>


### PR DESCRIPTION
Company_id is required but some users don't see this field then impossible to fill a lot without this fix