### PR TITLE
[FIX] Fix use of next_by_code only when name is Draft

### DIFF
--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -301,7 +301,8 @@ class BlanketOrder(models.Model):
             sequence_obj = self.env["ir.sequence"]
             if order.company_id:
                 sequence_obj = sequence_obj.with_company(order.company_id.id)
-            name = sequence_obj.next_by_code("sale.blanket.order")
+            if order.name == "Draft":
+                name = sequence_obj.next_by_code("sale.blanket.order")
             order.write({"confirmed": True, "name": name})
         return True
 

--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -303,6 +303,8 @@ class BlanketOrder(models.Model):
                 sequence_obj = sequence_obj.with_company(order.company_id.id)
             if order.name == "Draft":
                 name = sequence_obj.next_by_code("sale.blanket.order")
+            else:
+                name = order.name
             order.write({"confirmed": True, "name": name})
         return True
 


### PR DESCRIPTION
If you bring back a order to Draft state, when is confirmed, it changes is sequence
PR in order to fix https://github.com/OCA/sale-workflow/issues/2268