### PR TITLE
[14.0] [IMP] `sale_product_seasonality`: Make Seasonal configuration readonly depending on SO state

### DIFF
--- a/sale_product_seasonality/models/sale_order.py
+++ b/sale_product_seasonality/models/sale_order.py
@@ -11,11 +11,14 @@ from ..utils import roundTime
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    commitment_date_end = fields.Datetime()
+    commitment_date_end = fields.Datetime(
+        states={"done": [("readonly", True)], "cancel": [("readonly", True)]},
+    )
     seasonal_config_id = fields.Many2one(
         string="Product seasonal configuration",
         comodel_name="seasonal.config",
         default=lambda self: self._default_seasonal_config_id(),
+        states={"done": [("readonly", True)], "cancel": [("readonly", True)]},
     )
     season_allowed_product_ids = fields.Many2many(
         string="Season allowed products",


### PR DESCRIPTION
This commit modifies these two sale.order fields: `seasonal_config_id` and `commitment_date_end` to be readonly except for draft/sent orders (aka Quotations).

The motivation is to keep the feature aligned with core fields like `commitment_date`:
- https://github.com/odoo/odoo/blob/06e95b1f/addons/sale/models/sale.py#L256