### PR TITLE
[15.0][FIX] sale_stock_secondary_unit: Fix test, second qty manage qty done

### DIFF
--- a/sale_stock_secondary_unit/tests/test_sale_stock_secondary_unit.py
+++ b/sale_stock_secondary_unit/tests/test_sale_stock_secondary_unit.py
@@ -88,4 +88,5 @@ class TestSaleStockOrderSecondaryUnit(TransactionCase):
         self.order.order_line._onchange_helper_product_uom_for_secondary()
         self.order.action_confirm()
         picking = self.order.picking_ids
-        self.assertEqual(picking.move_line_ids.secondary_uom_qty, 5.0)
+        # Second qty on sml only manage done quantities
+        self.assertEqual(picking.move_line_ids.secondary_uom_qty, 0.0)


### PR DESCRIPTION
cc @Tecnativa 

ping   @carlosdauden @CarlosRoca13 

depends on:
- [x] https://github.com/OCA/stock-logistics-warehouse/pull/1606 (https://github.com/OCA/stock-logistics-warehouse/pull/1606/commits/7993a5684ff048ea5e602bd7d4f81697483f0618)