### PR TITLE
[16.0][FIX] sale_order_type: fix duplicate account code

### DIFF
--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -19,7 +19,7 @@ class TestSaleOrderType(common.TransactionCase):
         )
         self.account_model = self.env["account.account"]
         self.account = self.account_model.create(
-            {"code": "410000", "name": "Income", "account_type": "income"}
+            {"code": "income", "name": "Income", "account_type": "income"}
         )
         self.partner = self.env.ref("base.res_partner_1")
         self.partner_child_1 = self.env["res.partner"].create(


### PR DESCRIPTION
The code used in the tests "41000" is a code used in real registers and therefore when running the test it causes duplicate registration problems.

Fix done in v14 https://github.com/OCA/sale-workflow/pull/2510

cc @Tecnativa TT38604

@victoralmau @chienandalu please review