### PR TITLE
[14.0][FIX] sale_order_invoicing_finished_task: SOL with qty =< 0

### DIFF
--- a/sale_order_invoicing_finished_task/models/project.py
+++ b/sale_order_invoicing_finished_task/models/project.py
@@ -58,9 +58,8 @@ class ProjectTask(models.Model):
         if sale_line_id:
             sale_lines |= self.env["sale.order.line"].browse(sale_line_id)
         for sale_line in sale_lines:
-            if (
-                sale_line.state in ("done", "cancel")
-                or sale_line.invoice_status == "invoiced"
+            if sale_line.state in ("done", "cancel") or (
+                sale_line.invoice_status == "invoiced" and sale_line.product_uom_qty > 0
             ):
                 raise ValidationError(
                     _(


### PR DESCRIPTION
[FIX] manage correctly the case of SOL with qty<0,  even if falsely reported as "invoiced"

this error is a fix for the problem sale module has when computing the invoice_status of a sale order line with negative quantities, first found in this issue.

       https://github.com/OCA/sale-workflow/issues/2443

the fix allows the module to behave normally even with SOL's with qty<0, but the root of the problem is how odoo sales computes the invoice status of a SOL , without considering a possible qty<0.

      https://github.com/odoo/odoo/issues/118365


@maisim we have made this 14.0 branch for our internal use, but i bewlieve this should be solved in odoo/addons/sales.
same problem in v16.
