### PR TITLE
[14.0][FIX] product_form_sale_link: assure compatibility with sale_stock

### DIFF
--- a/product_form_sale_link/views/product_template.xml
+++ b/product_form_sale_link/views/product_template.xml
@@ -11,7 +11,7 @@
             ref="sale.product_template_form_view_sale_order_button"
         />
         <field name="arch" type="xml">
-            <button name="action_view_sales" position="after">
+            <div name="button_box" position="inside">
                 <button
                     class="oe_stat_button"
                     name="%(product_form_sale_link.action_product_template_sale_list)d"
@@ -20,7 +20,7 @@
                 >
                     <field string="Sales" name="sales_count" widget="statinfo" />
                 </button>
-            </button>
+            </div>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
The button 'action_view_sales' is replaced in sale_stock, so it cannot be referenced.