### PR TITLE
[15.0][IMP] sale_resource_booking: add multiples attendees in booking

### DIFF
--- a/sale_resource_booking/models/sale_order_line.py
+++ b/sale_resource_booking/models/sale_order_line.py
@@ -74,7 +74,7 @@ class SaleOrderLine(models.Model):
             }
             rbc_rel = line.product_id.resource_booking_type_combination_rel_id
             context = {
-                "default_partner_id": line.order_id.partner_id.id,
+                "default_partner_ids": [(4, line.order_id.partner_id.id)],
                 "default_combination_auto_assign": not rbc_rel,
                 "default_combination_id": rbc_rel.combination_id.id,
             }

--- a/sale_resource_booking/tests/test_sale_resource_booking.py
+++ b/sale_resource_booking/tests/test_sale_resource_booking.py
@@ -61,11 +61,9 @@ class SaleResourceBookingsCase(TransactionCase):
         self.assertTrue(order.resource_booking_ids)
         self.assertTrue(self.rbt.booking_ids)
         self.assertEqual(self.rbt.booking_count, 2)
-        # Use wizard to quickly assign partners
-        wiz = self._run_action(action["actions"][0])
-        with Form(wiz) as wiz_f:
-            with wiz_f.resource_booking_ids.edit(1) as booking_f:
-                booking_f.partner_id = partner2
+        # Add new attendees
+        for booking in order.resource_booking_ids:
+            booking.partner_ids += partner2
         # Click on "Bookings" smart button
         action = order.action_open_resource_bookings()
         bookings = self._run_action(action)
@@ -78,7 +76,8 @@ class SaleResourceBookingsCase(TransactionCase):
             self.assertFalse(booking.start)
             self.assertFalse(booking.stop)
             self.assertFalse(booking.meeting_id)
-        self.assertEqual(bookings.partner_id, order.partner_id | partner2)
+            self.assertEqual(order.partner_id, booking.partner_id)
+            self.assertTrue(partner2 in booking.partner_ids)
         if self.product.resource_booking_type_combination_rel_id:
             self.assertEqual(bookings.mapped("combination_auto_assign"), [False] * 2)
             self.assertEqual(

--- a/sale_resource_booking/wizards/sale_order_booking_confirm_views.xml
+++ b/sale_resource_booking/wizards/sale_order_booking_confirm_views.xml
@@ -23,7 +23,7 @@
                                 <field name="state" />
                                 <field name="type_id" />
                                 <field name="combination_id" />
-                                <field name="partner_id" />
+                                <field name="partner_ids" widget="many2many_tags" />
                                 <field name="start" />
                                 <field name="stop" />
                             </tree>


### PR DESCRIPTION
With this FIX the adaptations of the IMP https://github.com/OCA/calendar/pull/110 are made.

On the other hand, we change the name of the type_id field of the transient model resource_booking_sale that causes an error when creating a quotation from a resource.booking.type with the module sale_order_type installed. 