### PR TITLE
[14.0][FIX] sale workflow job email send before validation

### DIFF
--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -35,9 +35,13 @@ class AutomaticWorkflowJob(models.Model):
         " invoices, pickings..."
     )
 
-    def _do_validate_sale_order(self, sale, domain_filter):
+    def _do_validate_sale_order(
+        self, sale, domain_filter, send_order_confirmation=False
+    ):
         """Validate a sales order"""
         sale.action_confirm()
+        if send_order_confirmation:
+            self._do_send_order_confirmation_mail(sale)
 
     def _do_send_order_confirmation_mail(self, sale):
         """Send order confirmation mail"""
@@ -53,10 +57,10 @@ class AutomaticWorkflowJob(models.Model):
         for sale in sales:
             with savepoint(self.env.cr):
                 self._do_validate_sale_order(
-                    sale.with_company(sale.company_id), order_filter
+                    sale.with_company(sale.company_id),
+                    order_filter,
+                    self.env.context.get("send_order_confirmation_mail"),
                 )
-                if self.env.context.get("send_order_confirmation_mail"):
-                    self._do_send_order_confirmation_mail(sale)
 
     def _do_create_invoice(self, sale, domain_filter):
         """Create an invoice for a sales order"""

--- a/sale_automatic_workflow_ignore_exception/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow_ignore_exception/models/automatic_workflow_job.py
@@ -8,7 +8,11 @@ class AutomaticWorkflowJob(models.Model):
 
     _inherit = "automatic.workflow.job"
 
-    def _do_validate_sale_order(self, sale, domain_filter):
+    def _do_validate_sale_order(
+        self, sale, domain_filter, send_order_confirmation=False
+    ):
         if sale.workflow_process_id.ignore_exception_when_confirm:
             sale = sale.with_context(ignore_exception_when_confirm=True)
-        return super()._do_validate_sale_order(sale, domain_filter)
+        return super()._do_validate_sale_order(
+            sale, domain_filter, send_order_confirmation
+        )

--- a/sale_automatic_workflow_job/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow_job/models/automatic_workflow_job.py
@@ -8,7 +8,9 @@ from odoo.addons.queue_job.job import identity_exact
 class AutomaticWorkflowJob(models.Model):
     _inherit = "automatic.workflow.job"
 
-    def _do_validate_sale_order_job_options(self, sale, domain_filter):
+    def _do_validate_sale_order_job_options(
+        self, sale, domain_filter, send_order_confirmation=False
+    ):
         description = _("Validate sales order {}").format(sale.display_name)
         return {
             "description": description,
@@ -21,7 +23,9 @@ class AutomaticWorkflowJob(models.Model):
             domain_filter
         )
 
-    def _do_validate_sale_order(self, sale, domain_filter):
+    def _do_validate_sale_order(
+        self, sale, domain_filter, send_order_confirmation=False
+    ):
         """filter ensure no duplication"""
         if not sale.exists():
             return "Sale order does not exist"
@@ -29,8 +33,12 @@ class AutomaticWorkflowJob(models.Model):
             [("id", "=", sale.id)] + domain_filter
         ):
             return "{} {} job bypassed".format(sale.display_name, sale)
-        super()._do_validate_sale_order(sale, domain_filter)
-        return "{} {} confirmed successfully".format(sale.display_name, sale)
+        super()._do_validate_sale_order(sale, domain_filter, send_order_confirmation)
+        return "{} {} confirmed successfully {}".format(
+            sale.display_name,
+            sale,
+            "and confirmation email sent" if send_order_confirmation else "",
+        )
 
     def _do_send_order_confirmation_mail(self, sale):
         """Filtering to make sure the order is confirmed with

--- a/sale_automatic_workflow_job/tests/test_auto_workflow_job.py
+++ b/sale_automatic_workflow_job/tests/test_auto_workflow_job.py
@@ -45,6 +45,7 @@ class TestAutoWorkflowJob(TestCommon, TestAutomaticWorkflowMixin):
                     ("state", "=", "draft"),
                     ("workflow_process_id", "=", self.sale.workflow_process_id.id),
                 ],
+                False,
             )
             self.assert_job_delayed(
                 delayable_cls, delayable, "_do_validate_sale_order", args
@@ -150,6 +151,7 @@ class TestAutoWorkflowJob(TestCommon, TestAutomaticWorkflowMixin):
                 args=(
                     self.sale,
                     safe_eval(workflow.order_filter_id.domain) + workflow_domain,
+                    False,
                 ),
             )
             job = trap.enqueued_jobs[0]


### PR DESCRIPTION
When using the `sale_automatic_workflow_job` module the validation of
the order is done by a job. But the sending of the confirmation is done
in line. Causing the email to be sent before the validation of the
order.