### PR TITLE
[15.0][FIX] sale_procurement_group_by_line

### DIFF
--- a/sale_procurement_group_by_line/model/sale.py
+++ b/sale_procurement_group_by_line/model/sale.py
@@ -3,22 +3,20 @@
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
-from odoo.exceptions import UserError
+from odoo import fields, models
 from odoo.tools.float_utils import float_compare
-
-
-class SaleOrder(models.Model):
-    _inherit = "sale.order"
-
-    @api.model
-    def _prepare_procurement_group_by_line(self, line):
-        """Hook to be able to use line data on procurement group"""
-        return {"name": line.order_id.name}
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
+
+    procurement_group_id = fields.Many2one(
+        "procurement.group", "Procurement group", copy=False
+    )
+
+    def _get_procurement_group(self):
+        super()._get_procurement_group()
+        return self.procurement_group_id or False
 
     def _get_procurement_group_key(self):
         """Return a key with priority to be used to regroup lines in multiple
@@ -31,10 +29,12 @@ class SaleOrderLine(models.Model):
         """
         Launch procurement group run method.
         """
+        if self._context.get("skip_procurement"):
+            return True
         precision = self.env["decimal.precision"].precision_get(
             "Product Unit of Measure"
         )
-        errors = []
+        procurements = []
         groups = {}
         if not previous_product_uom_qty:
             previous_product_uom_qty = {}
@@ -45,13 +45,14 @@ class SaleOrderLine(models.Model):
             qty = line._get_qty_procurement(previous_product_uom_qty)
             if (
                 float_compare(qty, line.product_uom_qty, precision_digits=precision)
-                >= 0
+                == 0
             ):
                 continue
 
+            group_id = line._get_procurement_group()
+
             # Group the sales order lines with same procurement group
             # according to the group key
-            group_id = line.procurement_group_id or False
             for order_line in line.order_id.order_line:
                 g_id = order_line.procurement_group_id or False
                 if g_id:
@@ -60,14 +61,7 @@ class SaleOrderLine(models.Model):
                 group_id = groups.get(line._get_procurement_group_key())
 
             if not group_id:
-                vals = line.order_id._prepare_procurement_group_by_line(line)
-                vals.update(
-                    {
-                        "move_type": line.order_id.picking_policy,
-                        "sale_id": line.order_id.id,
-                        "partner_id": line.order_id.partner_shipping_id.id,
-                    }
-                )
+                vals = line._prepare_procurement_group_vals()
                 group_id = self.env["procurement.group"].create(vals)
             else:
                 # In case the procurement group is already created and the
@@ -93,32 +87,33 @@ class SaleOrderLine(models.Model):
                 product_qty, quant_uom
             )
 
-            try:
-                procurements = []
-                procurements.append(
-                    self.env["procurement.group"].Procurement(
-                        line.product_id,
-                        product_qty,
-                        procurement_uom,
-                        line.order_id.partner_shipping_id.property_stock_customer,
-                        line.name,
-                        line.order_id.name,
-                        line.order_id.company_id,
-                        values,
-                    )
+            procurements.append(
+                self.env["procurement.group"].Procurement(
+                    line.product_id,
+                    product_qty,
+                    procurement_uom,
+                    line.order_id.partner_shipping_id.property_stock_customer,
+                    line.display_name,
+                    line.order_id.name,
+                    line.order_id.company_id,
+                    values,
                 )
-                self.env["procurement.group"].run(procurements)
-                # We store the procured quantity in the UoM of the line to avoid
-                # duplicated procurements, specially for dropshipping and kits.
-                previous_product_uom_qty[line.id] = line.product_uom_qty
-            except UserError as error:
-                errors.append(error.args[0])
-        if errors:
-            raise UserError("\n".join(errors))
+            )
+            # We store the procured quantity in the UoM of the line to avoid
+            # duplicated procurements, specially for dropshipping and kits.
+            previous_product_uom_qty[line.id] = line.product_uom_qty
+        if procurements:
+            self.env["procurement.group"].run(procurements)
+        # This next block is currently needed only because the scheduler trigger is done
+        # by picking confirmation rather than stock.move confirmation
+        orders = self.mapped("order_id")
+        for order in orders:
+            pickings_to_confirm = order.picking_ids.filtered(
+                lambda p: p.state not in ["cancel", "done"]
+            )
+            if pickings_to_confirm:
+                # Trigger the Scheduler for Pickings
+                pickings_to_confirm.action_confirm()
         return super(
             SaleOrderLine, self.with_context(sale_group_by_line=True)
         )._action_launch_stock_rule(previous_product_uom_qty=previous_product_uom_qty)
-
-    procurement_group_id = fields.Many2one(
-        "procurement.group", "Procurement group", copy=False
-    )

--- a/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
+++ b/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
@@ -126,3 +126,14 @@ class TestSaleProcurementGroupByLine(TransactionCase):
         self.assertEqual(
             len(self.sale.picking_ids), 1, "Negative stock move should me merged"
         )
+
+    def test_06_update_sale_order_line_respect_procurement_group(self):
+        """
+        When launching the stock rule again, use maintain same procurement group in lines
+        """
+        self.sale.action_confirm()
+        proc_group = self.sale.order_line[1].procurement_group_id
+        self.assertEqual(len(self.line1.move_ids), 1)
+        self.sale.order_line[1].product_uom_qty += 1
+        self.assertEqual(self.sale.order_line[1].procurement_group_id, proc_group)
+        self.assertEqual(len(self.line1.move_ids), 1)

--- a/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
+++ b/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
@@ -92,9 +92,9 @@ class TestSaleProcurementGroupByLine(TransactionCase):
         self.sale.action_confirm()
         self.assertEqual(self.sale.state, "sale")
         self.assertEqual(len(self.line1.move_ids), 1)
-        self.assertEqual(self.line1.move_ids.name, self.line1.name)
+        self.assertEqual(self.line1.move_ids.name, self.line1.display_name)
         self.assertEqual(len(self.line2.move_ids), 1)
-        self.assertEqual(self.line2.move_ids.name, self.line2.name)
+        self.assertEqual(self.line2.move_ids.name, self.line2.display_name)
 
     def test_03_action_launch_procurement_rule_2(self):
         group_id = self.proc_group_model.create(

--- a/sale_sourced_by_line/model/sale.py
+++ b/sale_sourced_by_line/model/sale.py
@@ -4,20 +4,11 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
-
-    @api.model
-    def _prepare_procurement_group_by_line(self, line):
-        vals = super(SaleOrder, self)._prepare_procurement_group_by_line(line)
-        # for compatibility with sale_quotation_sourcing
-        if line._get_procurement_group_key()[0] == 10:
-            if line.warehouse_id:
-                vals["name"] += "/" + line.warehouse_id.name
-        return vals
 
     warehouse_id = fields.Many2one(
         "stock.warehouse",
@@ -43,6 +34,14 @@ class SaleOrderLine(models.Model):
         "Otherwise, it will get the warehouse of "
         "the sale order",
     )
+
+    def _prepare_procurement_group_vals(self):
+        vals = super(SaleOrderLine, self)._prepare_procurement_group_vals()
+        # for compatibility with sale_quotation_sourcing
+        if self._get_procurement_group_key()[0] == 10:
+            if self.warehouse_id:
+                vals["name"] += "/" + self.warehouse_id.name
+        return vals
 
     def _prepare_procurement_values(self, group_id=False):
         """Prepare specific key for moves or other components


### PR DESCRIPTION
Use sale line procurement group when launching the stock rule again for the same sale order line.

Steps to reproduce:

1. Create a SO with at least one sale order line
2. Confirm it
3. Increase the quantity in the sale order line
    3.1 Current behavior: A new procurement group is used and assigned to the sales order, new delivery is created
    3.2 Desired behavior: The procurement group of the sale order line is used and same delivery is used.

cc @ForgeFlow

