### PR TITLE
[15.0][FIX] sale_order_type: default sequence

### DIFF
--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -32,6 +32,19 @@ class SaleOrder(models.Model):
             [("company_id", "in", [self.env.company.id, False])], limit=1
         )
 
+    @api.model
+    def _default_sequence_id(self):
+        """We get the sequence in same way the core next_by_code method does so we can
+        get the proper default sequence"""
+        force_company = self.env.context.get("force_company")
+        if not force_company:
+            force_company = self.company_id.id or self.env.company.id
+        return self.env["ir.sequence"].search(
+            [("code", "=", "sale.order"), ("company_id", "in", [force_company, False])],
+            order="company_id",
+            limit=1,
+        )
+
     @api.depends("partner_id", "company_id")
     def _compute_sale_type_id(self):
         for record in self:
@@ -98,13 +111,22 @@ class SaleOrder(models.Model):
     def write(self, vals):
         """A sale type could have a different order sequence, so we could
         need to change it accordingly"""
+        default_sequence = self._default_sequence_id()
         if vals.get("type_id"):
             sale_type = self.env["sale.order.type"].browse(vals["type_id"])
             if sale_type.sequence_id:
                 for record in self:
+                    # An order with a type without sequence would get the default one.
+                    # We want to avoid changing the order reference when the new
+                    # sequence has the same default sequence.
+                    ignore_default_sequence = (
+                        not record.type_id.sequence_id
+                        and sale_type.sequence_id == default_sequence
+                    )
                     if (
                         record.state in {"draft", "sent"}
                         and record.type_id.sequence_id != sale_type.sequence_id
+                        and not ignore_default_sequence
                     ):
                         new_vals = vals.copy()
                         new_vals["name"] = sale_type.sequence_id.next_by_id(

--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -46,6 +46,7 @@ class TestSaleOrderType(common.TransactionCase):
             [("type", "=", "sale")], limit=1
         )
         self.default_sale_type_id = self.env["sale.order.type"].search([], limit=1)
+        self.default_sale_type_id.sequence_id = False
         self.warehouse = self.env["stock.warehouse"].create(
             {"name": "Warehouse Test", "code": "WT"}
         )
@@ -78,6 +79,15 @@ class TestSaleOrderType(common.TransactionCase):
                 "payment_term_id": self.immediate_payment.id,
                 "pricelist_id": self.sale_pricelist.id,
                 "incoterm_id": self.free_carrier.id,
+            }
+        )
+        self.sale_type_sequence_default = self.sale_type_quot.copy(
+            {
+                "name": "Test Sequence default",
+                "sequence_id": self.env["sale.order"]
+                .with_context(force_company=self.env.company.id)
+                ._default_sequence_id()
+                .id,
             }
         )
         self.partner.sale_type = self.sale_type
@@ -242,3 +252,14 @@ class TestSaleOrderType(common.TransactionCase):
         wizard.create_invoices()
         self.assertEqual(order.type_id.journal_id, order.invoice_ids[0].journal_id)
         self.assertEqual(order.type_id, order.invoice_ids[0].sale_type_id)
+
+    def test_sequence_default(self):
+        """When the previous type had no sequence the order gets the default one. The
+        sequence change shouldn't be triggered, otherwise we'd get a different number
+        from the same sequence"""
+        self.partner.sale_type = self.default_sale_type_id
+        order = self.create_sale_order()
+        order.onchange_partner_id()
+        name = order.name
+        order.type_id = self.sale_type_sequence_default
+        self.assertEqual(name, order.name, "The sequence shouldn't change!")


### PR DESCRIPTION
Forward of #2161 #2106 

When the sale type has no sequence, the order gets the default one. When we change the type and the sequence is the same that that default, we should change the name, as we'd get a new reference of the same sequence.

cc @Tecnativa TT37832

please review @victoralmau @cesar-tecnativa 