### PR TITLE
[16.0][IMP]sale_cancel_reason: set reason to false when status is != cancel

### DIFF
--- a/sale_cancel_reason/model/sale.py
+++ b/sale_cancel_reason/model/sale.py
@@ -22,6 +22,11 @@ class SaleOrder(models.Model):
                 return True
         return False
 
+    def action_draft(self):
+        res = super().action_draft()
+        self.write({"cancel_reason_id": False})
+        return res
+
 
 class SaleOrderCancelReason(models.Model):
     _name = "sale.order.cancel.reason"


### PR DESCRIPTION
I have find the following problem:

When a cancelled order, is moved to draft, it keeps the cancellation reason and this causes that if we group orders by cancellation reasons:

![Captura de pantalla de 2023-04-20 17-32-16](https://user-images.githubusercontent.com/110393853/233415420-ac3f37ba-bd03-4d3e-a6b6-b4151df0d98d.png)



we will get orders that are not cancelled, but were once cancelled.

With that change on action_draft, when we move the order to draft, again, the reason for cancellation will be reset. 