### PR TITLE
Hide(optional) discount_fixed

### DIFF
--- a/sale_fixed_discount/views/sale_order_views.xml
+++ b/sale_fixed_discount/views/sale_order_views.xml
@@ -23,6 +23,7 @@
                 <field
                     name="discount_fixed"
                     groups="product.group_discount_per_so_line"
+                    optional="show"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Setting optional="show" to the discount_fixed field in the sale order form view order lines