### PR TITLE
[13.0][FIX] sale_force_invoiced: Editable also for confirmed SOs

### DIFF
--- a/sale_force_invoiced/README.rst
+++ b/sale_force_invoiced/README.rst
@@ -51,8 +51,8 @@ Usage
 #. Deliver the products/services.
 #. Create an invoice and reduce the invoiced quantity. The sales order
    invoicing status is 'To Invoice'.
-#. Lock the Sale Order, to change the status of it to 'Done'.
-#. Check the field 'Force Invoiced'
+#. Check the field 'Force Invoiced'. The sales order invoicing status will be
+   'Invoiced'.
 
 Bug Tracker
 ===========

--- a/sale_force_invoiced/model/sale_order.py
+++ b/sale_force_invoiced/model/sale_order.py
@@ -13,7 +13,7 @@ class SaleOrder(models.Model):
         "fully invoiced, even when there may be ordered or delivered "
         "quantities pending to invoice.",
         readonly=True,
-        states={"done": [("readonly", False)]},
+        states={"done": [("readonly", False)], "sale": [("readonly", False)]},
         copy=False,
     )
 

--- a/sale_force_invoiced/readme/USAGE.rst
+++ b/sale_force_invoiced/readme/USAGE.rst
@@ -2,5 +2,5 @@
 #. Deliver the products/services.
 #. Create an invoice and reduce the invoiced quantity. The sales order
    invoicing status is 'To Invoice'.
-#. Lock the Sale Order, to change the status of it to 'Done'.
-#. Check the field 'Force Invoiced'
+#. Check the field 'Force Invoiced'. The sales order invoicing status will be
+   'Invoiced'.

--- a/sale_force_invoiced/static/description/index.html
+++ b/sale_force_invoiced/static/description/index.html
@@ -400,8 +400,8 @@ orders to appear in your ‘To Invoice’ list.</li>
 <li>Deliver the products/services.</li>
 <li>Create an invoice and reduce the invoiced quantity. The sales order
 invoicing status is ‘To Invoice’.</li>
-<li>Lock the Sale Order, to change the status of it to ‘Done’.</li>
-<li>Check the field ‘Force Invoiced’</li>
+<li>Check the field ‘Force Invoiced’. The sales order invoicing status will be
+‘Invoiced’.</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">


### PR DESCRIPTION
The check should be editable as well on non-locked SOs, because the invoicing status is independent from the lock status, and moreover, you may not have enabled the "Lock confirmed sales" option in settings, and thus, the locked status won't be never reachable.

@Tecnativa TT36813