### PR TITLE
[14.0][FIX] sale_order_invoicing_finished_task: Incorrect inheritance chain

### DIFF
--- a/sale_order_invoicing_finished_task/views/product_view.xml
+++ b/sale_order_invoicing_finished_task/views/product_view.xml
@@ -2,9 +2,15 @@
 <!-- Copyright 2017 Tecnativa - Sergio Teruel
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
-    <record id="view_product_timesheet_form" model="ir.ui.view">
+    <record
+        id="product_template_form_view_invoice_policy_inherit_sale_project"
+        model="ir.ui.view"
+    >
         <field name="model">product.template</field>
-        <field name="inherit_id" ref="sale_timesheet.view_product_timesheet_form" />
+        <field
+            name="inherit_id"
+            ref="sale_project.product_template_form_view_invoice_policy_inherit_sale_project"
+        />
         <field name="arch" type="xml">
             <field name="project_id" position="before">
                 <field


### PR DESCRIPTION
Previous parent view doesn't depend on the view that adds the field project_id, so we need to inherit from the proper view.

Old one: https://github.com/odoo/odoo/blob/0ab552a749e3fc4aa6c549909ccece3821c4cd09/addons/sale_timesheet/views/product_views.xml#L6

vs

Proper one: https://github.com/odoo/odoo/blob/0ab552a749e3fc4aa6c549909ccece3821c4cd09/addons/sale_project/views/product_views.xml#L11

As `sale_timesheet` depends on `sale_project`, no extra dependency needs to be added at manifest level.

@Tecnativa 