### PR TITLE
[14.0][FIX] sale_order_type: fix duplicate account code

### DIFF
--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -21,7 +21,7 @@ class TestSaleOrderType(common.TransactionCase):
         self.account_model = self.env["account.account"]
         self.user_type_id = self.env.ref("account.data_account_type_revenue")
         self.account = self.account_model.create(
-            {"code": "410000", "name": "Income", "user_type_id": self.user_type_id.id}
+            {"code": "income", "name": "Income", "user_type_id": self.user_type_id.id}
         )
         self.partner = self.env.ref("base.res_partner_1")
         self.partner_child_1 = self.env["res.partner"].create(


### PR DESCRIPTION
The code used in the tests "41000" is a code used in real registers and therefore when running the test it causes duplicate record problems.

![image](https://github.com/OCA/sale-workflow/assets/118818446/d94093ef-d384-456d-ac24-5e61c034980b)

cc @Tecnativa TT38604

@chienandalu @victoralmau please review