### PR TITLE
[16.0][FIX]sale_order_type: company_id singleton error

### DIFF
--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -36,7 +36,7 @@ class SaleOrder(models.Model):
     def _default_sequence_id(self):
         """We get the sequence in same way the core next_by_code method does so we can
         get the proper default sequence"""
-        force_company = self.company_id.id or self.env.company.id
+        force_company = self.env.company.id
         return self.env["ir.sequence"].search(
             [
                 ("code", "=", "sale.order"),
@@ -116,7 +116,6 @@ class SaleOrder(models.Model):
     def write(self, vals):
         """A sale type could have a different order sequence, so we could
         need to change it accordingly"""
-        default_sequence = self._default_sequence_id()
         if vals.get("type_id"):
             sale_type = self.env["sale.order.type"].browse(vals["type_id"])
             if sale_type.sequence_id:
@@ -126,7 +125,8 @@ class SaleOrder(models.Model):
                     # sequence has the same default sequence.
                     ignore_default_sequence = (
                         not record.type_id.sequence_id
-                        and sale_type.sequence_id == default_sequence
+                        and sale_type.sequence_id
+                        == record.with_company(record.company_id)._default_sequence_id()
                     )
                     if (
                         record.state in {"draft", "sent"}


### PR DESCRIPTION
Defining default_sequence before iteration may cause an _Expected singleton_ error if there is more than one company.
Moving it into the self iteration secures that only a company is involved avoiding the error.