### PR TITLE
[13.0][ADD] sale_stock_line_sequence

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -15,7 +15,8 @@ odoo_version: 13.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
 rebel_module_groups:
-- sale_order_line_sequence
+- sale_order_line_sequence,sale_stock_line_sequence
+- sale_sourced_by_line
 repo_description: This project aim to deal with modules related to manage sale and
     their related workflow.
 repo_name: Odoo Sales, Workflow and Organization

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,18 +36,11 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.6-odoo13.0:latest
-            include: "sale_order_line_sequence"
+            include: "sale_order_line_sequence,sale_stock_line_sequence"
             makepot: "true"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.6-ocb13.0:latest
-            include: "sale_order_line_sequence"
-            name: test with OCB
-          - container: ghcr.io/oca/oca-ci/py3.6-odoo13.0:latest
-            exclude: "sale_order_line_sequence,sale_sourced_by_line"
-            makepot: "true"
-            name: test with Odoo
-          - container: ghcr.io/oca/oca-ci/py3.6-ocb13.0:latest
-            exclude: "sale_order_line_sequence,sale_sourced_by_line"
+            include: "sale_order_line_sequence,sale_stock_line_sequence"
             name: test with OCB
           - container: ghcr.io/oca/oca-ci/py3.6-odoo13.0:latest
             include: "sale_sourced_by_line"
@@ -55,6 +48,13 @@ jobs:
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.6-ocb13.0:latest
             include: "sale_sourced_by_line"
+            name: test with OCB
+          - container: ghcr.io/oca/oca-ci/py3.6-odoo13.0:latest
+            exclude: "sale_order_line_sequence,sale_stock_line_sequence,sale_sourced_by_line"
+            makepot: "true"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.6-ocb13.0:latest
+            exclude: "sale_order_line_sequence,sale_stock_line_sequence,sale_sourced_by_line"
             name: test with OCB
     services:
       postgres:

--- a/sale_stock_line_sequence/__init__.py
+++ b/sale_stock_line_sequence/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/sale_stock_line_sequence/__manifest__.py
+++ b/sale_stock_line_sequence/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2023 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Sale Stock Order Line Sequence",
+    "summary": "Glue Module for Sale Order Line Sequence and Stock Picking Line Sequence",
+    "version": "13.0.1.0.0",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "category": "Sales",
+    "website": "https://github.com/OCA/sale-workflow",
+    "license": "AGPL-3",
+    "depends": [
+        "sale_stock",
+        "sale_order_line_sequence",
+        "stock_picking_line_sequence",
+    ],
+    "data": [],
+    "installable": True,
+    "auto_install": True,
+}

--- a/sale_stock_line_sequence/models/__init__.py
+++ b/sale_stock_line_sequence/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_stock_line_sequence/models/sale_order.py
+++ b/sale_stock_line_sequence/models/sale_order.py
@@ -1,0 +1,35 @@
+# Copyright 2023 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _update_moves_sequence(self):
+        for order in self:
+            if any(
+                [
+                    ptype in ["product", "consu"]
+                    for ptype in order.order_line.mapped("product_id.type")
+                ]
+            ):
+                pickings = order.picking_ids.filtered(
+                    lambda x: x.state not in ("done", "cancel")
+                )
+                if pickings:
+                    picking = pickings[0]
+                    order_lines = order.order_line.filtered(
+                        lambda l: l.product_id.type in ["product", "consu"]
+                    )
+                    for move, line in zip(
+                        sorted(picking.move_lines, key=lambda m: m.id), order_lines
+                    ):
+                        move.write({"sequence": line.sequence})
+
+    def write(self, line_values):
+        res = super(SaleOrder, self).write(line_values)
+        if "order_line" in line_values:
+            self._update_moves_sequence()
+        return res

--- a/sale_stock_line_sequence/readme/CONTRIBUTORS.rst
+++ b/sale_stock_line_sequence/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* ForgeFlow S.L. <contact@forgeflow.com>
+    * Oriol Miranda <oriol.miranda@forgeflow.com>

--- a/sale_stock_line_sequence/readme/DESCRIPTION.rst
+++ b/sale_stock_line_sequence/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Glue module between Sale Order Line Sequence and Stock Picking Line Sequence that assigns sequence correctly to the move associated with the sale order line it references when there are sections or notes in the sale order.

--- a/sale_stock_line_sequence/tests/__init__.py
+++ b/sale_stock_line_sequence/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_line_sequence

--- a/sale_stock_line_sequence/tests/test_line_sequence.py
+++ b/sale_stock_line_sequence/tests/test_line_sequence.py
@@ -1,0 +1,105 @@
+# Copyright 2023 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestSaleOrderLineSequence(TransactionCase):
+    def setUp(self):
+        super(TestSaleOrderLineSequence, self).setUp()
+        self.sale_order = self.env["sale.order"]
+        self.sale_order_line = self.env["sale.order.line"]
+        self.partner = self.env.ref("base.res_partner_1")
+        self.product = self.env.ref("product.product_product_4")
+
+    def test_sale_order_moves_line_sequence(self):
+        """
+            Verify that the sequence is correctly assigned to the move associated
+            with the sale order line it references.
+        """
+        vals = {
+            "partner_id": self.partner.id,
+            "order_line": [
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": self.product.id,
+                        "name": self.product.name,
+                        "product_uom_qty": 1.0,
+                        "price_unit": self.product.lst_price,
+                    },
+                ),
+                (0, 0, {"name": "Section 1", "display_type": "line_section"},),
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": self.product.id,
+                        "name": self.product.name,
+                        "product_uom_qty": 5.0,
+                        "price_unit": self.product.lst_price,
+                    },
+                ),
+                (0, 0, {"name": "Note 1", "display_type": "line_note"},),
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": self.product.id,
+                        "name": self.product.name,
+                        "product_uom_qty": 15.0,
+                        "price_unit": self.product.lst_price,
+                    },
+                ),
+            ],
+        }
+        so = self.sale_order.create(vals)
+        so.action_confirm()
+
+        moves = so.picking_ids[0].move_ids_without_package
+        self.assertNotEquals(len(so.order_line), len(moves))
+
+        for move in moves:
+            self.assertEqual(move.sequence, move.sale_line_id.sequence)
+
+    def test_write_purchase_order_line(self):
+        vals = {
+            "partner_id": self.partner.id,
+            "order_line": [
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": self.product.id,
+                        "name": self.product.name,
+                        "product_uom_qty": 1.0,
+                        "price_unit": self.product.lst_price,
+                    },
+                ),
+            ],
+        }
+        so = self.sale_order.create(vals)
+        so.action_confirm()
+
+        so.write(
+            {
+                "order_line": [
+                    (0, 0, {"name": "Note 1", "display_type": "line_note"}),
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "name": self.product.name,
+                            "product_uom_qty": 5.0,
+                            "price_unit": self.product.lst_price,
+                        },
+                    ),
+                ]
+            }
+        )
+
+        moves = so.picking_ids[0].move_ids_without_package
+        for move in moves:
+            self.assertEqual(move.sequence, move.sale_line_id.sequence)

--- a/setup/sale_stock_line_sequence/odoo/addons/sale_stock_line_sequence
+++ b/setup/sale_stock_line_sequence/odoo/addons/sale_stock_line_sequence
@@ -1,0 +1,1 @@
+../../../../sale_stock_line_sequence

--- a/setup/sale_stock_line_sequence/setup.py
+++ b/setup/sale_stock_line_sequence/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Glue module between Sale Order Line Sequence and Stock Picking Line Sequence.

Assigns sequence correctly to the move associated with the sale order line it references when there are sections or notes in the sale order.