### PR TITLE
[13.0][ADD] sale_order_line_remove: allows the removal of sale order lines

### DIFF
--- a/sale_order_line_remove/__init__.py
+++ b/sale_order_line_remove/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import tests

--- a/sale_order_line_remove/__manifest__.py
+++ b/sale_order_line_remove/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2023 ForgeFlow, S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Sale Order Line Remove",
+    "version": "13.0.1.0.0",
+    "category": "Sales",
+    "summary": "Allows removal of sale order lines from confirmed "
+    "orders if not invoiced or received",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/sale-workflow",
+    "license": "AGPL-3",
+    "depends": ["sale_stock"],
+    "data": [],
+    "installable": True,
+    "application": False,
+}

--- a/sale_order_line_remove/models/__init__.py
+++ b/sale_order_line_remove/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order

--- a/sale_order_line_remove/models/sale_order.py
+++ b/sale_order_line_remove/models/sale_order.py
@@ -1,0 +1,42 @@
+# Copyright 2023 ForgeFlow, S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _check_line_unlink(self):
+        non_removable_lines = super(SaleOrderLine, self)._check_line_unlink()
+        removable_lines = self.filtered(
+            lambda line: line.state in ("sale", "done")
+            and not line.invoice_lines
+            and not line.move_ids.filtered(lambda move: move.state == "done")
+        )
+        invoiced_lines = self.filtered(
+            lambda line: line.state in ("sale", "done") and line.invoice_lines
+        )
+        if invoiced_lines:
+            raise UserError(
+                _("You can not remove an order line that has been invoiced")
+            )
+        delivered_lines = self.filtered(
+            lambda line: line.state in ("sale", "done")
+            and line.move_ids.filtered(lambda move: move.state == "done")
+        )
+        if delivered_lines:
+            raise UserError(
+                _("You can not remove an order line that has been delivered")
+            )
+        return non_removable_lines - removable_lines
+
+    def unlink(self):
+        non_removable_lines = self._check_line_unlink()
+        for line in self - non_removable_lines:
+            line.move_ids.filtered(
+                lambda move: move.state not in ("done", "cancel")
+            )._action_cancel()
+            line.move_ids.filtered(lambda move: move.state != "done").unlink()
+        return super(SaleOrderLine, self).unlink()

--- a/sale_order_line_remove/readme/CONTRIBUTORS.rst
+++ b/sale_order_line_remove/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Joan Sisquella <joan.sisquella@forgeflow.com>

--- a/sale_order_line_remove/readme/DESCRIPTION.rst
+++ b/sale_order_line_remove/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This module allows the removal of sale order lines even after the order has been confirmed, under certain conditions. Specifically, a sale order line can be removed if:
+
+- It has not been invoiced.
+- It has not been delivered.

--- a/sale_order_line_remove/readme/USAGE.rst
+++ b/sale_order_line_remove/readme/USAGE.rst
@@ -1,0 +1,4 @@
+Once the module is installed:
+
+1. Go to a sale order.
+2. You can now delete a sale order line if it hasn't been invoiced or delivered.

--- a/sale_order_line_remove/tests/__init__.py
+++ b/sale_order_line_remove/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_order_line

--- a/sale_order_line_remove/tests/test_sale_order_line.py
+++ b/sale_order_line_remove/tests/test_sale_order_line.py
@@ -1,0 +1,123 @@
+# Copyright 2023 ForgeFlow, S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests import TransactionCase
+
+
+class TestSaleOrderLine(TransactionCase):
+    def setUp(self):
+        super(TestSaleOrderLine, self).setUp()
+        self.SaleOrder = self.env["sale.order"]
+        self.SaleOrderLine = self.env["sale.order.line"]
+        self.partner = self.env.ref("base.res_partner_2")
+        self.product = self.env.ref("product.product_product_4")
+        self.uom = self.env.ref("uom.product_uom_unit")
+
+    def test_check_line_unlink(self):
+        sale_order = self.SaleOrder.create({"partner_id": self.partner.id})
+        sale_order.action_confirm()
+        sale_order_line = self.SaleOrderLine.create(
+            {
+                "order_id": sale_order.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 1,
+                "product_uom": self.uom.id,
+            }
+        )
+        non_removable_lines = sale_order_line._check_line_unlink()
+        self.assertFalse(non_removable_lines, "Line should not be non-removable")
+
+    def test_unlink(self):
+        sale_order = self.SaleOrder.create({"partner_id": self.partner.id})
+        sale_order.action_confirm()
+        sale_order_line = self.SaleOrderLine.create(
+            {
+                "order_id": sale_order.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 1,
+                "product_uom": self.uom.id,
+            }
+        )
+        sale_order_line.unlink()
+        self.assertFalse(sale_order_line.exists(), "Sale order line was not deleted")
+
+    def test_check_line_not_unlinkable(self):
+        sale_order = self.SaleOrder.create({"partner_id": self.partner.id})
+        sale_order.action_confirm()
+        sale_order_line = self.SaleOrderLine.create(
+            {
+                "order_id": sale_order.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 1,
+                "product_uom": self.uom.id,
+            }
+        )
+        picking = sale_order.picking_ids[0]
+        picking.action_confirm()
+        picking.action_assign()
+        for move in picking.move_ids_without_package:
+            move.quantity_done = move.product_uom_qty
+        picking.button_validate()
+        with self.assertRaises(Exception):
+            sale_order_line._check_line_unlink()
+
+    def test_not_unlinkable_after_picking(self):
+        sale_order = self.SaleOrder.create({"partner_id": self.partner.id})
+        sale_order.action_confirm()
+        sale_order_line = self.SaleOrderLine.create(
+            {
+                "order_id": sale_order.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 1,
+                "product_uom": self.uom.id,
+            }
+        )
+        picking = sale_order.picking_ids[0]
+        picking.action_confirm()
+        picking.action_assign()
+        for move in picking.move_ids_without_package:
+            move.quantity_done = move.product_uom_qty
+        picking.button_validate()
+        with self.assertRaises(Exception):
+            sale_order_line.unlink()
+
+    def test_check_line_unlink_delivered(self):
+        sale_order = self.SaleOrder.create({"partner_id": self.partner.id})
+        sale_order.action_confirm()
+        sale_order_line = self.SaleOrderLine.create(
+            {
+                "order_id": sale_order.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 1,
+                "product_uom": self.uom.id,
+            }
+        )
+        picking = sale_order.picking_ids[0]
+        picking.action_confirm()
+        picking.action_assign()
+        for move in picking.move_ids_without_package:
+            move.quantity_done = move.product_uom_qty
+        picking.button_validate()
+        with self.assertRaises(Exception):
+            sale_order_line._check_line_unlink()
+
+    def test_check_line_unlink_invoiced(self):
+        sale_order = self.SaleOrder.create({"partner_id": self.partner.id})
+        sale_order.action_confirm()
+        sale_order_line = self.SaleOrderLine.create(
+            {
+                "order_id": sale_order.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 1,
+                "product_uom": self.uom.id,
+            }
+        )
+        picking = sale_order.picking_ids[0]
+        picking.action_confirm()
+        picking.action_assign()
+        for move in picking.move_ids_without_package:
+            move.quantity_done = move.product_uom_qty
+        picking.button_validate()
+        sale_order._create_invoices()
+        with self.assertRaises(Exception):
+            sale_order_line._check_line_unlink()

--- a/setup/sale_order_line_remove/odoo/addons/sale_order_line_remove
+++ b/setup/sale_order_line_remove/odoo/addons/sale_order_line_remove
@@ -1,0 +1,1 @@
+../../../../sale_order_line_remove

--- a/setup/sale_order_line_remove/setup.py
+++ b/setup/sale_order_line_remove/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Adding new module Sale Order Line Remove

This PR introduces a new module that allows for the removal of sale order lines in certain conditions. Users can now delete lines in confirmed sale orders if they haven't been invoiced or received. Additionally, associated stock moves in specific states will be removed.