### PR TITLE
[IMP] sale_stock_picking_blocking: auto-done use case with delivery blocking

### DIFF
--- a/sale_stock_picking_blocking/README.rst
+++ b/sale_stock_picking_blocking/README.rst
@@ -98,6 +98,7 @@ Contributors
 * Lois Rilo <lois.rilo@forgeflow.com>
 * Sudhir Arya <sudhir@erpharbor.com>
 * Julien Coux <julien.coux@camptocamp.com>
+* Souheil Bejaoui <souheil.bejaoui@acsone.eu>
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_stock_picking_blocking/models/sale_order.py
+++ b/sale_stock_picking_blocking/models/sale_order.py
@@ -17,6 +17,11 @@ class SaleOrder(models.Model):
         states={"draft": [("readonly", False)], "sent": [("readonly", False)]},
     )
 
+    def action_done(self):
+        return super(
+            SaleOrder, self.filtered(lambda s: not s.delivery_block_id)
+        ).action_done()
+
     @api.depends("partner_id", "payment_term_id")
     def _compute_delivery_block_id(self):
         """Add the 'Default Delivery Block Reason' if set in the partner
@@ -36,6 +41,8 @@ class SaleOrder(models.Model):
         )
         order_to_unblock.write({"delivery_block_id": False})
         order_to_unblock.order_line._action_launch_stock_rule()
+        if self.user_has_groups("sale.group_auto_done_setting"):
+            order_to_unblock.action_done()
         return True
 
     @api.returns("self", lambda value: value.id)

--- a/sale_stock_picking_blocking/readme/CONTRIBUTORS.rst
+++ b/sale_stock_picking_blocking/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Lois Rilo <lois.rilo@forgeflow.com>
 * Sudhir Arya <sudhir@erpharbor.com>
 * Julien Coux <julien.coux@camptocamp.com>
+* Souheil Bejaoui <souheil.bejaoui@acsone.eu>

--- a/sale_stock_picking_blocking/static/description/index.html
+++ b/sale_stock_picking_blocking/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -445,12 +446,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
 <li>Sudhir Arya &lt;<a class="reference external" href="mailto:sudhir&#64;erpharbor.com">sudhir&#64;erpharbor.com</a>&gt;</li>
 <li>Julien Coux &lt;<a class="reference external" href="mailto:julien.coux&#64;camptocamp.com">julien.coux&#64;camptocamp.com</a>&gt;</li>
+<li>Souheil Bejaoui &lt;<a class="reference external" href="mailto:souheil.bejaoui&#64;acsone.eu">souheil.bejaoui&#64;acsone.eu</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_stock_picking_blocking/tests/test_sale_stock_picking_blocking.py
+++ b/sale_stock_picking_blocking/tests/test_sale_stock_picking_blocking.py
@@ -49,6 +49,40 @@ class TestSaleDeliveryBlock(common.TransactionCase):
         }
         cls.sale_order_line = cls.sol_model.with_user(cls.user_test).create(sol_dict)
 
+    def test_block_with_auto_done_enabled(self):
+        # Set active auto done configuration
+        config = self.env["res.config.settings"].create(
+            {"group_auto_done_setting": True}
+        )
+        config.execute()
+        block_reason = self.block_model.with_user(self.user_test).create(
+            {"name": "Test Block."}
+        )
+        so = self.sale_order
+        so.write({"delivery_block_id": block_reason.id})
+        so.action_confirm()
+        self.assertEqual(so.state, "sale")
+        self._picking_comp(so)
+        pick = self._picking_comp(so)
+        self.assertEqual(pick, 0, "The delivery should have been blocked")
+        # Remove block
+        so.action_remove_delivery_block()
+        pick = self._picking_comp(so)
+        self.assertNotEqual(pick, 0, "A delivery should have been made")
+        self.assertEqual(so.state, "done")
+
+    def test_no_block_with_auto_done_enabled(self):
+        """Tests if normal behaviour without block."""
+        config = self.env["res.config.settings"].create(
+            {"group_auto_done_setting": True}
+        )
+        config.execute()
+        so = self.sale_order
+        so.action_confirm()
+        pick = self._picking_comp(so)
+        self.assertNotEqual(pick, 0, "A delivery should have been made")
+        self.assertEqual(so.state, "done")
+
     def _picking_comp(self, so):
         """count created pickings"""
         count = len(so.picking_ids)


### PR DESCRIPTION
Instead of forbidding the auto-done process with delivery blocking, this workaround allows orders that should be blocked to remain in the confirmed state and be set to 'done' when the block is removed by the user.