### PR TITLE
[14.0] [IMP] sale_order_product_assortment: Check products on write and create

### DIFF
--- a/sale_order_product_assortment/models/sale_order.py
+++ b/sale_order_product_assortment/models/sale_order.py
@@ -1,6 +1,7 @@
 # Copyright 2020 Tecnativa - Carlos Roca
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class SaleOrder(models.Model):
@@ -37,3 +38,31 @@ class SaleOrder(models.Model):
                     )
             if self.allowed_product_ids:
                 self.has_allowed_products = True
+
+    @api.onchange("partner_id", "partner_shipping_id", "partner_invoice_id")
+    def _onchange_partner_id(self):
+        """
+        Check if all the products in the order lines
+        contains products that are allowed for the partner
+        """
+        for order in self:
+            if order.has_allowed_products:
+                product_ids = order.order_line.mapped("product_id")
+                products_set = set(product_ids.ids)
+                allowed_products_set = set(order.allowed_product_ids.ids)
+                if not products_set <= allowed_products_set:
+                    products_not_allowed_set = products_set - allowed_products_set
+                    raise UserError(
+                        _(
+                            "This SO contains one or more products "
+                            "that are not allowed for partner %s:\n- %s"
+                        )
+                        % (
+                            order.partner_id.name,
+                            "\n- ".join(
+                                self.env["product.product"]
+                                .browse(products_not_allowed_set)
+                                .mapped("name")
+                            ),
+                        )
+                    )

--- a/sale_order_product_assortment/readme/CONTRIBUTORS.rst
+++ b/sale_order_product_assortment/readme/CONTRIBUTORS.rst
@@ -5,3 +5,5 @@
 * `Ooops404 <https://www.ooops404.com>`_:
 
   * Ilyas
+
+* PyTech SRL <info@pytech.it>

--- a/sale_order_product_assortment/tests/test_sale_order_product_assortment.py
+++ b/sale_order_product_assortment/tests/test_sale_order_product_assortment.py
@@ -1,7 +1,8 @@
 # Copyright 2020 Tecnativa - Carlos Roca
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase
+from odoo.exceptions import UserError
+from odoo.tests.common import Form, TransactionCase
 
 
 class TestProductAssortment(TransactionCase):
@@ -26,8 +27,21 @@ class TestProductAssortment(TransactionCase):
                 "whitelist_product_ids": [(4, product_1.id)],
             }
         )
-        sale_order_1 = self.sale_order_obj.create({"partner_id": self.partner_1.id})
-        self.assertEquals(
+        sale_order_1 = self.sale_order_obj.create(
+            {
+                "partner_id": self.partner_1.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product_1.id,
+                        },
+                    )
+                ],
+            }
+        )
+        self.assertEqual(
             sale_order_1.allowed_product_ids,
             assortment_with_whitelist.whitelist_product_ids,
         )
@@ -43,9 +57,32 @@ class TestProductAssortment(TransactionCase):
                 "partner_domain": "[('id', '=', %s)]" % self.partner_2.id,
             }
         )
-        sale_order_2 = self.sale_order_obj.create({"partner_id": self.partner_1.id})
+        sale_order_2 = self.sale_order_obj.create(
+            {
+                "partner_id": self.partner_1.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product_1.id,
+                        },
+                    )
+                ],
+            }
+        )
         self.assertNotIn(product_2, sale_order_2.allowed_product_ids)
         self.assertTrue(sale_order_2.has_allowed_products)
         sale_order_3 = self.sale_order_obj.create({"partner_id": self.partner_2.id})
         self.assertTrue(sale_order_3.has_allowed_products)
         self.assertNotIn(product_2, sale_order_3.allowed_product_ids)
+
+        so = Form(self.env["sale.order"])
+        with so.order_line.new() as line:
+            line.product_id = product_2
+
+        # Changing the partner while having an order line
+        # with a product that doesn't belong to the partner
+        # should raise an error
+        with self.assertRaises(UserError):
+            so.partner_id = self.partner_1


### PR DESCRIPTION
This PR aims to fix the following scenario:

- create assortment 1, allowed product: Product 1, allowed partner: Partner 1
- create assortment 2, allowed product: Product 2, allowed partner: Partner 2

Create SO, select partner 1, add product 1 to SOL > change partner to Partner 2 > save

With these changes if there are products that are not allowed by the assortment, it will raise an user error.