### PR TITLE
[IMP] pricelist_cache: use property field ondemand

### DIFF
--- a/pricelist_cache/models/res_partner.py
+++ b/pricelist_cache/models/res_partner.py
@@ -7,10 +7,6 @@ from odoo import _, exceptions, fields, models
 class Partner(models.Model):
     _inherit = "res.partner"
 
-    is_pricelist_cache_available = fields.Boolean(
-        related="property_product_pricelist.is_pricelist_cache_available"
-    )
-
     def _default_pricelist_cache_product_filter_id(self):
         # When the module is installed, Odoo creates the new field and at the
         # same time tries to set the default value for all existing records in
@@ -30,7 +26,7 @@ class Partner(models.Model):
     )
 
     def _pricelist_cache_get_prices(self):
-        if not self.is_pricelist_cache_available:
+        if not self.property_product_pricelist.is_pricelist_cache_available:
             raise exceptions.UserError(_("Pricelist caching in progress. Retry later"))
         pricelist = self._pricelist_cache_get_pricelist()
         products = self._pricelist_cache_get_products()


### PR DESCRIPTION
avoids searching partners based on property field
when updating product pricelist cache

####
Currently, the flow regarding this PR is:
1) calling PricelistCache:update_product_pricelist_cache
-> pricelist.is_pricelist_cache_computed = True
2) Pricelist:_compute_is_pricelist_cache_available (depends-triggered)
3) Partner:is_pricelist_cache_available is related field to what is computed in 2)

To populate the self.env.all.tocompute, models.py:_modified_triggers tries to find the partners, which are associated with the (updated) pricelist.

In a use case with one+ million contacts, on the tested system this partner search takes ~10min for each PricelistCache:update_product_pricelist_cache. Likely because the related field traverses property_product_pricelist.
Without this field (and partner search), PricelistCache:update_product_pricelist_cache takes ~1s.

Scanning the code, I can only find Partner.is_pricelist_cache_available being used in _pricelist_cache_get_prices. This implicitely expects self.ensure_one() from reading the first condition. Would it be fine then to resolve property_product_pricelist there?