### PR TITLE
[14.0][IMP] sale_automatic_workflow_job: Refactor and fix

### DIFF
--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -36,27 +36,14 @@ class AutomaticWorkflowJob(models.Model):
     )
 
     def _do_validate_sale_order(self, sale, domain_filter):
-        """Validate a sales order, filter ensure no duplication"""
-        if not self.env["sale.order"].search_count(
-            [("id", "=", sale.id)] + domain_filter
-        ):
-            return "{} {} job bypassed".format(sale.display_name, sale)
+        """Validate a sales order"""
         sale.action_confirm()
-        return "{} {} confirmed successfully".format(sale.display_name, sale)
 
     def _do_send_order_confirmation_mail(self, sale):
-        """Send order confirmation mail, while filtering to make sure the order is
-        confirmed with _do_validate_sale_order() function"""
-        if not self.env["sale.order"].search_count(
-            [("id", "=", sale.id), ("state", "=", "sale")]
-        ):
-            return "{} {} job bypassed".format(sale.display_name, sale)
+        """Send order confirmation mail"""
         if sale.user_id:
             sale = sale.with_user(sale.user_id)
         sale._send_order_confirmation_mail()
-        return "{} {} send order confirmation mail successfully".format(
-            sale.display_name, sale
-        )
 
     @api.model
     def _validate_sale_orders(self, order_filter):
@@ -72,16 +59,11 @@ class AutomaticWorkflowJob(models.Model):
                     self._do_send_order_confirmation_mail(sale)
 
     def _do_create_invoice(self, sale, domain_filter):
-        """Create an invoice for a sales order, filter ensure no duplication"""
-        if not self.env["sale.order"].search_count(
-            [("id", "=", sale.id)] + domain_filter
-        ):
-            return "{} {} job bypassed".format(sale.display_name, sale)
+        """Create an invoice for a sales order"""
         payment = self.env["sale.advance.payment.inv"].create({})
         payment.with_context(
             active_ids=sale.ids, active_model="sale.order"
         ).create_invoices()
-        return "{} {} create invoice successfully".format(sale.display_name, sale)
 
     @api.model
     def _create_invoices(self, create_filter):
@@ -95,15 +77,8 @@ class AutomaticWorkflowJob(models.Model):
                 )
 
     def _do_validate_invoice(self, invoice, domain_filter):
-        """Validate an invoice, filter ensure no duplication"""
-        if not self.env["account.move"].search_count(
-            [("id", "=", invoice.id)] + domain_filter
-        ):
-            return "{} {} job bypassed".format(invoice.display_name, invoice)
+        """Validate an invoice"""
         invoice.with_company(invoice.company_id).action_post()
-        return "{} {} validate invoice successfully".format(
-            invoice.display_name, invoice
-        )
 
     @api.model
     def _validate_invoices(self, validate_invoice_filter):
@@ -117,15 +92,8 @@ class AutomaticWorkflowJob(models.Model):
                 )
 
     def _do_validate_picking(self, picking, domain_filter):
-        """Validate a stock.picking, filter ensure no duplication"""
-        if not self.env["stock.picking"].search_count(
-            [("id", "=", picking.id)] + domain_filter
-        ):
-            return "{} {} job bypassed".format(picking.display_name, picking)
+        """Validate a stock.picking"""
         picking.validate_picking()
-        return "{} {} validate picking successfully".format(
-            picking.display_name, picking
-        )
 
     @api.model
     def _validate_pickings(self, picking_filter):
@@ -137,13 +105,8 @@ class AutomaticWorkflowJob(models.Model):
                 self._do_validate_picking(picking, picking_filter)
 
     def _do_sale_done(self, sale, domain_filter):
-        """Set a sales order to done, filter ensure no duplication"""
-        if not self.env["sale.order"].search_count(
-            [("id", "=", sale.id)] + domain_filter
-        ):
-            return "{} {} job bypassed".format(sale.display_name, sale)
+        """Set a sales order to done"""
         sale.action_done()
-        return "{} {} set done successfully".format(sale.display_name, sale)
 
     @api.model
     def _sale_done(self, sale_done_filter):

--- a/sale_automatic_workflow_job/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow_job/models/automatic_workflow_job.py
@@ -23,6 +23,8 @@ class AutomaticWorkflowJob(models.Model):
 
     def _do_validate_sale_order(self, sale, domain_filter):
         """filter ensure no duplication"""
+        if not sale.exists():
+            return "Sale order does not exist"
         if not self.env["sale.order"].search_count(
             [("id", "=", sale.id)] + domain_filter
         ):
@@ -33,6 +35,8 @@ class AutomaticWorkflowJob(models.Model):
     def _do_send_order_confirmation_mail(self, sale):
         """Filtering to make sure the order is confirmed with
         _do_validate_sale_order() function"""
+        if not sale.exists():
+            return "Sale order does not exist"
         if not self.env["sale.order"].search_count(
             [("id", "=", sale.id), ("state", "=", "sale")]
         ):
@@ -55,6 +59,8 @@ class AutomaticWorkflowJob(models.Model):
 
     def _do_create_invoice(self, sale, domain_filter):
         """filter ensure no duplication"""
+        if not sale.exists():
+            return "Sale order does not exist"
         if not self.env["sale.order"].search_count(
             [("id", "=", sale.id)] + domain_filter
         ):
@@ -77,6 +83,8 @@ class AutomaticWorkflowJob(models.Model):
 
     def _do_validate_invoice(self, invoice, domain_filter):
         """filter ensure no duplication"""
+        if not invoice.exists():
+            return "Invoice does not exist"
         if not self.env["account.move"].search_count(
             [("id", "=", invoice.id)] + domain_filter
         ):
@@ -101,6 +109,8 @@ class AutomaticWorkflowJob(models.Model):
 
     def _do_validate_picking(self, picking, domain_filter):
         """filter ensure no duplication"""
+        if not picking.exists():
+            return "Picking does not exist"
         if not self.env["stock.picking"].search_count(
             [("id", "=", picking.id)] + domain_filter
         ):
@@ -123,6 +133,8 @@ class AutomaticWorkflowJob(models.Model):
 
     def _do_sale_done(self, sale, domain_filter):
         """filter ensure no duplication"""
+        if not sale.exists():
+            return "Sale order does not exist"
         if not self.env["sale.order"].search_count(
             [("id", "=", sale.id)] + domain_filter
         ):

--- a/sale_automatic_workflow_job/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow_job/models/automatic_workflow_job.py
@@ -21,6 +21,27 @@ class AutomaticWorkflowJob(models.Model):
             domain_filter
         )
 
+    def _do_validate_sale_order(self, sale, domain_filter):
+        """filter ensure no duplication"""
+        if not self.env["sale.order"].search_count(
+            [("id", "=", sale.id)] + domain_filter
+        ):
+            return "{} {} job bypassed".format(sale.display_name, sale)
+        super()._do_validate_sale_order(sale, domain_filter)
+        return "{} {} confirmed successfully".format(sale.display_name, sale)
+
+    def _do_send_order_confirmation_mail(self, sale):
+        """Filtering to make sure the order is confirmed with
+        _do_validate_sale_order() function"""
+        if not self.env["sale.order"].search_count(
+            [("id", "=", sale.id), ("state", "=", "sale")]
+        ):
+            return "{} {} job bypassed".format(sale.display_name, sale)
+        super()._do_send_order_confirmation_mail(sale)
+        return "{} {} send order confirmation mail successfully".format(
+            sale.display_name, sale
+        )
+
     def _do_create_invoice_job_options(self, sale, domain_filter):
         description = _("Create invoices for sales order {}").format(sale.display_name)
         return {
@@ -31,6 +52,15 @@ class AutomaticWorkflowJob(models.Model):
     def _create_invoices(self, domain_filter):
         with_context = self.with_context(auto_delay_do_create_invoice=True)
         return super(AutomaticWorkflowJob, with_context)._create_invoices(domain_filter)
+
+    def _do_create_invoice(self, sale, domain_filter):
+        """filter ensure no duplication"""
+        if not self.env["sale.order"].search_count(
+            [("id", "=", sale.id)] + domain_filter
+        ):
+            return "{} {} job bypassed".format(sale.display_name, sale)
+        super()._do_create_invoice(sale, domain_filter)
+        return "{} {} create invoice successfully".format(sale.display_name, sale)
 
     def _do_validate_invoice_job_options(self, invoice, domain_filter):
         description = _("Validate invoice {}").format(invoice.display_name)
@@ -43,6 +73,17 @@ class AutomaticWorkflowJob(models.Model):
         with_context = self.with_context(auto_delay_do_validation=True)
         return super(AutomaticWorkflowJob, with_context)._validate_invoices(
             domain_filter
+        )
+
+    def _do_validate_invoice(self, invoice, domain_filter):
+        """filter ensure no duplication"""
+        if not self.env["account.move"].search_count(
+            [("id", "=", invoice.id)] + domain_filter
+        ):
+            return "{} {} job bypassed".format(invoice.display_name, invoice)
+        super()._do_validate_invoice(invoice, domain_filter)
+        return "{} {} validate invoice successfully".format(
+            invoice.display_name, invoice
         )
 
     def _do_validate_picking_job_options(self, picking, domain_filter):
@@ -58,6 +99,17 @@ class AutomaticWorkflowJob(models.Model):
             domain_filter
         )
 
+    def _do_validate_picking(self, picking, domain_filter):
+        """filter ensure no duplication"""
+        if not self.env["stock.picking"].search_count(
+            [("id", "=", picking.id)] + domain_filter
+        ):
+            return "{} {} job bypassed".format(picking.display_name, picking)
+        super()._do_validate_picking(picking, domain_filter)
+        return "{} {} validate picking successfully".format(
+            picking.display_name, picking
+        )
+
     def _do_sale_done_job_options(self, sale, domain_filter):
         description = _("Mark sales order {} as done").format(sale.display_name)
         return {
@@ -68,6 +120,15 @@ class AutomaticWorkflowJob(models.Model):
     def _sale_done(self, domain_filter):
         with_context = self.with_context(auto_delay_do_sale_done=True)
         return super(AutomaticWorkflowJob, with_context)._sale_done(domain_filter)
+
+    def _do_sale_done(self, sale, domain_filter):
+        """filter ensure no duplication"""
+        if not self.env["sale.order"].search_count(
+            [("id", "=", sale.id)] + domain_filter
+        ):
+            return "{} {} job bypassed".format(sale.display_name, sale)
+        super()._do_sale_done(sale, domain_filter)
+        return "{} {} set done successfully".format(sale.display_name, sale)
 
     def _register_hook(self):
         mapping = {


### PR DESCRIPTION
The extra filtering and return strings added in sale_automatic_workflow
are only useful if sale_automatic_workflow_job is used, as:

- the returned values are not used in sale_automatic_workflow
- the extra check sonly makes sense when a job is running these functions
asynchronously.


Check if the recordset being passed as parameter to the job function
still exists when the job is being run to avoid issues on deleted
records.

Said issues could be a CacheMiss or worse case, the job being stuck in
started state.