### PR TITLE
[IMP] sale_automatic_workflow: pay with same currency as invoice

### DIFF
--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -129,6 +129,7 @@ class AutomaticWorkflowJob(models.Model):
             "partner_id": invoice.partner_id.id,
             "partner_type": partner_type,
             "date": fields.Date.context_today(self),
+            "currency_id": invoice.currency_id.id,
         }
 
     @api.model


### PR DESCRIPTION
There is an instance where the invoice is using a currency but payment is registered as another currency, due to undetermined journal. This leads to invoice being partially paid due to exchance rate while converting from a currency to another.