### PR TITLE
[14.0][FIX] sales_team_security: Sync followers on partner creation

### DIFF
--- a/sales_team_security/models/res_partner.py
+++ b/sales_team_security/models/res_partner.py
@@ -62,7 +62,6 @@ class ResPartner(models.Model):
 
     def _remove_key_followers(self, partner):
         for record in self.mapped("commercial_partner_id"):
-            record.message_unsubscribe(partner_ids=partner.ids)
             # Look for delivery and invoice addresses
             childrens = record.child_ids.filtered(
                 lambda x: x.type in {"invoice", "delivery"}
@@ -73,12 +72,18 @@ class ResPartner(models.Model):
         """Sync followers in commercial partner + delivery/invoice contacts."""
         for record in self.mapped("commercial_partner_id"):
             followers = (record.child_ids + record).mapped("user_id.partner_id")
-            record.message_subscribe(partner_ids=followers.ids)
             # Look for delivery and invoice addresses
             childrens = record.child_ids.filtered(
                 lambda x: x.type in {"invoice", "delivery"}
             )
             (childrens + record).message_subscribe(partner_ids=followers.ids)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Sync followers on contact creation."""
+        records = super().create(vals_list)
+        records._add_followers_from_salesmans()
+        return records
 
     def write(self, vals):
         """If the salesman is changed, first remove the old salesman as follower


### PR DESCRIPTION
FW-port of #2231 

Steps to reproduce the problem:

- Create a main contact.
- Create a child contact of the main contact, selecting a salesperson.
- Go to the main contact, and check the followers.

Expected behavior:

The main contact has the salesperson as follower. The same if editing the child contact, the salesperson is changed.

Obtained result:

No follower for the salesperson.

That's because the `create` method is not intercepted to do the followers synchronization.

@Tecnativa TT39963