### PR TITLE
[15.0][FIX] sale_credit_point: Adjusting  partner credit_point constrain

### DIFF
--- a/sale_credit_point/models/partner.py
+++ b/sale_credit_point/models/partner.py
@@ -40,10 +40,11 @@ class ResPartner(models.Model):
 
     @api.constrains("credit_point")
     def _check_credit_point(self):
-        if self.credit_point < 0 and not self.credit_point_bypass_check():
-            raise exceptions.ValidationError(
-                _("You can't set a credit point lower than 0")
-            )
+        for partner in self:
+            if partner.credit_point < 0 and not partner.credit_point_bypass_check():
+                raise exceptions.ValidationError(
+                    _("You can't set a credit point lower than 0")
+                )
 
     def action_update_credit_point(self):
         """Open update credit point wizard."""


### PR DESCRIPTION
cc @Tecnativa

The `_check_credit_point method` has a contrain on  `credit_point`, but it is not evaluating how many partners are being passed. So when the method tries to evaluate a recordset with several partners, it will throw a value error complaining that it expects a singleton. With this modification we ensure that only one value is passed at the same time. 

ping @ernestotejeda 