### PR TITLE
[FIX] sale_order_product_recommendation: remove flaky create & new button from mobile view

### DIFF
--- a/sale_order_product_recommendation/README.rst
+++ b/sale_order_product_recommendation/README.rst
@@ -139,6 +139,20 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
+.. |maintainer-sergio-teruel| image:: https://github.com/sergio-teruel.png?size=40px
+    :target: https://github.com/sergio-teruel
+    :alt: sergio-teruel
+.. |maintainer-rafaelbn| image:: https://github.com/rafaelbn.png?size=40px
+    :target: https://github.com/rafaelbn
+    :alt: rafaelbn
+.. |maintainer-yajo| image:: https://github.com/yajo.png?size=40px
+    :target: https://github.com/yajo
+    :alt: yajo
+
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-sergio-teruel| |maintainer-rafaelbn| |maintainer-yajo| 
+
 This module is part of the `OCA/sale-workflow <https://github.com/OCA/sale-workflow/tree/16.0/sale_order_product_recommendation>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/sale_order_product_recommendation/__manifest__.py
+++ b/sale_order_product_recommendation/__manifest__.py
@@ -11,6 +11,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
+    "maintainers": ["sergio-teruel", "rafaelbn", "yajo"],
     "depends": [
         "sale",
     ],

--- a/sale_order_product_recommendation/static/description/index.html
+++ b/sale_order_product_recommendation/static/description/index.html
@@ -480,6 +480,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/sergio-teruel"><img alt="sergio-teruel" src="https://github.com/sergio-teruel.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/rafaelbn"><img alt="rafaelbn" src="https://github.com/rafaelbn.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/yajo"><img alt="yajo" src="https://github.com/yajo.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/sale-workflow/tree/16.0/sale_order_product_recommendation">OCA/sale-workflow</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/sale_order_product_recommendation/tests/test_recommendation.py
+++ b/sale_order_product_recommendation/tests/test_recommendation.py
@@ -50,7 +50,7 @@ class RecommendationCaseTests(RecommendationCase):
         self.assertEqual(wiz_line_prod3.units_included, 0)
         # Only 1 product if limited as such
         wizard.line_amount = 1
-        wizard._generate_recommendations()
+        wizard.generate_recommendations()
         self.assertEqual(len(wizard.line_ids), 2)
 
     def test_recommendations_archived_product(self):
@@ -62,7 +62,7 @@ class RecommendationCaseTests(RecommendationCase):
         self.prod_1.active = False
         self.prod_2.sale_ok = False
         wizard = self.wizard()
-        wizard._generate_recommendations()
+        wizard.generate_recommendations()
         self.assertNotIn(self.prod_1, wizard.line_ids.mapped("product_id"))
         self.assertNotIn(self.prod_2, wizard.line_ids.mapped("product_id"))
 
@@ -166,7 +166,7 @@ class RecommendationCaseTests(RecommendationCase):
         self.new_so.partner_shipping_id = self.partner_delivery
         wizard = self.wizard()
         wizard.use_delivery_address = True
-        wizard._generate_recommendations()
+        wizard.generate_recommendations()
         self.assertEqual(len(wizard.line_ids), 1)
         self.assertEqual(wizard.line_ids[0].product_id, self.prod_2)
 
@@ -178,7 +178,7 @@ class RecommendationCaseTests(RecommendationCase):
             .with_context(active_id=so.id)
             .create({})
         )
-        wizard._generate_recommendations()
+        wizard.generate_recommendations()
         wiz_line_prod1 = wizard.line_ids.filtered(lambda x: x.product_id == self.prod_1)
         self.assertEqual(wiz_line_prod1.units_included, 0.0)
         wizard.action_accept()
@@ -187,7 +187,7 @@ class RecommendationCaseTests(RecommendationCase):
 
         self.enable_force_zero_units_included()
         order_line.product_uom_qty = 1
-        wizard._generate_recommendations()
+        wizard.generate_recommendations()
         wiz_line_prod1 = wizard.line_ids.filtered(lambda x: x.product_id == self.prod_1)
         self.assertEqual(wiz_line_prod1.units_included, 0.0)
         wiz_line_prod1.units_included = 0
@@ -204,7 +204,7 @@ class RecommendationCaseTests(RecommendationCase):
             .with_context(active_id=so.id)
             .create({})
         )
-        wizard._generate_recommendations()
+        wizard.generate_recommendations()
         self.assertIn("service", wizard.line_ids.mapped("product_id.type"))
 
         # Add extended domain to exclude services
@@ -218,5 +218,5 @@ class RecommendationCaseTests(RecommendationCase):
             .with_context(active_id=so.id)
             .create({})
         )
-        wizard._generate_recommendations()
+        wizard.generate_recommendations()
         self.assertNotIn("service", wizard.line_ids.mapped("product_id.type"))

--- a/sale_order_product_recommendation/tests/test_recommendation_common.py
+++ b/sale_order_product_recommendation/tests/test_recommendation_common.py
@@ -132,7 +132,7 @@ class RecommendationCase(TransactionCase):
             .with_context(active_id=self.new_so.id)
             .create({})
         )
-        wizard._generate_recommendations()
+        wizard.generate_recommendations()
         return wizard
 
     def enable_force_zero_units_included(self):

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -112,7 +112,11 @@ class SaleOrderRecommendation(models.TransientModel):
         return vals
 
     @api.onchange("order_id", "months", "line_amount", "use_delivery_address")
-    def _generate_recommendations(self):
+    def _remove_recommendations(self):
+        """Empty the list of recommendations."""
+        self.line_ids = False
+
+    def generate_recommendations(self):
         """Generate lines according to context sale order."""
         last_compute = "{}-{}-{}-{}".format(
             self.id, self.months, self.line_amount, self.use_delivery_address
@@ -173,6 +177,14 @@ class SaleOrderRecommendation(models.TransientModel):
         self.line_ids = recommendation_lines.sorted(
             key=lambda x: x.times_delivered, reverse=True
         )
+        # Reopen wizard
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": self._name,
+            "res_id": self.id,
+            "view_mode": "form",
+            "target": "new",
+        }
 
     def action_accept(self):
         """Propagate recommendations to sale order."""

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
@@ -23,6 +23,7 @@
                             nolabel="1"
                             mode="tree,kanban"
                             colspan="2"
+                            attrs="{'invisible': [('line_ids', '=', [])]}"
                         >
                             <tree create="0" delete="0" editable="top">
                                 <field name="currency_id" invisible="1" />
@@ -91,6 +92,7 @@
                             </kanban>
                             <form>
                                 <group>
+                                    <field name="wizard_id" invisible="1" />
                                     <field
                                         name="product_id"
                                         readonly="1"
@@ -108,6 +110,15 @@
                 </sheet>
                 <footer>
                     <button
+                        attrs="{'invisible': [('line_ids', '!=', [])]}"
+                        class="btn-primary"
+                        icon="fa-refresh"
+                        name="generate_recommendations"
+                        string="Get recommendations"
+                        type="object"
+                    />
+                    <button
+                        attrs="{'invisible': [('line_ids', '=', [])]}"
                         name="action_accept"
                         type="object"
                         string="Accept"


### PR DESCRIPTION
Before this patch, mobile view displayed a "Save & New" button. Clicking on it didn't make sense (you couldn't add new lines in desktop view FWIW) and produced an exception.

https://github.com/OCA/sale-workflow/assets/973709/dbaf48c4-5c1c-48c7-8ae9-0df41ed0f34b



Now, the wizard lines are emptied when altering the form. The user must regenerate recommendations manually with a new button. [This makes the widget understand that it cannot create lines][1]. Thus, that "Save & New" button doesn't appear anymore, and the user can just edit the recommendator lines.


https://github.com/OCA/sale-workflow/assets/973709/9dda9583-d232-4294-a56c-0ddd0a6aa1bc



[1]: https://github.com/odoo/odoo/blob/23f01c533512cbfb33e90509e22cd3c3c4f99d40/addons/web/static/src/views/fields/relational_utils.js#L464

That "Save & New" button didn't make sense, because the user isn't expected to be able to create recommendation lines. Instead, recommendations should be auto-generated, and the user just uses them to apply changes to the sale order quickly.

@moduon MT-4393