### PR TITLE
[FIX] sale_packaging_default: reorder SO sub-form view too

### DIFF
--- a/sale_packaging_default/views/sale_order_view.xml
+++ b/sale_packaging_default/views/sale_order_view.xml
@@ -7,6 +7,7 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
+            <!-- Move packaging and packaging qty before product qty in tree view -->
             <xpath
                 expr="//field[@name='order_line']/tree/field[@name='product_uom_qty']"
                 position="before"
@@ -17,6 +18,21 @@
                 />
                 <xpath
                     expr="//field[@name='order_line']/tree/field[@name='product_packaging_qty']"
+                    position="move"
+                />
+            </xpath>
+
+            <!-- Move packaging and packaging qty before product qty in form view -->
+            <xpath
+                expr="//field[@name='order_line']/form//label[@for='product_uom_qty']"
+                position="before"
+            >
+                <xpath
+                    expr="//field[@name='order_line']/form//field[@name='product_packaging_id']"
+                    position="move"
+                />
+                <xpath
+                    expr="//field[@name='order_line']/form//field[@name='product_packaging_qty']"
                     position="move"
                 />
             </xpath>


### PR DESCRIPTION
When creating SO from mobile view or from "Commercial Quotations" menu installed by `sale_order_product_picker`, the pop-up form view that appears when clicking on the line kanban kard didn't have the fields in the correct order.

When you install `sale_packaging_default`, you expect this order:
1. Packaging.
2. Packaging qty.
3. Product qty.

@moduon MT-3930