### PR TITLE
[FIX] sale_rental: KeyError on create product with one variant

### DIFF
--- a/sale_rental/models/product.py
+++ b/sale_rental/models/product.py
@@ -81,5 +81,5 @@ class ProductTemplate(models.Model):
         for template in self:
             if len(template.product_variant_ids) == 1:
                 template.product_variant_ids.rented_product_id = (
-                    template.rented_product_tmpl_id.product_variant_ids[0].id
+                    template.rented_product_tmpl_id.product_variant_ids[:1].id
                 )


### PR DESCRIPTION
There is a bug if I try to create a product template with exactly one variant (one attribute + one value):
```
Traceback (most recent call last):
File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_http.py", line 237, in _dispatch
result = request.dispatch()
File "/usr/lib/python3/dist-packages/odoo/http.py", line 683, in dispatch
result = self._call_function(**self.params)
File "/usr/lib/python3/dist-packages/odoo/http.py", line 359, in _call_function
return checked_call(self.db, *args, **kwargs)
File "/usr/lib/python3/dist-packages/odoo/service/model.py", line 94, in wrapper
return f(dbname, *args, **kwargs)
File "/usr/lib/python3/dist-packages/odoo/http.py", line 347, in checked_call
result = self.endpoint(*a, **kw)
File "/usr/lib/python3/dist-packages/odoo/http.py", line 912, in __call__
return self.method(*args, **kw)
File "/usr/lib/python3/dist-packages/odoo/http.py", line 531, in response_wrap
response = f(*args, **kw)
File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/main.py", line 1394, in call_kw
return self._call_kw(model, method, args, kwargs)
File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/main.py", line 1386, in _call_kw
return call_kw(request.env[model], method, args, kwargs)
File "/usr/lib/python3/dist-packages/odoo/api.py", line 397, in call_kw
result = _call_kw_model_create(method, model, args, kwargs)
File "/usr/lib/python3/dist-packages/odoo/api.py", line 377, in _call_kw_model_create
result = method(recs, *args, **kwargs)
File "<decorator-gen-170>", line 2, in create
File "/usr/lib/python3/dist-packages/odoo/api.py", line 347, in _model_create_multi
return create(self, [arg])
File "/usr/lib/python3/dist-packages/odoo/addons/product/models/product_template.py", line 396, in create
templates = super(ProductTemplate, self).create(vals_list)
File "<decorator-gen-142>", line 2, in create
File "/usr/lib/python3/dist-packages/odoo/api.py", line 348, in _model_create_multi
return create(self, arg)
File "/usr/lib/python3/dist-packages/odoo/addons/mail/models/mail_thread.py", line 264, in create
threads = super(MailThread, self).create(vals_list)
File "<decorator-gen-64>", line 2, in create
File "/usr/lib/python3/dist-packages/odoo/api.py", line 348, in _model_create_multi
return create(self, arg)
File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_fields.py", line 534, in create
recs = super().create(vals_list)
File "<decorator-gen-13>", line 2, in create
File "/usr/lib/python3/dist-packages/odoo/api.py", line 348, in _model_create_multi
return create(self, arg)
File "/usr/lib/python3/dist-packages/odoo/models.py", line 3909, in create
fields[0].determine_inverse(batch_recs)
File "/usr/lib/python3/dist-packages/odoo/fields.py", line 1187, in determine_inverse
getattr(records, self.inverse)()
File "/opt/odoo/sale-workflow/sale_rental/models/product.py", line 84, in _inverse_rented_product_tmpl_id
template.rented_product_tmpl_id.product_variant_ids[0].id
File "/usr/lib/python3/dist-packages/odoo/models.py", line 5693, in __getitem__
return self.browse((self._ids[key],))
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
File "/usr/lib/python3/dist-packages/odoo/http.py", line 639, in _handle_exception
return super(JsonRequest, self)._handle_exception(exception)
File "/usr/lib/python3/dist-packages/odoo/http.py", line 315, in _handle_exception
raise exception.with_traceback(None) from new_cause
IndexError: tuple index out of range
```