### PR TITLE
[14.0][IMP] sale_order_partner_restrict: option "only_contacts"

### DIFF
--- a/sale_order_partner_restrict/models/res_company.py
+++ b/sale_order_partner_restrict/models/res_company.py
@@ -11,6 +11,11 @@ class ResCompany(models.Model):
             ("all", "All partners"),
             ("only_parents", "Only parent accounts (no contacts)"),
             ("parents_and_contacts", "Parent accounts and contacts"),
+            ("only_contacts", "Only contacts (no parent accounts)"),
+            (
+                "only_delivery_addresses",
+                "Only delivery addresses can be selected for SO customer",
+            ),
         ],
         "Partner Restriction on Sale Orders",
         default="all",

--- a/sale_order_partner_restrict/models/sale.py
+++ b/sale_order_partner_restrict/models/sale.py
@@ -40,6 +40,14 @@ class SaleOrder(models.Model):
                 ("parent_id", "=", False),
                 ("type", "=", "contact"),
             ]
+        elif self.sale_order_partner_restrict == "only_contacts":
+            partner_restrict_domain = [
+                ("company_id", "=", False),
+                ("parent_id", "!=", False),
+                ("type", "=", "contact"),
+            ]
+        elif self.sale_order_partner_restrict == "only_delivery_addresses":
+            partner_restrict_domain = [("type", "=", "delivery")]
         return partner_restrict_domain
 
     @api.onchange("sale_order_partner_restrict")

--- a/sale_order_partner_restrict/readme/CONTRIBUTORS.rst
+++ b/sale_order_partner_restrict/readme/CONTRIBUTORS.rst
@@ -1,1 +1,4 @@
 * Oriol Villamayor <oriol.villamayor@forgeflow.com>
+* Ooops404 <https://ooops404.com>
+* Cetmix <https://cetmix.com>
+* Dessan Hemrayev <dessanhemrayev@gmail.com>

--- a/sale_order_partner_restrict/readme/DESCRIPTION.rst
+++ b/sale_order_partner_restrict/readme/DESCRIPTION.rst
@@ -5,3 +5,5 @@ This configuration is available in Sales / Configuration / Settings, and the opt
 * All partners (default)
 * Only parent accounts (no contacts)
 * Parent accounts and contact persons
+* Only contacts (no parents account)
+* Only delivery addresses can be selected for SO customer

--- a/sale_order_partner_restrict/tests/test_sale_order_partner_restrict.py
+++ b/sale_order_partner_restrict/tests/test_sale_order_partner_restrict.py
@@ -24,6 +24,13 @@ class TestSaleOrderPartnerRestrict(SavepointCase):
                 "parent_id": cls.partner_parent.id,
             }
         )
+        cls.partner_delivery_address = cls.partner_model.create(
+            {
+                "name": "Partner delivery addresses",
+                "type": "delivery",
+                "parent_id": cls.partner_parent.id,
+            }
+        )
         cls.partner_diff_company = cls.partner_model.create(
             {
                 "name": "Partner Different Company",
@@ -46,6 +53,7 @@ class TestSaleOrderPartnerRestrict(SavepointCase):
         return so
 
     def test_sale_order_partner_restrict_option_all(self):
+        """Test for a restriction with the "all" option"""
         self.main_company.sale_order_partner_restrict = "all"
 
         self.assertTrue(
@@ -69,6 +77,8 @@ class TestSaleOrderPartnerRestrict(SavepointCase):
         )
 
     def test_sale_order_partner_restrict_option_only_parents(self):
+        """Test for a restriction with the "only_parents" option"""
+
         self.main_company.sale_order_partner_restrict = "only_parents"
 
         self.assertTrue(
@@ -92,6 +102,8 @@ class TestSaleOrderPartnerRestrict(SavepointCase):
             self._create_sale_order(self.partner_delivery)
 
     def test_sale_order_partner_restrict_option_parents_and_contacts(self):
+        """Test for a restriction with the "parents_and_contacts" option"""
+
         self.main_company.sale_order_partner_restrict = "parents_and_contacts"
 
         self.assertTrue(
@@ -113,5 +125,73 @@ class TestSaleOrderPartnerRestrict(SavepointCase):
 
         # Child and other type partner
         # shouldn't be available in 'parents_and_contacts' option
+        with self.assertRaises(ValidationError):
+            self._create_sale_order(self.partner_delivery)
+
+    def test_sale_order_partner_restrict_option_only_contacts(self):
+        """Test for a restriction with the "only_contacts" option"""
+
+        sale_order_partner_restrict = "only_contacts"
+        self.main_company.sale_order_partner_restrict = sale_order_partner_restrict
+
+        self.assertEqual(
+            self.main_company.sale_order_partner_restrict,
+            sale_order_partner_restrict,
+            "Must be equal to 'only_contacts'",
+        )
+
+        self.assertTrue(
+            self._create_sale_order(self.partner_child),
+            "Contact type partner" "should be available in 'only_contacts' option",
+        )
+
+        # Parent type partner shouldn't be available in 'only_contacts' option
+        with self.assertRaises(ValidationError):
+            self._create_sale_order(self.partner_parent)
+
+        # Partner from another company
+        # shouldn't be available on this company (option 'only_contacts')
+        with self.assertRaises(ValidationError):
+            self._create_sale_order(self.partner_diff_company)
+
+        # Child and other type partner
+        # shouldn't be available in 'only_contacts' option
+        with self.assertRaises(ValidationError):
+            self._create_sale_order(self.partner_delivery)
+
+    def test_sale_order_partner_restrict_option_only_delivery(self):
+        """Test for a restriction with the "only_delivery_addresses" option"""
+
+        sale_order_partner_restrict = "only_delivery_addresses"
+        self.main_company.sale_order_partner_restrict = sale_order_partner_restrict
+
+        self.assertEqual(
+            self.main_company.sale_order_partner_restrict,
+            sale_order_partner_restrict,
+            "Must be equal to 'only_contacts'",
+        )
+
+        self.assertTrue(
+            self._create_sale_order(self.partner_delivery_address),
+            "Contact type partner"
+            "should be available in 'only_delivery_addresses' option",
+        )
+
+        # Contact type partner shouldn't be available in
+        # 'only_delivery_addresses' option
+        with self.assertRaises(ValidationError):
+            self._create_sale_order(self.partner_child)
+
+        # Parent type partner shouldn't be available in 'only_delivery_addresses' option
+        with self.assertRaises(ValidationError):
+            self._create_sale_order(self.partner_parent)
+
+        # Partner from another company
+        # shouldn't be available on this company (option 'only_delivery_addresses')
+        with self.assertRaises(ValidationError):
+            self._create_sale_order(self.partner_diff_company)
+
+        # Child and other type partner
+        # shouldn't be available in 'only_delivery_addresses' option
         with self.assertRaises(ValidationError):
             self._create_sale_order(self.partner_delivery)


### PR DESCRIPTION
This module allows to set a domain on which partner can be chosen for SO
Added new an option restricting only contact partners on SO, excluding their parent accounts
Added new an option "delivery addresses only" , only delivery addresses can be selected for SO customer