### PR TITLE
[FIX]sale_advance_payment: Properly check outbound advance payments

### DIFF
--- a/sale_advance_payment/readme/CONTRIBUTORS.rst
+++ b/sale_advance_payment/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Omar Castiñeira Saaevdra <omar@comunitea.com>
+* Manuel Regidor <manuel.regidor@sygel.es>

--- a/sale_advance_payment/tests/test_sale_advance_payment.py
+++ b/sale_advance_payment/tests/test_sale_advance_payment.py
@@ -220,6 +220,23 @@ class TestSaleAdvancePayment(common.SavepointCase):
         advance_payment_4.make_advance_payment()
         self.assertEqual(self.sale_order_1.amount_residual, 2580)
 
+        # Check that the outbound amount is not greated than the
+        # amount paid in advanced (in EUR)
+        with self.assertRaises(ValidationError):
+            advance_payment_5 = (
+                self.env["account.voucher.wizard"]
+                .with_context(context_payment)
+                .create(
+                    {
+                        "journal_id": self.journal_eur_bank.id,
+                        "payment_type": "outbound",
+                        "amount_advance": 850.01,
+                        "order_id": self.sale_order_1.id,
+                    }
+                )
+            )
+            advance_payment_5.make_advance_payment()
+
         # Confirm Sale Order
         self.sale_order_1.action_confirm()
 

--- a/sale_advance_payment/wizard/sale_advance_payment_wzd.py
+++ b/sale_advance_payment/wizard/sale_advance_payment_wzd.py
@@ -56,17 +56,36 @@ class AccountVoucherWizard(models.TransientModel):
             raise exceptions.ValidationError(_("Amount of advance must be positive."))
         if self.env.context.get("active_id", False):
             self.onchange_date()
-            if (
-                float_compare(
-                    self.currency_amount,
-                    self.order_id.amount_residual,
-                    precision_digits=2,
-                )
-                > 0
-            ):
-                raise exceptions.ValidationError(
-                    _("Amount of advance is greater than residual amount on sale")
-                )
+            if self.payment_type == "inbound":
+                if (
+                    float_compare(
+                        self.currency_amount,
+                        self.order_id.amount_residual,
+                        precision_digits=2,
+                    )
+                    > 0
+                ):
+                    raise exceptions.ValidationError(
+                        _(
+                            "Inbound amount of advance is greater than residual amount on sale"
+                        )
+                    )
+            else:
+                paid_in_advanced = self.order_id.amount_total - self.amount_total
+                if (
+                    float_compare(
+                        self.currency_amount,
+                        paid_in_advanced,
+                        precision_digits=2,
+                    )
+                    > 0
+                ):
+                    raise exceptions.ValidationError(
+                        _(
+                            "Outbound amount of advance is greater than the "
+                            "advanced paid amount"
+                        )
+                    )
 
     @api.model
     def default_get(self, fields_list):


### PR DESCRIPTION
The amount advanced in outbound operations is wrongly checked.

For exemple:

1. The amount total of this sale order is $1000.
![advanced_1](https://github.com/OCA/sale-workflow/assets/62256279/906fee68-aacd-4b33-82bc-60fa1a840a4a)

2. A $800 inbound advanced payment is added.
![advanced_2](https://github.com/OCA/sale-workflow/assets/62256279/2f662979-8e20-4ea4-b620-afe33d655963)

3. The residual amount is now $200
![advanced_3](https://github.com/OCA/sale-workflow/assets/62256279/88757b4f-6edc-41e5-b43f-dff2b93f81c0)

4. A $800 advanced outbound payment (the amount already advanced) needs to be made, but the contrain is not correct so it cannot be completed.
![advanced_4](https://github.com/OCA/sale-workflow/assets/62256279/3ee61455-bf71-411f-9cc2-bfbc164fc504)

This fix sorts that out, so outbound advanced payments are checked differently to inbound advanced payments. Whereas the inbound payments check is left untouched, the inbound payments check now makes sure that the outbound amount is not greater than the amount already paid in advanced.