### PR TITLE
[13.0][FIX] sale_order_price_recalculation: Buttons visibility

### DIFF
--- a/sale_order_price_recalculation/i18n/es.po
+++ b/sale_order_price_recalculation/i18n/es.po
@@ -20,12 +20,12 @@ msgstr ""
 "X-Generator: Weblate 4.3.2\n"
 
 #. module: sale_order_price_recalculation
-#: model_terms:ir.ui.view,arch_db:sale_order_price_recalculation.sorp_view_order_form
+#: model_terms:ir.ui.view,arch_db:sale_order_price_recalculation.view_order_form
 msgid "Recalculate prices"
 msgstr "Recalcular precios"
 
 #. module: sale_order_price_recalculation
-#: model_terms:ir.ui.view,arch_db:sale_order_price_recalculation.sorp_view_order_form
+#: model_terms:ir.ui.view,arch_db:sale_order_price_recalculation.view_order_form
 msgid "Reset descriptions"
 msgstr "Restablecer descripciones"
 

--- a/sale_order_price_recalculation/i18n/sale_order_price_recalculation.pot
+++ b/sale_order_price_recalculation/i18n/sale_order_price_recalculation.pot
@@ -14,12 +14,12 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: sale_order_price_recalculation
-#: model_terms:ir.ui.view,arch_db:sale_order_price_recalculation.view_sales_order_auto_done_setting
+#: model_terms:ir.ui.view,arch_db:sale_order_price_recalculation.view_order_form
 msgid "Recalculate prices"
 msgstr ""
 
 #. module: sale_order_price_recalculation
-#: model_terms:ir.ui.view,arch_db:sale_order_price_recalculation.view_sales_order_auto_done_setting
+#: model_terms:ir.ui.view,arch_db:sale_order_price_recalculation.view_order_form
 msgid "Reset descriptions"
 msgstr ""
 

--- a/sale_order_price_recalculation/views/sale_order_view.xml
+++ b/sale_order_price_recalculation/views/sale_order_view.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <record id="view_sales_order_auto_done_setting" model="ir.ui.view">
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="name">sale.order.form - Add recompute buttons</field>
         <field name="model">sale.order</field>
-        <field name="inherit_id" ref="sale.view_sales_order_auto_done_setting" />
+        <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
-            <button name="action_unlock" position="after">
+            <field name="state" position="before">
                 <button
                     name="recalculate_prices"
                     class="ml-2 btn btn-default"
@@ -21,7 +22,7 @@
                     type="object"
                     attrs="{'invisible':[('state','not in', ['draft', 'sent'])]}"
                 />
-            </button>
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
With current inheritance, the buttons are only visible if you have the security group "Lock Confirmed Sales" in your user.

As we need to be seen in all cases, we modify the inheritance.

TT37124