### PR TITLE
[FIX] sale_packaging_default: compatible with `sale_order_product_picker`

### DIFF
--- a/sale_packaging_default/models/sale_order_line.py
+++ b/sale_packaging_default/models/sale_order_line.py
@@ -35,7 +35,10 @@ class SaleOrderLine(models.Model):
         # `product_uom_qty` to zero. In other cases, we are maybe getting
         # default values and this difference will get fixed by other compute
         # methods later.
-        if "product_uom_qty" not in self.env.context.get("changing_fields", set()):
+        if (
+            self.env.context.get("changing_fields")
+            and "product_uom_qty" not in self.env.context["changing_fields"]
+        ):
             return result
         for line in self:
             with suppress(ZeroDivisionError):

--- a/sale_packaging_default/tests/test_sale_packaging_default.py
+++ b/sale_packaging_default/tests/test_sale_packaging_default.py
@@ -93,3 +93,20 @@ class SalePackagingDefaultCase(ProductCommon):
             self.assertEqual(line_f.product_packaging_id, self.big_box)
             self.assertEqual(line_f.product_packaging_qty, 0)
             self.assertEqual(line_f.product_uom_qty, 0)
+
+    def test_sale_order_product_picker_compatibility(self):
+        """Emulate a call done by the product picker module and see it works.
+
+        This test asserts support for cross-compatibility with
+        `sale_order_product_picker`.
+        """
+        so_f = Form(
+            self.env["sale.order"].with_context(
+                default_product_id=self.product.id, default_price_unit=20
+            )
+        )
+        so_f.partner_id = self.partner
+        # User clicks on +1 button
+        with so_f.order_line.new() as line_f:
+            self.assertEqual(line_f.product_uom_qty, 1)
+            self.assertFalse(line_f.product_packaging_id)


### PR DESCRIPTION
Make sure that, when adding a new line that inherits the product by a `default_product_id` context, there is no warning about wrong amount of products.

@moduon MT-4369