### PR TITLE
[IMP] Add section note to sale blanket order

### DIFF
--- a/sale_blanket_order/report/templates.xml
+++ b/sale_blanket_order/report/templates.xml
@@ -49,31 +49,71 @@
                         </tr>
                     </thead>
                     <tbody class="sale_tbody">
+                        <t t-set="current_subtotal" t-value="0" />
                         <t t-foreach="doc.line_ids" t-as="l">
-                            <tr>
-                                <td>
-                                    <span t-field="l.product_id" />
-                                </td>
-                                <td class="text-right">
-                                    <span t-field="l.price_unit" />
-                                </td>
-                                <td class="text-center">
-                                    <span t-field="l.date_schedule" />
-                                </td>
-                                <td class="text-right">
-                                    <span t-field="l.original_uom_qty" />
-                                    <span
-                                        t-field="l.product_uom"
-                                        groups="uom.group_uom"
-                                    />
-                                </td>
-                                <td class="text-right">
-                                    <span
-                                        t-field="l.price_subtotal"
-                                        t-options='{"widget": "monetary", "display_currency": l.currency_id}'
-                                    />
-                                </td>
+                            <t
+                                t-set="current_subtotal"
+                                t-value="current_subtotal + l.price_subtotal"
+                                groups="account.group_show_line_subtotals_tax_excluded"
+                            />
+                            <t
+                                t-set="current_subtotal"
+                                t-value="current_subtotal + l.price_total"
+                                groups="account.group_show_line_subtotals_tax_included"
+                            />
+                            <tr
+                                t-att-class="'bg-200 font-weight-bold o_line_section' if l.display_type == 'line_section' else 'font-italic o_line_note' if l.display_type == 'line_note' else ''"
+                            >
+                                <t t-if="not l.display_type">
+                                    <td>
+                                        <span t-field="l.product_id" />
+                                    </td>
+                                    <td class="text-right">
+                                        <span t-field="l.price_unit" />
+                                    </td>
+                                    <td class="text-center">
+                                        <span t-field="l.date_schedule" />
+                                    </td>
+                                    <td class="text-right">
+                                        <span t-field="l.original_uom_qty" />
+                                        <span
+                                            t-field="l.product_uom"
+                                            groups="uom.group_uom"
+                                        />
+                                    </td>
+                                    <td class="text-right">
+                                        <span
+                                            t-field="l.price_subtotal"
+                                            t-options='{"widget": "monetary", "display_currency": l.currency_id}'
+                                        />
+                                    </td>
+                                </t>
+                                <t t-if="l.display_type == 'line_section'">
+                                    <td name="td_section_line" colspan="99">
+                                        <span t-field="l.name" />
+                                    </td>
+                                    <t t-set="current_section" t-value="l" />
+                                    <t t-set="current_subtotal" t-value="0" />
+                                </t>
+                                <t t-if="l.display_type == 'line_note'">
+                                    <td name="td_note_line" colspan="99">
+                                        <span t-field="l.name" />
+                                    </td>
+                                </t>
                             </tr>
+                            <t
+                                t-if="current_section and (l_last or doc.line_ids[l_index+1].display_type == 'line_section')"
+                            >
+                                <tr class="is-subtotal text-right">
+                                    <td name="td_section_subtotal" colspan="99">
+                                        <strong class="mr16">Subtotal</strong>
+                                        <span
+                                            t-esc="current_subtotal"
+                                            t-options='{"widget": "monetary", "display_currency": doc.pricelist_id.currency_id}'
+                                        />
+                                    </td>
+                                </tr>
+                            </t>
                         </t>
                     </tbody>
                 </table>

--- a/sale_blanket_order/tests/test_blanket_orders.py
+++ b/sale_blanket_order/tests/test_blanket_orders.py
@@ -81,7 +81,15 @@ class TestSaleBlanketOrders(common.TransactionCase):
                             "original_uom_qty": 20.0,
                             "price_unit": 0.0,  # will be updated later
                         },
-                    )
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "My section",
+                            "display_type": "line_section",
+                        },
+                    ),
                 ],
             }
         )
@@ -120,12 +128,22 @@ class TestSaleBlanketOrders(common.TransactionCase):
                         0,
                         0,
                         {
+                            "product_id": False,
+                            "product_uom": False,
+                            "name": "My section",
+                            "display_type": "line_section",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
                             "product_id": self.product.id,
                             "product_uom": self.product.uom_id.id,
                             "original_uom_qty": 20.0,
                             "price_unit": 30.0,
                         },
-                    )
+                    ),
                 ],
             }
         )

--- a/sale_blanket_order/views/sale_blanket_order_views.xml
+++ b/sale_blanket_order/views/sale_blanket_order_views.xml
@@ -118,13 +118,35 @@
                             <field
                                 name="line_ids"
                                 attrs="{'readonly': [('state', 'in', ('open','expired'))]}"
+                                widget="section_and_note_one2many"
                             >
                                 <tree editable="bottom">
+                                    <control>
+                                        <create
+                                            name="add_product_control"
+                                            string="Add a product"
+                                        />
+                                        <create
+                                            name="add_section_control"
+                                            string="Add a section"
+                                            context="{'default_display_type': 'line_section'}"
+                                        />
+                                        <create
+                                            name="add_note_control"
+                                            string="Add a note"
+                                            context="{'default_display_type': 'line_note'}"
+                                        />
+                                    </control>
+                                    <field name="display_type" invisible="1" />
+                                    <field name="name" widget="section_and_note_text" />
                                     <field name="sequence" widget="handle" />
-                                    <field name="name" invisible="1" />
                                     <field
                                         name="product_id"
                                         context="{'partner_id':parent.partner_id, 'quantity':original_uom_qty, 'company_id': parent.company_id}"
+                                        attrs="{
+                                            'required': [('display_type', '=', False)],
+                                            'invisible': [('display_type', '=', True)],
+                                        }"
                                     />
                                     <field
                                         name="analytic_tag_ids"
@@ -138,9 +160,20 @@
                                         name="original_uom_qty"
                                         string="Original Qty"
                                         context="{'partner_id':parent.partner_id, 'quantity':original_uom_qty, 'company_id': parent.company_id}"
+                                        attrs="{
+                                            'required': [('display_type', '=', False)],
+                                            'invisible': [('display_type', '=', True)],
+                                        }"
                                     />
+
                                     <field name="product_uom" groups="uom.group_uom" />
-                                    <field name="price_unit" />
+                                    <field
+                                        name="price_unit"
+                                        attrs="{
+                                            'required': [('display_type', '=', False)],
+                                            'invisible': [('display_type', '=', True)],
+                                        }"
+                                    />
                                     <field name="date_schedule" />
                                     <field name="ordered_uom_qty" />
                                     <field name="invoiced_uom_qty" />
@@ -152,8 +185,18 @@
                                         domain="[('type_tax_use','=','sale')]"
                                         context="{'default_type_tax_use': 'sale'}"
                                         options="{'no_create': True}"
+                                        attrs="{
+                                            'required': [('display_type', '=', False)],
+                                            'invisible': [('display_type', '=', True)],
+                                        }"
                                     />
-                                    <field name="price_subtotal" widget="monetary" />
+                                    <field
+                                        name="price_subtotal"
+                                        widget="monetary"
+                                        attrs="{
+                                            'invisible': [('display_type', '=', True)],
+                                        }"
+                                    />
                                 </tree>
                             </field>
                             <group class="oe_subtotal_footer oe_right">

--- a/sale_blanket_order/wizard/create_sale_orders.py
+++ b/sale_blanket_order/wizard/create_sale_orders.py
@@ -78,7 +78,9 @@ class BlanketOrderWizard(models.TransientModel):
                     "partner_id": bol.partner_id,
                 },
             )
-            for bol in bo_lines.filtered(lambda l: l.remaining_uom_qty != 0.0)
+            for bol in bo_lines.filtered(
+                lambda l: not l.display_type and l.remaining_uom_qty != 0.0
+            )
         ]
         return lines
 


### PR DESCRIPTION
### Context
Improve the usability of the OCA Blanket order module by adding the section/note system available as standard in sale orders and customer invoices.

The improvement does NOT include the following:
- Sale orders should include sections and notes coming from the blanket order. That feature requires more analyses because we need a mechanism to decide if a section is added or not depending on the existence of section child order lines. 