### PR TITLE
[14.0] [FIX] sale_discount_display_amount: switch field positions

### DIFF
--- a/sale_discount_display_amount/report/sale_report_template.xml
+++ b/sale_discount_display_amount/report/sale_report_template.xml
@@ -6,22 +6,25 @@
     >
         <xpath expr="//tr[hasclass('o_total')]" position="before">
             <t groups="product.group_discount_per_so_line" t-if="doc.discount_total">
-                <tr class="border-black">
-                    <td name="td_discount_total_label">
-                        <strong>Discount</strong>
-                    </td>
-                    <td name="td_discount_total" class="text-right">
-                        <span t-field="doc.discount_total" />
-                    </td>
-                </tr>
-                <tr
-                    t-if="doc.company_id.report_total_without_discount and doc.price_total_no_discount != doc.amount_total"
-                >
+                <t
+                    t-set="is_discount"
+                    t-value="doc.company_id.report_total_without_discount and doc.price_total_no_discount != doc.amount_total"
+                />
+                <tr class="border-black" t-if="is_discount">
                     <td name="td_total_without_discount_label">
                         <strong>Total Without Discount</strong>
                     </td>
                     <td name="td_total_without_discount" class="text-right">
                         <span t-field="doc.price_total_no_discount" />
+                    </td>
+                </tr>
+
+                <tr t-attf-class="{{ 'border-black' if not is_discount else '' }}">
+                    <td name="td_discount_total_label">
+                        <strong>Discount</strong>
+                    </td>
+                    <td name="td_discount_total" class="text-right">
+                        <span t-field="doc.discount_total" />
                     </td>
                 </tr>
             </t>


### PR DESCRIPTION
Switched position of "Discount" and "Total Without Discount"

Before
![immagine](https://github.com/OCA/sale-workflow/assets/42804718/9baa5b84-05c0-4a57-80ee-a8e54f4d79c3)

After
![immagine](https://github.com/OCA/sale-workflow/assets/42804718/f07fde55-4459-4e85-b213-bee963297ba2)
