### PR TITLE
[13.0][FIX] sale_procurement_group_by_line: fix fill previous_product_uom_qty

### DIFF
--- a/sale_procurement_group_by_line/model/sale.py
+++ b/sale_procurement_group_by_line/model/sale.py
@@ -85,7 +85,6 @@ class SaleOrderLine(models.Model):
 
             values = line._prepare_procurement_values(group_id=group_id)
             product_qty = line.product_uom_qty - qty
-            product_qty_uom = product_qty
 
             procurement_uom = line.product_uom
             quant_uom = line.product_id.uom_id
@@ -116,7 +115,7 @@ class SaleOrderLine(models.Model):
                 self.env["procurement.group"].run(procurements)
                 # We store the procured quantity in the UoM of the line to avoid
                 # duplicated procurements, specially for dropshipping and kits.
-                previous_product_uom_qty[line.id] = product_qty_uom
+                previous_product_uom_qty[line.id] = line.product_uom_qty
             except UserError as error:
                 errors.append(error.name)
         if errors:


### PR DESCRIPTION
Before the fix, when new quantities are added into an already confirmed
line, we are writing in the previous_product_uom_qty only the new qty that
has been processed, not the total amount that has actually been
processed for the line.

Due to this, when we call super() on _action_launch_stock_rule, the new
quantities are procured again, as we have not really updated the amount
in previous_product_uom_qty including what we have already procured
before calling super().

Now, we put in previous_product_uom_qty the total quantity that we have
procured for that line, which is basically the product_uom_qty of the line.

@ForgeFlow