### PR TITLE
[FIX] sale_order_type: default type from partner

### DIFF
--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -28,6 +28,15 @@ class SaleOrder(models.Model):
 
     @api.model
     def _default_type_id(self):
+        ctx_partner_id = self.env.context.get("default_partner_id", False)
+        if ctx_partner_id:
+            partner = self.env["res.partner"].browse(ctx_partner_id)
+            sale_type = (
+                partner.with_company(self.company_id).sale_type
+                or partner.commercial_partner_id.with_company(self.company_id).sale_type
+            )
+            if sale_type:
+                return sale_type
         return self.env["sale.order.type"].search(
             [("company_id", "in", [self.env.company.id, False])], limit=1
         )


### PR DESCRIPTION
When creating a sale order from the partner view "Sales" button, the `type_id` field is always the default value. Since the order already has a stored value for this field and also a partner by context the field isn't computed and so the value of the `type_id` isn't the expected one.
I changed the default method so that it checks the context for `default_partner_id`.

In order to reproduce the error we have to access the partner form of any partner, assign it a `sale_type` different than the one returned by the default search. Then we just click on 'Sales' button and create a new one. At this moment we can see that the sale type is not the partner's.