### PR TITLE
[15.0][FIX] sale_procurement_group_by_line: group negative moves when reducing qty in a sales order

### DIFF
--- a/sale_procurement_group_by_line/model/__init__.py
+++ b/sale_procurement_group_by_line/model/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import sale
+from . import stock_move

--- a/sale_procurement_group_by_line/model/sale.py
+++ b/sale_procurement_group_by_line/model/sale.py
@@ -115,9 +115,9 @@ class SaleOrderLine(models.Model):
                 errors.append(error.args[0])
         if errors:
             raise UserError("\n".join(errors))
-        return super()._action_launch_stock_rule(
-            previous_product_uom_qty=previous_product_uom_qty
-        )
+        return super(
+            SaleOrderLine, self.with_context(sale_group_by_line=True)
+        )._action_launch_stock_rule(previous_product_uom_qty=previous_product_uom_qty)
 
     procurement_group_id = fields.Many2one(
         "procurement.group", "Procurement group", copy=False

--- a/sale_procurement_group_by_line/model/stock_move.py
+++ b/sale_procurement_group_by_line/model/stock_move.py
@@ -1,0 +1,19 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _update_candidate_moves_list(self, candidate_moves_list):
+        """
+        We want to merge stock moves within the procurement group only
+        """
+        res = super()._update_candidate_moves_list(candidate_moves_list)
+        if self.env.context.get("sale_group_by_line"):
+            candidate_moves_list.append(
+                self.sale_line_id.procurement_group_id.stock_move_ids
+            )
+        return res

--- a/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
+++ b/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
@@ -64,7 +64,7 @@ class TestSaleProcurementGroupByLine(TransactionCase):
         )
         return self.sale
 
-    def test_procurement_group_by_line(self):
+    def test_01_procurement_group_by_line(self):
         self.sale.action_confirm()
         self.assertEqual(
             self.line2.procurement_group_id,
@@ -83,7 +83,7 @@ class TestSaleProcurementGroupByLine(TransactionCase):
         wiz.process()
         self.assertTrue(self.picking_ids, "Procurement Group should have picking")
 
-    def test_action_launch_procurement_rule_1(self):
+    def test_02_action_launch_procurement_rule_1(self):
         group_id = self.proc_group_model.create(
             {"move_type": "one", "sale_id": self.sale.id, "name": self.sale.name}
         )
@@ -96,7 +96,7 @@ class TestSaleProcurementGroupByLine(TransactionCase):
         self.assertEqual(len(self.line2.move_ids), 1)
         self.assertEqual(self.line2.move_ids.name, self.line2.name)
 
-    def test_action_launch_procurement_rule_2(self):
+    def test_03_action_launch_procurement_rule_2(self):
         group_id = self.proc_group_model.create(
             {"move_type": "one", "sale_id": self.sale.id, "name": self.sale.name}
         )
@@ -105,7 +105,7 @@ class TestSaleProcurementGroupByLine(TransactionCase):
         self.sale.action_confirm()
         self.assertEqual(self.line2.procurement_group_id, group_id)
 
-    def test_action_launch_procurement_rule_3(self):
+    def test_04_action_launch_procurement_rule_3(self):
         group_id = self.proc_group_model.create(
             {"move_type": "one", "sale_id": self.sale.id, "name": self.sale.name}
         )
@@ -115,4 +115,14 @@ class TestSaleProcurementGroupByLine(TransactionCase):
         self.assertNotEqual(self.line1.procurement_group_id, group_id)
         self.assertEqual(
             self.line1.procurement_group_id, self.line2.procurement_group_id
+        )
+
+    def test_05_merged_stock_moves_from_same_procurement(self):
+        """
+        Reduce the qty in the sale order and check no extra picking is created
+        """
+        self.sale.action_confirm()
+        self.sale.order_line[1].product_uom_qty = 0.0
+        self.assertEqual(
+            len(self.sale.picking_ids), 1, "Negative stock move should me merged"
         )


### PR DESCRIPTION
Reducing the qty in a sales order in v15 will update the stock moves by creating a negative stock moves and then merging it with the existing stock moves. The thing is, with this module installed Odoo will not merge the negative move. That will cause a return picking to be created, weird. 

Steps to reproduce:

- Create a sales order with one sale order line and confirm it
- Add another line for the same product and save
- The customer disagrees, so you set the quantity in this second line to zero
- Odoo creates and incoming shipment from customers to stock, instead of reducing the existing stock move to have zero quantity.

Useful links:
A procurement is launch when saving the sale order line with zero qty
https://github.com/odoo/odoo/blob/15.0/addons/sale_stock/models/sale_order.py#L434

The procurement has negative qty
https://github.com/odoo/odoo/blob/15.0/addons/sale_stock/models/sale_order.py#L583

A negative stock move is created:
https://github.com/odoo/odoo/blob/15.0/addons/stock/models/stock_rule.py#L268

Odoo tries to merge within the same picking
https://github.com/odoo/odoo/blob/15.0/addons/stock/models/stock_move.py#L1237

For some reason, with the sale_procurement_group_by_line installed, this is filter returns nothing and the negative move is not merged:
https://github.com/odoo/odoo/blob/15.0/addons/stock/models/stock_move.py#L876

When it does not merge it converts the move to a return
https://github.com/odoo/odoo/blob/15.0/addons/stock/models/stock_move.py#L1254

The solution is to include the stock moves of the procurement group within the stock moves to do the merge. Those are not included by default.

Test added that checks this use case.

cc @ForgeFlow