### PR TITLE
[11.0][FIX] sale_order_action_invoice_create_hook: invoice type

### DIFF
--- a/sale_order_action_invoice_create_hook/hooks.py
+++ b/sale_order_action_invoice_create_hook/hooks.py
@@ -109,10 +109,11 @@ def post_load_hook():
         # END HOOK
 
         for invoice in invoices.values():
+            invoice.compute_taxes()
             if not invoice.invoice_line_ids:
                 raise UserError(_('There is no invoicable line.'))
             # If invoice is negative, do a refund invoice instead
-            if invoice.amount_untaxed < 0:
+            if invoice.amount_total < 0:
                 invoice.type = 'out_refund'
                 for line in invoice.invoice_line_ids:
                     line.quantity = -line.quantity


### PR DESCRIPTION
Use the same logic as the `sale` addon.

https://github.com/OCA/OCB/blob/700f30ab649eaf2b6c3f83adb405dc28704a2f83/addons/sale/models/sale.py#L457

https://github.com/OCA/OCB/commit/e6ff16cbba3802ca17c7bc110d91674580edd38b