### PR TITLE
[15.0][MIG] sale_credit_point: Migrate to version 15.0

### DIFF
--- a/sale_credit_point/README.rst
+++ b/sale_credit_point/README.rst
@@ -21,7 +21,8 @@ Features and usage
 ------------------
 
 Partner model has a new field `credit_point` which can be updated easily
-via a smart button on the partner form.
+via a smart button on the partner form. Smart button displays
+`current points / sum of all points increases this year`.
 
 A new currency is created `PT` (points) and is used by default
 for `credit_point` field.
@@ -36,6 +37,9 @@ is compared with partner's credit:
       but the context has key `skip_credit_check` -> order can be confirmed
 
 If the order is confirmed the credit is deducted from partner.
+
+History of all credit point allocations can be looked up
+in `sales -> configuration -> credit point history`.
 
 
 Bug Tracker
@@ -58,6 +62,7 @@ Contributors
 ------------
 
 * Simone Orsi <simone.orsi@camptocamp.com>
+* Mykhailo Panarin <m.panarin@mobilunity.com>
 
 Do not contact contributors directly about support or help with technical issues.
 

--- a/sale_credit_point/README.rst
+++ b/sale_credit_point/README.rst
@@ -1,0 +1,78 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=================
+Sale Credit Point
+=================
+
+Sale based on partners' credit point.
+
+Use case
+--------
+
+You have employees that have some credit (up to you where this come from)
+and you allow employees to buy products based on this credit.
+
+Products are sold by points rather than money.
+
+
+Features and usage
+------------------
+
+Partner model has a new field `credit_point` which can be updated easily
+via a smart button on the partner form.
+
+A new currency is created `PT` (points) and is used by default
+for `credit_point` field.
+
+On order confirmation the amount of the order
+is compared with partner's credit:
+
+   a. credit is not enough on partner -> the order cannot be confirmed
+   b. no credit is left on partner
+      but the user is member of `Manage credit point` -> order can be confirmed
+   c. no credit is left on partner
+      but the context has key `skip_credit_check` -> order can be confirmed
+
+If the order is confirmed the credit is deducted from partner.
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/sale-workflow/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://odoo-community.org/logo.png>`_.
+
+Contributors
+------------
+
+* Simone Orsi <simone.orsi@camptocamp.com>
+
+Do not contact contributors directly about support or help with technical issues.
+
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/sale_credit_point/__init__.py
+++ b/sale_credit_point/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import models
+from . import wizards

--- a/sale_credit_point/__init__.py
+++ b/sale_credit_point/__init__.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 from . import models
 from . import wizards

--- a/sale_credit_point/__manifest__.py
+++ b/sale_credit_point/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Sale Credit Points',
-    'version': '11.0.1.0.2',
+    'version': '11.0.1.0.3',
     'category': 'Sales',
     'license': 'AGPL-3',
     'author': 'Camptocamp, Odoo Community Association (OCA)',

--- a/sale_credit_point/__manifest__.py
+++ b/sale_credit_point/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Sale Credit Points',
-    'version': '11.0.1.0.1',
+    'version': '11.0.1.0.2',
     'category': 'Sales',
     'license': 'AGPL-3',
     'author': 'Camptocamp, Odoo Community Association (OCA)',

--- a/sale_credit_point/__manifest__.py
+++ b/sale_credit_point/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Sale Credit Points',
+    'version': '11.0.1.0.0',
+    'category': 'Sales',
+    'license': 'AGPL-3',
+    'author': 'Camptocamp, Odoo Community Association (OCA)',
+    'website': 'http://www.camptocamp.com/',
+    'depends': [
+        'sale',
+    ],
+    'data': [
+        'security/groups.xml',
+        'data/res_currency.xml',
+        'views/partner.xml',
+        'wizards/manage_credit_point.xml',
+    ],
+}

--- a/sale_credit_point/__manifest__.py
+++ b/sale_credit_point/__manifest__.py
@@ -2,21 +2,21 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
-    'name': 'Sale Credit Points',
-    'version': '11.0.1.0.3',
-    'category': 'Sales',
-    'license': 'AGPL-3',
-    'author': 'Camptocamp, Odoo Community Association (OCA)',
-    'website': 'http://www.camptocamp.com/',
-    'depends': [
-        'sale',
+    "name": "Sale Credit Points",
+    "version": "11.0.1.0.3",
+    "category": "Sales",
+    "license": "AGPL-3",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/sale-workflow",
+    "depends": [
+        "sale",
     ],
-    'data': [
-        'security/groups.xml',
-        'security/ir.model.access.csv',
-        'data/res_currency.xml',
-        'views/partner.xml',
-        'views/point_history.xml',
-        'wizards/manage_credit_point.xml',
+    "data": [
+        "security/groups.xml",
+        "security/ir.model.access.csv",
+        "data/res_currency.xml",
+        "views/partner.xml",
+        "views/point_history.xml",
+        "wizards/manage_credit_point.xml",
     ],
 }

--- a/sale_credit_point/__manifest__.py
+++ b/sale_credit_point/__manifest__.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Camptocamp SA
+# Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
@@ -12,9 +12,11 @@
         'sale',
     ],
     'data': [
+        'security/ir.model.access.csv',
         'security/groups.xml',
         'data/res_currency.xml',
         'views/partner.xml',
+        'views/point_history.xml',
         'wizards/manage_credit_point.xml',
     ],
 }

--- a/sale_credit_point/__manifest__.py
+++ b/sale_credit_point/__manifest__.py
@@ -1,9 +1,9 @@
-# Copyright 2018 Camptocamp SA
+# Copyright 2018-2022 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Sale Credit Points",
-    "version": "11.0.1.0.3",
+    "version": "15.0.1.0.0",
     "category": "Sales",
     "license": "AGPL-3",
     "author": "Camptocamp, Odoo Community Association (OCA)",

--- a/sale_credit_point/__manifest__.py
+++ b/sale_credit_point/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Sale Credit Points',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'category': 'Sales',
     'license': 'AGPL-3',
     'author': 'Camptocamp, Odoo Community Association (OCA)',

--- a/sale_credit_point/__manifest__.py
+++ b/sale_credit_point/__manifest__.py
@@ -12,8 +12,8 @@
         'sale',
     ],
     'data': [
-        'security/ir.model.access.csv',
         'security/groups.xml',
+        'security/ir.model.access.csv',
         'data/res_currency.xml',
         'views/partner.xml',
         'views/point_history.xml',

--- a/sale_credit_point/data/res_currency.xml
+++ b/sale_credit_point/data/res_currency.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+  <record id="res_currency_pt" model="res.currency">
+    <field name="name">PT</field>
+    <field name="symbol">PT</field>
+    <field name="rounding">1</field>
+    <field name="position">after</field>
+  </record>
+</odoo>

--- a/sale_credit_point/data/res_currency.xml
+++ b/sale_credit_point/data/res_currency.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
   <record id="res_currency_pt" model="res.currency">
     <field name="name">PT</field>

--- a/sale_credit_point/i18n/fr.po
+++ b/sale_credit_point/i18n/fr.po
@@ -1,0 +1,199 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale_credit_point
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-01-11 13:46+0000\n"
+"PO-Revision-Date: 2018-01-11 15:51+0100\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: \n"
+"X-Generator: Poedit 1.8.7.1\n"
+
+#. module: sale_credit_point
+#: code:addons/sale_credit_point/wizards/manage_credit_point.py:39
+#, python-format
+msgid "A comment is needed to the update credit"
+msgstr "Un commentaire est nécessaire pour mettre à jour un crédit."
+
+#. module: sale_credit_point
+#: model:ir.ui.view,arch_db:sale_credit_point.wiz_manage_credit_point
+msgid "Cancel"
+msgstr "Annuler"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_comment
+msgid "Comment"
+msgstr "Commentaires"
+
+#. module: sale_credit_point
+#: model:ir.model,name:sale_credit_point.model_res_partner
+msgid "Contact"
+msgstr "Contact"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_create_uid
+msgid "Created by"
+msgstr "Créé par"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_create_date
+msgid "Created on"
+msgstr "Créé le"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_res_partner_credit_point_currency_id
+#: model:ir.model.fields,field_description:sale_credit_point.field_res_users_credit_point_currency_id
+msgid "Credit Point Currency"
+msgstr "Devise pour le crédit de point"
+
+#. module: sale_credit_point
+#: code:addons/sale_credit_point/models/partner.py:54
+#, python-format
+msgid "Credit updated to %s. Reason: %s"
+msgstr "Crédit mis à jour de %s. Raison: %s"
+
+#. module: sale_credit_point
+#: selection:wiz.manage.credit.point,operation:0
+msgid "Decrease"
+msgstr "Diminuer"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_display_name
+msgid "Display Name"
+msgstr "Nom affiché"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_id
+msgid "ID"
+msgstr "ID"
+
+#. module: sale_credit_point
+#: selection:wiz.manage.credit.point,operation:0
+msgid "Increase"
+msgstr "Augmenter"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point___last_update
+msgid "Last Modified on"
+msgstr "Dernière Modification le"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_write_uid
+msgid "Last Updated by"
+msgstr "Dernière mise à jour par"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_write_date
+msgid "Last Updated on"
+msgstr "Dernière mise à jour le"
+
+#. module: sale_credit_point
+#: model:res.groups,name:sale_credit_point.group_manage_credit_point
+msgid "Manage credit point"
+msgstr "Mise à jour credit"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_partner_ids
+msgid "Partners"
+msgstr "Partenaires"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_credit_point
+#: model:ir.ui.view,arch_db:sale_credit_point.view_partner_form_points
+msgid "Points"
+msgstr "Points"
+
+#. module: sale_credit_point
+#: model:ir.ui.view,arch_db:sale_credit_point.view_partner_search_points
+msgid "Points > 0"
+msgstr "Points > 0"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_res_partner_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_res_users_credit_point
+msgid "Points Attribution"
+msgstr "Points Attribution"
+
+#. module: sale_credit_point
+#: model:ir.model,name:sale_credit_point.model_sale_order
+msgid "Quotation"
+msgstr "Devis"
+
+#. module: sale_credit_point
+#: model:ir.ui.view,arch_db:sale_credit_point.wiz_manage_credit_point
+msgid "Reason for the modification"
+msgstr "Raison de la modification"
+
+#. module: sale_credit_point
+#: selection:wiz.manage.credit.point,operation:0
+msgid "Replace"
+msgstr "Remplacer"
+
+#. module: sale_credit_point
+#: code:addons/sale_credit_point/models/sale_order.py:28
+#, python-format
+msgid "SO %s"
+msgstr ""
+
+#. module: sale_credit_point
+#: code:addons/sale_credit_point/models/sale_order.py:21
+#, python-format
+msgid "Sale Order amount total (%s) is higher than your available credit (%s)."
+msgstr "Le montant de la commande (%s) est supérieur à votre credit (%s)."
+
+#. module: sale_credit_point
+#: model:ir.ui.view,arch_db:sale_credit_point.wiz_manage_credit_point
+msgid "Selected partner(s) will be updated."
+msgstr "Les partenaires sélectionnés"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_operation
+msgid "Type of operation"
+msgstr "Type d'opération"
+
+#. module: sale_credit_point
+#: model:ir.ui.view,arch_db:sale_credit_point.wiz_manage_credit_point
+msgid "Update Credit"
+msgstr "Mise à jour du crédit"
+
+#. module: sale_credit_point
+#: model:ir.actions.act_window,name:sale_credit_point.action_add_credit_point
+msgid "Update Credit Point"
+msgstr "Mise à jour credit"
+
+#. module: sale_credit_point
+#: code:addons/sale_credit_point/models/partner.py:35
+#, python-format
+msgid "You can't set a credit point lower than 0"
+msgstr "Il n'est pas possible d'affecter une attribution logistique plus petite que 0"
+
+#. module: sale_credit_point
+#: model:ir.model,name:sale_credit_point.model_wiz_manage_credit_point
+msgid "wiz.manage.credit.point"
+msgstr "Mise à jour credit"
+
+#~ msgid "Partner"
+#~ msgstr "Partenaire"
+
+#~ msgid "Partner currency id"
+#~ msgstr "Devise du partenaire"
+
+#~ msgid "Points to replace"
+#~ msgstr "Points to replace"
+
+#~ msgid "Sales Order"
+#~ msgstr "Bon de commande"
+
+#~ msgid "You must add a comment to the change of credit point"
+#~ msgstr "Il est nécessaire d'ajouter un commentaire"
+
+#~ msgid "points.attribution.wizard"
+#~ msgstr "points.attribution.wizard"

--- a/sale_credit_point/i18n/fr.po
+++ b/sale_credit_point/i18n/fr.po
@@ -88,8 +88,8 @@ msgstr "Historique des crédits"
 #: code:addons/odoo/external-src/odoo-sale-addons/sale_credit_point/models/partner.py:69
 #: code:addons/sale_credit_point/models/partner.py:69
 #, python-format
-msgid "Credit updated to %s. Reason: %s"
-msgstr "Crédit mis à jour de %s. Raison: %s"
+msgid "Credit updated to {points}. Reason: {comment}"
+msgstr "Crédit mis à jour de {points}. Raison: {comment}"
 
 #. module: sale_credit_point
 #: selection:credit.point.history,operation:0
@@ -203,8 +203,8 @@ msgstr "SO %s"
 #: code:addons/odoo/external-src/odoo-sale-addons/sale_credit_point/models/sale_order.py:20
 #: code:addons/sale_credit_point/models/sale_order.py:20
 #, python-format
-msgid "Sale Order amount total (%s) is higher than your available credit (%s)."
-msgstr "Le montant de la commande (%s) est supérieur à votre credit (%s)."
+msgid "Sale Order amount total ({amount}) is higher than your available credit ({points})."
+msgstr "Le montant de la commande ({amount}) est supérieur à votre credit ({points})."
 
 #. module: sale_credit_point
 #: code:addons/odoo/external-src/odoo-sale-addons/sale_credit_point/models/sale_order.py:43
@@ -216,10 +216,6 @@ msgid "Sale Order canceled"
 msgstr "Commande annulée"
 
 #. module: sale_credit_point
-#: model:ir.ui.view,arch_db:sale_credit_point.view_credit_point_history_search
-msgid "Search Invoice"
-msgstr "Chercher une facture"
-
 #: model:ir.ui.view,arch_db:sale_credit_point.view_credit_point_history_search
 msgid "Search Invoice"
 msgstr "Chercher une facture"

--- a/sale_credit_point/i18n/fr.po
+++ b/sale_credit_point/i18n/fr.po
@@ -1,6 +1,6 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#   * sale_credit_point
+#	* sale_credit_point
 #
 msgid ""
 msgstr ""
@@ -12,7 +12,7 @@ msgstr ""
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 "Language: fr\n"
 "X-Generator: Poedit 1.8.7.1\n"
@@ -82,7 +82,7 @@ msgstr "Credit Points History"
 #. module: sale_credit_point
 #: model:ir.ui.menu,name:sale_credit_point.menu_credit_point_history
 msgid "Credit point history"
-msgstr "Credit point history"
+msgstr "Historique des crédits"
 
 #. module: sale_credit_point
 #: code:addons/odoo/external-src/odoo-sale-addons/sale_credit_point/models/partner.py:69
@@ -220,6 +220,10 @@ msgstr "Commande annulée"
 msgid "Search Invoice"
 msgstr "Chercher une facture"
 
+#: model:ir.ui.view,arch_db:sale_credit_point.view_credit_point_history_search
+msgid "Search Invoice"
+msgstr "Chercher une facture"
+
 #. module: sale_credit_point
 #: model:ir.ui.view,arch_db:sale_credit_point.wiz_manage_credit_point
 msgid "Selected partner(s) will be updated."
@@ -249,7 +253,7 @@ msgstr "Mise à jour credit"
 #: model:ir.model.fields,field_description:sale_credit_point.field_res_partner_yearly_point_increase
 #: model:ir.model.fields,field_description:sale_credit_point.field_res_users_yearly_point_increase
 msgid "Yearly points increase"
-msgstr "Augmentation de crédit annuelle"
+msgstr "Yearly points increase"
 
 #. module: sale_credit_point
 #: code:addons/odoo/external-src/odoo-sale-addons/sale_credit_point/models/partner.py:50
@@ -267,21 +271,3 @@ msgstr "credit.point.history"
 #: model:ir.model,name:sale_credit_point.model_wiz_manage_credit_point
 msgid "wiz.manage.credit.point"
 msgstr "Mise à jour credit"
-
-#~ msgid "Partner"
-#~ msgstr "Partenaire"
-
-#~ msgid "Partner currency id"
-#~ msgstr "Devise du partenaire"
-
-#~ msgid "Points to replace"
-#~ msgstr "Points to replace"
-
-#~ msgid "Sales Order"
-#~ msgstr "Bon de commande"
-
-#~ msgid "You must add a comment to the change of credit point"
-#~ msgstr "Il est nécessaire d'ajouter un commentaire"
-
-#~ msgid "points.attribution.wizard"
-#~ msgstr "points.attribution.wizard"

--- a/sale_credit_point/i18n/fr.po
+++ b/sale_credit_point/i18n/fr.po
@@ -1,27 +1,33 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* sale_credit_point
+#   * sale_credit_point
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 10.0+e\n"
+"Project-Id-Version: Odoo Server 11.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-01-11 13:46+0000\n"
-"PO-Revision-Date: 2018-01-11 15:51+0100\n"
+"POT-Creation-Date: 2018-05-31 13:56+0000\n"
+"PO-Revision-Date: 2018-05-31 15:59+0200\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
-"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"Language: fr\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
 #. module: sale_credit_point
-#: code:addons/sale_credit_point/wizards/manage_credit_point.py:39
+#: code:addons/odoo/external-src/odoo-sale-addons/sale_credit_point/wizards/manage_credit_point.py:35
+#: code:addons/sale_credit_point/wizards/manage_credit_point.py:35
 #, python-format
 msgid "A comment is needed to the update credit"
 msgstr "Un commentaire est nécessaire pour mettre à jour un crédit."
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_credit_point_history_amount
+msgid "Amount"
+msgstr "Montant"
 
 #. module: sale_credit_point
 #: model:ir.ui.view,arch_db:sale_credit_point.wiz_manage_credit_point
@@ -29,6 +35,7 @@ msgid "Cancel"
 msgstr "Annuler"
 
 #. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_credit_point_history_comment
 #: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_comment
 msgid "Comment"
 msgstr "Commentaires"
@@ -39,6 +46,12 @@ msgid "Contact"
 msgstr "Contact"
 
 #. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_credit_point_history_create_date
+msgid "Create Date"
+msgstr "Date de création"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_credit_point_history_create_uid
 #: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_create_uid
 msgid "Created by"
 msgstr "Créé par"
@@ -49,48 +62,78 @@ msgid "Created on"
 msgstr "Créé le"
 
 #. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_res_partner_credit_history_ids
+#: model:ir.model.fields,field_description:sale_credit_point.field_res_users_credit_history_ids
+msgid "Credit History"
+msgstr "Credit History"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_credit_point_history_credit_point_currency_id
 #: model:ir.model.fields,field_description:sale_credit_point.field_res_partner_credit_point_currency_id
 #: model:ir.model.fields,field_description:sale_credit_point.field_res_users_credit_point_currency_id
 msgid "Credit Point Currency"
 msgstr "Devise pour le crédit de point"
 
 #. module: sale_credit_point
-#: code:addons/sale_credit_point/models/partner.py:54
+#: model:ir.actions.act_window,name:sale_credit_point.credit_point_history_action
+msgid "Credit Points History"
+msgstr "Credit Points History"
+
+#. module: sale_credit_point
+#: model:ir.ui.menu,name:sale_credit_point.menu_credit_point_history
+msgid "Credit point history"
+msgstr "Credit point history"
+
+#. module: sale_credit_point
+#: code:addons/odoo/external-src/odoo-sale-addons/sale_credit_point/models/partner.py:69
+#: code:addons/sale_credit_point/models/partner.py:69
 #, python-format
 msgid "Credit updated to %s. Reason: %s"
 msgstr "Crédit mis à jour de %s. Raison: %s"
 
 #. module: sale_credit_point
+#: selection:credit.point.history,operation:0
 #: selection:wiz.manage.credit.point,operation:0
 msgid "Decrease"
 msgstr "Diminuer"
 
 #. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_credit_point_history_display_name
 #: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_display_name
 msgid "Display Name"
-msgstr "Nom affiché"
+msgstr "Nom à afficher"
 
 #. module: sale_credit_point
+#: model:ir.ui.view,arch_db:sale_credit_point.view_credit_point_history_search
+msgid "Group By"
+msgstr "Regrouper par"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_credit_point_history_id
 #: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_id
 msgid "ID"
 msgstr "ID"
 
 #. module: sale_credit_point
+#: selection:credit.point.history,operation:0
 #: selection:wiz.manage.credit.point,operation:0
 msgid "Increase"
 msgstr "Augmenter"
 
 #. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_credit_point_history___last_update
 #: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point___last_update
 msgid "Last Modified on"
-msgstr "Dernière Modification le"
+msgstr "Dernière modification le"
 
 #. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_credit_point_history_write_uid
 #: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_write_uid
 msgid "Last Updated by"
 msgstr "Dernière mise à jour par"
 
 #. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_credit_point_history_write_date
 #: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_write_date
 msgid "Last Updated on"
 msgstr "Dernière mise à jour le"
@@ -99,6 +142,17 @@ msgstr "Dernière mise à jour le"
 #: model:res.groups,name:sale_credit_point.group_manage_credit_point
 msgid "Manage credit point"
 msgstr "Mise à jour credit"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_credit_point_history_operation
+msgid "Operation"
+msgstr "Operation"
+
+#. module: sale_credit_point
+#: model:ir.model.fields,field_description:sale_credit_point.field_credit_point_history_partner_id
+#: model:ir.ui.view,arch_db:sale_credit_point.view_credit_point_history_search
+msgid "Partner"
+msgstr "Partenaire"
 
 #. module: sale_credit_point
 #: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_partner_ids
@@ -133,26 +187,48 @@ msgid "Reason for the modification"
 msgstr "Raison de la modification"
 
 #. module: sale_credit_point
+#: selection:credit.point.history,operation:0
 #: selection:wiz.manage.credit.point,operation:0
 msgid "Replace"
 msgstr "Remplacer"
 
 #. module: sale_credit_point
-#: code:addons/sale_credit_point/models/sale_order.py:28
+#: code:addons/odoo/external-src/odoo-sale-addons/sale_credit_point/models/sale_order.py:27
+#: code:addons/sale_credit_point/models/sale_order.py:27
 #, python-format
 msgid "SO %s"
-msgstr ""
+msgstr "SO %s"
 
 #. module: sale_credit_point
-#: code:addons/sale_credit_point/models/sale_order.py:21
+#: code:addons/odoo/external-src/odoo-sale-addons/sale_credit_point/models/sale_order.py:20
+#: code:addons/sale_credit_point/models/sale_order.py:20
 #, python-format
 msgid "Sale Order amount total (%s) is higher than your available credit (%s)."
 msgstr "Le montant de la commande (%s) est supérieur à votre credit (%s)."
 
 #. module: sale_credit_point
+#: code:addons/odoo/external-src/odoo-sale-addons/sale_credit_point/models/sale_order.py:43
+#: code:addons/odoo/external-src/odoo-sale-addons/sale_credit_point/models/sale_order.py:45
+#: code:addons/sale_credit_point/models/sale_order.py:43
+#: code:addons/sale_credit_point/models/sale_order.py:45
+#, python-format
+msgid "Sale Order canceled"
+msgstr "Commande annulée"
+
+#. module: sale_credit_point
+#: model:ir.ui.view,arch_db:sale_credit_point.view_credit_point_history_search
+msgid "Search Invoice"
+msgstr "Chercher une facture"
+
+#. module: sale_credit_point
 #: model:ir.ui.view,arch_db:sale_credit_point.wiz_manage_credit_point
 msgid "Selected partner(s) will be updated."
 msgstr "Les partenaires sélectionnés"
+
+#. module: sale_credit_point
+#: model:ir.ui.view,arch_db:sale_credit_point.view_credit_point_history_search
+msgid "This Year"
+msgstr "Cette année"
 
 #. module: sale_credit_point
 #: model:ir.model.fields,field_description:sale_credit_point.field_wiz_manage_credit_point_operation
@@ -170,10 +246,22 @@ msgid "Update Credit Point"
 msgstr "Mise à jour credit"
 
 #. module: sale_credit_point
-#: code:addons/sale_credit_point/models/partner.py:35
+#: model:ir.model.fields,field_description:sale_credit_point.field_res_partner_yearly_point_increase
+#: model:ir.model.fields,field_description:sale_credit_point.field_res_users_yearly_point_increase
+msgid "Yearly points increase"
+msgstr "Augmentation de crédit annuelle"
+
+#. module: sale_credit_point
+#: code:addons/odoo/external-src/odoo-sale-addons/sale_credit_point/models/partner.py:50
+#: code:addons/sale_credit_point/models/partner.py:50
 #, python-format
 msgid "You can't set a credit point lower than 0"
 msgstr "Il n'est pas possible d'affecter une attribution logistique plus petite que 0"
+
+#. module: sale_credit_point
+#: model:ir.model,name:sale_credit_point.model_credit_point_history
+msgid "credit.point.history"
+msgstr "credit.point.history"
 
 #. module: sale_credit_point
 #: model:ir.model,name:sale_credit_point.model_wiz_manage_credit_point

--- a/sale_credit_point/models/__init__.py
+++ b/sale_credit_point/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import partner
+from . import sale_order

--- a/sale_credit_point/models/__init__.py
+++ b/sale_credit_point/models/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from . import partner
 from . import sale_order
+from . import point_history

--- a/sale_credit_point/models/partner.py
+++ b/sale_credit_point/models/partner.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models, api, exceptions, _
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    credit_point = fields.Monetary(
+        string='Points Attribution',
+        currency_field='credit_point_currency_id',
+        readonly=True,
+        default=0,
+    )
+    credit_point_currency_id = fields.Many2one(
+        comodel_name='res.currency',
+        default=lambda self: self._default_credit_point_currency_id()
+    )
+
+    def _default_credit_point_currency_id(self):
+        curr = self.env.ref('sale_credit_point.res_currency_pt',
+                            raise_if_not_found=False)
+        return curr.id if curr else None
+
+    def credit_point_bypass_check(self):
+        group = 'sale_credit_point.group_manage_credit_point'
+        return (self.user_has_groups(group) or
+                self.env.context.get('skip_credit_check'))
+
+    @api.constrains('credit_point')
+    def _check_credit_point(self):
+        if self.credit_point < 0 and not self.credit_point_bypass_check():
+            raise exceptions.ValidationError(_(
+                "You can't set a credit point lower than 0"))
+
+    @api.multi
+    def action_update_credit_point(self):
+        """Open update credit point wizard."""
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'wiz.manage.credit.point',
+            'src_model': 'res.partner',
+            'view_mode': 'form',
+            'target': 'new',
+            'context': {'default_partner_ids': self.ids},
+        }
+
+    def _credit_point_update(self, amount, comment=''):
+        self.credit_point = amount
+        if comment:
+            self.message_post(body=(_(
+                'Credit updated to %s. Reason: %s'
+            ) % (self.credit_point, comment)))
+
+    def credit_point_replace(self, amount, comment=''):
+        self._credit_point_update(amount, comment=comment)
+
+    def credit_point_increase(self, amount, comment=''):
+        self._credit_point_update(self.credit_point + amount, comment=comment)
+
+    def credit_point_decrease(self, amount, comment=''):
+        self._credit_point_update(self.credit_point - amount, comment=comment)

--- a/sale_credit_point/models/partner.py
+++ b/sale_credit_point/models/partner.py
@@ -1,13 +1,7 @@
-# Copyright 2018 Camptocamp SA
+# Copyright 2018-2022 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import _, api, exceptions, fields, models
-
-POINT_OPERATIONS = [
-    ("replace", "Replace"),
-    ("increase", "Increase"),
-    ("decrease", "Decrease"),
-]
 
 
 class ResPartner(models.Model):
@@ -51,7 +45,6 @@ class ResPartner(models.Model):
                 _("You can't set a credit point lower than 0")
             )
 
-    @api.multi
     def action_update_credit_point(self):
         """Open update credit point wizard."""
         self.ensure_one()

--- a/sale_credit_point/models/partner.py
+++ b/sale_credit_point/models/partner.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models, api, exceptions, _
+from odoo import _, api, exceptions, fields, models
 
 POINT_OPERATIONS = [
     ("replace", "Replace"),
@@ -11,81 +11,83 @@ POINT_OPERATIONS = [
 
 
 class ResPartner(models.Model):
-    _inherit = 'res.partner'
+    _inherit = "res.partner"
 
     credit_point = fields.Monetary(
-        string='Points Attribution',
-        currency_field='credit_point_currency_id',
+        string="Points Attribution",
+        currency_field="credit_point_currency_id",
         readonly=True,
         default=0,
     )
     yearly_point_increase = fields.Monetary(
-        string='Yearly points increase',
-        currency_field='credit_point_currency_id',
+        string="Yearly points increase",
+        currency_field="credit_point_currency_id",
         readonly=True,
-        compute="_compute_yearly_point_increase"
+        compute="_compute_yearly_point_increase",
     )
     credit_history_ids = fields.One2many(
         comodel_name="credit.point.history",
         inverse_name="partner_id",
     )
     credit_point_currency_id = fields.Many2one(
-        comodel_name='res.currency',
-        default=lambda self: self._default_credit_point_currency_id()
+        comodel_name="res.currency",
+        default=lambda self: self._default_credit_point_currency_id(),
     )
 
     def _default_credit_point_currency_id(self):
-        curr = self.env.ref('sale_credit_point.res_currency_pt',
-                            raise_if_not_found=False)
+        curr = self.env.ref(
+            "sale_credit_point.res_currency_pt", raise_if_not_found=False
+        )
         return curr.id if curr else None
 
     def credit_point_bypass_check(self):
-        group = 'sale_credit_point.group_manage_credit_point'
-        return (self.user_has_groups(group) or
-                self.env.context.get('skip_credit_check'))
+        group = "sale_credit_point.group_manage_credit_point"
+        return self.user_has_groups(group) or self.env.context.get("skip_credit_check")
 
-    @api.constrains('credit_point')
+    @api.constrains("credit_point")
     def _check_credit_point(self):
         if self.credit_point < 0 and not self.credit_point_bypass_check():
-            raise exceptions.ValidationError(_(
-                "You can't set a credit point lower than 0"))
+            raise exceptions.ValidationError(
+                _("You can't set a credit point lower than 0")
+            )
 
     @api.multi
     def action_update_credit_point(self):
         """Open update credit point wizard."""
         self.ensure_one()
         return {
-            'type': 'ir.actions.act_window',
-            'res_model': 'wiz.manage.credit.point',
-            'src_model': 'res.partner',
-            'view_mode': 'form',
-            'target': 'new',
-            'context': {'default_partner_ids': self.ids},
+            "type": "ir.actions.act_window",
+            "res_model": "wiz.manage.credit.point",
+            "src_model": "res.partner",
+            "view_mode": "form",
+            "target": "new",
+            "context": {"default_partner_ids": self.ids},
         }
 
-    def _credit_point_update(self, amount, comment=''):
+    def _credit_point_update(self, amount, comment=""):
         self.credit_point = amount
         if comment:
-            self.message_post(body=(_(
-                'Credit updated to %s. Reason: %s'
-            ) % (self.credit_point, comment)))
+            msg = _("Credit updated to {points}. Reason: {comment}")
+            self.message_post(
+                body=msg.format(points=self.credit_point, comment=comment)
+            )
 
-    def credit_point_replace(self, amount, comment=''):
+    def credit_point_replace(self, amount, comment=""):
         self._credit_point_update(amount, comment=comment)
 
-    def credit_point_increase(self, amount, comment=''):
+    def credit_point_increase(self, amount, comment=""):
         self._credit_point_update(self.credit_point + amount, comment=comment)
 
-    def credit_point_decrease(self, amount, comment=''):
+    def credit_point_decrease(self, amount, comment=""):
         self._credit_point_update(self.credit_point - amount, comment=comment)
 
     def update_history(self, amount, operation, comment):
         history_model = self.env["credit.point.history"]
         vals = {
-            'partner_id': self.id,
-            'operation': operation,
-            'amount': amount,
-            'comment': comment,
+            "partner_id": self.id,
+            "operation": operation,
+            "amount": amount,
+            "comment": comment,
         }
         return history_model.create(vals)
 

--- a/sale_credit_point/models/point_history.py
+++ b/sale_credit_point/models/point_history.py
@@ -1,13 +1,18 @@
-# Copyright 2018 Camptocamp SA
+# Copyright 2018-2022 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
 
-from .partner import POINT_OPERATIONS
+POINT_OPERATIONS = [
+    ("replace", "Replace"),
+    ("increase", "Increase"),
+    ("decrease", "Decrease"),
+]
 
 
 class PointHistory(models.Model):
     _name = "credit.point.history"
+    _description = "CreditPointHistory"
     _rec_name = "partner_id"
 
     partner_id = fields.Many2one(

--- a/sale_credit_point/models/point_history.py
+++ b/sale_credit_point/models/point_history.py
@@ -1,0 +1,36 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+from .partner import POINT_OPERATIONS
+
+
+class PointHistory(models.Model):
+    _name = "credit.point.history"
+    _rec_name = "partner_id"
+
+    partner_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Partner",
+        required=True,
+    )
+    operation = fields.Selection(
+        string="Operation",
+        selection=POINT_OPERATIONS,
+        required=True,
+    )
+    amount = fields.Monetary(
+        string='Amount',
+        currency_field='credit_point_currency_id',
+        readonly=True,
+        default=0,
+        required=True,
+    )
+    credit_point_currency_id = fields.Many2one(
+        related="partner_id.credit_point_currency_id",
+        readonly=True,
+    )
+    create_date = fields.Datetime()
+    comment = fields.Char(
+        string="Comment"
+    )

--- a/sale_credit_point/models/point_history.py
+++ b/sale_credit_point/models/point_history.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
+
 from .partner import POINT_OPERATIONS
 
 
@@ -15,13 +16,11 @@ class PointHistory(models.Model):
         required=True,
     )
     operation = fields.Selection(
-        string="Operation",
         selection=POINT_OPERATIONS,
         required=True,
     )
     amount = fields.Monetary(
-        string='Amount',
-        currency_field='credit_point_currency_id',
+        currency_field="credit_point_currency_id",
         readonly=True,
         default=0,
         required=True,
@@ -31,6 +30,4 @@ class PointHistory(models.Model):
         readonly=True,
     )
     create_date = fields.Datetime()
-    comment = fields.Char(
-        string="Comment"
-    )
+    comment = fields.Char()

--- a/sale_credit_point/models/sale_order.py
+++ b/sale_credit_point/models/sale_order.py
@@ -3,6 +3,7 @@
 
 from odoo import api, models, _
 from odoo.exceptions import UserError
+from odoo import tools
 
 
 class SaleOrder(models.Model):
@@ -29,8 +30,15 @@ class SaleOrder(models.Model):
     @api.multi
     def action_confirm(self):
         """Check credit before confirmation, update credit if check passed."""
-        for sale in self:
-            sale.credit_point_check()
-            sale.partner_id.credit_point_decrease(
-                sale.amount_total, comment=self.credit_point_decrease_msg)
+        install_module = tools.config.get('init')
+        """
+        At installation, odoo core demo data is calling  on SO.
+        It was leading to an error related to this module, as the demo partner
+        didn't had any credit point
+        """
+        if 'sale_credit_point' not in install_module:
+            for sale in self:
+                sale.credit_point_check()
+                sale.partner_id.credit_point_decrease(
+                    sale.amount_total, comment=self.credit_point_decrease_msg)
         return super().action_confirm()

--- a/sale_credit_point/models/sale_order.py
+++ b/sale_credit_point/models/sale_order.py
@@ -9,10 +9,15 @@ from odoo import tools
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    def credit_point_check(self):
+    def credit_point_check(self, user=None):
         """Verify order amount against credit point budget."""
+        # Introduced this check as from website sale_orders are created
+        # from admin. If admin is in manage_credits group - all users will
+        # bypass check. This way, we can check specific user from request
+        if not user:
+            user = self.env.user
         self.ensure_one()
-        if not self.partner_id.credit_point_bypass_check():
+        if not self.partner_id.sudo(user.id).credit_point_bypass_check():
             if self.amount_total > self.partner_id.credit_point:
                 raise UserError(self.credit_point_check_failed_msg)
 

--- a/sale_credit_point/models/sale_order.py
+++ b/sale_credit_point/models/sale_order.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017 Camptocamp SA
+# Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, models, _
@@ -34,4 +33,4 @@ class SaleOrder(models.Model):
             sale.credit_point_check()
             sale.partner_id.credit_point_decrease(
                 sale.amount_total, comment=self.credit_point_decrease_msg)
-        return super(SaleOrder, self).action_confirm()
+        return super().action_confirm()

--- a/sale_credit_point/models/sale_order.py
+++ b/sale_credit_point/models/sale_order.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models, _
+from odoo.exceptions import UserError
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    def credit_point_check(self):
+        """Verify order amount against credit point budget."""
+        self.ensure_one()
+        if not self.partner_id.credit_point_bypass_check():
+            if self.amount_total > self.partner_id.credit_point:
+                raise UserError(self.credit_point_check_failed_msg)
+
+    @property
+    def credit_point_check_failed_msg(self):
+        return _(
+            "Sale Order amount total (%s) "
+            "is higher than your available credit (%s)."
+        ) % (self.amount_total, self.partner_id.credit_point)
+
+    @property
+    def credit_point_decrease_msg(self):
+        return _('SO %s') % self.name
+
+    @api.multi
+    def action_confirm(self):
+        """Check credit before confirmation, update credit if check passed."""
+        for sale in self:
+            sale.credit_point_check()
+            sale.partner_id.credit_point_decrease(
+                sale.amount_total, comment=self.credit_point_decrease_msg)
+        return super(SaleOrder, self).action_confirm()

--- a/sale_credit_point/models/sale_order.py
+++ b/sale_credit_point/models/sale_order.py
@@ -53,6 +53,4 @@ class SaleOrder(models.Model):
             if sale.state == 'sale':
                 sale.partner_id.credit_point_increase(
                     sale.amount_total, _("Sale Order canceled"))
-                sale.partner_id.update_history(
-                    sale.amount_total, "increase", _("Sale Order canceled"))
             super(SaleOrder, sale).action_cancel()

--- a/sale_credit_point/models/sale_order.py
+++ b/sale_credit_point/models/sale_order.py
@@ -31,11 +31,10 @@ class SaleOrder(models.Model):
     def action_confirm(self):
         """Check credit before confirmation, update credit if check passed."""
         install_module = tools.config.get('init')
-        """
-        At installation, odoo core demo data is calling  on SO.
-        It was leading to an error related to this module, as the demo partner
-        didn't had any credit point
-        """
+        # At installation, odoo core demo data is calling  on SO.
+        # It was leading to an error related to this module, as the demo
+        # partner didn't had any credit point
+
         if 'sale_credit_point' not in install_module:
             for sale in self:
                 sale.credit_point_check()

--- a/sale_credit_point/models/sale_order.py
+++ b/sale_credit_point/models/sale_order.py
@@ -41,3 +41,13 @@ class SaleOrder(models.Model):
                 sale.partner_id.credit_point_decrease(
                     sale.amount_total, comment=self.credit_point_decrease_msg)
         return super().action_confirm()
+
+    @api.multi
+    def action_cancel(self):
+        for sale in self:
+            if sale.state == 'sale':
+                sale.partner_id.credit_point_increase(
+                    sale.amount_total, _("Sale Order canceled"))
+                sale.partner_id.update_history(
+                    sale.amount_total, "increase", _("Sale Order canceled"))
+            super(SaleOrder, sale).action_cancel()

--- a/sale_credit_point/models/sale_order.py
+++ b/sale_credit_point/models/sale_order.py
@@ -1,13 +1,12 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, models, _
+from odoo import _, api, models, tools
 from odoo.exceptions import UserError
-from odoo import tools
 
 
 class SaleOrder(models.Model):
-    _inherit = 'sale.order'
+    _inherit = "sale.order"
 
     def credit_point_check(self, user=None):
         """Verify order amount against credit point budget."""
@@ -23,34 +22,37 @@ class SaleOrder(models.Model):
 
     @property
     def credit_point_check_failed_msg(self):
-        return _(
-            "Sale Order amount total (%s) "
-            "is higher than your available credit (%s)."
-        ) % (self.amount_total, self.partner_id.credit_point)
+        msg = _(
+            "Sale Order amount total ({amount}) is higher"
+            " than your available credit ({points})."
+        )
+        return msg.format(amount=self.amount_total, points=self.partner_id.credit_point)
 
     @property
     def credit_point_decrease_msg(self):
-        return _('SO %s') % self.name
+        return _("SO %s") % self.name
 
     @api.multi
     def action_confirm(self):
         """Check credit before confirmation, update credit if check passed."""
-        install_module = tools.config.get('init')
+        install_module = tools.config.get("init")
         # At installation, odoo core demo data is calling  on SO.
         # It was leading to an error related to this module, as the demo
         # partner didn't had any credit point
 
-        if 'sale_credit_point' not in install_module:
+        if "sale_credit_point" not in install_module:
             for sale in self:
                 sale.credit_point_check()
                 sale.partner_id.credit_point_decrease(
-                    sale.amount_total, comment=self.credit_point_decrease_msg)
+                    sale.amount_total, comment=self.credit_point_decrease_msg
+                )
         return super().action_confirm()
 
     @api.multi
     def action_cancel(self):
         for sale in self:
-            if sale.state == 'sale':
+            if sale.state == "sale":
                 sale.partner_id.credit_point_increase(
-                    sale.amount_total, _("Sale Order canceled"))
-            super(SaleOrder, sale).action_cancel()
+                    sale.amount_total, _("Sale Order canceled")
+                )
+        return super().action_cancel()

--- a/sale_credit_point/security/groups.xml
+++ b/sale_credit_point/security/groups.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <record id="group_manage_credit_point" model="res.groups">
+    <field name="name">Manage credit point</field>
+    <field name="implied_ids" eval="[(4, ref('base.group_partner_manager'))]"/>
+  </record>
+
+</odoo>

--- a/sale_credit_point/security/groups.xml
+++ b/sale_credit_point/security/groups.xml
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
   <record id="group_manage_credit_point" model="res.groups">
     <field name="name">Manage credit point</field>
-    <field name="implied_ids" eval="[(4, ref('base.group_partner_manager'))]"/>
+    <field name="implied_ids" eval="[(4, ref('base.group_partner_manager'))]" />
   </record>
 
 </odoo>

--- a/sale_credit_point/security/ir.model.access.csv
+++ b/sale_credit_point/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_credit_point_history,access_credit_point_history,model_credit_point_history,,1,1,1,1

--- a/sale_credit_point/security/ir.model.access.csv
+++ b/sale_credit_point/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_credit_point_history,access_credit_point_history,model_credit_point_history,,1,1,1,1
+credit_points_access_res_users,credit_points_access_res_users,base.model_res_users,sale_credit_point.group_manage_credit_point,1,1,0,0

--- a/sale_credit_point/security/ir.model.access.csv
+++ b/sale_credit_point/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_credit_point_history,access_credit_point_history,model_credit_point_history,,1,1,1,1
 credit_points_access_res_users,credit_points_access_res_users,base.model_res_users,sale_credit_point.group_manage_credit_point,1,1,0,0
+sale_credit_point.access_wiz_manage_credit_point,access_wiz_manage_credit_point,sale_credit_point.model_wiz_manage_credit_point,base.group_user,1,1,1,1

--- a/sale_credit_point/tests/__init__.py
+++ b/sale_credit_point/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_credit
 from . import test_wizard
 from . import test_sale_order
+from . import test_credit_history

--- a/sale_credit_point/tests/__init__.py
+++ b/sale_credit_point/tests/__init__.py
@@ -1,0 +1,3 @@
+from . import test_credit
+from . import test_wizard
+from . import test_sale_order

--- a/sale_credit_point/tests/test_credit.py
+++ b/sale_credit_point/tests/test_credit.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import SavepointCase
+from odoo import exceptions
+
+
+class TestCredit(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestCredit, cls).setUpClass()
+        cls.partner = cls.env['res.partner'].create({
+            'name': 'John Credit',
+        })
+        cls.currency = cls.env.ref('sale_credit_point.res_currency_pt')
+
+    def test_default_currency(self):
+        self.assertEqual(self.partner.credit_point_currency_id, self.currency)
+
+    def test_default_credit(self):
+        self.assertEqual(self.partner.credit_point, 0)
+
+    def test_credit_replace(self):
+        self.partner.credit_point = 10
+        self.partner.credit_point_replace(100)
+        self.assertEqual(self.partner.credit_point, 100)
+
+    def test_credit_increase(self):
+        self.partner.credit_point = 10
+        self.partner.credit_point_increase(25)
+        self.assertEqual(self.partner.credit_point, 35)
+
+    def test_credit_decrease(self):
+        self.partner.credit_point = 10
+        self.partner.credit_point_decrease(5)
+        self.assertEqual(self.partner.credit_point, 5)
+
+    def _test_message(self, msg):
+        self.assertIn(msg, self.partner.message_ids[0].body)
+
+    def test_credit_replace_with_message(self):
+        self.partner.credit_point = 10
+        msg = 'Wrong amount dude!'
+        self.partner.credit_point_replace(100, comment=msg)
+        self.assertEqual(self.partner.credit_point, 100)
+        self._test_message(msg)
+
+    def test_credit_increase_with_message(self):
+        self.partner.credit_point = 10
+        msg = 'I have money dude!'
+        self.partner.credit_point_increase(25, comment=msg)
+        self.assertEqual(self.partner.credit_point, 35)
+        self._test_message(msg)
+
+    def test_credit_decrease_with_message(self):
+        self.partner.credit_point = 10
+        msg = 'I less money dude!'
+        self.partner.credit_point_decrease(5, comment=msg)
+        self.assertEqual(self.partner.credit_point, 5)
+        self._test_message(msg)
+
+    def test_credit_cannot_be_negative(self):
+        self.partner.credit_point = 10
+        with self.assertRaises(exceptions.ValidationError):
+            self.partner.credit_point_decrease(20)
+
+    def test_credit_negative_bypass_flag(self):
+        self.partner.credit_point = 10
+        self.partner.with_context(
+            skip_credit_check=True).credit_point_decrease(20)
+        self.assertEqual(self.partner.credit_point, -10)
+
+    def test_credit_negative_bypass_group(self):
+        self.env.user.groups_id |= \
+            self.env.ref('sale_credit_point.group_manage_credit_point')
+        self.partner.credit_point = 10
+        self.partner.credit_point_decrease(20)
+        self.assertEqual(self.partner.credit_point, -10)

--- a/sale_credit_point/tests/test_credit.py
+++ b/sale_credit_point/tests/test_credit.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017 Camptocamp
+# Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.tests.common import SavepointCase
@@ -10,10 +9,10 @@ class TestCredit(SavepointCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestCredit, cls).setUpClass()
-        cls.partner = cls.env['res.partner'].create({
-            'name': 'John Credit',
-        })
+        super().setUpClass()
+        cls.partner = cls.env['res.partner'].with_context(
+            tracking_disable=True
+        ).create({'name': 'John Wizard'})
         cls.currency = cls.env.ref('sale_credit_point.res_currency_pt')
 
     def test_default_currency(self):

--- a/sale_credit_point/tests/test_credit.py
+++ b/sale_credit_point/tests/test_credit.py
@@ -1,19 +1,20 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import SavepointCase
 from odoo import exceptions
+from odoo.tests.common import SavepointCase
 
 
 class TestCredit(SavepointCase):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.partner = cls.env['res.partner'].with_context(
-            tracking_disable=True
-        ).create({'name': 'John Wizard'})
-        cls.currency = cls.env.ref('sale_credit_point.res_currency_pt')
+        cls.partner = (
+            cls.env["res.partner"]
+            .with_context(tracking_disable=True)
+            .create({"name": "John Wizard"})
+        )
+        cls.currency = cls.env.ref("sale_credit_point.res_currency_pt")
 
     def test_default_currency(self):
         self.assertEqual(self.partner.credit_point_currency_id, self.currency)
@@ -41,21 +42,21 @@ class TestCredit(SavepointCase):
 
     def test_credit_replace_with_message(self):
         self.partner.credit_point = 10
-        msg = 'Wrong amount dude!'
+        msg = "Wrong amount dude!"
         self.partner.credit_point_replace(100, comment=msg)
         self.assertEqual(self.partner.credit_point, 100)
         self._test_message(msg)
 
     def test_credit_increase_with_message(self):
         self.partner.credit_point = 10
-        msg = 'I have money dude!'
+        msg = "I have money dude!"
         self.partner.credit_point_increase(25, comment=msg)
         self.assertEqual(self.partner.credit_point, 35)
         self._test_message(msg)
 
     def test_credit_decrease_with_message(self):
         self.partner.credit_point = 10
-        msg = 'I less money dude!'
+        msg = "I less money dude!"
         self.partner.credit_point_decrease(5, comment=msg)
         self.assertEqual(self.partner.credit_point, 5)
         self._test_message(msg)
@@ -67,13 +68,13 @@ class TestCredit(SavepointCase):
 
     def test_credit_negative_bypass_flag(self):
         self.partner.credit_point = 10
-        self.partner.with_context(
-            skip_credit_check=True).credit_point_decrease(20)
+        self.partner.with_context(skip_credit_check=True).credit_point_decrease(20)
         self.assertEqual(self.partner.credit_point, -10)
 
     def test_credit_negative_bypass_group(self):
-        self.env.user.groups_id |= \
-            self.env.ref('sale_credit_point.group_manage_credit_point')
+        self.env.user.groups_id |= self.env.ref(
+            "sale_credit_point.group_manage_credit_point"
+        )
         self.partner.credit_point = 10
         self.partner.credit_point_decrease(20)
         self.assertEqual(self.partner.credit_point, -10)

--- a/sale_credit_point/tests/test_credit.py
+++ b/sale_credit_point/tests/test_credit.py
@@ -1,11 +1,11 @@
-# Copyright 2018 Camptocamp SA
+# Copyright 2018-2022 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import exceptions
-from odoo.tests.common import SavepointCase
+from odoo.tests.common import TransactionCase
 
 
-class TestCredit(SavepointCase):
+class TestCredit(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/sale_credit_point/tests/test_credit_history.py
+++ b/sale_credit_point/tests/test_credit_history.py
@@ -5,47 +5,30 @@ from odoo.tests.common import TransactionCase
 
 
 class TestHistory(TransactionCase):
-
     def setUp(self):
         super().setUp()
         self.history_model = self.env["credit.point.history"]
-        self.partner = self.env['res.partner'].with_context(
-            tracking_disable=True
-        ).create({'name': 'John Wizard'})
-        self.wiz_model = self.env['wiz.manage.credit.point']
+        self.partner = (
+            self.env["res.partner"]
+            .with_context(tracking_disable=True)
+            .create({"name": "John Wizard"})
+        )
+        self.wiz_model = self.env["wiz.manage.credit.point"]
         self.wiz_vals = [
+            {"operation": "increase", "credit_point": 15, "comment": "test"},
+            {"operation": "increase", "credit_point": 25, "comment": "test"},
+            {"operation": "replace", "credit_point": 15, "comment": "test"},
+            {"operation": "decrease", "credit_point": 5, "comment": "test"},
             {
-                'operation': 'increase',
-                'credit_point': 15,
-                'comment': 'test'
-            },
-            {
-                'operation': 'increase',
-                'credit_point': 25,
-                'comment': 'test'
-            },
-            {
-                'operation': 'replace',
-                'credit_point': 15,
-                'comment': 'test'
-            },
-            {
-                'operation': 'decrease',
-                'credit_point': 5,
-                'comment': 'test'
-            },
-            {
-                'operation': 'decrease',
-                'credit_point': 5,
-                'comment': 'test',
+                "operation": "decrease",
+                "credit_point": 5,
+                "comment": "test",
             },
         ]
 
     def _run_wiz(self):
         for vals in self.wiz_vals:
-            vals.update({
-                'partner_ids': [(6, 0, self.partner.ids)]
-            })
+            vals.update({"partner_ids": [(6, 0, self.partner.ids)]})
             wiz = self.wiz_model.new(vals)
             wiz.action_update_credit()
 
@@ -58,16 +41,19 @@ class TestHistory(TransactionCase):
         self._run_wiz()
         history = self.history_model.sudo().search([])
         history = history.filtered(
-            lambda x: x.operation == 'increase' and
-            x.partner_id == self.partner
+            lambda x: x.operation == "increase" and x.partner_id == self.partner
         )
         self.assertEqual(len(history), 2)
-        self.assertEqual(self.partner.yearly_point_increase,
-                         sum(history.mapped("amount")))
-        self.env.cr.execute("update credit_point_history set "
-                            "create_date='1994-10-03 10:00:00' where id=%s",
-                            (history[0].id,))
+        self.assertEqual(
+            self.partner.yearly_point_increase, sum(history.mapped("amount"))
+        )
+        self.env.cr.execute(
+            "update credit_point_history set "
+            "create_date='1994-10-03 10:00:00' where id=%s",
+            (history[0].id,),
+        )
         self.partner._compute_yearly_point_increase()
-        self.assertNotEqual(self.partner.yearly_point_increase,
-                            sum(history.mapped("amount")))
+        self.assertNotEqual(
+            self.partner.yearly_point_increase, sum(history.mapped("amount"))
+        )
         self.assertEqual(self.partner.yearly_point_increase, history[1].amount)

--- a/sale_credit_point/tests/test_credit_history.py
+++ b/sale_credit_point/tests/test_credit_history.py
@@ -1,0 +1,73 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestHistory(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.history_model = self.env["credit.point.history"]
+        self.partner = self.env['res.partner'].with_context(
+            tracking_disable=True
+        ).create({'name': 'John Wizard'})
+        self.wiz_model = self.env['wiz.manage.credit.point']
+        self.wiz_vals = [
+            {
+                'operation': 'increase',
+                'credit_point': 15,
+                'comment': 'test'
+            },
+            {
+                'operation': 'increase',
+                'credit_point': 25,
+                'comment': 'test'
+            },
+            {
+                'operation': 'replace',
+                'credit_point': 15,
+                'comment': 'test'
+            },
+            {
+                'operation': 'decrease',
+                'credit_point': 5,
+                'comment': 'test'
+            },
+            {
+                'operation': 'decrease',
+                'credit_point': 5,
+                'comment': 'test',
+            },
+        ]
+
+    def _run_wiz(self):
+        for vals in self.wiz_vals:
+            vals.update({
+                'partner_ids': [(6, 0, self.partner.ids)]
+            })
+            wiz = self.wiz_model.new(vals)
+            wiz.action_update_credit()
+
+    def test_history_creation(self):
+        self._run_wiz()
+        history = self.history_model.sudo().search([])
+        self.assertEqual(len(history), len(self.wiz_vals))
+
+    def test_yearly_credit_increase(self):
+        self._run_wiz()
+        history = self.history_model.sudo().search([])
+        history = history.filtered(
+            lambda x: x.operation == 'increase' and
+            x.partner_id == self.partner
+        )
+        self.assertEqual(len(history), 2)
+        self.assertEqual(self.partner.yearly_point_increase,
+                         sum(history.mapped("amount")))
+        self.env.cr.execute("update credit_point_history set "
+                            "create_date='1994-10-03 10:00:00' where id=%s",
+                            (history[0].id,))
+        self.partner._compute_yearly_point_increase()
+        self.assertNotEqual(self.partner.yearly_point_increase,
+                            sum(history.mapped("amount")))
+        self.assertEqual(self.partner.yearly_point_increase, history[1].amount)

--- a/sale_credit_point/tests/test_credit_history.py
+++ b/sale_credit_point/tests/test_credit_history.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Camptocamp SA
+# Copyright 2018-2022 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.tests.common import TransactionCase
@@ -29,7 +29,7 @@ class TestHistory(TransactionCase):
     def _run_wiz(self):
         for vals in self.wiz_vals:
             vals.update({"partner_ids": [(6, 0, self.partner.ids)]})
-            wiz = self.wiz_model.new(vals)
+            wiz = self.wiz_model.create(vals)
             wiz.action_update_credit()
 
     def test_history_creation(self):

--- a/sale_credit_point/tests/test_sale_order.py
+++ b/sale_credit_point/tests/test_sale_order.py
@@ -60,3 +60,21 @@ class TestSaleOrder(TestSale):
         so.action_confirm()
         self.assertNotEqual(so.state, 'draft')
         self.assertEqual(so.partner_id.credit_point, -10)
+
+    def test_so_cancel_ok(self):
+        so = self._create_so()
+        so.partner_id.credit_point = 100
+        so.action_confirm()
+        self.assertEqual(so.state, 'sale')
+        self.assertEqual(so.partner_id.credit_point, 90)
+        so.action_cancel()
+        self.assertEqual(so.state, 'cancel')
+        self.assertEqual(so.partner_id.credit_point, 100)
+        # Test if SO is still in draft
+        so2 = self._create_so()
+        so2.partner_id.credit_point = 100
+        self.assertEqual(so2.state, 'draft')
+        self.assertEqual(so2.partner_id.credit_point, 100)
+        so2.action_cancel()
+        self.assertEqual(so2.state, 'cancel')
+        self.assertEqual(so2.partner_id.credit_point, 100)

--- a/sale_credit_point/tests/test_sale_order.py
+++ b/sale_credit_point/tests/test_sale_order.py
@@ -1,42 +1,45 @@
-# Copyright 2018 Camptocamp SA
+# Copyright 2018-2022 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import exceptions
+from odoo.tests.common import tagged
 
-from odoo.addons.sale.tests.test_sale_common import TestSale
+from odoo.addons.sale.tests.common import TestSaleCommon
 
 
-class TestSaleOrder(TestSale):
+@tagged("post_install", "-at_install")
+class TestSaleOrder(TestSaleCommon):
     def setUp(self):
         super().setUp()
-        self.product = self.products["prod_order"]
+        self.product = self.product_a
         self.product.list_price = 10
         self.product.currency_id = self.env[
             "res.partner"
         ]._default_credit_point_currency_id()
-        self.portal_user = self.env.ref("base.demo_user0")
+        self.portal_user = self.env.ref("base.demo_user0").sudo()
         self.portal_user.partner_id.credit_point = 0
 
     def _create_so(self):
-        self.product = self.products["prod_order"]
-        return self.env["sale.order"].create(
-            {
-                "partner_id": self.partner.id,
-                "order_line": [
-                    (
-                        0,
-                        0,
-                        {
-                            "name": self.product.name,
-                            "product_id": self.product.id,
-                            "product_uom_qty": 1,
-                            "product_uom": self.product.uom_id.id,
-                            "price_unit": self.product.list_price,
-                        },
-                    )
-                ],
-            }
-        )
+        self.product = self.product_a
+        self.product.taxes_id = False
+        vals = {
+            "partner_id": self.partner_a.id,
+            "order_line": [
+                (
+                    0,
+                    0,
+                    {
+                        "name": self.product.name,
+                        "product_id": self.product.id,
+                        "product_uom_qty": 1,
+                        "product_uom": self.product.uom_id.id,
+                        "price_unit": self.product.list_price,
+                    },
+                )
+            ],
+        }
+        so = self.env["sale.order"].create(vals)
+        return so.with_context(test_sale_credit_point=True)
 
     def test_so_confirm_ok(self):
         so = self._create_so()
@@ -99,7 +102,7 @@ class TestSaleOrder(TestSale):
         with self.assertRaises(exceptions.AccessError):
             # portal user doesn't have the rights
             # this is handled by record rules
-            so.sudo(self.portal_user.id).credit_point_check()
+            so.with_user(self.portal_user.id).credit_point_check()
         with self.assertRaises(exceptions.UserError):
             # nor can handle it via sudo with passing of the user
             so.sudo().credit_point_check(self.portal_user)

--- a/sale_credit_point/tests/test_sale_order.py
+++ b/sale_credit_point/tests/test_sale_order.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import exceptions
+from odoo.addons.sale.tests.test_sale_common import TestSale
+
+
+class TestSaleOrder(TestSale):
+
+    def setUp(self):
+        super(TestSaleOrder, self).setUp()
+        self.product = self.products['prod_order']
+        self.product.list_price = 10
+        self.product.currency_id = \
+            self.env['res.partner']._default_credit_point_currency_id()
+
+    def _create_so(self):
+        self.product = self.products['prod_order']
+        return self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.product.name,
+                    'product_id': self.product.id,
+                    'product_uom_qty': 1,
+                    'product_uom': self.product.uom_id.id,
+                    'price_unit': self.product.list_price})
+            ],
+        })
+
+    def test_so_confirm_ok(self):
+        so = self._create_so()
+        so.partner_id.credit_point = 100
+        self.assertEqual(so.state, 'draft')
+        so.action_confirm()
+        self.assertNotEqual(so.state, 'draft')
+        self.assertEqual(so.partner_id.credit_point, 90)
+
+    def test_so_confirm_not_enough_credit(self):
+        so = self._create_so()
+        so.partner_id.credit_point = 0
+        self.assertEqual(so.state, 'draft')
+        with self.assertRaises(exceptions.UserError):
+            so.action_confirm()
+
+    def test_so_confirm_not_enough_credit_bypass_flag(self):
+        so = self._create_so()
+        so.partner_id.credit_point = 0
+        self.assertEqual(so.state, 'draft')
+        so.with_context(skip_credit_check=True).action_confirm()
+        self.assertNotEqual(so.state, 'draft')
+        self.assertEqual(so.partner_id.credit_point, -10)
+
+    def test_so_confirm_not_enough_credit_bypass_group(self):
+        so = self._create_so()
+        so.partner_id.credit_point = 0
+        self.assertEqual(so.state, 'draft')
+        self.env.user.groups_id |= \
+            self.env.ref('sale_credit_point.group_manage_credit_point')
+        so.action_confirm()
+        self.assertNotEqual(so.state, 'draft')
+        self.assertEqual(so.partner_id.credit_point, -10)

--- a/sale_credit_point/tests/test_sale_order.py
+++ b/sale_credit_point/tests/test_sale_order.py
@@ -2,90 +2,99 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import exceptions
+
 from odoo.addons.sale.tests.test_sale_common import TestSale
 
 
 class TestSaleOrder(TestSale):
-
     def setUp(self):
         super().setUp()
-        self.product = self.products['prod_order']
+        self.product = self.products["prod_order"]
         self.product.list_price = 10
-        self.product.currency_id = \
-            self.env['res.partner']._default_credit_point_currency_id()
+        self.product.currency_id = self.env[
+            "res.partner"
+        ]._default_credit_point_currency_id()
         self.portal_user = self.env.ref("base.demo_user0")
         self.portal_user.partner_id.credit_point = 0
 
     def _create_so(self):
-        self.product = self.products['prod_order']
-        return self.env['sale.order'].create({
-            'partner_id': self.partner.id,
-            'order_line': [
-                (0, 0, {
-                    'name': self.product.name,
-                    'product_id': self.product.id,
-                    'product_uom_qty': 1,
-                    'product_uom': self.product.uom_id.id,
-                    'price_unit': self.product.list_price})
-            ],
-        })
+        self.product = self.products["prod_order"]
+        return self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product.name,
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1,
+                            "product_uom": self.product.uom_id.id,
+                            "price_unit": self.product.list_price,
+                        },
+                    )
+                ],
+            }
+        )
 
     def test_so_confirm_ok(self):
         so = self._create_so()
         so.partner_id.credit_point = 100
-        self.assertEqual(so.state, 'draft')
+        self.assertEqual(so.state, "draft")
         so.action_confirm()
-        self.assertNotEqual(so.state, 'draft')
+        self.assertNotEqual(so.state, "draft")
         self.assertEqual(so.partner_id.credit_point, 90)
 
     def test_so_confirm_not_enough_credit(self):
         so = self._create_so()
         so.partner_id.credit_point = 0
-        self.assertEqual(so.state, 'draft')
+        self.assertEqual(so.state, "draft")
         with self.assertRaises(exceptions.UserError):
             so.action_confirm()
 
     def test_so_confirm_not_enough_credit_bypass_flag(self):
         so = self._create_so()
         so.partner_id.credit_point = 0
-        self.assertEqual(so.state, 'draft')
+        self.assertEqual(so.state, "draft")
         so.with_context(skip_credit_check=True).action_confirm()
-        self.assertNotEqual(so.state, 'draft')
+        self.assertNotEqual(so.state, "draft")
         self.assertEqual(so.partner_id.credit_point, -10)
 
     def test_so_confirm_not_enough_credit_bypass_group(self):
         so = self._create_so()
         so.partner_id.credit_point = 0
-        self.assertEqual(so.state, 'draft')
-        self.env.user.groups_id |= \
-            self.env.ref('sale_credit_point.group_manage_credit_point')
+        self.assertEqual(so.state, "draft")
+        self.env.user.groups_id |= self.env.ref(
+            "sale_credit_point.group_manage_credit_point"
+        )
         so.action_confirm()
-        self.assertNotEqual(so.state, 'draft')
+        self.assertNotEqual(so.state, "draft")
         self.assertEqual(so.partner_id.credit_point, -10)
 
     def test_so_cancel_ok(self):
         so = self._create_so()
         so.partner_id.credit_point = 100
         so.action_confirm()
-        self.assertEqual(so.state, 'sale')
+        self.assertEqual(so.state, "sale")
         self.assertEqual(so.partner_id.credit_point, 90)
         so.action_cancel()
-        self.assertEqual(so.state, 'cancel')
+        self.assertEqual(so.state, "cancel")
         self.assertEqual(so.partner_id.credit_point, 100)
         # Test if SO is still in draft
         so2 = self._create_so()
         so2.partner_id.credit_point = 100
-        self.assertEqual(so2.state, 'draft')
+        self.assertEqual(so2.state, "draft")
         self.assertEqual(so2.partner_id.credit_point, 100)
         so2.action_cancel()
-        self.assertEqual(so2.state, 'cancel')
+        self.assertEqual(so2.state, "cancel")
         self.assertEqual(so2.partner_id.credit_point, 100)
 
     def test_so_credit_check_user(self):
         so = self._create_so()
-        self.env.user.groups_id = [(4, self.env.ref(
-            'sale_credit_point.group_manage_credit_point'
-        ).id)]
+        self.env.user.groups_id = [
+            (4, self.env.ref("sale_credit_point.group_manage_credit_point").id)
+        ]
         so.partner_id.credit_point = 0
         with self.assertRaises(exceptions.AccessError):
             # portal user doesn't have the rights

--- a/sale_credit_point/tests/test_sale_order.py
+++ b/sale_credit_point/tests/test_sale_order.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017 Camptocamp
+# Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import exceptions
@@ -9,7 +8,7 @@ from odoo.addons.sale.tests.test_sale_common import TestSale
 class TestSaleOrder(TestSale):
 
     def setUp(self):
-        super(TestSaleOrder, self).setUp()
+        super().setUp()
         self.product = self.products['prod_order']
         self.product.list_price = 10
         self.product.currency_id = \

--- a/sale_credit_point/tests/test_sale_order.py
+++ b/sale_credit_point/tests/test_sale_order.py
@@ -13,9 +13,6 @@ class TestSaleOrder(TestSale):
         self.product.list_price = 10
         self.product.currency_id = \
             self.env['res.partner']._default_credit_point_currency_id()
-        self.env.user.groups_id = [(4, self.env.ref(
-            'sale_credit_point.group_manage_credit_point'
-        ).id)]
         self.portal_user = self.env.ref("base.demo_user0")
         self.portal_user.partner_id.credit_point = 0
 
@@ -86,9 +83,13 @@ class TestSaleOrder(TestSale):
 
     def test_so_credit_check_user(self):
         so = self._create_so()
+        self.env.user.groups_id = [(4, self.env.ref(
+            'sale_credit_point.group_manage_credit_point'
+        ).id)]
         so.partner_id.credit_point = 0
-        with self.assertRaises(exceptions.UserError):
+        with self.assertRaises(exceptions.AccessError):
             # portal user doesn't have the rights
+            # this is handled by record rules
             so.sudo(self.portal_user.id).credit_point_check()
         with self.assertRaises(exceptions.UserError):
             # nor can handle it via sudo with passing of the user

--- a/sale_credit_point/tests/test_wizard.py
+++ b/sale_credit_point/tests/test_wizard.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017 Camptocamp
+# Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo.tests.common import SavepointCase
@@ -10,10 +9,10 @@ class TestWizard(SavepointCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestWizard, cls).setUpClass()
-        cls.partner = cls.env['res.partner'].create({
-            'name': 'John Wizard',
-        })
+        super().setUpClass()
+        cls.partner = cls.env['res.partner'].with_context(
+            tracking_disable=True
+        ).create({'name': 'John Wizard'})
         cls.wiz_model = cls.env['wiz.manage.credit.point']
 
     def _get_wiz(self, **kw):

--- a/sale_credit_point/tests/test_wizard.py
+++ b/sale_credit_point/tests/test_wizard.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import SavepointCase
+from odoo import exceptions
+
+
+class TestWizard(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestWizard, cls).setUpClass()
+        cls.partner = cls.env['res.partner'].create({
+            'name': 'John Wizard',
+        })
+        cls.wiz_model = cls.env['wiz.manage.credit.point']
+
+    def _get_wiz(self, **kw):
+        vals = {
+            'partner_ids': [(6, 0, self.partner.ids)]
+        }
+        vals.update(**kw)
+        return self.wiz_model.new(vals)
+
+    def _test_message(self, msg):
+        self.assertIn(msg, self.partner.message_ids[0].body)
+
+    def test_defaults(self):
+        wiz = self._get_wiz()
+        self.assertIn(self.partner, wiz.partner_ids)
+
+    def test_no_comment(self):
+        wiz = self._get_wiz(
+            operation='replace',
+        )
+        with self.assertRaises(exceptions.UserError):
+            wiz.action_update_credit()
+
+    def test_credit_replace(self):
+        msg = 'I have money dude!'
+        wiz = self._get_wiz(
+            operation='replace',
+            credit_point=100,
+            comment=msg,
+        )
+        wiz.action_update_credit()
+        self.assertEqual(self.partner.credit_point, 100)
+        self._test_message(msg)
+
+    def test_credit_increase(self):
+        self.partner.credit_point = 10
+        msg = 'I have more money dude!'
+        wiz = self._get_wiz(
+            operation='increase',
+            credit_point=10,
+            comment=msg,
+        )
+        wiz.action_update_credit()
+        self.assertEqual(self.partner.credit_point, 20)
+        self._test_message(msg)
+
+    def test_credit_decrease(self):
+        self.partner.credit_point = 10
+        msg = 'I have less money dude!'
+        wiz = self._get_wiz(
+            operation='decrease',
+            credit_point=10,
+            comment=msg,
+        )
+        wiz.action_update_credit()
+        self.assertEqual(self.partner.credit_point, 0)
+        self._test_message(msg)

--- a/sale_credit_point/tests/test_wizard.py
+++ b/sale_credit_point/tests/test_wizard.py
@@ -1,11 +1,11 @@
-# Copyright 2018 Camptocamp SA
+# Copyright 2018-2022 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import exceptions
-from odoo.tests.common import SavepointCase
+from odoo.tests.common import TransactionCase
 
 
-class TestWizard(SavepointCase):
+class TestWizard(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -16,21 +16,27 @@ class TestWizard(SavepointCase):
         )
         cls.wiz_model = cls.env["wiz.manage.credit.point"]
 
-    def _get_wiz(self, **kw):
+    def _get_wiz(self, need_write=True, **kw):
         vals = {"partner_ids": [(6, 0, self.partner.ids)]}
         vals.update(**kw)
-        return self.wiz_model.new(vals)
+        if need_write:
+            method = self.wiz_model.create
+        else:
+            method = self.wiz_model.new
+        return method(vals)
 
     def _test_message(self, msg):
         self.assertIn(msg, self.partner.message_ids[0].body)
 
     def test_defaults(self):
-        wiz = self._get_wiz()
-        self.assertIn(self.partner, wiz.partner_ids)
+        wiz = self._get_wiz(need_write=False)
+        self.assertIn(self.partner.id, wiz.partner_ids.ids)
 
     def test_no_comment(self):
         wiz = self._get_wiz(
+            need_write=False,
             operation="replace",
+            credit_point=0,
         )
         with self.assertRaises(exceptions.UserError):
             wiz.action_update_credit()

--- a/sale_credit_point/tests/test_wizard.py
+++ b/sale_credit_point/tests/test_wizard.py
@@ -1,24 +1,23 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import SavepointCase
 from odoo import exceptions
+from odoo.tests.common import SavepointCase
 
 
 class TestWizard(SavepointCase):
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.partner = cls.env['res.partner'].with_context(
-            tracking_disable=True
-        ).create({'name': 'John Wizard'})
-        cls.wiz_model = cls.env['wiz.manage.credit.point']
+        cls.partner = (
+            cls.env["res.partner"]
+            .with_context(tracking_disable=True)
+            .create({"name": "John Wizard"})
+        )
+        cls.wiz_model = cls.env["wiz.manage.credit.point"]
 
     def _get_wiz(self, **kw):
-        vals = {
-            'partner_ids': [(6, 0, self.partner.ids)]
-        }
+        vals = {"partner_ids": [(6, 0, self.partner.ids)]}
         vals.update(**kw)
         return self.wiz_model.new(vals)
 
@@ -31,15 +30,15 @@ class TestWizard(SavepointCase):
 
     def test_no_comment(self):
         wiz = self._get_wiz(
-            operation='replace',
+            operation="replace",
         )
         with self.assertRaises(exceptions.UserError):
             wiz.action_update_credit()
 
     def test_credit_replace(self):
-        msg = 'I have money dude!'
+        msg = "I have money dude!"
         wiz = self._get_wiz(
-            operation='replace',
+            operation="replace",
             credit_point=100,
             comment=msg,
         )
@@ -49,9 +48,9 @@ class TestWizard(SavepointCase):
 
     def test_credit_increase(self):
         self.partner.credit_point = 10
-        msg = 'I have more money dude!'
+        msg = "I have more money dude!"
         wiz = self._get_wiz(
-            operation='increase',
+            operation="increase",
             credit_point=10,
             comment=msg,
         )
@@ -61,9 +60,9 @@ class TestWizard(SavepointCase):
 
     def test_credit_decrease(self):
         self.partner.credit_point = 10
-        msg = 'I have less money dude!'
+        msg = "I have less money dude!"
         wiz = self._get_wiz(
-            operation='decrease',
+            operation="decrease",
             credit_point=10,
             comment=msg,
         )

--- a/sale_credit_point/views/partner.xml
+++ b/sale_credit_point/views/partner.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+  <record id="view_partner_form_points" model="ir.ui.view">
+    <field name="name">res.partner.form.points</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="base.view_partner_form"/>
+    <field name="arch" type="xml">
+      <div name="button_box" position="inside">
+        <button name="action_update_credit_point" type="object" class="oe_stat_button" icon="fa-money">
+          <field string="Points" name="credit_point" widget="statinfo"/>
+        </button>
+      </div>
+    </field>
+  </record>
+
+  <record id="view_partner_search_points" model="ir.ui.view">
+    <field name="name">res.partner.search.points</field>
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="base.view_res_partner_filter"/>
+    <field name="arch" type="xml">
+      <field name="name" position="after">
+        <field name="credit_point"/>
+      </field>
+      <xpath expr="//filter[@name='type_company']" position="after">
+        <separator/>
+        <filter string="Points &gt; 0" name="credit_point" domain="[('credit_point','&gt;',0)]"/>
+      </xpath>
+    </field>
+  </record>
+
+</odoo>

--- a/sale_credit_point/views/partner.xml
+++ b/sale_credit_point/views/partner.xml
@@ -8,7 +8,7 @@
     <field name="arch" type="xml">
       <div name="button_box" position="inside">
         <button name="action_update_credit_point" type="object" class="oe_stat_button" icon="fa-money">
-          <field string="Points" name="credit_point" widget="statinfo"/>
+            <span><field string="Points" name="credit_point" widget="statinfo"/> / <field name="yearly_point_increase" string=" " widget="statinfo"/></span>
         </button>
       </div>
     </field>

--- a/sale_credit_point/views/partner.xml
+++ b/sale_credit_point/views/partner.xml
@@ -1,14 +1,27 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
   <record id="view_partner_form_points" model="ir.ui.view">
     <field name="name">res.partner.form.points</field>
     <field name="model">res.partner</field>
-    <field name="inherit_id" ref="base.view_partner_form"/>
+    <field name="inherit_id" ref="base.view_partner_form" />
     <field name="arch" type="xml">
       <div name="button_box" position="inside">
-        <button name="action_update_credit_point" type="object" class="oe_stat_button" icon="fa-money">
-            <span><field string="Points" name="credit_point" widget="statinfo"/> / <field name="yearly_point_increase" string=" " widget="statinfo"/></span>
+        <button
+                    name="action_update_credit_point"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-money"
+                >
+            <span><field
+                            string="Points"
+                            name="credit_point"
+                            widget="statinfo"
+                        /> / <field
+                            name="yearly_point_increase"
+                            string=" "
+                            widget="statinfo"
+                        /></span>
         </button>
       </div>
     </field>
@@ -17,14 +30,18 @@
   <record id="view_partner_search_points" model="ir.ui.view">
     <field name="name">res.partner.search.points</field>
     <field name="model">res.partner</field>
-    <field name="inherit_id" ref="base.view_res_partner_filter"/>
+    <field name="inherit_id" ref="base.view_res_partner_filter" />
     <field name="arch" type="xml">
       <field name="name" position="after">
-        <field name="credit_point"/>
+        <field name="credit_point" />
       </field>
       <xpath expr="//filter[@name='type_company']" position="after">
-        <separator/>
-        <filter string="Points &gt; 0" name="credit_point" domain="[('credit_point','&gt;',0)]"/>
+        <separator />
+        <filter
+                    string="Points &gt; 0"
+                    name="credit_point"
+                    domain="[('credit_point','&gt;',0)]"
+                />
       </xpath>
     </field>
   </record>

--- a/sale_credit_point/views/point_history.xml
+++ b/sale_credit_point/views/point_history.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_credit_point_history_tree" model="ir.ui.view">
+        <field name="name">view.credit.point.history.tree</field>
+        <field name="model">credit.point.history</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="partner_id" readonly="True"/>
+                <field name="operation" readonly="True"/>
+                <field name="amount" readonly="True"/>
+                <field name="credit_point_currency_id" readonly="True"/>
+                <field name="credit_point_currency_id" readonly="True" invisible="1" />
+                <field name="create_date" readonly="True"/>
+                <field name="comment" readonly="True"/>
+            </tree>
+        </field>
+    </record>
+
+        <record id="view_credit_point_history_search" model="ir.ui.view">
+            <field name="name">credit.point.history.search</field>
+            <field name="model">credit.point.history</field>
+            <field name="arch" type="xml">
+                <search string="Search Invoice">
+                    <field name="create_date"/>
+                    <field name="partner_id"/>
+                    <filter string="This Year" name="year" domain="[('create_date','&lt;=', time.strftime('%%Y-12-31')),('create_date','&gt;=',time.strftime('%%Y-01-01'))]"/>
+                    <group expand="1" string="Group By">
+                        <filter string="Partner" name="partner"
+                            context="{'group_by':'partner_id'}"/>
+                    </group>
+               </search>
+            </field>
+        </record>
+
+    <record id="credit_point_history_action" model="ir.actions.act_window">
+        <field name="name">Credit Points History</field>
+        <field name="res_model">credit.point.history</field>
+        <field name="search_view_id" ref="view_credit_point_history_search"/>
+        <field name="context">{'search_default_year': 1,'search_default_partner': 1 , 'group_by_no_leaf':1}</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree</field>
+    </record>
+
+    <menuitem name="Credit point history" parent="sale.menu_sale_config"
+              sequence="99"
+              action="credit_point_history_action"
+              id="menu_credit_point_history"/>
+
+</odoo>

--- a/sale_credit_point/views/point_history.xml
+++ b/sale_credit_point/views/point_history.xml
@@ -46,7 +46,6 @@
         <field
             name="context"
         >{'search_default_year': 1,'search_default_partner': 1 , 'group_by_no_leaf':1}</field>
-        <field name="view_type">form</field>
         <field name="view_mode">tree</field>
     </record>
 

--- a/sale_credit_point/views/point_history.xml
+++ b/sale_credit_point/views/point_history.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
     <record id="view_credit_point_history_tree" model="ir.ui.view">
@@ -6,12 +6,12 @@
         <field name="model">credit.point.history</field>
         <field name="arch" type="xml">
             <tree>
-                <field name="partner_id" readonly="True"/>
-                <field name="operation" readonly="True"/>
-                <field name="amount" readonly="True"/>
-                <field name="credit_point_currency_id" readonly="True"/>
-                <field name="create_date" readonly="True"/>
-                <field name="comment" readonly="True"/>
+                <field name="partner_id" readonly="True" />
+                <field name="operation" readonly="True" />
+                <field name="amount" readonly="True" />
+                <field name="credit_point_currency_id" readonly="True" />
+                <field name="create_date" readonly="True" />
+                <field name="comment" readonly="True" />
             </tree>
         </field>
     </record>
@@ -21,12 +21,19 @@
             <field name="model">credit.point.history</field>
             <field name="arch" type="xml">
                 <search string="Search Invoice">
-                    <field name="create_date"/>
-                    <field name="partner_id"/>
-                    <filter string="This Year" name="year" domain="[('create_date','&lt;=', time.strftime('%%Y-12-31')),('create_date','&gt;=',time.strftime('%%Y-01-01'))]"/>
+                    <field name="create_date" />
+                    <field name="partner_id" />
+                    <filter
+                    string="This Year"
+                    name="year"
+                    domain="[('create_date','&lt;=', time.strftime('%%Y-12-31')),('create_date','&gt;=',time.strftime('%%Y-01-01'))]"
+                />
                     <group expand="1" string="Group By">
-                        <filter string="Partner" name="partner"
-                            context="{'group_by':'partner_id'}"/>
+                        <filter
+                        string="Partner"
+                        name="partner"
+                        context="{'group_by':'partner_id'}"
+                    />
                     </group>
                </search>
             </field>
@@ -35,15 +42,20 @@
     <record id="credit_point_history_action" model="ir.actions.act_window">
         <field name="name">Credit Points History</field>
         <field name="res_model">credit.point.history</field>
-        <field name="search_view_id" ref="view_credit_point_history_search"/>
-        <field name="context">{'search_default_year': 1,'search_default_partner': 1 , 'group_by_no_leaf':1}</field>
+        <field name="search_view_id" ref="view_credit_point_history_search" />
+        <field
+            name="context"
+        >{'search_default_year': 1,'search_default_partner': 1 , 'group_by_no_leaf':1}</field>
         <field name="view_type">form</field>
         <field name="view_mode">tree</field>
     </record>
 
-    <menuitem name="Credit point history" parent="sale.menu_sale_config"
-              sequence="99"
-              action="credit_point_history_action"
-              id="menu_credit_point_history"/>
+    <menuitem
+        name="Credit point history"
+        parent="sale.menu_sale_config"
+        sequence="99"
+        action="credit_point_history_action"
+        id="menu_credit_point_history"
+    />
 
 </odoo>

--- a/sale_credit_point/views/point_history.xml
+++ b/sale_credit_point/views/point_history.xml
@@ -10,7 +10,6 @@
                 <field name="operation" readonly="True"/>
                 <field name="amount" readonly="True"/>
                 <field name="credit_point_currency_id" readonly="True"/>
-                <field name="credit_point_currency_id" readonly="True" invisible="1" />
                 <field name="create_date" readonly="True"/>
                 <field name="comment" readonly="True"/>
             </tree>

--- a/sale_credit_point/wizards/__init__.py
+++ b/sale_credit_point/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import manage_credit_point

--- a/sale_credit_point/wizards/manage_credit_point.py
+++ b/sale_credit_point/wizards/manage_credit_point.py
@@ -1,8 +1,8 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017 Camptocamp SA
+# Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models, api, exceptions, _
+from ..models.partner import POINT_OPERATIONS
 
 
 class ManageCreditPoint(models.TransientModel):
@@ -23,11 +23,7 @@ class ManageCreditPoint(models.TransientModel):
     )
     operation = fields.Selection(
         string="Type of operation",
-        selection=[
-            ("replace", "Replace"),
-            ("increase", "Increase"),
-            ("decrease", "Decrease"),
-        ],
+        selection=POINT_OPERATIONS,
         required=True,
     )
 
@@ -41,3 +37,8 @@ class ManageCreditPoint(models.TransientModel):
         for partner in self.partner_ids:
             handler = getattr(partner, 'credit_point_' + self.operation)
             handler(self.credit_point, comment=self.comment)
+            partner.update_history(
+                self.credit_point,
+                self.operation,
+                self.comment
+            )

--- a/sale_credit_point/wizards/manage_credit_point.py
+++ b/sale_credit_point/wizards/manage_credit_point.py
@@ -1,13 +1,14 @@
-# Copyright 2018 Camptocamp SA
+# Copyright 2018-2022 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, api, exceptions, fields, models
+from odoo import _, exceptions, fields, models
 
-from ..models.partner import POINT_OPERATIONS
+from ..models.point_history import POINT_OPERATIONS
 
 
 class ManageCreditPoint(models.TransientModel):
     _name = "wiz.manage.credit.point"
+    _description = "Wizard to Manage Credit Points"
 
     credit_point = fields.Integer(
         string="Points",
@@ -27,7 +28,6 @@ class ManageCreditPoint(models.TransientModel):
         required=True,
     )
 
-    @api.multi
     def action_update_credit(self):
         self.ensure_one()
         if not self.comment:

--- a/sale_credit_point/wizards/manage_credit_point.py
+++ b/sale_credit_point/wizards/manage_credit_point.py
@@ -1,24 +1,24 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models, api, exceptions, _
+from odoo import _, api, exceptions, fields, models
+
 from ..models.partner import POINT_OPERATIONS
 
 
 class ManageCreditPoint(models.TransientModel):
-    _name = 'wiz.manage.credit.point'
+    _name = "wiz.manage.credit.point"
 
     credit_point = fields.Integer(
-        string='Points',
+        string="Points",
         required=True,
     )
     partner_ids = fields.Many2many(
-        'res.partner',
-        string='Partners',
+        "res.partner",
+        string="Partners",
         required=True,
     )
     comment = fields.Text(
-        string='Comment',
         required=True,
     )
     operation = fields.Selection(
@@ -31,14 +31,8 @@ class ManageCreditPoint(models.TransientModel):
     def action_update_credit(self):
         self.ensure_one()
         if not self.comment:
-            raise exceptions.UserError(
-                _("A comment is needed to the update credit")
-            )
+            raise exceptions.UserError(_("A comment is needed to the update credit"))
         for partner in self.partner_ids:
-            handler = getattr(partner, 'credit_point_' + self.operation)
+            handler = getattr(partner, "credit_point_" + self.operation)
             handler(self.credit_point, comment=self.comment)
-            partner.update_history(
-                self.credit_point,
-                self.operation,
-                self.comment
-            )
+            partner.update_history(self.credit_point, self.operation, self.comment)

--- a/sale_credit_point/wizards/manage_credit_point.py
+++ b/sale_credit_point/wizards/manage_credit_point.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models, api, exceptions, _
+
+
+class ManageCreditPoint(models.TransientModel):
+    _name = 'wiz.manage.credit.point'
+
+    credit_point = fields.Integer(
+        string='Points',
+        required=True,
+    )
+    partner_ids = fields.Many2many(
+        'res.partner',
+        string='Partners',
+        required=True,
+    )
+    comment = fields.Text(
+        string='Comment',
+        required=True,
+    )
+    operation = fields.Selection(
+        string="Type of operation",
+        selection=[
+            ("replace", "Replace"),
+            ("increase", "Increase"),
+            ("decrease", "Decrease"),
+        ],
+        required=True,
+    )
+
+    @api.multi
+    def action_update_credit(self):
+        self.ensure_one()
+        if not self.comment:
+            raise exceptions.UserError(
+                _("A comment is needed to the update credit")
+            )
+        for partner in self.partner_ids:
+            handler = getattr(partner, 'credit_point_' + self.operation)
+            handler(self.credit_point, comment=self.comment)

--- a/sale_credit_point/wizards/manage_credit_point.xml
+++ b/sale_credit_point/wizards/manage_credit_point.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+  <act_window id="action_add_credit_point"
+              name="Update Credit Point"
+              src_model="res.partner"
+              res_model="wiz.manage.credit.point"
+              view_mode="form"
+              target="new"
+              key2="client_action_multi"
+              context="{'default_partner_ids': active_ids}"/>
+
+  <record id="wiz_manage_credit_point" model="ir.ui.view">
+    <field name="name">Credit Point Update</field>
+    <field name="model">wiz.manage.credit.point</field>
+    <field name="arch" type="xml">
+      <form string="Update Credit">
+        <sheet>
+          <h3>
+            Selected partner(s) will be updated.
+          </h3>
+          <field name="partner_ids">
+            <tree>
+              <field name="name"/>
+              <field name="credit_point"/>
+            </tree>
+          </field>
+          <group name="operation" col="4">
+            <field name="operation" colspan="2"/>
+            <field name="credit_point" colspan="2"/>
+          </group>
+          <field name="comment"
+                 placeholder="Reason for the modification"/>
+        </sheet>
+        <footer>
+          <button string="Update Credit" name="action_update_credit" type="object" class="btn-primary"/>
+          <button string="Cancel" class="btn-default" special="cancel" />
+        </footer>
+        </form>
+    </field>
+  </record>
+
+</odoo>

--- a/sale_credit_point/wizards/manage_credit_point.xml
+++ b/sale_credit_point/wizards/manage_credit_point.xml
@@ -1,17 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
 
-  <act_window
-        id="action_add_credit_point"
-        name="Update Credit Point"
-        src_model="res.partner"
-        res_model="wiz.manage.credit.point"
-        view_mode="form"
-        target="new"
-        key2="client_action_multi"
-        context="{'default_partner_ids': active_ids}"
-    />
-
   <record id="wiz_manage_credit_point" model="ir.ui.view">
     <field name="name">Credit Point Update</field>
     <field name="model">wiz.manage.credit.point</field>
@@ -44,6 +33,17 @@
         </footer>
         </form>
     </field>
+  </record>
+
+  <record id="action_add_credit_point" model="ir.actions.act_window">
+      <field name="name">Update Credit Point</field>
+      <field name="binding_model_id" ref="base.model_res_partner" />
+      <field name="binding_view_types">form</field>
+      <field name="res_model">wiz.manage.credit.point</field>
+      <field name="view_mode">form</field>
+      <field name="view_id" ref="wiz_manage_credit_point" />
+      <field name="target">new</field>
+      <field name="context">{'default_partner_ids': active_ids}</field>
   </record>
 
 </odoo>

--- a/sale_credit_point/wizards/manage_credit_point.xml
+++ b/sale_credit_point/wizards/manage_credit_point.xml
@@ -1,14 +1,16 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
 
-  <act_window id="action_add_credit_point"
-              name="Update Credit Point"
-              src_model="res.partner"
-              res_model="wiz.manage.credit.point"
-              view_mode="form"
-              target="new"
-              key2="client_action_multi"
-              context="{'default_partner_ids': active_ids}"/>
+  <act_window
+        id="action_add_credit_point"
+        name="Update Credit Point"
+        src_model="res.partner"
+        res_model="wiz.manage.credit.point"
+        view_mode="form"
+        target="new"
+        key2="client_action_multi"
+        context="{'default_partner_ids': active_ids}"
+    />
 
   <record id="wiz_manage_credit_point" model="ir.ui.view">
     <field name="name">Credit Point Update</field>
@@ -21,19 +23,23 @@
           </h3>
           <field name="partner_ids">
             <tree>
-              <field name="name"/>
-              <field name="credit_point"/>
+              <field name="name" />
+              <field name="credit_point" />
             </tree>
           </field>
           <group name="operation" col="4">
-            <field name="operation" colspan="2"/>
-            <field name="credit_point" colspan="2"/>
+            <field name="operation" colspan="2" />
+            <field name="credit_point" colspan="2" />
           </group>
-          <field name="comment"
-                 placeholder="Reason for the modification"/>
+          <field name="comment" placeholder="Reason for the modification" />
         </sheet>
         <footer>
-          <button string="Update Credit" name="action_update_credit" type="object" class="btn-primary"/>
+          <button
+                        string="Update Credit"
+                        name="action_update_credit"
+                        type="object"
+                        class="btn-primary"
+                    />
           <button string="Cancel" class="btn-default" special="cancel" />
         </footer>
         </form>

--- a/setup/sale_credit_point/odoo/addons/sale_credit_point
+++ b/setup/sale_credit_point/odoo/addons/sale_credit_point
@@ -1,0 +1,1 @@
+../../../../sale_credit_point

--- a/setup/sale_credit_point/setup.cfg
+++ b/setup/sale_credit_point/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal=1

--- a/setup/sale_credit_point/setup.cfg
+++ b/setup/sale_credit_point/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup/sale_credit_point/setup.py
+++ b/setup/sale_credit_point/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
* From V11.0 https://github.com/OCA/sale-workflow/pull/579

Excerpt from README:

> Sale based on partners' credit point.
> ### Use case
>
> You have employees that have some credit (up to you where this come from)
> and you allow employees to buy products based on this credit.
>
> Products are sold by points rather than money.