### PR TITLE
[16.0] sale_quotation_number: fix company sequence lookup

### DIFF
--- a/sale_quotation_number/models/sale_order.py
+++ b/sale_quotation_number/models/sale_order.py
@@ -14,7 +14,12 @@ class SaleOrder(models.Model):
     def create(self, vals_list):
         for vals in vals_list:
             if self.is_using_quotation_number(vals):
-                sequence = self.env["ir.sequence"].next_by_code("sale.quotation")
+                company_id = vals.get("company_id", self.env.company.id)
+                sequence = (
+                    self.with_company(company_id)
+                    .env["ir.sequence"]
+                    .next_by_code("sale.quotation")
+                )
                 vals["name"] = sequence or "/"
         return super().create(vals_list)
 
@@ -47,6 +52,10 @@ class SaleOrder(models.Model):
                 quo = order.origin + ", " + order.name
             else:
                 quo = order.name
-            sequence = self.env["ir.sequence"].next_by_code("sale.order")
+            sequence = (
+                self.with_company(order.company_id.id)
+                .env["ir.sequence"]
+                .next_by_code("sale.order")
+            )
             order.write({"origin": quo, "name": sequence})
         return super().action_confirm()


### PR DESCRIPTION
Ported commit from this [PR](https://github.com/OCA/sale-workflow/pull/2625)

Message from it:

> This PR is to fix a not completely correct behavior of this module in a multicompany context.
> 
> Example: we have three companies active in the drop-down menu on the right (A, B and C) and the active one is A. So, self.env.company is A.
> Sales --> Quotations --> Create.
> 
> I can create a quotation with company_id = B.
> When i save, the module calculates the sequence calling next_by_code but, if not explicitly stated, the company considered is self.env.company, so A.
> 
> In this case, i have a Quotation with company B but with the sequence of company A, which is wrong.
> 
> The same happens when I confirm a quotation of company B.