### PR TITLE
[IMP] sale_order_line_date: update existing moves date_deadline

### DIFF
--- a/sale_order_line_date/models/sale_order_line.py
+++ b/sale_order_line_date/models/sale_order_line.py
@@ -28,3 +28,16 @@ class SaleOrderLine(models.Model):
                 }
             )
         return vals
+
+    def write(self, vals):
+        res = super().write(vals)
+        moves_to_upd = set()
+        if "commitment_date" in vals:
+            for move in self.move_ids:
+                if move.state not in ["cancel", "done"]:
+                    moves_to_upd.add(move.id)
+        if moves_to_upd:
+            self.env["stock.move"].browse(moves_to_upd).write(
+                {"date_deadline": vals.get("commitment_date")}
+            )
+        return res

--- a/sale_order_line_date/tests/test_sale_order_line_date.py
+++ b/sale_order_line_date/tests/test_sale_order_line_date.py
@@ -154,3 +154,8 @@ class TestSaleOrderLineDates(TransactionCase):
         self._assert_equal_dates(
             self.sale_line3.commitment_date, self.sale_line3.move_ids.date_deadline
         )
+        # Test line date change after confirmation
+        self.sale_line1.write({"commitment_date": self.dt2})
+        self._assert_equal_dates(
+            self.sale_line1.commitment_date, self.sale_line1.move_ids.date_deadline
+        )


### PR DESCRIPTION
Update existing moves `date_deadline` when writing on sol's `commitment_date`. This is useful when the `sale.order` is already confirmed.