### PR TITLE
[15.0][IMP] sale_order_line_menu: Added invoice lines in tree view

### DIFF
--- a/sale_order_line_menu/readme/CONTRIBUTORS.rst
+++ b/sale_order_line_menu/readme/CONTRIBUTORS.rst
@@ -6,3 +6,5 @@
 * `Moduon Team <https://moduon.team>`:
 
   * Eduardo de Miguel <edu@moduon.team>
+  * Rafael Blasco <rafaelbn@moduon.team>
+  * Emilio Pascual <emilio@moduon.team>

--- a/sale_order_line_menu/views/sale_order_line_views.xml
+++ b/sale_order_line_menu/views/sale_order_line_views.xml
@@ -63,6 +63,15 @@
             <xpath expr="//field[@name='name']" position="attributes">
                 <attribute name="optional">show</attribute>
             </xpath>
+            <xpath expr="//tree" position="inside">
+                <field
+                    name="invoice_lines"
+                    widget="many2many_tags"
+                    groups="account.group_account_invoice"
+                    optional="hide"
+                    domain="[('move_id.partner_id', 'child_of', parent.parent_partner_id), ('sale_line_ids', 'not in', parent.order_line), ('exclude_from_invoice_tab', '=', False), ('move_id.move_type', 'in', ('out_invoice', 'out_refund', 'out_receipt'))]"
+                />
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Added invoice lines in tree view

@moduon MT-2028

![image](https://github.com/OCA/sale-workflow/assets/53056345/25d8b3ed-67ed-4a77-9ba3-f9a8406cd861)

![image](https://github.com/OCA/sale-workflow/assets/53056345/bee608a9-4e9b-4efa-b7be-1e5f6f89d084)
