### PR TITLE
[13.0][FIX] sale_order_invoicing_finished_task: invoiceable field is not updated

### DIFF
--- a/sale_order_invoicing_finished_task/views/project_view.xml
+++ b/sale_order_invoicing_finished_task/views/project_view.xml
@@ -39,4 +39,16 @@
             </div>
         </field>
     </record>
+    <!-- Need to get related field invoicing_finished_task when _onchange_stage_id
+         and save invoiceable value in kanban view -->
+    <record id="view_task_kanban" model="ir.ui.view">
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.view_task_kanban" />
+        <field name="arch" type="xml">
+            <field name="user_id" position="after">
+                <field name="sale_line_id" />
+                <field name="invoiceable" />
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
… properly in kanban view drag and drop.

The field invoicing_finished_task is False If sale_line_id is not defined in kanban view.
The field invoiceable is not saved If it is not defined in kanban view.

Included in v12 https://github.com/OCA/sale-workflow/pull/1416
Suggested in first v13 migration:
https://github.com/OCA/sale-workflow/pull/1272#issuecomment-762111413
Removed in final v13 migration against the initial comment:
https://github.com/OCA/sale-workflow/pull/1457#issue-805536248
https://github.com/OCA/sale-workflow/pull/1457/commits/af564cfa63a0c1ec54b3e722bf11908a4fccd5cd#diff-d46fbb56a1f8a0adea78c245fd20f4b94ad4f420e94d5658a4365d40651545c0L44-L55

@Tecnativa TT35656