### PR TITLE
[16.0][FIX] sale_exception, fixes decoration-danger cases

### DIFF
--- a/sale_exception/__manifest__.py
+++ b/sale_exception/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Sale Exception",
     "summary": "Custom exceptions on sale order",
-    "version": "16.0.1.0.1",
+    "version": "16.0.1.0.2",
     "category": "Generic Modules/Sale",
     "author": "Akretion, "
     "Sodexis, "

--- a/sale_exception/models/sale_order_line.py
+++ b/sale_exception/models/sale_order_line.py
@@ -11,8 +11,9 @@ class SaleOrderLine(models.Model):
     _name = "sale.order.line"
 
     exception_ids = fields.Many2many(
-        "exception.rule", string="Exceptions", copy=False, readonly=True
+        related="order_id.exception_ids", string="Exceptions", copy=False, readonly=True
     )
+    has_exception = fields.Boolean(compute="_compute_has_exceptions", default=False)
     exceptions_summary = fields.Html(
         readonly=True, compute="_compute_exceptions_summary"
     )
@@ -27,6 +28,14 @@ class SaleOrderLine(models.Model):
                 rec.exceptions_summary = rec._get_exception_summary()
             else:
                 rec.exceptions_summary = False
+
+    @api.depends("exception_ids")
+    def _compute_has_exceptions(self):
+        for rec in self:
+            if not rec.exception_ids:
+                rec.has_exception = False
+            else:
+                rec.has_exception = True
 
     def _get_exception_summary(self):
         return "<ul>%s</ul>" % "".join(

--- a/sale_exception/views/sale_view.xml
+++ b/sale_exception/views/sale_view.xml
@@ -65,13 +65,13 @@
                 </div>
             </xpath>
             <xpath expr="//field[@name='order_line']/tree" position="inside">
-                <field name="exception_ids" invisible="1" />
+                <field name="has_exception" invisible="1" />
                 <field name="ignore_exception" invisible="1" />
             </xpath>
             <xpath expr="//field[@name='order_line']/tree" position="attributes">
                 <attribute
                     name="decoration-danger"
-                >not ignore_exception and exception_ids</attribute>
+                >not ignore_exception and has_exception</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
It happens that exception_ids is always being evaluated as True, so the condition 'not ignore_exception and exception_ids' is not behaving as excepting