### PR TITLE
[14.0][FIX] sale_product_set: Add company_id from order

### DIFF
--- a/sale_product_set/models/product_set_line.py
+++ b/sale_product_set/models/product_set_line.py
@@ -35,4 +35,5 @@ class ProductSetLine(models.Model):
             "product_uom": self.product_id.uom_id.id,
             "sequence": max_sequence + self.sequence,
             "discount": self.discount,
+            "company_id": order.company_id.id,
         }


### PR DESCRIPTION
Due to https://github.com/odoo/odoo/commit/86febae278f08864e83017d43f6aa9d67165d664
company should be set on lines

Solves: #1947 