### PR TITLE
[15.0][FIX] sale_advance_payment: fixed negative amount_residual

### DIFF
--- a/sale_advance_payment/__manifest__.py
+++ b/sale_advance_payment/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Sale Advance Payment",
-    "version": "15.0.1.0.2",
+    "version": "15.0.1.0.3",
     "author": "Comunitea, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "category": "Sales",


### PR DESCRIPTION
Issue: https://github.com/OCA/sale-workflow/issues/2480


Just tried to make SO with negative zero amount residual, but with no luck. So, seeing this issue, I made some changes:
If SO is in `paid` state, `amount_residual` would be setted to zero, just to be sure, that it not change somehow to minus zero.
