### PR TITLE
[13.0][IMP] sale_tier_validation: Make tests more resilient

### DIFF
--- a/sale_tier_validation/tests/test_tier_validation.py
+++ b/sale_tier_validation/tests/test_tier_validation.py
@@ -13,7 +13,10 @@ class TestSaleTierValidation(common.SavepointCase):
         cls.so_model = cls.env.ref("sale.model_sale_order")
 
         # Create users
-        group_ids = cls.env.ref("base.group_system").ids
+        group_ids = (
+            cls.env.ref("base.group_system")
+            + cls.env.ref("sales_team.group_sale_salesman_all_leads")
+        ).ids
         cls.test_user_1 = cls.env["res.users"].create(
             {
                 "name": "John",


### PR DESCRIPTION
cc @Tecnativa

Why this??
When someone extends this module, for example, when a review is rejected automaticlly the so is confirmed applying any automated action the test crash because the user has not read access  to so.. 

ping @carlosdauden @chienandalu @LoisRForgeFlow 