### PR TITLE
[15.0][FIX] sale_order_type: Default value not set for compute fields

### DIFF
--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -1,5 +1,6 @@
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 # Copyright 2020 Tecnativa - Pedro M. Baeza
+# Copyright 2023 Tecnativa - Sergio Teruel
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from datetime import datetime, timedelta
 
@@ -20,7 +21,6 @@ class SaleOrder(models.Model):
             "done": [("readonly", True)],
             "cancel": [("readonly", True)],
         },
-        default=lambda so: so._default_type_id(),
         ondelete="restrict",
         copy=True,
         check_company=True,
@@ -46,19 +46,20 @@ class SaleOrder(models.Model):
     @api.depends("partner_id", "company_id")
     def _compute_sale_type_id(self):
         for record in self:
-            if not record.partner_id:
-                record.type_id = self.env["sale.order.type"].search(
-                    [("company_id", "in", [self.env.company.id, False])], limit=1
-                )
-            else:
-                sale_type = (
-                    record.partner_id.with_company(record.company_id).sale_type
-                    or record.partner_id.commercial_partner_id.with_company(
-                        record.company_id
-                    ).sale_type
-                )
-                if sale_type:
-                    record.type_id = sale_type
+            # Specific partner sale type value
+            sale_type = (
+                record.partner_id.with_company(record.company_id).sale_type
+                or record.partner_id.commercial_partner_id.with_company(
+                    record.company_id
+                ).sale_type
+            )
+            # Default user sale type value
+            if not sale_type:
+                sale_type = record.default_get(["type_id"]).get("type_id", False)
+            # Get first sale type value
+            if not sale_type:
+                sale_type = record._default_type_id()
+            record.type_id = sale_type
 
     @api.onchange("type_id")
     def onchange_type_id(self):


### PR DESCRIPTION
"default" key in compute fields (store, writeable) has no set when a record is created with default values in context because the onchange not are triggered.
This is a behavior to increase performance...

cc @Tecnativa TT43405 

ping @carlosdauden @chienandalu 