### PR TITLE
[14.0][IMP] sale_cancel_reason: Do not copy cancel reason on order duplicate

### DIFF
--- a/sale_cancel_reason/model/sale.py
+++ b/sale_cancel_reason/model/sale.py
@@ -13,6 +13,7 @@ class SaleOrder(models.Model):
         readonly=True,
         ondelete="restrict",
         tracking=True,
+        copy=False,
     )
 
     def _show_cancel_wizard(self):


### PR DESCRIPTION
When a sale order is duplicated the cancel reason should not be copied.

ping @CasVissers-360ERP