### PR TITLE
[16.0][IMP]sale_order_line_menu: set no visible sale order line menu …

### DIFF
--- a/sale_order_line_menu/views/sale_order_line_views.xml
+++ b/sale_order_line_menu/views/sale_order_line_views.xml
@@ -25,6 +25,7 @@
         name="Order Lines"
         action="action_orders_lines"
         parent="sale.sale_order_menu"
+        groups="sales_team.group_sale_salesman"
         sequence="21"
     />
 


### PR DESCRIPTION
I have found the following problem.
If you do not have any permission on Sales in the Settings > Users & Companies > Sales, you are able to watch the sale order line menu and the different lines inside it. 
![Captura desde 2023-07-26 11-47-56](https://github.com/OCA/sale-workflow/assets/134701949/e3d07dfa-7f7f-4c83-a8b9-30657c9e7ec5)
![Captura desde 2023-07-26 11-49-01](https://github.com/OCA/sale-workflow/assets/134701949/62db5329-b7a2-4e4c-93ce-37cf72b587c8)
With this change, the problem will be reset