### PR TITLE
[16.0][IMP]sale_order_line_menu: set no visible sections and notes in sale order lines menu

### DIFF
--- a/sale_order_line_menu/views/sale_order_line_views.xml
+++ b/sale_order_line_menu/views/sale_order_line_views.xml
@@ -15,6 +15,9 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">sale.order.line</field>
         <field name="view_mode">tree,pivot</field>
+        <field
+            name="domain"
+        >[('display_type', 'not in', ['line_section', 'line_note'])]</field>
     </record>
 
     <menuitem


### PR DESCRIPTION
I have found the following problem.
When an order is created and it added sections or notes, after that, the sections or notes appear in the sale order line menu:

![Captura desde 2023-05-26 13-48-25](https://github.com/OCA/sale-workflow/assets/134701949/91f4f177-c92b-4146-b44a-c65b368814ba)

With that change on sale order line act window, the problem will be reset.
