### PR TITLE
[FIX] sale_blanket_order - proper taxes computation

### DIFF
--- a/sale_blanket_order/views/sale_blanket_order_views.xml
+++ b/sale_blanket_order/views/sale_blanket_order_views.xml
@@ -212,6 +212,7 @@
                                         groups="analytic.group_analytic_accounting"
                                         force_save="1"
                                     />
+                                    <field name="fiscal_position_id" />
                                 </group>
                             </group>
                         </page>


### PR DESCRIPTION
Correct taxes computation according to fiscal position:
* Add `fiscal_position_id` into form view
* Add `onchange` method to properly recompute taxes after fiscal position change

Somehow associated PR #2416 
Fixes #2440 