### PR TITLE
[FIX] sale_exception : so line decoration-danger condition

### DIFF
--- a/sale_exception/models/sale_order_line.py
+++ b/sale_exception/models/sale_order_line.py
@@ -19,6 +19,14 @@ class SaleOrderLine(models.Model):
     ignore_exception = fields.Boolean(
         related="order_id.ignore_exception", store=True, string="Ignore Exceptions"
     )
+    is_exception_danger = fields.Boolean(compute="_compute_is_exception_danger")
+
+    @api.depends("exception_ids", "ignore_exception")
+    def _compute_is_exception_danger(self):
+        for rec in self:
+            rec.is_exception_danger = (
+                len(rec.exception_ids) > 0 and not rec.ignore_exception
+            )
 
     @api.depends("exception_ids", "ignore_exception")
     def _compute_exceptions_summary(self):

--- a/sale_exception/tests/test_multi_records.py
+++ b/sale_exception/tests/test_multi_records.py
@@ -71,10 +71,12 @@ class TestSaleExceptionMultiRecord(TransactionCase):
         )
 
         orders = so1 + so2 + so3
+        # ensure init state
         for order in orders:
-            # ensure init state
             self.assertTrue(order.state == "draft")
             self.assertTrue(len(order.exception_ids) == 0)
+        self.assertFalse(so1.order_line[0].is_exception_danger)
+        self.assertFalse(so3.order_line[0].is_exception_danger)
 
         self.env["sale.order"].test_all_draft_orders()
 
@@ -82,6 +84,7 @@ class TestSaleExceptionMultiRecord(TransactionCase):
 
         self.assertTrue(so1.state == "draft")
         self.assertTrue(len(so1.exception_ids) == 0)
+        self.assertFalse(so1.order_line[0].is_exception_danger)
 
         self.assertTrue(so2.state == "draft")
         self.assertTrue(exception_no_sol in so2.exception_ids)
@@ -97,6 +100,7 @@ class TestSaleExceptionMultiRecord(TransactionCase):
                 "</ul>"
             ),
         )
+        self.assertTrue(so3.order_line[0].is_exception_danger)
 
         # test return value of detect_exception()
 

--- a/sale_exception/views/sale_view.xml
+++ b/sale_exception/views/sale_view.xml
@@ -65,13 +65,10 @@
                 </div>
             </xpath>
             <xpath expr="//field[@name='order_line']/tree" position="inside">
-                <field name="exception_ids" invisible="1" />
-                <field name="ignore_exception" invisible="1" />
+                <field name="is_exception_danger" invisible="1" />
             </xpath>
             <xpath expr="//field[@name='order_line']/tree" position="attributes">
-                <attribute
-                    name="decoration-danger"
-                >not ignore_exception and exception_ids</attribute>
+                <attribute name="decoration-danger">is_exception_danger</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
The decoration-danger condition of the so line was using exception_ids as True or False depending on the fact there was exception or not. But having an empty Many2many is not evaluated as False in this case and any so line is red right after creation. So decoration-danger depends now on a computed boolean taking the length of exception_ids into account.