### PR TITLE
[14.0][ADD] sale_automatic_workflow_periodicity

### DIFF
--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -164,9 +164,12 @@ class AutomaticWorkflowJob(models.Model):
             ).reconcile()
         return payment
 
+    def _sale_workflow_domain(self, workflow):
+        return [("workflow_process_id", "=", workflow.id)]
+
     @api.model
     def run_with_workflow(self, sale_workflow):
-        workflow_domain = [("workflow_process_id", "=", sale_workflow.id)]
+        workflow_domain = self._sale_workflow_domain(sale_workflow)
         if sale_workflow.validate_order:
             self.with_context(
                 send_order_confirmation_mail=sale_workflow.send_order_confirmation_mail
@@ -198,9 +201,14 @@ class AutomaticWorkflowJob(models.Model):
             )
 
     @api.model
+    def _workflow_process_to_run_domain(self):
+        return []
+
+    @api.model
     def run(self):
         """Must be called from ir.cron"""
         sale_workflow_process = self.env["sale.workflow.process"]
-        for sale_workflow in sale_workflow_process.search([]):
+        domain = self._workflow_process_to_run_domain()
+        for sale_workflow in sale_workflow_process.search(domain):
             self.run_with_workflow(sale_workflow)
         return True

--- a/sale_automatic_workflow_periodicity/__init__.py
+++ b/sale_automatic_workflow_periodicity/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_automatic_workflow_periodicity/__manifest__.py
+++ b/sale_automatic_workflow_periodicity/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+{
+    "name": "Sale Automatic Workflow Periodicity",
+    "summary": "Adds a period for the execution of a workflow.",
+    "version": "14.0.1.0.0",
+    "category": "Sales Management",
+    "license": "AGPL-3",
+    "author": "Camptocamp, " "Odoo Community Association (OCA)",
+    "maintainers": ["TDu"],
+    "website": "https://github.com/OCA/sale-workflow",
+    "depends": ["sale_automatic_workflow"],
+    "data": ["views/sale_workflow_process_view.xml"],
+}

--- a/sale_automatic_workflow_periodicity/models/__init__.py
+++ b/sale_automatic_workflow_periodicity/models/__init__.py
@@ -1,0 +1,2 @@
+from . import automatic_workflow_job
+from . import sale_workflow_process

--- a/sale_automatic_workflow_periodicity/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow_periodicity/models/automatic_workflow_job.py
@@ -1,0 +1,42 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import api, fields, models
+
+
+class AutomaticWorkflowJob(models.Model):
+    _inherit = "automatic.workflow.job"
+
+    def run_with_workflow(self, sale_workflow):
+        res = super().run_with_workflow(sale_workflow)
+        if sale_workflow.periodicity:
+            sale_workflow.next_execution = fields.Datetime.add(
+                fields.Datetime.now(), seconds=sale_workflow.periodicity
+            )
+        return res
+
+    @api.model
+    def _workflow_process_to_run_domain(self):
+        return [
+            "|",
+            ("periodicity", "=", 0),
+            "|",
+            "&",
+            ("periodicity", ">", 0),
+            ("next_execution", "<=", fields.Datetime.now()),
+            ("next_execution", "=", False),
+        ]
+
+    def _sale_workflow_domain(self, workflow):
+        domain = super()._sale_workflow_domain(workflow)
+        if workflow.periodicity_check_create_date:
+            domain.append(
+                (
+                    "create_date",
+                    "<",
+                    fields.Datetime.subtract(
+                        fields.Datetime.now(), seconds=workflow.periodicity
+                    ),
+                )
+            )
+        return domain

--- a/sale_automatic_workflow_periodicity/models/sale_workflow_process.py
+++ b/sale_automatic_workflow_periodicity/models/sale_workflow_process.py
@@ -1,0 +1,28 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import fields, models
+
+
+class SaleWorkflowProcess(models.Model):
+    _inherit = "sale.workflow.process"
+
+    periodicity = fields.Integer(
+        string="Run every (in seconds)",
+        help="Sets a periodicity for this workflow to be executed (in seconds)",
+    )
+    next_execution = fields.Datetime(readonly=True)
+    periodicity_check_create_date = fields.Boolean(
+        string="Enforce on creation time",
+        help="When checked only sales created before the last execution will be processed.",
+    )
+
+    def write(self, vals):
+        if "periodicity" in vals.keys():
+            periodicity = vals["periodicity"]
+            if periodicity == 0:
+                vals["next_execution"] = False
+            else:
+                now = fields.Datetime.now()
+                vals["next_execution"] = fields.Datetime.add(now, seconds=periodicity)
+        return super().write(vals)

--- a/sale_automatic_workflow_periodicity/readme/CONTRIBUTORS.rst
+++ b/sale_automatic_workflow_periodicity/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>
+* Simone Orsi <simone.orsi@camptocamp.com>

--- a/sale_automatic_workflow_periodicity/readme/DESCRIPTION.rst
+++ b/sale_automatic_workflow_periodicity/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+This module allows to set a period at which a workflow is going to be executed.
+
+The period of execution can be set in seconds in the workflow configuration. The
+next execution time is displayed below it.
+
+Another option `Enforce on creation time` can be used so only sales created before
+the last execution will be processed.

--- a/sale_automatic_workflow_periodicity/tests/__init__.py
+++ b/sale_automatic_workflow_periodicity/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_auto_workflow_periodicity

--- a/sale_automatic_workflow_periodicity/tests/test_auto_workflow_periodicity.py
+++ b/sale_automatic_workflow_periodicity/tests/test_auto_workflow_periodicity.py
@@ -1,0 +1,92 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from datetime import timedelta
+
+from freezegun import freeze_time
+
+from odoo.tests import tagged
+
+from odoo.addons.sale_automatic_workflow.tests.common import (
+    TestAutomaticWorkflowMixin,
+    TestCommon,
+)
+
+
+@tagged("post_install", "-at_install")
+class TestAutoWorkflowPeriodicity(TestCommon, TestAutomaticWorkflowMixin):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                tracking_disable=True,
+                # Compatibility with sale_automatic_workflow_job: even if
+                # the module is installed, ensure we don't delay a job.
+                # Thus, we test the usual flow.
+                _job_force_sync=True,
+            )
+        )
+
+    def test_delayed_execution_15_minutes(self):
+        """Check sales are delayed processing."""
+        workflow = self.create_full_automatic()
+        # Execute every 15 minutes
+        workflow.periodicity = 900
+        workflow.next_execution = False
+        self.sale1 = self.create_sale_order(workflow)
+        # Fist execution at 12:00
+        with freeze_time("2023-05-08 12:00:00"):
+            self.env["automatic.workflow.job"].run()
+        self.assertEqual(self.sale1.state, "sale")
+        self.sale2 = self.create_sale_order(workflow)
+        # 5 minutes later no execution should happen
+        with freeze_time("2023-05-08 12:05:00"):
+            self.env["automatic.workflow.job"].run()
+        self.assertEqual(self.sale2.state, "draft")
+        # 15 minutes after 12:00 it is executed
+        with freeze_time("2023-05-08 12:15:09"):
+            self.env["automatic.workflow.job"].run()
+        self.assertEqual(self.sale2.state, "sale")
+
+    def test_change_period_reset_next_exceution(self):
+        """Check changing the period does reset the next execution."""
+        workflow = self.create_full_automatic()
+        # Execute every 15 minutes
+        workflow.periodicity = 900
+        workflow.next_execution = False
+        self.sale1 = self.create_sale_order(workflow)
+        with freeze_time("2023-05-08 12:00:00"):
+            self.env["automatic.workflow.job"].run()
+        self.assertEqual(self.sale1.state, "sale")
+        self.assertTrue(workflow.next_execution)
+        workflow.periodicity = 0
+        self.assertFalse(workflow.next_execution)
+        with freeze_time("2023-05-08 12:30:00"):
+            workflow.periodicity = 900
+        self.assertEqual(
+            workflow.next_execution.strftime("%Y-%m-%d %H:%M:%S"), "2023-05-08 12:45:00"
+        )
+
+    def test_enforce_on_creation_time(self):
+        workflow = self.create_full_automatic()
+        # Execute every 15 minutes
+        workflow.periodicity = 900
+        workflow.next_execution = False
+        workflow.periodicity_check_create_date = True
+        self.sale1 = self.create_sale_order(workflow)
+        create_date = self.sale1.create_date
+        # Less than 15 minutes since the sale has been created
+        run_date = create_date + timedelta(seconds=800)
+        with freeze_time(run_date):
+            self.env["automatic.workflow.job"].run()
+        # It is not process by the job
+        self.assertEqual(self.sale1.state, "draft")
+        workflow.next_execution = False
+        # More than 15 minutes
+        run_date = create_date + timedelta(seconds=1000)
+        with freeze_time(run_date):
+            self.env["automatic.workflow.job"].run()
+        # It is processed
+        self.assertEqual(self.sale1.state, "sale")

--- a/sale_automatic_workflow_periodicity/views/sale_workflow_process_view.xml
+++ b/sale_automatic_workflow_periodicity/views/sale_workflow_process_view.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+  <record id="sale_workflow_process_view_form" model="ir.ui.view">
+    <field name="name">sale.order.form.automatic.delay.inherit</field>
+    <field name="model">sale.workflow.process</field>
+    <field
+            name="inherit_id"
+            ref="sale_automatic_workflow.sale_workflow_process_view_form"
+        />
+    <field name="arch" type="xml">
+
+        <group name="sale_order_confirm" position="before">
+          <group
+                    name="workflow_periodicity_exec"
+                    string="Workflow execution periodicity"
+                >
+            <field name="periodicity" />
+            <field name="next_execution" />
+            <field name="periodicity_check_create_date" />
+          </group>
+        </group>
+
+    </field>
+  </record>
+</odoo>

--- a/setup/sale_automatic_workflow_periodicity/odoo/addons/sale_automatic_workflow_periodicity
+++ b/setup/sale_automatic_workflow_periodicity/odoo/addons/sale_automatic_workflow_periodicity
@@ -1,0 +1,1 @@
+../../../../sale_automatic_workflow_periodicity

--- a/setup/sale_automatic_workflow_periodicity/setup.py
+++ b/setup/sale_automatic_workflow_periodicity/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module allows to set a frequency at which a workflow is going to be executed.

The frequency of execution can be set in seconds in the workflow configuration. The
next execution time is displayed below it.