### PR TITLE
[16.0][FIX] sell_only_by_packaging: When selecting a product_packaging_id, product_packaging_qty should not be a float value (triggering a Warning)

### DIFF
--- a/sell_only_by_packaging/models/sale_order_line.py
+++ b/sell_only_by_packaging/models/sale_order_line.py
@@ -1,13 +1,14 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
+from math import ceil
+
 from odoo import _, api, models
 from odoo.exceptions import ValidationError
 from odoo.tools import float_compare
 
 
 class SaleOrderLine(models.Model):
-
     _inherit = "sale.order.line"
 
     @api.constrains(
@@ -46,6 +47,14 @@ class SaleOrderLine(models.Model):
         )
         self.product_uom_qty = qty
         return True
+
+    @api.onchange("product_packaging_id")
+    def _onchange_product_packaging_id(self):
+        # Round up to the next integer and avoid the Warning raised by
+        # _onchange_product_packaging_id defined in the sale addon
+        ceiled_product_packaging_qty = ceil(self.product_packaging_qty)
+        self.product_packaging_qty = ceiled_product_packaging_qty or 1
+        return super()._onchange_product_packaging_id()
 
     @api.onchange("product_uom_qty")
     def _onchange_product_uom_qty(self):

--- a/sell_only_by_packaging/tests/test_sale_line_onchanges.py
+++ b/sell_only_by_packaging/tests/test_sale_line_onchanges.py
@@ -21,3 +21,12 @@ class TestPackaging(Common):
         # 20*30 = 600
         expected_qty = PL_PRODUCT_QTY
         self.assertEqual(self.order_line.product_uom_qty, expected_qty)
+
+    def test_compute_qties_with_new_packaging_id(self):
+        with Form(self.order) as so:
+            with so.order_line.edit(0) as line:
+                line.product_uom_qty = 0
+                line.product_packaging_id = self.packaging_tu
+
+        self.assertEqual(self.order_line.product_packaging_qty, 1)
+        self.assertEqual(self.order_line.product_uom_qty, TU_PRODUCT_QTY)


### PR DESCRIPTION
The actual state of the code (AS-IS) triggers a Warning for each product_packaging_id selected if the float_compare with precision_digits=self.product_uom.rounding returns a value different from 0 (0 meaning equal to)
```
float_compare(newqty, self.product_uom_qty, precision_rounding=self.product_uom.rounding) != 0
```
This means that the user can possibly face one Warning pop-up window for each line where he selects a product_packaging_id if the conditions are met.

Warning triggered by following onchange coming from sale addon 

```
@api.onchange('product_packaging_id')
def _onchange_product_packaging_id(self):
  if self.product_packaging_id and self.product_uom_qty:
      newqty = self.product_packaging_id._check_qty(self.product_uom_qty, self.product_uom, "UP")
      if float_compare(newqty, self.product_uom_qty, precision_rounding=self.product_uom.rounding) != 0:
          return {
              'warning': {
                  'title': _('Warning'),
                  'message': _(
                      "This product is packaged by %(pack_size).2f %(pack_name)s. You should sell %(quantity).2f %(unit)s.",
                      pack_size=self.product_packaging_id.qty,
                      pack_name=self.product_id.uom_id.name,
                      quantity=newqty,
                      unit=self.product_uom.name
                  ),
              },
          }
```


This PR (TO-BE) implements a ceil of product_packaging_qty whenever product_packaging_id changes in order to avoid the Warning pop-up when choosing a product_packaging_id

**Use case explanation**

When we select a packaging, if the quantity of packaging is not a integer (float), round it up to an integer. Furthermore, If the quantity of packaging is 0, set it to 1.

**Reason for the change:**

Products that are sold by packaging cannot be sold by partial packaging (for example : 0.5, 1.75 pack is not possible).

Therefore, the warning in the pop-up will always be displayed and its content becomes useless for the user. Users waste 1 click per sales order line to close systematically this pop-up. 