### PR TITLE
[15.0][FW][IMP] sale_order_revision: 'New Revision' quick button on confirmed Sales Orders

### DIFF
--- a/sale_order_revision/models/sale_order.py
+++ b/sale_order_revision/models/sale_order.py
@@ -42,3 +42,11 @@ class SaleOrder(models.Model):
             "default_current_revision_id": self.id,
         }
         return action
+
+    def action_cancel_create_revision(self):
+        for sale in self:
+            sale.action_cancel()
+            action = sale.create_revision()
+        if len(self) == 1:
+            return action
+        return {}

--- a/sale_order_revision/tests/test_sale_order_revision.py
+++ b/sale_order_revision/tests/test_sale_order_revision.py
@@ -76,3 +76,9 @@ class TestSaleOrderRevision(test_base_revision.TestBaseRevision):
         sale_order_3 = sale_order_2.copy()
         # Check the 'Order Reference' of the copied Sale Order
         self.assertEqual(sale_order_3.name, sale_order_3.unrevisioned_name)
+
+    def test_action_cancel_create_revision(self):
+        sale = self._create_tester()
+        sale.action_cancel_create_revision()
+        self.assertEqual(sale.state, "cancel", "Original SO was cancelled")
+        self.assertTrue(sale.current_revision_id, "A new SO version was created")

--- a/sale_order_revision/view/sale_order.xml
+++ b/sale_order_revision/view/sale_order.xml
@@ -23,6 +23,12 @@
                     string="New Revision of Quotation"
                     type="object"
                 />
+                <button
+                    name="action_cancel_create_revision"
+                    states="sale"
+                    string="New Revision"
+                    type="object"
+                />
             </xpath>
             <xpath expr="//button[@name='action_view_invoice']" position="after">
                 <button


### PR DESCRIPTION
Forward port of https://github.com/OCA/sale-workflow/pull/2346