### PR TITLE
 [FIX] sale_blanket_order: total in pdf report not visible

### DIFF
--- a/sale_blanket_order/report/templates.xml
+++ b/sale_blanket_order/report/templates.xml
@@ -77,27 +77,32 @@
                         </t>
                     </tbody>
                 </table>
+                <div class="clearfix">
                 <div class="row">
-                    <div class="col-xs-4 pull-right">
-                        <table class="table table-condensed">
+                <div
+                            t-attf-class="#{'col-6' if report_type != 'html' else 'col-sm-7 col-md-6'} ml-auto"
+                        >
+
+
+                        <table class="table table-sm">
                             <tr class="border-black">
                                 <td>
                                     <strong>Subtotal</strong>
                                 </td>
                                 <td class="text-right">
                                     <span
-                                        t-field="doc.amount_untaxed"
-                                        t-options='{"widget": "monetary", "display_currency": doc.currency_id}'
-                                    />
+                                            t-field="doc.amount_untaxed"
+                                            t-options='{"widget": "monetary", "display_currency": doc.currency_id}'
+                                        />
                                 </td>
                             </tr>
                             <tr>
                                 <td>Taxes</td>
                                 <td class="text-right">
                                     <span
-                                        t-field="doc.amount_tax"
-                                        t-options='{"widget": "monetary", "display_currency": doc.currency_id}'
-                                    />
+                                            t-field="doc.amount_tax"
+                                            t-options='{"widget": "monetary", "display_currency": doc.currency_id}'
+                                        />
                                 </td>
                             </tr>
                             <tr class="border-black">
@@ -106,14 +111,17 @@
                                 </td>
                                 <td class="text-right">
                                     <span
-                                        t-field="doc.amount_total"
-                                        t-options='{"widget": "monetary", "display_currency": doc.currency_id}'
-                                    />
+                                            t-field="doc.amount_total"
+                                            t-options='{"widget": "monetary", "display_currency": doc.currency_id}'
+                                        />
                                 </td>
                             </tr>
                         </table>
-                    </div>
+
                 </div>
+                </div>
+                </div>
+
                 <p t-field="doc.note" />
                 <div class="oe_structure" />
             </div>


### PR DESCRIPTION
The table with the total amount & taxes was not visible in pdf at the end of the document.

I'm taking the same code done for the [report saleorder_document](https://github.com/odoo/odoo/blob/15.0/addons/sale/report/sale_report_templates.xml#L143) to be more compliant with odoo core

**Before**
[blanket_before.pdf](https://github.com/OCA/sale-workflow/files/8968755/blanket_before.pdf)

**After**
[blanket_after.pdf](https://github.com/OCA/sale-workflow/files/8968757/blanket_after.pdf)


