### PR TITLE
[15.0][FIX] sale_order_secondary_unit: Make test resilient

### DIFF
--- a/sale_invoice_policy/models/res_config_settings.py
+++ b/sale_invoice_policy/models/res_config_settings.py
@@ -10,10 +10,6 @@ class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
     sale_default_invoice_policy = fields.Selection(
-        selection=[
-            ("order", "Ordered quantities"),
-            ("delivery", "Delivered quantities"),
-        ],
         related="default_invoice_policy",
         string="Default Sale Invoice Policy",
         readonly=True,

--- a/sale_missing_tracking/views/sale_missing_tracking_views.xml
+++ b/sale_missing_tracking/views/sale_missing_tracking_views.xml
@@ -178,7 +178,10 @@
                                         type="object"
                                         class="btn btn-primary pull-right"
                                     >
-                                        <i class="fa fa-exclamation-circle" />
+                                        <i
+                                            class="fa fa-exclamation-circle"
+                                            title="Create exception"
+                                        />
                                     </button>
                                 </div>
                             </div>

--- a/sale_order_secondary_unit/tests/test_sale_order_secondary_unit.py
+++ b/sale_order_secondary_unit/tests/test_sale_order_secondary_unit.py
@@ -88,8 +88,10 @@ class TestSaleOrderSecondaryUnit(TransactionCase):
         self.order.order_line.secondary_uom_id = self.secondary_unit.id
         self.order.order_line.secondary_uom_id.write({"dependency_type": "independent"})
 
+        # Remember previous UoM quantity for avoiding interactions with other modules
+        previous_uom_qty = self.order.order_line.product_uom_qty
         self.order.order_line.write({"secondary_uom_qty": 2})
-        self.assertEqual(self.order.order_line.product_uom_qty, 1)
+        self.assertEqual(self.order.order_line.product_uom_qty, previous_uom_qty)
         self.assertEqual(self.order.order_line.secondary_uom_qty, 2)
 
         self.order.order_line.write({"product_uom_qty": 17})

--- a/sale_stock_invoice_plan/tests/test_sale_invoice_plan.py
+++ b/sale_stock_invoice_plan/tests/test_sale_invoice_plan.py
@@ -231,7 +231,7 @@ class TestSaleInvoicePlan(common.TestSaleCommon):
         with self.assertRaises(ValidationError) as e:
             wizard.with_context(**ctx).create_invoices_by_plan()
         self.assertIn(
-            "Plan quantity: 5.0, exceed invoiceable quantity: 3.0", e.exception.name
+            "Plan quantity: 5.0, exceed invoiceable quantity: 3.0", e.exception.args[0]
         )
         # Deliver all the rest and create invoice plan again
         pick = self.so_product.picking_ids.filtered(lambda l: l.state != "done")


### PR DESCRIPTION
As the test should only test that no change on the UoM quantity is done when modifying the secondary unit, we remember the existing quantity and compare it later with the final value, instead of testing against a fixed value, so any interaction with other modules don't interfere.

@Tecnativa