### PR TITLE
[12.0][FIX] show bom in view sale order line form

### DIFF
--- a/sale_mrp_bom/views/sale_order.xml
+++ b/sale_mrp_bom/views/sale_order.xml
@@ -9,7 +9,7 @@
             <xpath expr="//field[@name='order_line']//tree//field[@name='name']" position="after">
                 <field name="bom_id" groups="sale_mrp_bom.sale_mrp_bom_group"/>
             </xpath>
-            <xpath expr="//field[@name='order_line']//form//field[@name='customer_lead']" position="after">
+            <xpath expr="//field[@name='order_line']//form//label[@for='customer_lead']" position="before">
                 <field name="bom_id" groups="sale_mrp_bom.sale_mrp_bom_group"/>
             </xpath>
         </field>


### PR DESCRIPTION
BOM is not visible in form sale order line view:

![Screenshot(14)](https://user-images.githubusercontent.com/7657311/193135201-d7e39c74-6a57-4388-b2ed-b2a947dca083.png)

with correct access configured:

![Screenshot(10)](https://user-images.githubusercontent.com/7657311/193135292-9c59a63b-9a9c-45f1-9a2f-de4689b24f91.png)
