### PR TITLE
[14.0] [IMP] `sale_invoice_blocking`: Make field readonly for cancelled orders

### DIFF
--- a/sale_invoice_blocking/models/sale_order.py
+++ b/sale_invoice_blocking/models/sale_order.py
@@ -10,6 +10,7 @@ class SaleOrder(models.Model):
     invoice_blocking_reason_id = fields.Many2one(
         "invoice.blocking.reason",
         string="Blocking for invoicing",
+        states={"cancel": [("readonly", True)]},
     )
 
     @api.depends("invoice_blocking_reason_id", "state", "order_line.invoice_status")


### PR DESCRIPTION
To be aligned with core behaviour where most fields are readonly when the order is cancelled.