### PR TITLE
[14.0] [FIX] `sale_quick`: put warehouse and to_date in context

### DIFF
--- a/sale_quick/models/sale_order.py
+++ b/sale_quick/models/sale_order.py
@@ -11,10 +11,19 @@ class SaleOrder(models.Model):
     _inherit = ["sale.order", "product.mass.addition"]
 
     def _get_context_add_products(self):
-        return {
+        res = {
             "search_default_filter_to_sale": 1,
             "quick_access_rights_sale": 1,
         }
+        # Lazy dependency with sale_stock
+        if "warehouse_id" in self._fields:
+            res.update(
+                {
+                    "warehouse": self.warehouse_id.id,
+                    "to_date": self.commitment_date,
+                }
+            )
+        return res
 
     def _get_domain_add_products(self):
         return []


### PR DESCRIPTION
This is to properly compute the stock related fields.

To avoid a dependency with `sale_stock`, do it lazily