### PR TITLE
[15.0][FIX] sale_order_type: Remove warning in tests

### DIFF
--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -36,9 +36,7 @@ class SaleOrder(models.Model):
     def _default_sequence_id(self):
         """We get the sequence in same way the core next_by_code method does so we can
         get the proper default sequence"""
-        force_company = self.env.context.get("force_company")
-        if not force_company:
-            force_company = self.company_id.id or self.env.company.id
+        force_company = self.company_id.id or self.env.company.id
         return self.env["ir.sequence"].search(
             [("code", "=", "sale.order"), ("company_id", "in", [force_company, False])],
             order="company_id",

--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -85,7 +85,7 @@ class TestSaleOrderType(common.TransactionCase):
             {
                 "name": "Test Sequence default",
                 "sequence_id": self.env["sale.order"]
-                .with_context(force_company=self.env.company.id)
+                .with_company(self.env.company.id)
                 ._default_sequence_id()
                 .id,
             }


### PR DESCRIPTION
Remove warning in tests: Context key 'force_company' is no longer supported. Use with_company(company) instead.

Please @pedrobaeza can you review it?

@Tecnativa