### PR TITLE
[14.0][FIX] Stop deleting lot on sale order cancelation

### DIFF
--- a/sale_order_lot_generator/models/sale_order.py
+++ b/sale_order_lot_generator/models/sale_order.py
@@ -22,10 +22,3 @@ class SaleOrder(models.Model):
     def action_confirm(self):
         self.generate_prodlot()
         return super().action_confirm()
-
-    def action_cancel(self):
-        res = super().action_cancel()
-        for sale in self:
-            for line in sale.order_line:
-                line.lot_id.unlink()
-        return res


### PR DESCRIPTION
When you cancel a sale order the lot could have been already bought or produce so we want to avoid deleting it automaticaly.