### PR TITLE
[15.0][FIX] sale_planner_calendar: Event_type_id no exists in planner calendar event

### DIFF
--- a/sale_planner_calendar/models/sale_order.py
+++ b/sale_planner_calendar/models/sale_order.py
@@ -62,7 +62,7 @@ class SaleOrder(models.Model):
         ]
         if planner_summary.event_type_id:
             calendar_event_domain.append(
-                ("event_type_id", "=", planner_summary.event_type_id.id)
+                ("calendar_event_id.categ_ids", "in", planner_summary.event_type_id.ids)
             )
         calendar_events = self.env["sale.planner.calendar.event"].search(
             calendar_event_domain


### PR DESCRIPTION
cc @Tecnativa TT43335

ping @carlosdauden @CarlosRoca13 