### PR TITLE
[FIX] sale_order_product_recommendation_packaging_default: can add product without packaging

### DIFF
--- a/sale_order_product_recommendation_packaging_default/tests/test_recommendation.py
+++ b/sale_order_product_recommendation_packaging_default/tests/test_recommendation.py
@@ -97,6 +97,16 @@ class PackagingRecommendationCase(test_recommendation_common.RecommendationCase)
             self.assertEqual(line.units_included, 0)
             line.product_packaging_qty = 2
             self.assertEqual(line.units_included, 24)
+        with wiz_f.line_ids.edit(1) as line:
+            # Product 3 is sold by units
+            self.assertFalse(line.product_packaging_id)
+            self.assertEqual(line.product_packaging_qty, 0)
+            self.assertEqual(line.units_included, 0)
+            # I want to sell 100 units of product 3
+            line.units_included = 100
+            self.assertFalse(line.product_packaging_id)
+            self.assertEqual(line.product_packaging_qty, 0)
+            self.assertEqual(line.units_included, 100)
         with wiz_f.line_ids.edit(2) as line:
             self.assertEqual(line.product_packaging_id, self.prod_1_dozen)
             # I cannot sell product 1 in pallets
@@ -124,6 +134,12 @@ class PackagingRecommendationCase(test_recommendation_common.RecommendationCase)
                     "product_packaging_id": self.prod_2_dozen.id,
                     "product_packaging_qty": 2,
                     "product_uom_qty": 24,
+                },
+                {
+                    "product_id": self.prod_3.id,
+                    "product_packaging_id": False,
+                    "product_packaging_qty": 0,
+                    "product_uom_qty": 100,
                 },
                 {
                     "product_id": self.prod_1.id,

--- a/sale_order_product_recommendation_packaging_default/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation_packaging_default/wizards/sale_order_recommendation.py
@@ -81,5 +81,6 @@ class SaleOrderRecommendationLine(models.TransientModel):
         """Prepare product packaging info for new sale order line."""
         result = super()._prepare_new_so_line(line_form, sequence)
         line_form.product_packaging_id = self.product_packaging_id
-        line_form.product_packaging_qty = self.product_packaging_qty
+        if self.product_packaging_id:
+            line_form.product_packaging_qty = self.product_packaging_qty
         return result

--- a/sale_order_product_recommendation_packaging_default/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation_packaging_default/wizards/sale_order_recommendation_view.xml
@@ -24,6 +24,7 @@
                     groups="product.group_stock_packaging"
                     optional="show"
                     widget="numeric_step"
+                    attrs="{'invisible': [('product_packaging_id', '=', False)]}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Before this patch, when a product had no packaging, we got an error.

<details>

```
Traceback (most recent call last):
  File "/opt/odoo/auto/addons/sale_order_product_recommendation_packaging_default/tests/test_recommendation.py", line 128, in test_computes
    wiz.action_accept()
  File "/opt/odoo/auto/addons/sale_order_product_recommendation/wizards/sale_order_recommendation.py", line 187, in action_accept
    wiz_line._prepare_new_so_line(line_form, sequence)
  File "/opt/odoo/auto/addons/sale_order_product_recommendation_packaging_default/wizards/sale_order_recommendation.py", line 84, in _prepare_new_so_line
    line_form.product_packaging_qty = self.product_packaging_qty
  File "/opt/odoo/custom/src/odoo/odoo/tests/common.py", line 2238, in __setattr__
    assert not self._get_modifier(field, 'invisible'), \
AssertionError: can't write on invisible field product_packaging_qty
```

</details>

@moduon MT-4326