### PR TITLE
[16.0][IMP] sale_triple_discount: Compute amount with decimal precision of 16

### DIFF
--- a/sale_triple_discount/models/sale_order_line.py
+++ b/sale_triple_discount/models/sale_order_line.py
@@ -107,6 +107,8 @@ class SaleOrderLine(models.Model):
         # to invalidate the cache to avoid to flush the records to the database.
         # This is safe because we are going to restore the original value at the end
         # of the method.
+        digits = discount_field._digits
+        self.env["sale.order.line"]._fields["discount"]._digits = (16, 16)
         with self.env.protecting([discount_field], self):
             old_values = {}
             for line in self:
@@ -120,6 +122,7 @@ class SaleOrderLine(models.Model):
                 line.with_context(
                     restoring_triple_discount=True,
                 ).update({"discount": old_values[line.id]})
+            self.env["sale.order.line"]._fields["discount"]._digits = digits
 
     def _convert_to_tax_base_line_dict(self):
         self.ensure_one()

--- a/sale_triple_discount/tests/test_sale_triple_discount.py
+++ b/sale_triple_discount/tests/test_sale_triple_discount.py
@@ -208,3 +208,11 @@ class TestSaleOrder(common.TransactionCase):
         self.assertAlmostEqual(self.so_line2.price_subtotal, 600.0)
         self.assertAlmostEqual(self.order.amount_untaxed, 1200.0)
         self.assertAlmostEqual(self.order.amount_tax, 180.0)
+
+    def test_07_discount_16_digits(self):
+        self.so_line1.product_uom_qty = 2.0
+        self.so_line1.price_unit = 138.0
+        self.so_line1.discount = 45.0
+        self.so_line1.discount2 = 5.0
+        self.so_line1.discount3 = 10.0
+        self.assertAlmostEqual(self.so_line1.price_subtotal, 129.79)


### PR DESCRIPTION
- Force the calculation to be with full decimal precision, this is equivalent to the current computation in invoices
https://github.com/OCA/account-invoicing/blob/d2e12c03b50011bb788cf482346710f0fefe0de3/account_invoice_triple_discount/models/account_move_line.py#L73-L74