### PR TITLE
[FIX] sale_order_product_recommendation: freezegun hack

### DIFF
--- a/sale_order_product_recommendation/tests/test_recommendation.py
+++ b/sale_order_product_recommendation/tests/test_recommendation.py
@@ -2,15 +2,11 @@
 # Copyright 2020 Tecnativa - Pedro M. Baeza
 # Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
-from freezegun import freeze_time
-
 from odoo.exceptions import UserError
 
 from .test_recommendation_common import RecommendationCase
 
 
-@freeze_time("2021-10-02 15:30:00")
 class RecommendationCaseTests(RecommendationCase):
     def test_recommendations(self):
         """Recommendations are OK."""

--- a/sale_order_product_recommendation/tests/test_recommendation_common.py
+++ b/sale_order_product_recommendation/tests/test_recommendation_common.py
@@ -5,11 +5,14 @@ from freezegun import freeze_time
 from odoo.tests.common import TransactionCase
 
 
-@freeze_time("2021-10-02 15:30:00")
 class RecommendationCase(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # HACK https://github.com/spulec/freezegun/issues/485
+        freezer = freeze_time("2021-10-02 15:30:00")
+        freezer.__enter__()
+        cls.addClassCleanup(freezer.__exit__)
         # Remove this variable in v16 and put instead:
         # from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
         DISABLED_MAIL_CONTEXT = {


### PR DESCRIPTION
As seen in https://github.com/spulec/freezegun/issues/485, when decorating a class with `@freezegun.freeze_time()`, class cleanups are not properly executed.

For Odoo, this means that the cursor is not properly closed. Thus, if you happen to run a test for another module after this one that needs a Postgres-level lock that conflicts with this module's, it will fail.

This change does the same, but without decorating the class. Then, the cleanups work as expected.

The error is reproducible with:

    odoo --stop-after-init -i sale_order_product_recommendation,sale_partner_selectable_option --test-enable --test-tags /sale_order_product_recommendation,/sale_partner_selectable_option

@moduon MT-1075