### PR TITLE
[13.0][IMP] product_form_sale_link: fix compatibility with sale_stock and not filter out quotations

### DIFF
--- a/product_form_sale_link/views/product_template.xml
+++ b/product_form_sale_link/views/product_template.xml
@@ -11,7 +11,7 @@
             ref="sale.product_template_form_view_sale_order_button"
         />
         <field name="arch" type="xml">
-            <button name="action_view_sales" position="after">
+            <div name="button_box" position="inside">
                 <button
                     class="oe_stat_button"
                     name="%(product_form_sale_link.action_product_template_sale_list)d"
@@ -20,7 +20,7 @@
                 >
                     <field string="Sales" name="sales_count" widget="statinfo" />
                 </button>
-            </button>
+            </div>
         </field>
     </record>
 </odoo>

--- a/product_form_sale_link/views/sale_order_line.xml
+++ b/product_form_sale_link/views/sale_order_line.xml
@@ -2,20 +2,36 @@
 <!-- Copyright 2019 ACSONE SA/NV
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
+    <record id="view_sales_order_line_filter" model="ir.ui.view">
+        <field name="model">sale.order.line</field>
+        <field name="name">sale.order.line.select (in product_form_sale_link)</field>
+        <field name="inherit_id" ref="sale.view_sales_order_line_filter" />
+        <field name="arch" type="xml">
+            <filter name="to_invoice" position="before">
+                <filter
+                    string="Quotations"
+                    name="draft"
+                    domain="[('state','in',('draft', 'sent'))]"
+                />
+                <filter
+                    string="Sales Orders"
+                    name="sales"
+                    domain="[('state','in',('sale','done'))]"
+                />
+                <separator />
+            </filter>
+        </field>
+    </record>
     <record id="action_product_template_sale_list" model="ir.actions.act_window">
         <field name="name">Sale Order Lines</field>
         <field name="res_model">sale.order.line</field>
-        <field name="context">{}</field>
-        <field
-            name="domain"
-        >[('state', 'in', ['sale', 'done']), ('product_id.product_tmpl_id', 'in', active_ids)]</field>
+        <field name="context">{'search_default_sales':1}</field>
+        <field name="domain">[('product_id.product_tmpl_id', 'in', active_ids)]</field>
     </record>
     <record id="action_product_product_sale_list" model="ir.actions.act_window">
         <field name="name">Sale Order Lines</field>
         <field name="res_model">sale.order.line</field>
-        <field name="context">{}</field>
-        <field
-            name="domain"
-        >[('state', 'in', ['sale', 'done']), ('product_id', 'in', active_ids)]</field>
+        <field name="context">{'search_default_sales':1}</field>
+        <field name="domain">[('product_id', 'in', active_ids)]</field>
     </record>
 </odoo>

--- a/sale_advance_payment/tests/test_sale_advance_payment.py
+++ b/sale_advance_payment/tests/test_sale_advance_payment.py
@@ -3,6 +3,7 @@
 
 import json
 
+from odoo import fields
 from odoo.tests import common
 
 
@@ -70,9 +71,22 @@ class TestSaleAdvancePayment(common.SavepointCase):
 
         cls.currency_euro = cls.env["res.currency"].search([("name", "=", "EUR")])
         cls.currency_usd = cls.env["res.currency"].search([("name", "=", "USD")])
-        cls.currency_rate = cls.env["res.currency.rate"].create(
-            {"rate": 1.20, "currency_id": cls.currency_usd.id}
+        cls.currency_rate = cls.env["res.currency.rate"].search(
+            [
+                ("currency_id", "=", cls.currency_usd.id),
+                ("name", "=", fields.Date.today()),
+            ]
         )
+        if cls.currency_rate:
+            cls.currency_rate.write({"rate": 1.20})
+        else:
+            cls.currency_rate = cls.env["res.currency.rate"].create(
+                {
+                    "rate": 1.20,
+                    "currency_id": cls.currency_usd.id,
+                    "name": fields.Date.today(),
+                }
+            )
 
         cls.journal_eur_bank = cls.env["account.journal"].create(
             {


### PR DESCRIPTION
Standard module sale_stock replaces the button used in the inherited product template view, which gives an error when trying to install the module (https://github.com/odoo/odoo/blob/1fc4b241ab4cb4753228127a1829033deb16602e/addons/sale_stock/views/stock_views.xml#L78).

This PR also proposes to remove the filtering of the SO Lines based on the state as users may want to also see quotations. To not modify the current behavior a default filter is added.

Similar proposal as in https://github.com/OCA/purchase-workflow/pull/1682