### PR TITLE
[16.0][IMP] sale_automatic_workflow: add send invoice option

### DIFF
--- a/sale_automatic_workflow/README.rst
+++ b/sale_automatic_workflow/README.rst
@@ -89,6 +89,7 @@ Contributors
 * Akim Juillerat <akim.juillerat@camptocamp.com>
 * Thomas Fossoul <thomas@niboo.com>
 * Phuc Tran Thanh <phuc@trobz.com>
+* John Herholz <j.longneck@gmail.com>
 
 Other credits
 ~~~~~~~~~~~~~

--- a/sale_automatic_workflow/data/automatic_workflow_data.xml
+++ b/sale_automatic_workflow/data/automatic_workflow_data.xml
@@ -34,6 +34,14 @@
         >[('state', '=', 'draft'), ('posted_before', '=', False)]</field>
         <field name="user_id" ref="base.user_root" />
     </record>
+    <record id="automatic_workflow_send_invoice_filter" model="ir.filters">
+        <field name="name">Automatic Workflow Send Invoice Filter</field>
+        <field name="model_id">account.move</field>
+        <field
+            name="domain"
+        >[('state', '=', 'posted'), ('is_move_sent', '=', False), ('move_type', '=', 'out_invoice')]</field>
+        <field name="user_id" ref="base.user_root" />
+    </record>
     <record id="automatic_workflow_sale_done_filter" model="ir.filters">
         <field name="name">Automatic Workflow Sale Done Filter</field>
         <field name="model_id">sale.order</field>
@@ -65,6 +73,11 @@
         <field
             name="validate_invoice_filter_id"
             eval="automatic_workflow_validate_invoice_filter"
+        />
+        <field name="send_invoice" eval="1" />
+        <field
+            name="send_invoice_filter_id"
+            eval="automatic_workflow_send_invoice_filter"
         />
         <field name="invoice_date_is_order_date" eval="0" />
         <field name="validate_picking" eval="0" />

--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -116,6 +116,52 @@ class AutomaticWorkflowJob(models.Model):
                     invoice.with_company(invoice.company_id), validate_invoice_filter
                 )
 
+    def _do_send_invoice(self, invoice, domain_filter):
+        """Validate an invoice, filter ensure no duplication"""
+        if not self.env["account.move"].search_count(
+            [("id", "=", invoice.id)] + domain_filter
+        ):
+            return "{} {} job bypassed".format(invoice.display_name, invoice)
+
+        # take the context from the actual action_invoice_sent method
+        action = invoice.action_invoice_sent()
+        action_context = action["context"]
+
+        # Create the email using the wizard
+        invoice_send_wizard = (
+            self.env["account.invoice.send"]
+            .with_context(
+                action_context,
+                mark_invoice_as_sent=True,
+                active_ids=[invoice.id],
+                force_email=True,
+            )
+            .create(
+                {
+                    "is_print": False,
+                    "composition_mode": "comment",
+                    "model": "account.move",
+                    "res_id": invoice.id,
+                }
+            )
+        )
+
+        invoice_send_wizard.onchange_is_email()
+        invoice_send_wizard._send_email()
+
+        return "{} {} sent invoice successfully".format(invoice.display_name, invoice)
+
+    @api.model
+    def _send_invoices(self, send_invoice_filter):
+        move_obj = self.env["account.move"]
+        invoices = move_obj.search(send_invoice_filter)
+        _logger.debug("Invoices to send: %s", invoices.ids)
+        for invoice in invoices:
+            with savepoint(self.env.cr):
+                self._do_send_invoice(
+                    invoice.with_company(invoice.company_id), send_invoice_filter
+                )
+
     def _do_validate_picking(self, picking, domain_filter):
         """Validate a stock.picking, filter ensure no duplication"""
         if not self.env["stock.picking"].search_count(
@@ -217,6 +263,10 @@ class AutomaticWorkflowJob(models.Model):
             self._validate_invoices(
                 safe_eval(sale_workflow.validate_invoice_filter_id.domain)
                 + workflow_domain
+            )
+        if sale_workflow.send_invoice:
+            self._send_invoices(
+                safe_eval(sale_workflow.send_invoice_filter_id.domain) + workflow_domain
             )
         if sale_workflow.sale_done:
             self._sale_done(

--- a/sale_automatic_workflow/models/sale_workflow_process.py
+++ b/sale_automatic_workflow/models/sale_workflow_process.py
@@ -53,6 +53,11 @@ class SaleWorkflowProcess(models.Model):
         string="Validate Invoice Filter Domain",
         related="validate_invoice_filter_id.domain",
     )
+    send_invoice = fields.Boolean()
+    send_invoice_filter_domain = fields.Text(
+        string="Send Invoice Filter Domain",
+        related="send_invoice_filter_id.domain",
+    )
     validate_picking = fields.Boolean(string="Confirm and Transfer Picking")
     picking_filter_domain = fields.Text(
         string="Picking Filter Domain", related="picking_filter_id.domain"
@@ -110,6 +115,13 @@ class SaleWorkflowProcess(models.Model):
         string="Validate Invoice Filter",
         default=lambda self: self._default_filter(
             "sale_automatic_workflow." "automatic_workflow_validate_invoice_filter"
+        ),
+    )
+    send_invoice_filter_id = fields.Many2one(
+        "ir.filters",
+        string="Send Invoice Filter",
+        default=lambda self: self._default_filter(
+            "sale_automatic_workflow." "automatic_workflow_send_invoice_filter"
         ),
     )
     sale_done_filter_id = fields.Many2one(

--- a/sale_automatic_workflow/readme/CONTRIBUTORS.rst
+++ b/sale_automatic_workflow/readme/CONTRIBUTORS.rst
@@ -9,3 +9,4 @@
 * Akim Juillerat <akim.juillerat@camptocamp.com>
 * Thomas Fossoul <thomas@niboo.com>
 * Phuc Tran Thanh <phuc@trobz.com>
+* John Herholz <j.longneck@gmail.com>

--- a/sale_automatic_workflow/readme/DESCRIPTION.rst
+++ b/sale_automatic_workflow/readme/DESCRIPTION.rst
@@ -15,6 +15,7 @@ A workflow can:
   * Send order confirmation mail (only when order confirmed)
   * Create an invoice
   * Validate the invoice
+  * Send the invoice via e-mail
   * Confirm the picking
 
 This module is used by Magentoerpconnect and Prestashoperpconnect.

--- a/sale_automatic_workflow/tests/common.py
+++ b/sale_automatic_workflow/tests/common.py
@@ -10,13 +10,28 @@ class TestCommon(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.user = cls.env["res.users"].create(
+            {
+                "name": "Sales Person",
+                "login": "salesperson",
+                "password": "salesperson",
+                "groups_id": [
+                    (4, cls.env.ref("sales_team.group_sale_manager").id),
+                    (4, cls.env.ref("account.group_account_manager").id),
+                ],
+            }
+        )
+        cls.user.partner_id.email = "salesperson@example.com"
 
 
 class TestAutomaticWorkflowMixin(object):
     def create_sale_order(self, workflow, override=None):
         sale_obj = self.env["sale.order"]
 
-        partner_values = {"name": "Imperator Caius Julius Caesar Divus"}
+        partner_values = {
+            "name": "Imperator Caius Julius Caesar Divus",
+            "email": "test@example.com",
+        }
         partner = self.env["res.partner"].create(partner_values)
 
         product_values = {"name": "Bread", "list_price": 5, "type": "product"}
@@ -65,6 +80,7 @@ class TestAutomaticWorkflowMixin(object):
                 "validate_picking": True,
                 "create_invoice": True,
                 "validate_invoice": True,
+                "send_invoice": True,
                 "invoice_date_is_order_date": True,
             }
         )

--- a/sale_automatic_workflow/tests/test_automatic_workflow.py
+++ b/sale_automatic_workflow/tests/test_automatic_workflow.py
@@ -1,16 +1,20 @@
 # Copyright 2014 Camptocamp SA (author: Guewen Baconnier)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+import logging
 from datetime import timedelta
 from unittest import mock
 
 from odoo import fields
 from odoo.tests import tagged
+from odoo.tools.safe_eval import safe_eval
 
 from .common import TestAutomaticWorkflowMixin, TestCommon
 
+_logger = logging.getLogger(__name__)
 
-@tagged("post_install", "-at_install")
+
+@tagged("post_install", "-at_install", "mail_composer")
 class TestAutomaticWorkflow(TestCommon, TestAutomaticWorkflowMixin):
     def setUp(self):
         super().setUp()
@@ -183,3 +187,67 @@ class TestAutomaticWorkflow(TestCommon, TestAutomaticWorkflowMixin):
                 lambda x: x.subtype_id == self.env.ref("mail.mt_comment")
             )
         )
+
+    def test_automatic_invoice_send_mail(self):
+        workflow = self.create_full_automatic()
+        workflow.send_invoice = False
+        sale = self.create_sale_order(workflow)
+        sale.user_id = self.user.id
+        sale._onchange_workflow_process_id()
+        self.run_job()
+        invoice = sale.invoice_ids
+        invoice.message_subscribe(partner_ids=[invoice.partner_id.id])
+        invoice.company_id.invoice_is_email = True
+        previous_message_ids = invoice.message_ids
+        workflow.send_invoice = True
+        sale._onchange_workflow_process_id()
+        self.run_job()
+
+        new_messages = self.env["mail.message"].search(
+            [
+                ("id", "in", invoice.message_ids.ids),
+                ("id", "not in", previous_message_ids.ids),
+            ]
+        )
+
+        self.assertTrue(
+            new_messages.filtered(
+                lambda x: x.subtype_id == self.env.ref("mail.mt_comment")
+            )
+        )
+
+    def test_job_bypassing(self):
+        workflow = self.create_full_automatic()
+        workflow_job = self.env["automatic.workflow.job"]
+        sale = self.create_sale_order(workflow)
+        sale._onchange_workflow_process_id()
+
+        create_invoice_filter = [
+            ("state", "in", ["sale", "done"]),
+            ("invoice_status", "=", "to invoice"),
+            ("workflow_process_id", "=", sale.workflow_process_id.id),
+        ]
+        order_filter = safe_eval(workflow.order_filter_id.domain)
+        validate_invoice_filter = safe_eval(workflow.validate_invoice_filter_id.domain)
+        send_invoice_filter = safe_eval(workflow.send_invoice_filter_id.domain)
+
+        # Trigger everything, then check if sale and invoice jobs are bypassed
+        self.run_job()
+
+        invoice = sale.invoice_ids
+
+        res_so_validate = workflow_job._do_validate_sale_order(sale, order_filter)
+        # TODO send confirmation bypassing is not working yet, needs fix
+        workflow_job._do_send_order_confirmation_mail(sale)
+        res_create_invoice = workflow_job._do_create_invoice(
+            sale, create_invoice_filter
+        )
+        res_validate_invoice = workflow_job._do_validate_invoice(
+            invoice, validate_invoice_filter
+        )
+        res_send_invoice = workflow_job._do_send_invoice(invoice, send_invoice_filter)
+
+        self.assertIn("job bypassed", res_so_validate)
+        self.assertIn("job bypassed", res_create_invoice)
+        self.assertIn("job bypassed", res_validate_invoice)
+        self.assertIn("job bypassed", res_send_invoice)

--- a/sale_automatic_workflow/tests/test_multicompany.py
+++ b/sale_automatic_workflow/tests/test_multicompany.py
@@ -77,20 +77,24 @@ class TestMultiCompany(TestCommon):
         cls.customer_fr = (
             cls.env["res.partner"]
             .with_context(default_company_id=cls.company_fr.id)
-            .create({"name": "Customer FR"})
+            .create({"name": "Customer FR", "email": "test_fr@example.com"})
         )
         cls.product_fr = cls.create_product({"name": "Evian bottle", "list_price": 2.0})
 
         cls.env.user.company_id = cls.company_ch.id
         coa.try_loading(company=cls.env.user.company_id)
-        cls.customer_ch = cls.env["res.partner"].create({"name": "Customer CH"})
+        cls.customer_ch = cls.env["res.partner"].create(
+            {"name": "Customer CH", "email": "test_ch@example.com"}
+        )
         cls.product_ch = cls.create_product(
             {"name": "Henniez bottle", "list_price": 3.0}
         )
 
         cls.env.user.company_id = cls.company_be.id
         coa.try_loading(company=cls.env.user.company_id)
-        cls.customer_be = cls.env["res.partner"].create({"name": "Customer BE"})
+        cls.customer_be = cls.env["res.partner"].create(
+            {"name": "Customer BE", "email": "test_be@example.com"}
+        )
         cls.product_be = (
             cls.env["product.template"]
             .create(
@@ -107,7 +111,7 @@ class TestMultiCompany(TestCommon):
         cls.env.user.company_id = cls.company_fr_daughter.id
         coa.try_loading(company=cls.env.user.company_id)
         cls.customer_fr_daughter = cls.env["res.partner"].create(
-            {"name": "Customer FR Daughter"}
+            {"name": "Customer FR Daughter", "email": "test_daughter_fr@example.com"}
         )
         cls.product_fr_daughter = cls.create_product(
             {"name": "Contrex bottle", "list_price": 1.5}

--- a/sale_automatic_workflow/views/sale_workflow_process_view.xml
+++ b/sale_automatic_workflow/views/sale_workflow_process_view.xml
@@ -204,6 +204,42 @@
                         <div class="row">
                             <div class="col-sm-4">
                                 <label
+                                    for="send_invoice"
+                                    class="col-lg-7 o_light_label"
+                                />
+                                <field name="send_invoice" nolabel="1" />
+                            </div>
+                            <div class="col-sm-8">
+                                <label
+                                    for="send_invoice_filter_id"
+                                    attrs="{'required':[('send_invoice','=',True)], 'invisible':[('send_invoice','!=',True)]}"
+                                />
+                                <div
+                                    attrs="{'required':[('send_invoice','=',True)], 'invisible':[('send_invoice','!=',True)]}"
+                                >
+                                    <field
+                                        name="send_invoice_filter_domain"
+                                        widget="domain"
+                                        attrs="{'invisible': [('send_invoice_filter_id', '=', False)]}"
+                                        options="{'model': 'account.move'}"
+                                    />
+                                    <div class="oe_edit_only oe_inline">
+                                        Set selection based on a search filter:
+                                        <field
+                                            name="send_invoice_filter_id"
+                                            domain="[('model_id', '=', 'account.move')]"
+                                            class="oe_inline"
+                                            context="{'default_model_id': 'account.move', 'default_active': False, 'active_test': False}"
+                                            can_create="true"
+                                            can_write="true"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-sm-4">
+                                <label
                                     for="register_payment"
                                     class="col-lg-7 o_light_label"
                                 />


### PR DESCRIPTION
This PR adds another checkbox to workflows in order to send invoices automatically to customers.

This solves issue [2640](https://github.com/OCA/sale-workflow/issues/2640)

Added additional tests for job bypassing to get code coverage.
(Check if workflow process doesn't trigger the same records multiple times)

Setup:
- Install module
- Create a sale workflow
- Check "Send invoice"
- The default filter already checks for invoices that are not sent, you can change the filter to your needs
- Create sale order with this workflow
- Create invoice or let it be created from your workflow, validate it.
- The invoice will be sent during next workflow job execution