### PR TITLE
[15.0][FIX] sale_elaboration: Header of table messy

### DIFF
--- a/sale_elaboration/reports/report_deliveryslip.xml
+++ b/sale_elaboration/reports/report_deliveryslip.xml
@@ -28,7 +28,7 @@
                 separator=", "
             />
         </xpath>
-        <xpath expr="//th[@name='th_sm_quantity']" position="after">
+        <xpath expr="//table[@name='stock_move_table']/thead/tr" position="after">
             <th name="th_sm_elaboration">
                 <strong>Elab.</strong>
             </th>
@@ -40,7 +40,7 @@
                 />
             </td>
         </xpath>
-        <xpath expr="//th[@name='th_sml_quantity']" position="after">
+        <xpath expr="//table[@name='stock_move_line_table']/thead/tr" position="inside">
             <th name="th_sml_elaboration">
                 <strong>Elaboration</strong>
             </th>


### PR DESCRIPTION
cc @Tecnativa TT42658

Before this patch when we print the report_deliveryslip the result is messy:
![image](https://github.com/OCA/sale-workflow/assets/35952655/ba125fb7-7a0f-40b4-aa1c-ac980370e1e8)

After ththe header is correct:
![image](https://github.com/OCA/sale-workflow/assets/35952655/7b4b2815-d8e9-45e6-8438-d14644d15521)

ping @sergio-teruel @carlosdauden 