### PR TITLE
[IMP] sale_automatic_workflow : do not copy the workflow_process_id when copying the models

### DIFF
--- a/sale_automatic_workflow/models/account_move.py
+++ b/sale_automatic_workflow/models/account_move.py
@@ -10,5 +10,5 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     workflow_process_id = fields.Many2one(
-        comodel_name="sale.workflow.process", string="Sale Workflow Process"
+        comodel_name="sale.workflow.process", string="Sale Workflow Process", copy=False
     )

--- a/sale_automatic_workflow/models/sale_order.py
+++ b/sale_automatic_workflow/models/sale_order.py
@@ -14,6 +14,7 @@ class SaleOrder(models.Model):
         comodel_name="sale.workflow.process",
         string="Automatic Workflow",
         ondelete="restrict",
+        copy=False,
     )
     all_qty_delivered = fields.Boolean(
         compute="_compute_all_qty_delivered",

--- a/sale_automatic_workflow/models/stock_picking.py
+++ b/sale_automatic_workflow/models/stock_picking.py
@@ -11,7 +11,7 @@ class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     workflow_process_id = fields.Many2one(
-        comodel_name="sale.workflow.process", string="Sale Workflow Process"
+        comodel_name="sale.workflow.process", string="Sale Workflow Process", copy=False
     )
 
     def validate_picking(self):

--- a/sale_automatic_workflow/tests/test_automatic_workflow.py
+++ b/sale_automatic_workflow/tests/test_automatic_workflow.py
@@ -149,6 +149,22 @@ class TestAutomaticWorkflow(TestCommon, TestAutomaticWorkflowMixin):
         invoice = sale.invoice_ids
         self.assertEqual(invoice.journal_id.id, new_sale_journal.id)
 
+    def test_no_copy(self):
+        workflow = self.create_full_automatic()
+        sale = self.create_sale_order(workflow)
+        self.run_job()
+        invoice = sale.invoice_ids
+        self.assertTrue(sale.workflow_process_id)
+        self.assertTrue(invoice.workflow_process_id)
+        sale2 = sale.copy()
+        invoice2 = invoice.copy()
+        self.assertFalse(sale2.workflow_process_id)
+        self.assertFalse(invoice2.workflow_process_id)
+        picking = sale.picking_ids
+        self.assertTrue(picking.workflow_process_id)
+        picking2 = picking.copy()
+        self.assertFalse(picking2.workflow_process_id)
+
     def test_automatic_sale_order_confirmation_mail(self):
         workflow = self.create_full_automatic()
         workflow.send_order_confirmation_mail = True


### PR DESCRIPTION
problem : if you copy it, the move/SO can be processed by the job too fast for the user to be able to perform his job
@Cedric-Pigeon 