### PR TITLE
[FIX] sale_packaging_default: setting product_uom_qty to 0 empties packaging

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,8 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.17.2
+_commit: v1.19.2
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
+convert_readme_fragments_to_markdown: false
 generate_requirements_txt: true
 github_check_license: true
 github_ci_extra_env: {}
@@ -14,9 +15,12 @@ odoo_test_flavor: Both
 odoo_version: 16.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
-rebel_module_groups: []
+rebel_module_groups:
+- sell_only_by_packaging
 repo_description: 'TODO: add repo description.'
 repo_name: sale-workflow
 repo_slug: sale-workflow
 repo_website: https://github.com/OCA/sale-workflow
+use_pyproject_toml: false
+use_ruff: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,17 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
+            include: "sell_only_by_packaging"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
+            include: "sell_only_by_packaging"
+            name: test with OCB
+            makepot: "true"
+          - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
+            exclude: "sell_only_by_packaging"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
+            exclude: "sell_only_by_packaging"
             name: test with OCB
             makepot: "true"
     services:
@@ -49,6 +58,9 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
+    env:
+      INCLUDE: "${{ matrix.include }}"
+      EXCLUDE: "${{ matrix.exclude }}"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 /.venv
 /.pytest_cache
+/.ruff_cache
 
 # C extensions
 *.so

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,8 @@ exclude: |
   ^docs/_templates/.*\.html$|
   # Don't bother non-technical authors with formatting issues in docs
   readme/.*\.(rst|md)$|
+  # Ignore build and dist directories in addons
+  /build/|/dist/|
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
@@ -36,7 +38,7 @@ repos:
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
   - repo: https://github.com/oca/maintainer-tools
-    rev: 969238e47c07d0c40573acff81d170f63245d738
+    rev: f71041f22b8cd68cf7c77b73a14ca8d8cd190a60
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
@@ -49,6 +51,7 @@ repos:
           - --org-name=OCA
           - --repo-name=sale-workflow
           - --if-source-changed
+          - --keep-source-digest
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
     rev: v0.0.25
     hooks:

--- a/sale_packaging_default/models/sale_order_line.py
+++ b/sale_packaging_default/models/sale_order_line.py
@@ -1,10 +1,23 @@
 # Copyright 2023 Moduon Team S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+from contextlib import suppress
+
 from odoo import api, models
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
+
+    def onchange(self, values, field_name, field_onchange):
+        """Record which field was being changed."""
+        if isinstance(field_name, list):
+            names = set(field_name)
+        elif field_name:
+            names = {field_name}
+        else:
+            names = set()
+        _self = self.with_context(changing_fields=names)
+        return super(SaleOrderLine, _self).onchange(values, field_name, field_onchange)
 
     @api.depends("product_id", "product_uom_qty", "product_uom")
     def _compute_product_packaging_id(self):
@@ -16,7 +29,22 @@ class SaleOrderLine(models.Model):
                         [("sales_default", "=", True), ("sales", "=", True)]
                     )[:1]
                 )
-        return super()._compute_product_packaging_id()
+        result = super()._compute_product_packaging_id()
+        # If there's no way to package the desired qty, remove the packaging.
+        # It is only done when the user is currently manually setting
+        # `product_uom_qty` to zero. In other cases, we are maybe getting
+        # default values and this difference will get fixed by other compute
+        # methods later.
+        if "product_uom_qty" not in self.env.context.get("changing_fields", set()):
+            return result
+        for line in self:
+            with suppress(ZeroDivisionError):
+                if (
+                    line.product_uom_qty
+                    and line.product_uom_qty % line.product_packaging_id.qty
+                ):
+                    line.product_packaging_id = False
+        return result
 
     @api.depends("product_packaging_id", "product_uom", "product_uom_qty")
     def _compute_product_packaging_qty(self):
@@ -27,7 +55,10 @@ class SaleOrderLine(models.Model):
                 continue
             # Reset to 1 packaging if it's empty or not a whole number
             if not line.product_packaging_qty or line.product_packaging_qty % 1:
-                line.product_packaging_qty = 1
+                line.product_packaging_qty = int(
+                    "product_uom_qty"
+                    not in self.env.context.get("changing_fields", set())
+                )
         return result
 
     @api.depends(
@@ -41,4 +72,5 @@ class SaleOrderLine(models.Model):
         # undeclared dependency over `product_packaging_qty`, which depends
         # again on `product_uom_qty`.
         _self = self.with_context(keep_product_packaging=True)
-        return super(SaleOrderLine, _self)._compute_product_uom_qty()
+        result = super(SaleOrderLine, _self)._compute_product_uom_qty()
+        return result

--- a/sale_packaging_default/tests/test_sale_packaging_default.py
+++ b/sale_packaging_default/tests/test_sale_packaging_default.py
@@ -83,3 +83,13 @@ class SalePackagingDefaultCase(ProductCommon):
             line_f.product_uom_qty = 120
             self.assertEqual(line_f.product_packaging_qty, 10)
             self.assertEqual(line_f.product_packaging_id, self.dozen)
+            # If I set a uom qty without packaging, it is emptied
+            line_f.product_uom_qty = 7
+            self.assertFalse(line_f.product_packaging_id)
+            self.assertEqual(line_f.product_packaging_qty, 0)
+            self.assertEqual(line_f.product_uom_qty, 7)
+            # Setting zero uom qty resets to the default packaging
+            line_f.product_uom_qty = 0
+            self.assertEqual(line_f.product_packaging_id, self.big_box)
+            self.assertEqual(line_f.product_packaging_qty, 0)
+            self.assertEqual(line_f.product_uom_qty, 0)

--- a/sell_only_by_packaging/tests/test_sale_only_by_packaging.py
+++ b/sell_only_by_packaging/tests/test_sale_only_by_packaging.py
@@ -49,14 +49,15 @@ class TestSaleProductByPackagingOnly(Common):
         """
         self.product.sell_only_by_packaging = True
         packaging = self.packaging_tu
-        self.order_line.product_packaging_id = packaging
         # For this step, the qty is not forced on the packaging
         # But the warning will be raise because the value of packaging qty is
         # not integer package
         with self.assertRaises(ValidationError):
-            self.order_line.product_packaging_qty = 0.6
-            self.assertAlmostEqual(
-                self.order_line.product_uom_qty, 12, places=self.precision
+            self.order_line.write(
+                {
+                    "product_packaging_id": packaging,
+                    "product_packaging_qty": 0.6,
+                }
             )
 
         # Now force the qty on the packaging


### PR DESCRIPTION
Before this patch, we had this problem:

1. Add new SO line.
2. Set a packaging and a packaging qty. The UoM qty is computed. Good.
3. Set UoM qty to zero. Packaging and packaging qty remain with previous value. Bad.

When user sets UoM to zero, Odoo should remove any packaging information.

Notice that, when adding a new line, that qty will be zero at the beginning, but we will want to still get the defaults. Thus, this change is only applied when the user *is* actually setting that value, and not on any other circumstance. I needed to override the `onchange()` method to propagate that information.

@moduon MT-3930