### PR TITLE
[14.0] sale_quotation_number: fix company sequence lookup

### DIFF
--- a/sale_quotation_number/models/sale_order.py
+++ b/sale_quotation_number/models/sale_order.py
@@ -13,7 +13,12 @@ class SaleOrder(models.Model):
     @api.model
     def create(self, vals):
         if self.is_using_quotation_number(vals):
-            sequence = self.env["ir.sequence"].next_by_code("sale.quotation")
+            company_id = vals.get("company_id", self.env.company.id)
+            sequence = (
+                self.with_company(company_id)
+                .env["ir.sequence"]
+                .next_by_code("sale.quotation")
+            )
             vals["name"] = sequence or "/"
         return super(SaleOrder, self).create(vals)
 
@@ -46,6 +51,10 @@ class SaleOrder(models.Model):
                 quo = order.origin + ", " + order.name
             else:
                 quo = order.name
-            sequence = self.env["ir.sequence"].next_by_code("sale.order")
+            sequence = (
+                self.with_company(order.company_id.id)
+                .env["ir.sequence"]
+                .next_by_code("sale.order")
+            )
             order.write({"origin": quo, "name": sequence})
         return super().action_confirm()

--- a/sale_quotation_number/tests/test_sale_order.py
+++ b/sale_quotation_number/tests/test_sale_order.py
@@ -2,15 +2,28 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import UserError
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import SavepointCase
 
 
-class TestSaleOrder(TransactionCase):
-    def setUp(self, *args, **kwargs):
-        super(TestSaleOrder, self).setUp()
-        self.sale_order_model = self.env["sale.order"]
-        company = self.env.company
+class TestSaleOrder(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.sale_order_model = cls.env["sale.order"]
+        company = cls.env.company
         company.keep_name_so = False
+        cls.company1 = cls.env["res.company"].create(
+            {"name": "Test Company 1", "keep_name_so": False}
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "Test Partner"})
+        cls.order_company1 = cls.env["sale.order"].create(
+            {
+                "name": "SQ/2023/001",
+                "partner_id": cls.partner.id,
+                "company_id": cls.company1.id,
+            }
+        )
 
     def test_enumeration(self):
         order1 = self.sale_order_model.create(
@@ -84,3 +97,14 @@ class TestSaleOrder(TransactionCase):
         # Now the SQ can be confirmed
         order.action_confirm()
         self.assertEqual(next_name, order.name)
+
+    def test_sequence_assignment(self):
+        sequence_id = self.env["ir.sequence"].search(
+            [
+                ("code", "=", "sale.order"),
+                ("company_id", "in", [self.order_company1.company_id.id, False]),
+            ]
+        )
+        next_name = sequence_id.get_next_char(sequence_id.number_next_actual)
+        self.order_company1.action_confirm()
+        self.assertEqual(next_name, self.order_company1.name)


### PR DESCRIPTION
This PR is to fix a not completely correct behavior of this module in a multicompany context. 

Example: we have three companies active in the drop-down menu on the right (A, B and C) and the active one is A. So,  `self.env.company` is A. 
Sales --> Quotations --> Create. 

I can create a quotation with company_id = B. 
When i save, the module calculates the sequence calling `next_by_code` but, if not explicitly stated, the company considered is `self.env.company`, so A. 

In this case, i have a Quotation with company B but with the sequence of company A, which is wrong. 

The same happens when I confirm a quotation of company B. 