### PR TITLE
[14.0][FIX] sale_order_type: Disable compute when exist default_journal_id

### DIFF
--- a/sale_order_type/models/account_move.py
+++ b/sale_order_type/models/account_move.py
@@ -19,11 +19,17 @@ class AccountMove(models.Model):
     )
 
     @api.depends("partner_id", "company_id")
+    @api.depends_context(
+        "default_move_type", "default_journal_id", "active_model", "company"
+    )
     def _compute_sale_type_id(self):
         # If create invoice from sale order, sale type will not computed.
-        if not self.env.context.get("default_move_type", False) or self.env.context.get(
-            "active_model", False
-        ) in ["sale.order", "sale.advance.payment.inv"]:
+        if (
+            not self.env.context.get("default_move_type", False)
+            or self.env.context.get("default_journal_id", False)
+            or self.env.context.get("active_model", False)
+            in ["sale.order", "sale.advance.payment.inv"]
+        ):
             return
         self.sale_type_id = self.env["sale.order.type"]
         for record in self:

--- a/sale_order_type/tests/__init__.py
+++ b/sale_order_type/tests/__init__.py
@@ -3,3 +3,4 @@
 from . import test_account_invoice_report
 from . import test_sale_order_report
 from . import test_sale_order_type
+from . import test_account_invoice

--- a/sale_order_type/tests/test_account_invoice.py
+++ b/sale_order_type/tests/test_account_invoice.py
@@ -1,0 +1,30 @@
+import odoo.tests.common as common
+from odoo.tests import Form, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAccountInvoice(common.TransactionCase):
+    def test_account_invoice_create(self):
+        self.journal_1 = self.env["account.journal"].search(
+            [("type", "=", "sale")], limit=1
+        )
+        self.journal_2 = self.env["account.journal"].search(
+            [("type", "=", "purchase")], limit=1
+        )
+        self.partner = self.env.ref("base.res_partner_1")
+        self.action_invoice_1 = self.journal_1.action_create_new()
+        self.action_invoice_2 = self.journal_2.action_create_new()
+        new_invoice_1 = Form(
+            self.env["account.move"].with_context(self.action_invoice_1["context"]),
+            view=self.env["ir.model.data"].xmlid_to_res_id("account.view_move_form"),
+        )
+        new_invoice_2 = Form(
+            self.env["account.move"].with_context(self.action_invoice_2["context"]),
+            view=self.env["ir.model.data"].xmlid_to_res_id("account.view_move_form"),
+        )
+        new_invoice_1.partner_id = self.partner
+        new_invoice_2.partner_id = self.partner
+        new_invoice_1.save()
+        new_invoice_2.save()
+        self.assertEqual(self.journal_1.id, new_invoice_1.journal_id.id)
+        self.assertEqual(self.journal_2.id, new_invoice_2.journal_id.id)


### PR DESCRIPTION
When the "default_journal_id" context value exists, the compute field should not be activated. This occurs for example when an invoice is created from the invoice kanban board, which ignores the context variable and inserts an incorrect journal.