### PR TITLE
[16.0][IMP] sale_exception: Improved wizard view and don't ignore exceptions with "is blocking" checked

### DIFF
--- a/sale_exception/wizard/sale_exception_confirm.py
+++ b/sale_exception/wizard/sale_exception_confirm.py
@@ -14,6 +14,7 @@ class SaleExceptionConfirm(models.TransientModel):
 
     def action_confirm(self):
         self.ensure_one()
-        if self.ignore:
+        exceptions_blocking = self.exception_ids.filtered("is_blocking")
+        if self.ignore and not exceptions_blocking:
             self.related_model_id.ignore_exception = True
         return super().action_confirm()

--- a/sale_exception/wizard/sale_exception_confirm_view.xml
+++ b/sale_exception/wizard/sale_exception_confirm_view.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <form string="Blocked in draft due to exceptions">
                 <group>
-                    <field name="exception_ids" nolabel="1" colspan="4">
+                    <field name="exception_ids" nolabel="1" colspan="2">
                         <tree>
                             <field name="name" />
                             <field name="description" />


### PR DESCRIPTION
After testing the migrated module, I’ve found some improvements:

- Description field is noy properly displayed; user needs to scroll to the right to see it.

- Allow to ignore exceptions even if the “is blocking” option is checked