### PR TITLE
[FIX] sale_automatic_workflow: revert patch from method _create_invoices

### DIFF
--- a/sale_automatic_workflow/__manifest__.py
+++ b/sale_automatic_workflow/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Sale Automatic Workflow",
-    "version": "16.0.1.0.1",
+    "version": "16.0.1.0.2",
     "category": "Sales Management",
     "license": "AGPL-3",
     "author": "Akretion, "

--- a/sale_automatic_workflow/tests/test_automatic_workflow.py
+++ b/sale_automatic_workflow/tests/test_automatic_workflow.py
@@ -80,6 +80,14 @@ class TestAutomaticWorkflow(TestCommon, TestAutomaticWorkflowMixin):
         # Make sure this addon works properly in regards to it.
         mock_path = "odoo.addons.sale.models.sale_order.SaleOrder._create_invoices"
         with mock.patch(mock_path) as mocked:
+            module_sale_order_action_invoice_create_hook = self.env[
+                "ir.module.module"
+            ].search([("name", "=", "sale_order_action_invoice_create_hook")])
+            if (
+                module_sale_order_action_invoice_create_hook
+                and module_sale_order_action_invoice_create_hook.state == "installed"
+            ):
+                sale._revert_method("_create_invoices")
             sale._create_invoices()
             mocked.assert_called()
         self.assertEqual(line.qty_delivered, 0.0)


### PR DESCRIPTION
Fixed test cases by reverting patch from method **"_create_invoices"** which is patched from module **_sale_order_action_invoice_create_hook_**.

Module **_sale_order_action_invoice_create_hook_**'s pull request: #2479 