### PR TITLE
[13.0][FIX] sale_invoice_plan: Typo error _sql_constraint instead of _sql_constraints

### DIFF
--- a/sale_invoice_plan/models/sale.py
+++ b/sale_invoice_plan/models/sale.py
@@ -189,7 +189,7 @@ class SaleInvoicePlan(models.Model):
         compute="_compute_invoiced",
         help="If this line already invoiced",
     )
-    _sql_constraint = [
+    _sql_constraints = [
         (
             "unique_instalment",
             "UNIQUE (sale_id, installment)",


### PR DESCRIPTION
@Tecnativa