### PR TITLE
[14.0][IMP] sale_stock_return_request: optional sales order filter / shortcut from sales order

### DIFF
--- a/sale_stock_return_request/__manifest__.py
+++ b/sale_stock_return_request/__manifest__.py
@@ -12,5 +12,5 @@
     "application": False,
     "installable": True,
     "depends": ["sale_stock", "stock_return_request"],
-    "data": ["views/sale_return_request_views.xml"],
+    "data": ["views/sale_order_views.xml", "views/sale_return_request_views.xml"],
 }

--- a/sale_stock_return_request/models/__init__.py
+++ b/sale_stock_return_request/models/__init__.py
@@ -1,1 +1,2 @@
+from . import sale_order
 from . import stock_return_request

--- a/sale_stock_return_request/models/sale_order.py
+++ b/sale_stock_return_request/models/sale_order.py
@@ -1,0 +1,49 @@
+# Copyright 2023 Solvos Consultoría Informática
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+import ast
+
+from odoo import fields, models
+from odoo.tools import float_compare
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    show_create_return_request = fields.Boolean(
+        compute="_compute_show_create_return_request",
+    )
+
+    def _get_returnable_lines(self):
+        return self.order_line.filtered(
+            lambda x: x.product_id.type != "service"
+            and float_compare(
+                x.qty_delivered, 0.0, precision_rounding=x.product_uom.rounding
+            )
+            > 0
+        )
+
+    def _compute_show_create_return_request(self):
+        for order in self:
+            order.show_create_return_request = len(order._get_returnable_lines()) > 0
+
+    def action_create_return_request(self):
+        self.ensure_one()
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "sale_stock_return_request.action_sale_stock_return_request_tree"
+        )
+        action["views"] = [
+            (
+                self.env.ref("stock_return_request.view_stock_return_request_form").id,
+                "form",
+            )
+        ]
+        action["context"] = {
+            **ast.literal_eval(action["context"]),
+            "default_partner_id": self.partner_id.id,
+            "default_filter_sale_order_ids": [(4, self.id)],
+            "default_line_ids": [
+                (0, 0, {"product_id": line.product_id.id})
+                for line in self._get_returnable_lines()
+            ],
+        }
+        return action

--- a/sale_stock_return_request/readme/CONTRIBUTORS.rst
+++ b/sale_stock_return_request/readme/CONTRIBUTORS.rst
@@ -4,3 +4,7 @@
   * Pedro M. Baeza
   * David Vidal
   * César A. Sánchez
+
+* `Solvos <https://www.solvos.es>`_:
+
+  * David Alonso

--- a/sale_stock_return_request/views/sale_order_views.xml
+++ b/sale_stock_return_request/views/sale_order_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="name">sale.order.form (in sale_stock_return_request)</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="groups_id" eval="[(4, ref('stock.group_stock_user'))]" />
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_draft']" position="after">
+                <field name="show_create_return_request" invisible="1" />
+                <button
+                    name="action_create_return_request"
+                    string="Create Return Request"
+                    type="object"
+                    attrs="{'invisible': [('show_create_return_request', '=', False)]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_stock_return_request/views/sale_return_request_views.xml
+++ b/sale_stock_return_request/views/sale_return_request_views.xml
@@ -22,6 +22,15 @@
                     attrs="{'invisible': [('sale_order_ids', '=', [])]}"
                 />
             </xpath>
+            <xpath expr="//field[@name='to_refund']" position="after">
+                <field
+                    name="filter_sale_order_ids"
+                    widget="many2many_tags"
+                    domain="[('partner_id', '=', partner_id)]"
+                    attrs="{'invisible': [('return_type', '!=', 'customer')]}"
+                    options="{'no_quick_create': True, 'no_create_edit' : True, 'no_create' : True}"
+                />
+            </xpath>
         </field>
     </record>
     <record id="action_sale_stock_return_request_tree" model="ir.actions.act_window">


### PR DESCRIPTION
Sometimes seleting some orders to be returned for a certain customer could be useful, specially when we want return a sales order with a lot of pickings. Adding a filter and/or having a shortcut from sale order it could be performed.

Optional sales orders filter preview:

![imagen](https://github.com/OCA/sale-workflow/assets/12749832/4d91e951-1516-4f5c-943b-501145d9d59b)

Available action from an order ready to be returned:

![imagen](https://github.com/OCA/sale-workflow/assets/12749832/c1af703b-a3f7-4d8a-810f-a54e712f507d)

From this button, request return is created with initial data (partner, returnable products) filled:

![imagen](https://github.com/OCA/sale-workflow/assets/12749832/55408052-2c67-4f46-8360-c2c4e40db332)
