### PR TITLE
[16.0][FIX] partner_contact_sale_info_propagation: Fix method signature for…

### DIFF
--- a/partner_contact_sale_info_propagation/models/res_partner.py
+++ b/partner_contact_sale_info_propagation/models/res_partner.py
@@ -63,12 +63,11 @@ class ResPartner(models.Model):
         return res
 
     @api.model
-    def get_view(self, view_id=None, view_type="form", toolbar=False, submenu=False):
+    def get_view(self, view_id=None, view_type="form", **options):
         res = super().get_view(
             view_id=view_id,
             view_type=view_type,
-            toolbar=toolbar,
-            submenu=submenu,
+            **options,
         )
         if view_type == "form":
             partner_xml = etree.XML(res["arch"])


### PR DESCRIPTION
… get_view()

This error from the migration #2257 prevent the display of partner form