### PR TITLE
[15.0][IMP] sale_order_product_recommendation: Change context value to avoid warning logs

### DIFF
--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -233,7 +233,7 @@ class SaleOrderRecommendationLine(models.TransientModel):
         for one in self:
             if price_origin == "pricelist":
                 one.price_unit = one.product_id.with_context(
-                    partner=one.partner_id.id,
+                    partner=one.partner_id,
                     pricelist=one.pricelist_id.id,
                     quantity=one.units_included,
                 ).price


### PR DESCRIPTION
Change context value to avoid warning logs

`unsupported operand type(s) for "==": 'res.partner()' == '230'`

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa 