### PR TITLE
[16.0][FIX] sale_tier_validation: Sales order states in tier validation: Port PR 2549 from 15.0 to 16.0

### DIFF
--- a/sale_tier_validation/models/sale_order.py
+++ b/sale_tier_validation/models/sale_order.py
@@ -7,8 +7,8 @@ from odoo import models
 class SaleOrder(models.Model):
     _name = "sale.order"
     _inherit = ["sale.order", "tier.validation"]
-    _state_from = ["draft", "sent", "to approve"]
-    _state_to = ["sale", "approved"]
+    _state_from = ["draft", "sent"]
+    _state_to = ["sale", "done"]
 
     _tier_validation_manual_config = False
 


### PR DESCRIPTION
Forward port of https://github.com/OCA/sale-workflow/pull/2549.