### PR TITLE
[15.0][IMP] sale_order_type: Add post_install tag in tests to prevent test errors

### DIFF
--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -6,9 +6,10 @@ from freezegun import freeze_time
 
 import odoo.tests.common as common
 from odoo import fields
-from odoo.tests import Form
+from odoo.tests import Form, tagged
 
 
+@tagged("post_install", "-at_install")
 class TestSaleOrderType(common.TransactionCase):
     def setUp(self):
         super(TestSaleOrderType, self).setUp()
@@ -128,7 +129,8 @@ class TestSaleOrderType(common.TransactionCase):
         )
 
     def create_sale_order(self, partner=False):
-        sale_form = Form(self.env["sale.order"])
+        # Set a custom context to "disable" the behavior of sale_isolated_quotation
+        sale_form = Form(self.env["sale.order"].with_context(order_sequence="test"))
         sale_form.partner_id = partner or self.partner
         with sale_form.order_line.new() as order_line:
             order_line.product_id = self.product


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/sale-workflow/pull/2290

Add `post_install` tag in tests to prevent test errors

Please @pedrobaeza can you review it?

@Tecnativa