### PR TITLE
[15.0][IMP]sale_quotation_number: Boolean to determine whether quotation sequence has been used

### DIFF
--- a/sale_quotation_number/__manifest__.py
+++ b/sale_quotation_number/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Sale Quotation Numeration",
     "summary": "Different sequence for sale quotations",
-    "version": "15.0.1.0.1",
+    "version": "15.0.1.0.2",
     "category": "Sales Management",
     "website": "https://github.com/OCA/sale-workflow",
     "author": "Elico Corp, "

--- a/sale_quotation_number/migrations/15.0.1.0.2/post-migration.py
+++ b/sale_quotation_number/migrations/15.0.1.0.2/post-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2023 Manuel Regidor  <manuel.regidor@sygel.es> (Sygel)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+import odoo
+
+
+def migrate(cr, version):
+    env = odoo.api.Environment(cr, odoo.SUPERUSER_ID, {})
+    orders = (
+        env["sale.order"]
+        .search(
+            [
+                ("state", "in", ["draft", "sent"]),
+                ("company_id.keep_name_so", "=", False),
+            ]
+        )
+        .filtered(lambda a: a.name[:2] == "SQ")
+    )
+    orders.write({"quotation_seq_used": True})


### PR DESCRIPTION
With the current module, the sale order number is only changed from the quotation sequence to the sale order sequence if the first two first characters of the sale order number in draft state are "SQ", which is the default prefix. If this sequence is edited, the sale order number in quotation state will be kept when the sale order is validated and it will not use the sequence for validated sale orders.

Solution: a boolean field has been added to sale orders to indicate whether the quotation sequence has been used. This field is set to True when a new sale order is created and will return to False when the sale order is validated. When the sale order is validated, it will be checked whether the used sequence is the quotation sequence using this new field. If so, the sale order number will be changed. With this solution, the change of the number will be applied no matter what is the sequence configuration. It would also be interesting to add a field to res.company to set the sale quotation sequence that has to be used.