### PR TITLE
[14.0][ENH] sale_cancel_confirm, add config param sale.order.cancel_confirm_disable

### DIFF
--- a/sale_cancel_confirm/__manifest__.py
+++ b/sale_cancel_confirm/__manifest__.py
@@ -9,6 +9,9 @@
     "license": "AGPL-3",
     "website": "https://github.com/OCA/sale-workflow",
     "depends": ["base_cancel_confirm", "sale"],
+    "data": [
+        "data/config_parameter.xml",
+    ],
     "auto_install": False,
     "installable": True,
     "maintainers": ["kittiu"],

--- a/sale_cancel_confirm/data/config_parameter.xml
+++ b/sale_cancel_confirm/data/config_parameter.xml
@@ -1,0 +1,6 @@
+<odoo noupdate="1">
+    <record id="sale_order_cancel_confirm_disable" model="ir.config_parameter">
+        <field name="key">sale.order.cancel_confirm_disable</field>
+        <field name="value">True</field>
+    </record>
+</odoo>

--- a/sale_cancel_confirm/readme/CONFIGURE.rst
+++ b/sale_cancel_confirm/readme/CONFIGURE.rst
@@ -1,0 +1,5 @@
+By default, the sale cancel confirm will be disabled.
+
+To enable sale cancel confirm, update system parameter,
+
+* sale_cancel_confirm, add `sale.order.cancel_confirm_disable = False`


### PR DESCRIPTION
By default, the sale cancel confirm will be disabled.

To enable sale cancel confirm, update system parameter,

* sale_cancel_confirm, add `sale.order.cancel_confirm_disable = False`
