### PR TITLE
[16.0][FIX]sale_exception: upsell error

### DIFF
--- a/sale_exception/models/sale_order.py
+++ b/sale_exception/models/sale_order.py
@@ -16,6 +16,8 @@ class SaleOrder(models.Model):
         return "sale_ids"
 
     def detect_exceptions(self):
+        if self.subscription_management == "upsell":
+            return False
         all_exceptions = super().detect_exceptions()
         lines = self.mapped("order_line")
         all_exceptions += lines.detect_exceptions()


### PR DESCRIPTION
When an upsell (subscription) is confirmed, the sale exception arises, but due to the subscription's action_confirm it updates the parent sale order lines even if the exception is not ignored.
Furthermore, if the upsell is confirmed, the subscription lines are updated again. It is thought that if a subscription is in progress an upsell could be done.