### PR TITLE
[FIX] sale_order_product_picker: store packaging information

### DIFF
--- a/sale_order_product_picker/views/sale_order_views.xml
+++ b/sale_order_product_picker/views/sale_order_views.xml
@@ -114,6 +114,14 @@
                 <field name="state" />
                 <field name="is_different_price" />
                 <field name="list_price" />
+                <field
+                    name="product_packaging_id"
+                    groups="product.group_stock_packaging"
+                />
+                <field
+                    name="product_packaging_qty"
+                    groups="product.group_stock_packaging"
+                />
             </xpath>
             <xpath
                 expr="//field[@name='order_line']/kanban//t[@t-out='record.price_unit.value']/.."


### PR DESCRIPTION
Previous situation: when packagings are enabled in sale configuration, if a product had any packaging, the packaging and its qty wasn't saved when clicking on the "+1 unit" button.

This could lead to incongruent situations:
- A handpicked packaging and qty combination didn't match with the product uom qty.
- Possibly valid packaging and qty combinations were not computed automatically, as they were when filling from the normal sale order view.

@moduon MT-3930