### PR TITLE
[14.0][IMP] Update copier template + warning removal

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,9 +1,14 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.7.0
+_commit: v1.8.0
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
 dependency_installation_mode: PIP
 generate_requirements_txt: true
+github_check_license: true
+github_enable_codecov: true
+github_enable_makepot: true
+github_enable_stale_action: true
+github_enforce_dev_status_compatibility: true
 include_wkhtmltopdf: false
 odoo_version: 14.0
 org_name: Odoo Community Association (OCA)

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ build/
 develop-eggs/
 dist/
 eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,19 +119,15 @@ repos:
       - id: flake8
         name: flake8
         additional_dependencies: ["flake8-bugbear==20.1.4"]
-  - repo: https://github.com/PyCQA/pylint
-    rev: v2.11.1
+  - repo: https://github.com/OCA/pylint-odoo
+    rev: 7.0.0
     hooks:
-      - id: pylint
+      - id: pylint_odoo
         name: pylint with optional checks
         args:
           - --rcfile=.pylintrc
           - --exit-zero
         verbose: true
-        additional_dependencies: &pylint_deps
-          - pylint-odoo==5.0.5
-      - id: pylint
-        name: pylint with mandatory checks
+      - id: pylint_odoo
         args:
           - --rcfile=.pylintrc-mandatory
-        additional_dependencies: *pylint_deps

--- a/sale_order_line_discount_validation/report/sale_report.py
+++ b/sale_order_line_discount_validation/report/sale_report.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Open Source Integrators
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import _, api, models
-from odoo.exceptions import Warning
+from odoo.exceptions import UserError
 
 
 class SaleOrderReport(models.AbstractModel):
@@ -16,7 +16,7 @@ class SaleOrderReport(models.AbstractModel):
                 lambda r: r.discount >= rec.env.company.sale_discount_limit
             ) and rec.state not in ("approved", "done"):
                 rec._request_approval()
-                raise Warning(
+                raise UserError(
                     _(
                         "Your quotation has been sent for approval. You will be "
                         "notified when it is approved or refused."


### PR DESCRIPTION
Update copier template to v1.8.0 to test https://github.com/OCA/oca-addons-repo-template/pull/149 + removal of a warning.

@Tecnativa