### PR TITLE
[12.0][FIX] sale_invoice_plan: rounds the value to the rounding precision of the product's unit of measure

### DIFF
--- a/sale_invoice_plan/models/sale.py
+++ b/sale_invoice_plan/models/sale.py
@@ -237,6 +237,7 @@ class SaleInvoicePlan(models.Model):
             else:
                 plan_qty = order_line.product_uom_qty * (percent/100)
                 prec = order_line.product_uom.rounding
+                plan_qty = round(plan_qty, precision_rounding=prec)
                 if float_compare(plan_qty, line.quantity, prec) == 1:
                     raise ValidationError(
                         _('Plan quantity: %s, exceed invoiceable quantity: %s'


### PR DESCRIPTION
Testing product invoicing to 0.01 rounding accuracy generates a difference between the amount invoiced according to invoices VS the amount invoiced on the sales order.

Unit of messure: hour
Quantity: 1.0
Price: 100.00
Installment quantity: 3

