### PR TITLE
[15.0] sale_partner_incoterm: add incoterm address 

### DIFF
--- a/sale_partner_incoterm/__manifest__.py
+++ b/sale_partner_incoterm/__manifest__.py
@@ -10,6 +10,6 @@
     "author": "Opener B.V.,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "depends": ["sale_stock"],
-    "data": ["views/res_partner.xml"],
+    "data": ["views/res_partner.xml", "views/sale_order.xml"],
     "installable": True,
 }

--- a/sale_partner_incoterm/models/res_partner.py
+++ b/sale_partner_incoterm/models/res_partner.py
@@ -12,3 +12,7 @@ class Partner(models.Model):
         comodel_name="account.incoterms",
         help="The default incoterm for new sales orders for this customer.",
     )
+    sale_incoterm_address_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Default Sale Incoterm Address",
+    )

--- a/sale_partner_incoterm/models/sale_order.py
+++ b/sale_partner_incoterm/models/sale_order.py
@@ -1,14 +1,24 @@
 # Copyright 2015 Opener B.V. (<https://opener.am>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, models
+from odoo import api, fields, models
 
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
+    incoterm_address_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Incoterm Address",
+    )
+
     @api.onchange("partner_id")
     def onchange_partner_id(self):
         res = super().onchange_partner_id()
-        self.incoterm = self.partner_id.sale_incoterm_id
+        self.update(
+            {
+                "incoterm": self.partner_id.sale_incoterm_id.id,
+                "incoterm_address_id": self.partner_id.sale_incoterm_address_id.id,
+            }
+        )
         return res

--- a/sale_partner_incoterm/tests/test_sale_partner_incoterm.py
+++ b/sale_partner_incoterm/tests/test_sale_partner_incoterm.py
@@ -12,7 +12,11 @@ class TestSalePartnerIncoterm(TransactionCase):
         """
         customer = self.env.ref("base.res_partner_3")
         incoterm = self.env["account.incoterms"].search([], limit=1)
-        customer.write({"sale_incoterm_id": incoterm.id})
+        address = self.env["res.partner"].search([], limit=1)
+        customer.write(
+            {"sale_incoterm_id": incoterm.id, "sale_incoterm_address_id": address.id}
+        )
         sale_order = self.env["sale.order"].create({"partner_id": customer.id})
         sale_order.onchange_partner_id()
         self.assertEqual(sale_order.incoterm, incoterm)
+        self.assertEqual(sale_order.incoterm_address_id, address)

--- a/sale_partner_incoterm/views/res_partner.xml
+++ b/sale_partner_incoterm/views/res_partner.xml
@@ -14,6 +14,10 @@
                     widget="selection"
                     groups="sale_stock.group_display_incoterm"
                 />
+                <field
+                    name="sale_incoterm_address_id"
+                    groups="sale_stock.group_display_incoterm"
+                />
             </field>
         </field>
     </record>

--- a/sale_partner_incoterm/views/sale_order.xml
+++ b/sale_partner_incoterm/views/sale_order.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="sale_stock_sale_order_form_inherit" model="ir.ui.view">
+        <field name="name">sale.stock.sale.order.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale_stock.view_order_form_inherit_sale_stock" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='incoterm']" position="after">
+                <field name="incoterm_address_id" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add a new field in res_partner model for the default incoterm address. This works in onchange_partner_id as sale_incoterm_id does

OCA port pr #2217 from 14.0 to 15.0
