### PR TITLE
[14.0] [FIX] sale_blanket_order

### DIFF
--- a/sale_blanket_order/wizard/create_sale_orders.py
+++ b/sale_blanket_order/wizard/create_sale_orders.py
@@ -100,7 +100,7 @@ class BlanketOrderWizard(models.TransientModel):
     def _prepare_so_line_vals(self, line):
         return {
             "product_id": line.product_id.id,
-            "name": line.product_id.name,
+            "name": line.product_id.display_name,
             "product_uom": line.product_uom.id,
             "sequence": line.blanket_line_id.sequence,
             "price_unit": line.blanket_line_id.price_unit,


### PR DESCRIPTION
When sale order line is created from blanket order, product's name is not complete. Before, only the product name was taken, now, display_name.