### PR TITLE
[13.0][FIX] product_form_sale_link: replace sales_count by a coherent one

### DIFF
--- a/product_form_sale_link/__init__.py
+++ b/product_form_sale_link/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_form_sale_link/models/__init__.py
+++ b/product_form_sale_link/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product_template
+from . import product_product

--- a/product_form_sale_link/models/product_product.py
+++ b/product_form_sale_link/models/product_product.py
@@ -1,0 +1,32 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    sale_lines_count = fields.Integer(
+        compute="_compute_sale_lines_count", string="Sold"
+    )
+
+    def _compute_sale_lines_count(self):
+        if not self.user_has_groups("sales_team.group_sale_salesman") or not self.ids:
+            self.sale_lines_count = 0.0
+            return
+        domain = [
+            ("state", "in", ["sale", "done"]),
+            ("product_id", "in", self.ids),
+            ("company_id", "in", self.env.companies.ids),
+        ]
+        sale_line_data = (
+            self.env["sale.order.line"]
+            .sudo()
+            .read_group(domain, ["product_id"], ["product_id"])
+        )
+        mapped_data = {
+            m["product_id"][0]: m["product_id_count"] for m in sale_line_data
+        }
+        for product in self:
+            product.sale_lines_count = mapped_data.get(product.id, 0)

--- a/product_form_sale_link/models/product_template.py
+++ b/product_form_sale_link/models/product_template.py
@@ -1,0 +1,24 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo import api, fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    sale_lines_count = fields.Float(compute="_compute_sale_lines_count", string="Sold")
+
+    @api.depends("product_variant_ids.sale_lines_count")
+    def _compute_sale_lines_count(self):
+        for product in self:
+            product.sale_lines_count = sum(
+                [
+                    p.sale_lines_count
+                    for p in product.with_context(active_test=False).product_variant_ids
+                ]
+            )

--- a/product_form_sale_link/views/product_product.xml
+++ b/product_form_sale_link/views/product_product.xml
@@ -14,8 +14,9 @@
                     name="%(product_form_sale_link.action_product_product_sale_list)d"
                     type="action"
                     icon="fa-list"
+                    attrs="{'invisible': [('sale_ok', '=', False)]}"
                 >
-                    <field string="Sales" name="sales_count" widget="statinfo" />
+                    <field string="Sales" name="sale_lines_count" widget="statinfo" />
                 </button>
             </button>
         </field>

--- a/product_form_sale_link/views/product_template.xml
+++ b/product_form_sale_link/views/product_template.xml
@@ -17,8 +17,9 @@
                     name="%(product_form_sale_link.action_product_template_sale_list)d"
                     type="action"
                     icon="fa-list"
+                    attrs="{'invisible': [('sale_ok', '=', False)]}"
                 >
-                    <field string="Sales" name="sales_count" widget="statinfo" />
+                    <field string="Sales" name="sale_lines_count" widget="statinfo" />
                 </button>
             </button>
         </field>


### PR DESCRIPTION
Backport of https://github.com/OCA/sale-workflow/pull/2120.