### PR TITLE
[FIX] sale_automatic_workflow: Currency from Invoice

### DIFF
--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -129,6 +129,7 @@ class AutomaticWorkflowJob(models.Model):
             "partner_id": invoice.partner_id.id,
             "partner_type": partner_type,
             "date": fields.Date.context_today(self),
+            "currency_id": invoice.currency_id.id,
         }
 
     @api.model
@@ -157,6 +158,7 @@ class AutomaticWorkflowJob(models.Model):
             (payment_lines + lines).filtered_domain(
                 [("account_id", "=", account.id), ("reconciled", "=", False)]
             ).reconcile()
+        return payment
 
     @api.model
     def run_with_workflow(self, sale_workflow):

--- a/sale_automatic_workflow_payment_mode/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow_payment_mode/models/automatic_workflow_job.py
@@ -21,7 +21,7 @@ class AutomaticWorkflowJob(models.Model):
         return vals
 
     def _register_payment_invoice(self, invoice):
-        if not invoice.payment_mode_id.fixed_journal_id:
+        if invoice.payment_mode_id and not invoice.payment_mode_id.fixed_journal_id:
             _logger.debug(
                 "Unable to Register Payment for invoice %s: "
                 "Payment mode %s must have fixed journal",


### PR DESCRIPTION
When payment is created, the currency_id is not obtained from invoice instead the value is taken from company default.