### PR TITLE
[16.0][FIX] sale_order_revision unit tests adapted to base_revision

### DIFF
--- a/sale_order_revision/tests/test_sale_order_revision.py
+++ b/sale_order_revision/tests/test_sale_order_revision.py
@@ -1,8 +1,6 @@
 # Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
-from odoo.tests import Form
-
 from odoo.addons.base_revision.tests import test_base_revision
 
 
@@ -14,12 +12,15 @@ class TestSaleOrderRevision(test_base_revision.TestBaseRevision):
         cls.partner = cls.env["res.partner"].create({"name": "Mr Odoo"})
         cls.product = cls.env["product.product"].create({"name": "Test product"})
 
-    def _create_tester(self):
-        sale_form = Form(self.revision_model)
-        sale_form.partner_id = self.partner
-        with sale_form.order_line.new() as line_form:
-            line_form.product_id = self.product
-        return sale_form.save()
+    def _create_tester(self, vals_list=None):
+        if not vals_list:
+            vals_list = [{}]
+        for vals in vals_list:
+            if "partner_id" not in vals:
+                vals["partner_id"] = self.partner.id
+            if "order_line" not in vals:
+                vals["order_line"] = [(0, 0, {"product_id": self.product.id})]
+        return super()._create_tester(vals_list)
 
     @staticmethod
     def _revision_sale_order(sale_order):
@@ -64,15 +65,3 @@ class TestSaleOrderRevision(test_base_revision.TestBaseRevision):
         self.assertEqual(revision_2.revision_number, 2)
         self.assertEqual(revision_2.name.endswith("-02"), True)
         self.assertEqual(revision_2.has_old_revisions, True)
-
-    def test_simple_copy(self):
-        """Check copy process"""
-        # Create a Sale Order
-        sale_order_2 = self._create_tester()
-        # Check the 'Order Reference' of the Sale Order
-        self.assertEqual(sale_order_2.name, sale_order_2.unrevisioned_name)
-
-        # Copy the Sale Order
-        sale_order_3 = sale_order_2.copy()
-        # Check the 'Order Reference' of the copied Sale Order
-        self.assertEqual(sale_order_3.name, sale_order_3.unrevisioned_name)


### PR DESCRIPTION
Unfortunately this https://github.com/OCA/server-ux/pull/672 breaks one unit test.

requires https://github.com/OCA/server-ux/pull/698