### PR TITLE
[15.0][FIX] sale_planner_calendar: Use same domain in Sales Follower Orders…

### DIFF
--- a/sale_planner_calendar/__manifest__.py
+++ b/sale_planner_calendar/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Sale planner calendar",
     "summary": "Sale planner calendar",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.0.1",
     "development_status": "Beta",
     "category": "Sale",
     "website": "https://github.com/OCA/sale-workflow",

--- a/sale_planner_calendar/migrations/15.0.1.0.1/noupdate_changes.xml
+++ b/sale_planner_calendar/migrations/15.0.1.0.1/noupdate_changes.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="sale_order_follower_rule" model="ir.rule">
+        <field name="name">Sales Follower Orders</field>
+        <field ref="sale.model_sale_order" name="model_id" />
+        <field
+            name="domain_force"
+        >['|', ('message_partner_ids', 'in', user.partner_id.ids), ('partner_id.message_partner_ids', 'in', user.partner_id.ids)]</field>
+        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]" />
+    </record>
+    <record id="sale_order_line_follower_rule" model="ir.rule">
+        <field name="name">Sales Follower Order Lines</field>
+        <field ref="sale.model_sale_order_line" name="model_id" />
+        <field
+            name="domain_force"
+        >['|', ('order_id.message_partner_ids', 'in', user.partner_id.ids), ('order_partner_id.message_partner_ids', 'in', user.partner_id.ids)]</field>
+        <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]" />
+    </record>
+</odoo>

--- a/sale_planner_calendar/migrations/15.0.1.0.1/post-migration.py
+++ b/sale_planner_calendar/migrations/15.0.1.0.1/post-migration.py
@@ -1,0 +1,10 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade  # pylint: disable=W7936
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, "sale_planner_calendar", "migrations/15.0.1.0.1/noupdate_changes.xml"
+    )

--- a/sale_planner_calendar/security/sale_planner_calendar_security.xml
+++ b/sale_planner_calendar/security/sale_planner_calendar_security.xml
@@ -24,7 +24,7 @@
         <field ref="sale.model_sale_order" name="model_id" />
         <field
             name="domain_force"
-        >[('message_partner_ids', 'in', user.partner_id.ids)]</field>
+        >['|', ('message_partner_ids', 'in', user.partner_id.ids), ('partner_id.message_partner_ids', 'in', user.partner_id.ids)]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]" />
     </record>
     <record id="sale_order_line_follower_rule" model="ir.rule">
@@ -32,7 +32,7 @@
         <field ref="sale.model_sale_order_line" name="model_id" />
         <field
             name="domain_force"
-        >['|', ('order_id.message_partner_ids', 'in', user.partner_id.ids), ('order_id.partner_id.message_partner_ids', 'in', user.partner_id.ids)]</field>
+        >['|', ('order_id.message_partner_ids', 'in', user.partner_id.ids), ('order_partner_id.message_partner_ids', 'in', user.partner_id.ids)]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]" />
     </record>
 


### PR DESCRIPTION
… and Sales Follower Order Lines

With previous domain user can view sale order lines but can't view related sale order:
https://github.com/OCA/sale-workflow/blob/1ea366b5b1e5f2e8326e305d940f980bd65dfd08/sale_planner_calendar/security/sale_planner_calendar_security.xml#L22-L37

@Tecnativa TT40792