### PR TITLE
[14.0][FIX] sale_order_line_chained_move: Fix infinite recursion

### DIFF
--- a/sale_order_line_chained_move/hooks.py
+++ b/sale_order_line_chained_move/hooks.py
@@ -3,11 +3,13 @@
 from odoo import SUPERUSER_ID, api
 
 
-def __find_origin_moves(moves):
+def __find_origin_moves(moves, visited=None):
     all_moves = moves
-    for move in moves:
+    unvisited_moves = (moves - visited) if visited else moves
+    for move in unvisited_moves:
+        visited = visited + move if visited else move
         if move.move_orig_ids:
-            all_moves |= __find_origin_moves(move.move_orig_ids)
+            all_moves |= __find_origin_moves(move.move_orig_ids, visited)
     return all_moves
 
 


### PR DESCRIPTION
The `__find_origin_moves` function doesn't take into account loops in the chains of origin moves.  Fix this by adding a "visited" record set which will make sure that any move that has already be expanded won't be processed again.

This will allow updating the modules (`odoo-bin -u all`) even when there is existing data which has cycles in their origin graph.  The error for that case looked like this:

    INFO odoo odoo.modules.loading: Loading module sale_order_line_chained_move (185/225)
    INFO odoo odoo.modules.registry: module sale_order_line_chained_move: creating or updating database tables
    WARNING odoo odoo.modules.loading: Transient module states were reset
    ERROR odoo odoo.modules.registry: Failed to load registry
    CRITICAL odoo odoo.service.server: Failed to initialize database `odoo`.
    Traceback (most recent call last):
      File ".../odoo/odoo/service/server.py", line 1201, in preload_registries
        registry = Registry.new(dbname, update_module=update_module)
      File ".../odoo/odoo/modules/registry.py", line 89, in new
        odoo.modules.load_modules(registry._db, force_demo, status, update_module)
      File ".../odoo/odoo/modules/loading.py", line 459, in load_modules
        processed_modules += load_marked_modules(cr, graph,
      File ".../odoo/odoo/modules/loading.py", line 347, in load_marked_modules
        loaded, processed = load_module_graph(
      File ".../odoo/odoo/modules/loading.py", line 240, in load_module_graph
        getattr(py_module, post_init)(cr, registry)
      File ".../thirdparty/odoo/addons/sale_order_line_chained_move/hooks.py", line 32, in post_init_hook
        _fill_in_related_sale_line(env)
      File ".../thirdparty/odoo/addons/sale_order_line_chained_move/hooks.py", line 26, in _fill_in_related_sale_line
        __fill_related(move.move_orig_ids, move.sale_line_id)
      File ".../thirdparty/odoo/addons/sale_order_line_chained_move/hooks.py", line 18, in __fill_related
        moves_to_write |= __find_origin_moves(move.move_orig_ids)
      File ".../thirdparty/odoo/addons/sale_order_line_chained_move/hooks.py", line 10, in __find_origin_moves
        all_moves |= __find_origin_moves(move.move_orig_ids)
      File ".../thirdparty/odoo/addons/sale_order_line_chained_move/hooks.py", line 10, in __find_origin_moves
        all_moves |= __find_origin_moves(move.move_orig_ids)
      File ".../thirdparty/odoo/addons/sale_order_line_chained_move/hooks.py", line 10, in __find_origin_moves
        all_moves |= __find_origin_moves(move.move_orig_ids)
      [Previous line repeated 978 more times]
      File ".../thirdparty/odoo/addons/sale_order_line_chained_move/hooks.py", line 9, in __find_origin_moves
        if move.move_orig_ids:
      File ".../odoo/odoo/fields.py", line 2495, in __get__
        return super().__get__(records, owner)
      File ".../odoo/odoo/fields.py", line 1083, in __get__
        return self.convert_to_record(value, record)
      File ".../odoo/odoo/fields.py", line 2963, in convert_to_record
        prefetch_ids = IterableGenerator(prefetch_x2many_ids, record, self)
    RecursionError: maximum recursion depth exceeded

This is cherry-picked from 0b95c169c4841 / GitHub PR #2638.