### PR TITLE
[FIX] sale_advance_payment: residual amount

### DIFF
--- a/sale_advance_payment/models/sale.py
+++ b/sale_advance_payment/models/sale.py
@@ -82,7 +82,10 @@ class SaleOrder(models.Model):
                     advance_amount += line_amount
             # Consider payments in related invoices.
             invoice_paid_amount = 0.0
-            for inv in order.invoice_ids:
+            # Filter out credit notes (returns)
+            for inv in order.invoice_ids.filtered(
+                lambda x: x.move_type == "out_invoice"
+            ):
                 invoice_paid_amount += inv.amount_total - inv.amount_residual
             amount_residual = order.amount_total - advance_amount - invoice_paid_amount
             payment_state = "not_paid"

--- a/sale_advance_payment/tests/test_sale_advance_payment.py
+++ b/sale_advance_payment/tests/test_sale_advance_payment.py
@@ -408,3 +408,52 @@ class TestSaleAdvancePayment(common.SavepointCase):
         self.sale_order_1.invalidate_cache()
         self.assertEqual(self.sale_order_1.amount_residual, 1300)
         self.assertEqual(invoice.amount_residual, 0)
+
+    def test_04_residual_amount_with_credit_note(self):
+        PaymentRegister = self.env["account.payment.register"]
+        payment_register_vals = {
+            "amount": 3600.0,
+            "group_payment": True,
+            "payment_difference_handling": "open",
+        }
+
+        self.assertEqual(
+            self.sale_order_1.amount_residual,
+            3600,
+        )
+        # Confirm Sale Order
+        self.sale_order_1.action_confirm()
+
+        # Create Invoice
+        invoice = self.sale_order_1._create_invoices()
+        invoice.action_post()
+        self.assertEqual(invoice.amount_residual, 3600)
+
+        # Pay invoice in full
+        PaymentRegister.with_context(
+            active_model="account.move", active_ids=invoice.ids
+        ).create(payment_register_vals)._create_payments()
+        self.assertEqual(self.sale_order_1.amount_residual, 0)
+
+        # Reverse paid invoice
+        move_reversal = (
+            self.env["account.move.reversal"]
+            .with_context(active_model="account.move", active_ids=invoice.ids)
+            .create(
+                {
+                    "date": fields.Date.today(),
+                    "reason": "client wanted refund",
+                    "refund_method": "refund",
+                }
+            )
+        )
+        reversal = move_reversal.reverse_moves()
+        reverse_move = self.env["account.move"].browse(reversal["res_id"])
+        reverse_move.action_post()
+
+        # Pay reverse invoice in full
+        PaymentRegister.with_context(
+            active_model="account.move", active_ids=reverse_move.ids
+        ).create(payment_register_vals)._create_payments()
+        self.assertEqual(reverse_move.amount_residual, 0)
+        self.assertEqual(self.sale_order_1.amount_residual, 0)


### PR DESCRIPTION
Resolve the problem in the sale order residual amount display when a credit note is issued.

Calculation before fix example:

`invoice_paid_amount += inv.amount_total - inv.amount_residual`

As there are 2 invoices (one out invoice and once refund invoice both paid fully)

```
invoice_paid_amount += inv.amount_total - inv.amount_residual
invoice_paid_amount = (320.0 - 0) + (320 - 0)
```

Sale order residual amount is going to be calculated like:

```
amount_residual = order.amount_total - advance_amount - invoice_paid_amount
amount_residual = 320.0 - 0 - 640  
amount_residual = -320 
```

Sale order is going to display residual amount as -320.

![Invoices-Odoo-single-reversal](https://github.com/OCA/sale-workflow/assets/10747735/9afde4b0-8ac0-42fc-b27b-9304debc97c9)
![S00035-Odoo-single-case](https://github.com/OCA/sale-workflow/assets/10747735/11b53450-c096-46ec-bd3c-aa71de5fcab1)
