### PR TITLE
[14.0][IMP] sale_partner_incoterm

### DIFF
--- a/sale_partner_incoterm/__manifest__.py
+++ b/sale_partner_incoterm/__manifest__.py
@@ -10,6 +10,6 @@
     "author": "Opener B.V.,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "depends": ["sale_stock"],
-    "data": ["views/res_partner.xml"],
+    "data": ["views/res_partner.xml", "views/sale_order.xml"],
     "installable": True,
 }

--- a/sale_partner_incoterm/i18n/es.po
+++ b/sale_partner_incoterm/i18n/es.po
@@ -1,23 +1,19 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# * sale_partner_incoterm
+# 	* sale_partner_incoterm
 #
-# Translators:
 msgid ""
 msgstr ""
-"Project-Id-Version: sale-workflow (8.0)\n"
+"Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-23 08:14+0000\n"
-"PO-Revision-Date: 2020-07-27 10:19+0000\n"
-"Last-Translator: Daniel Martinez Vila <daniel.martinez@qubiq.es>\n"
-"Language-Team: Spanish (http://www.transifex.com/oca/OCA-sale-workflow-8-0/"
-"language/es/)\n"
-"Language: es\n"
+"POT-Creation-Date: 2022-10-07 09:18+0000\n"
+"PO-Revision-Date: 2022-10-07 09:18+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 3.10\n"
+"Plural-Forms: \n"
 
 #. module: sale_partner_incoterm
 #: model:ir.model,name:sale_partner_incoterm.model_res_partner
@@ -25,11 +21,40 @@ msgid "Contact"
 msgstr "Contacto"
 
 #. module: sale_partner_incoterm
+#: model:ir.model.fields,field_description:sale_partner_incoterm.field_res_partner__sale_incoterm_address_id
+#: model:ir.model.fields,field_description:sale_partner_incoterm.field_res_users__sale_incoterm_address_id
+msgid "Default Sale Incoterm Address"
+msgstr "Dirección Incoterm de Venta por defecto"
+
+#. module: sale_partner_incoterm
 #: model:ir.model.fields,field_description:sale_partner_incoterm.field_res_partner__sale_incoterm_id
 #: model:ir.model.fields,field_description:sale_partner_incoterm.field_res_users__sale_incoterm_id
 #: model_terms:ir.ui.view,arch_db:sale_partner_incoterm.view_partner_property_form
 msgid "Default Sales Incoterm"
 msgstr "Incoterm de venta por defecto"
+
+#. module: sale_partner_incoterm
+#: model:ir.model.fields,field_description:sale_partner_incoterm.field_res_partner__display_name
+#: model:ir.model.fields,field_description:sale_partner_incoterm.field_sale_order__display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: sale_partner_incoterm
+#: model:ir.model.fields,field_description:sale_partner_incoterm.field_res_partner__id
+#: model:ir.model.fields,field_description:sale_partner_incoterm.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: sale_partner_incoterm
+#: model:ir.model.fields,field_description:sale_partner_incoterm.field_sale_order__incoterm_address_id
+msgid "Incoterm Address"
+msgstr ""
+
+#. module: sale_partner_incoterm
+#: model:ir.model.fields,field_description:sale_partner_incoterm.field_res_partner____last_update
+#: model:ir.model.fields,field_description:sale_partner_incoterm.field_sale_order____last_update
+msgid "Last Modified on"
+msgstr "Última modificación el"
 
 #. module: sale_partner_incoterm
 #: model:ir.model,name:sale_partner_incoterm.model_sale_order
@@ -41,6 +66,3 @@ msgstr "Órdenes de venta"
 #: model:ir.model.fields,help:sale_partner_incoterm.field_res_users__sale_incoterm_id
 msgid "The default incoterm for new sales orders for this customer."
 msgstr "Incoterm por defecto para nuevos pedidos de este cliente."
-
-#~ msgid "Partner"
-#~ msgstr "Empresa"

--- a/sale_partner_incoterm/models/res_partner.py
+++ b/sale_partner_incoterm/models/res_partner.py
@@ -12,3 +12,7 @@ class Partner(models.Model):
         comodel_name="account.incoterms",
         help="The default incoterm for new sales orders for this customer.",
     )
+    sale_incoterm_address_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Default Sale Incoterm Address",
+    )

--- a/sale_partner_incoterm/models/sale_order.py
+++ b/sale_partner_incoterm/models/sale_order.py
@@ -1,14 +1,24 @@
 # Copyright 2015 Opener B.V. (<https://opener.am>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
+    incoterm_address_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Incoterm Address",
+    )
+
     @api.onchange("partner_id")
     def onchange_partner_id(self):
         res = super().onchange_partner_id()
-        self.incoterm = self.partner_id.sale_incoterm_id
+        self.update(
+            {
+                "incoterm": self.partner_id.sale_incoterm_id.id,
+                "incoterm_address_id": self.partner_id.sale_incoterm_address_id.id,
+            }
+        )
         return res

--- a/sale_partner_incoterm/tests/test_sale_partner_incoterm.py
+++ b/sale_partner_incoterm/tests/test_sale_partner_incoterm.py
@@ -12,7 +12,11 @@ class TestSalePartnerIncoterm(TransactionCase):
         """
         customer = self.env.ref("base.res_partner_3")
         incoterm = self.env["account.incoterms"].search([], limit=1)
-        customer.write({"sale_incoterm_id": incoterm.id})
+        address = self.env["res.partner"].search([], limit=1)
+        customer.write(
+            {"sale_incoterm_id": incoterm.id, "sale_incoterm_address_id": address.id}
+        )
         sale_order = self.env["sale.order"].create({"partner_id": customer.id})
         sale_order.onchange_partner_id()
         self.assertEqual(sale_order.incoterm, incoterm)
+        self.assertEqual(sale_order.incoterm_address_id, address)

--- a/sale_partner_incoterm/views/res_partner.xml
+++ b/sale_partner_incoterm/views/res_partner.xml
@@ -14,6 +14,10 @@
                     widget="selection"
                     groups="sale_stock.group_display_incoterm"
                 />
+                <field
+                    name="sale_incoterm_address_id"
+                    groups="sale_stock.group_display_incoterm"
+                />
             </field>
         </field>
     </record>

--- a/sale_partner_incoterm/views/sale_order.xml
+++ b/sale_partner_incoterm/views/sale_order.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="sale_stock_sale_order_form_inherit" model="ir.ui.view">
+        <field name="name">sale.stock.sale.order.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale_stock.view_order_form_inherit_sale_stock" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='incoterm']" position="after">
+                <field name="incoterm_address_id" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Add a new field in `res_partner` model for the default incoterm address. This works in `onchange_partner_id` as `sale_incoterm_id` does