### PR TITLE
[14.0] [FIX] sale_automatic_workflow_payment_mode: avoid overwritting/removing SO's workflow if payment.mode hasn't one set

### DIFF
--- a/sale_automatic_workflow_payment_mode/models/sale_order.py
+++ b/sale_automatic_workflow_payment_mode/models/sale_order.py
@@ -9,6 +9,5 @@ class SaleOrder(models.Model):
 
     @api.onchange("payment_mode_id")
     def onchange_payment_mode_set_workflow(self):
-        pay_mode = self.payment_mode_id
-        workflow = pay_mode.workflow_process_id if pay_mode else False
-        self.workflow_process_id = workflow
+        if self.payment_mode_id.workflow_process_id:
+            self.workflow_process_id = self.payment_mode_id.workflow_process_id

--- a/sale_automatic_workflow_payment_mode/tests/test_automatic_workflow_payment_mode.py
+++ b/sale_automatic_workflow_payment_mode/tests/test_automatic_workflow_payment_mode.py
@@ -58,10 +58,6 @@ class TestAutomaticWorkflowPaymentMode(TestCommon, TestAutomaticWorkflowMixin):
             }
         )
         sale = self.create_sale_order(workflow)
-
-        sale.payment_mode_id = False
-        sale.onchange_payment_mode_set_workflow()
-        self.assertFalse(sale.workflow_process_id)
         sale.payment_mode_id = self.pay_mode
         sale._onchange_workflow_process_id()
         sale.onchange_payment_mode_set_workflow()


### PR DESCRIPTION
It seems this feature was added during the 14.0 migration PR, here: 111bb97c7
But it wasn't like this before, and IMO it was ok.


ping @hailangvn 