### PR TITLE
[15.0][FIX] sale_invoice_plan: hide create invoice button

### DIFF
--- a/sale_invoice_plan/views/sale_view.xml
+++ b/sale_invoice_plan/views/sale_view.xml
@@ -89,6 +89,22 @@
                     attrs="{'invisible': [('invoice_plan_process', '=', False)]}"
                 />
             </xpath>
+            <xpath
+                expr="//button[@name='%(sale.action_view_sale_advance_payment_inv)d'][1]"
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'invisible': ['|', ('invoice_plan_process', '=', True), ('invoice_status', '!=', 'to invoice')]}</attribute>
+            </xpath>
+            <xpath
+                expr="//button[@name='%(sale.action_view_sale_advance_payment_inv)d'][2]"
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'invisible': ['|', ('invoice_plan_process', '=', True), '|', ('invoice_status', '!=', 'no'), ('state', '!=', 'sale')]}</attribute>
+            </xpath>
             <xpath expr="/form/sheet/notebook/page" position="after">
                 <page
                     string="Invoice Plan"


### PR DESCRIPTION
This pull request is used to hide **Create Invoice** button when **Use Invoice Plan** because an invoice that was created by **Create Invoice** button does not link with the invoice plan.