### PR TITLE
[15.0][FIX] sale_order_secondary_unit: Fix incorrect header position inheritance

### DIFF
--- a/sale_order_secondary_unit/report/sale_report_templates.xml
+++ b/sale_order_secondary_unit/report/sale_report_templates.xml
@@ -5,7 +5,7 @@
         inherit_id="sale.report_saleorder_document"
     >
         <xpath
-            expr="//table[hasclass('table','table-sm','o_main_table')]//th[2]"
+            expr="//table[hasclass('table','table-sm','o_main_table')]//th[@name='th_quantity']"
             position="before"
         >
             <th name="th_secondary_uom_id" class="text-right" groups="uom.group_uom">


### PR DESCRIPTION
cc @Tecnativa TT40001

Commit from v13 --> https://github.com/OCA/sale-workflow/pull/2237/commits/dea6c51896678c300a34a3d42d358969e8cf40cb

ping @chienandalu @CarlosRoca13 