### PR TITLE
[14.0][FIX] sale_blanket_order and sale_order_revision: add sudo

### DIFF
--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -327,7 +327,7 @@ class BlanketOrder(models.Model):
 
     def action_view_sale_orders(self):
         sale_orders = self._get_sale_orders()
-        action = self.env.ref("sale.action_orders").read()[0]
+        action = self.env.ref("sale.action_orders").sudo().read()[0]
         if len(sale_orders) > 0:
             action["domain"] = [("id", "in", sale_orders.ids)]
             action["context"] = [("id", "in", sale_orders.ids)]
@@ -336,9 +336,13 @@ class BlanketOrder(models.Model):
         return action
 
     def action_view_sale_blanket_order_line(self):
-        action = self.env.ref(
-            "sale_blanket_order" ".act_open_sale_blanket_order_lines_view_tree"
-        ).read()[0]
+        action = (
+            self.env.ref(
+                "sale_blanket_order" ".act_open_sale_blanket_order_lines_view_tree"
+            )
+            .sudo()
+            .read()[0]
+        )
         lines = self.mapped("line_ids")
         if len(lines) > 0:
             action["domain"] = [("id", "in", lines.ids)]

--- a/sale_order_revision/models/sale_order.py
+++ b/sale_order_revision/models/sale_order.py
@@ -35,7 +35,7 @@ class SaleOrder(models.Model):
     def action_view_revisions(self):
         self.ensure_one()
         action = self.env.ref("sale.action_orders")
-        result = action.read()[0]
+        result = action.sudo().read()[0]
         result["domain"] = ["|", ("active", "=", False), ("active", "=", True)]
         result["context"] = {
             "active_test": 0,


### PR DESCRIPTION
Add sudo() to sale_blanket_order and sale_order_revision modules.

Steps to reproduce issue:

Sales > Orders > Orders > Select a Sales Order with a Revision > Click Prev. revisions smart button
Sales > Orders > Blanket Orders > Select a Blanket Order > Click Sale Orders smart button
Sales > Orders > Blanket Orders > Select a Blanket Order > Click Lines smart button
