### PR TITLE
[16.0][FIX] sale_order_general_discount_triple:default general discount in line

### DIFF
--- a/sale_order_general_discount/models/sale_order.py
+++ b/sale_order_general_discount/models/sale_order.py
@@ -22,6 +22,10 @@ class SaleOrder(models.Model):
             so.general_discount = so.partner_id.sale_discount
 
     @api.model
+    def _get_discount_field_to_replace(self):
+        return "discount"
+
+    @api.model
     def get_view(self, view_id=None, view_type="form", **options):
         """The purpose of this is to write a context on "order_line" field
         respecting other contexts on this field.
@@ -37,7 +41,9 @@ class SaleOrder(models.Model):
                 order_line_field = order_line_fields[0]
                 context = order_line_field.attrib.get("context", "{}").replace(
                     "{",
-                    "{'default_discount': general_discount, ",
+                    "{{'default_{}': general_discount, ".format(
+                        self._get_discount_field_to_replace()
+                    ),
                     1,
                 )
                 order_line_field.attrib["context"] = context

--- a/sale_order_general_discount_triple/models/sale_order.py
+++ b/sale_order_general_discount_triple/models/sale_order.py
@@ -24,3 +24,9 @@ class SaleOrder(models.Model):
             line._compute_discount2()
             line._compute_discount3()
         return res
+
+    @api.model
+    def _get_discount_field_to_replace(self):
+        return self.env["sale.order.line"]._get_discount_field_position(
+            "general_discount"
+        )


### PR DESCRIPTION
In the case of an order with a global discount, where the global discount is configured for the 'discount2' field, if a product is added and optional products are included, the optional products are inserted into the order. However, the global discount is applied to the 'discount' field instead of the configured field.


https://github.com/OCA/sale-workflow/assets/55379877/388d82fc-f256-4196-8867-630d40217c14

