### PR TITLE
[15.0][FIX] sale_order_revision: Users can access the smart button Prev. revision

### DIFF
--- a/sale_order_revision/models/sale_order.py
+++ b/sale_order_revision/models/sale_order.py
@@ -34,12 +34,11 @@ class SaleOrder(models.Model):
 
     def action_view_revisions(self):
         self.ensure_one()
-        action = self.env.ref("sale.action_orders")
-        result = action.read()[0]
-        result["domain"] = ["|", ("active", "=", False), ("active", "=", True)]
-        result["context"] = {
+        action = self.env["ir.actions.act_window"]._for_xml_id("sale.action_orders")
+        action["domain"] = ["|", ("active", "=", False), ("active", "=", True)]
+        action["context"] = {
             "active_test": 0,
             "search_default_current_revision_id": self.id,
             "default_current_revision_id": self.id,
         }
-        return result
+        return action


### PR DESCRIPTION
Fix the error when another user clicks the smart button Prev. revision on sale.order view.

![Selection_116](https://github.com/OCA/sale-workflow/assets/51266019/aa46187a-4a00-4b86-b98b-7be4c6456403)
