### PR TITLE
[13.0] [IMP] `sale_coupon_program_management`: use default taxes when creating discount product

### DIFF
--- a/sale_coupon_product_management/models/sale_coupon_program.py
+++ b/sale_coupon_product_management/models/sale_coupon_program.py
@@ -107,8 +107,6 @@ class SaleCouponProgram(models.Model):
             "name": name,
             "categ_id": category.id,
             "type": "service",
-            "taxes_id": False,
-            "supplier_taxes_id": False,
             "sale_ok": category.program_product_sale_ok,
             "purchase_ok": False,
             "invoice_policy": "order",


### PR DESCRIPTION
explicitly forcing to false makes it impossible to configure defaults.
besides, default taxes are probably fine. Usually the discount will use the same vat than the rest of the products