### PR TITLE
[FIX] sale_blanket_order: do not use supplier_taxes_id

### DIFF
--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -629,12 +629,12 @@ class BlanketOrderLine(models.Model):
             if self.env.uid == SUPERUSER_ID:
                 company_id = self.env.company.id
                 self.taxes_id = fpos.map_tax(
-                    self.product_id.supplier_taxes_id.filtered(
+                    self.product_id.taxes_id.filtered(
                         lambda r: r.company_id.id == company_id
                     )
                 )
             else:
-                self.taxes_id = fpos.map_tax(self.product_id.supplier_taxes_id)
+                self.taxes_id = fpos.map_tax(self.product_id.taxes_id)
 
     @api.depends(
         "sale_lines.order_id.state",


### PR DESCRIPTION
Backporting a fix from 14.0 migration. 
This PR is made according to [closed PR](https://github.com/OCA/sale-workflow/pull/2230) and related with issue #2228 , since it appears to be abandoned.