### PR TITLE
[15.0][IMP] sale_automatic_workflow: make datetime test more reliable.

### DIFF
--- a/sale_automatic_workflow/readme/CONTRIBUTORS.rst
+++ b/sale_automatic_workflow/readme/CONTRIBUTORS.rst
@@ -9,3 +9,4 @@
 * Akim Juillerat <akim.juillerat@camptocamp.com>
 * Thomas Fossoul <thomas@niboo.com>
 * Phuc Tran Thanh <phuc@trobz.com>
+* César A. Sánchez <Tecnativa>

--- a/sale_automatic_workflow/tests/test_automatic_workflow.py
+++ b/sale_automatic_workflow/tests/test_automatic_workflow.py
@@ -43,7 +43,7 @@ class TestAutomaticWorkflow(TestCommon, TestAutomaticWorkflowMixin):
         workflow = self.create_full_automatic()
         # date_order on sale.order is date + time
         # invoice_date on account.move is date only
-        last_week_time = fields.Datetime.now() - timedelta(days=7)
+        last_week_time = fields.Datetime.from_string("2022-01-01") - timedelta(days=7)
         override = {"date_order": last_week_time}
         sale = self.create_sale_order(workflow, override=override)
         sale._onchange_workflow_process_id()


### PR DESCRIPTION
Previous version sometime fails depending on when the test was executed. 