### PR TITLE
[IMP] sale_order_product_picker: quick add 1 packaging

### DIFF
--- a/sale_order_product_picker/README.rst
+++ b/sale_order_product_picker/README.rst
@@ -59,6 +59,12 @@ Usage
    * On page Picker you can search for products.
    * You can:
       * Add a line by clicking on +1 button.
+      * Add a packaging by clicking on +1 button.
+
+        For this to work, product packagings must be enabled in settings, and
+        the product must have at least one packaging configured for sales.
+
+        Only the 1st one for sales will be used for the picker shortcut.
       * Add/edit/delete a line by clicking the kanban card.
       * Show image on fullscreen by clicking it.
 
@@ -93,6 +99,8 @@ Contributors
   * Sergio Teruel
   * Carlos Dauden
   * Carlos Roca
+
+* Jairo Llopis (`Moduon <https://www.moduon.team/>`__)
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_order_product_picker/i18n/es.po
+++ b/sale_order_product_picker/i18n/es.po
@@ -6,16 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-04-20 09:25+0000\n"
-"PO-Revision-Date: 2023-11-26 18:33+0000\n"
-"Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
+"POT-Creation-Date: 2023-12-01 11:32+0000\n"
+"PO-Revision-Date: 2023-12-01 11:33+0000\n"
+"Last-Translator: Jairo Llopis <jairo@moduon.team>\n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"X-Generator: Poedit 3.4\n"
 
 #. module: sale_order_product_picker
 #: model_terms:ir.ui.view,arch_db:sale_order_product_picker.view_order_form
@@ -73,6 +73,11 @@ msgid "Commercial Quotations"
 msgstr "Presupuestos (Comerciales)"
 
 #. module: sale_order_product_picker
+#: model:ir.model.fields,field_description:sale_order_product_picker.field_sale_order_picker__qty_per_packaging
+msgid "Contained Quantity"
+msgstr "Cantidad contenida"
+
+#. module: sale_order_product_picker
 #: model:ir.model.fields,field_description:sale_order_product_picker.field_sale_order_picker__create_uid
 msgid "Created by"
 msgstr "Creado por"
@@ -90,8 +95,7 @@ msgstr "Moneda"
 #. module: sale_order_product_picker
 #: model:ir.model.fields,help:sale_order_product_picker.field_sale_order_picker__uom_id
 msgid "Default unit of measure used for all stock operations."
-msgstr ""
-"Unidad de medida por defecto usada para todas las operaciones de Inventario."
+msgstr "Unidad de medida por defecto usada para todas las operaciones de Inventario."
 
 #. module: sale_order_product_picker
 #: model:ir.model.fields,field_description:sale_order_product_picker.field_sale_order_picker__qty_delivered
@@ -187,6 +191,11 @@ msgid "Origin"
 msgstr "Origen"
 
 #. module: sale_order_product_picker
+#: model:ir.model.fields,field_description:sale_order_product_picker.field_sale_order_picker__product_packaging_id
+msgid "Packaging"
+msgstr "Envase"
+
+#. module: sale_order_product_picker
 #: model:ir.model.fields,field_description:sale_order_product_picker.field_sale_order__picker_ids
 #: model_terms:ir.ui.view,arch_db:sale_order_product_picker.view_order_form
 msgid "Picker"
@@ -243,6 +252,11 @@ msgstr "Variantes de productos (Selector)"
 #: model:ir.model.fields,field_description:sale_order_product_picker.field_sale_order_picker__product_uom_qty
 msgid "Quantity"
 msgstr "Cantidad"
+
+#. module: sale_order_product_picker
+#: model:ir.model.fields,help:sale_order_product_picker.field_sale_order_picker__qty_per_packaging
+msgid "Quantity of products contained in the packaging."
+msgstr "Cantidad de productos contenidos en el envase."
 
 #. module: sale_order_product_picker
 #: model:ir.model.fields,field_description:sale_order_product_picker.field_sale_order_picker__sale_line_id
@@ -304,163 +318,3 @@ msgstr "Usar dirección de entrega"
 #: model:ir.model,name:sale_order_product_picker.model_sale_order_picker
 msgid "sale.order.picker"
 msgstr "sale.order.picker"
-
-#, python-format
-#~ msgid ""
-#~ "\n"
-#~ "                <div class=\"modal o_legacy_dialog o_technical_modal\" id="
-#~ "\"picker-image-full-modal\" role=\"dialog\">\n"
-#~ "                    <div class=\"modal-dialog modal-lg ui-draggable modal-"
-#~ "dialog-centered\">\n"
-#~ "                        <!-- Modal content-->\n"
-#~ "                        <div class=\"modal-content\">\n"
-#~ "                            <div class=\"modal-header ui-draggable-handle"
-#~ "\">\n"
-#~ "                                <button type=\"button\" class=\"close\" "
-#~ "data-dismiss=\"modal\">&times;</button>\n"
-#~ "                            </div>\n"
-#~ "                            <div class=\"modal-body text-center\">\n"
-#~ "                                <img src=\"/web/image/product.product/"
-#~ "${product_id}/image_1920\" style=\"max-width: 100%; object-fit: contain;"
-#~ "\" alt=\"Product image\"/>\n"
-#~ "                            </div>\n"
-#~ "                        </div>\n"
-#~ "                    </div>\n"
-#~ "                </div>"
-#~ msgstr ""
-#~ "\n"
-#~ "                <div class=\"modal o_legacy_dialog o_technical_modal\" id="
-#~ "\"picker-image-full-modal\" role=\"dialog\">\n"
-#~ "                    <div class=\"modal-dialog modal-lg ui-draggable modal-"
-#~ "dialog-centered\">\n"
-#~ "                        <!-- Modal content-->\n"
-#~ "                        <div class=\"modal-content\">\n"
-#~ "                            <div class=\"modal-header ui-draggable-handle"
-#~ "\">\n"
-#~ "                                <button type=\"button\" class=\"close\" "
-#~ "data-dismiss=\"modal\">&times;</button>\n"
-#~ "                            </div>\n"
-#~ "                            <div class=\"modal-body text-center\">\n"
-#~ "                                <img src=\"/web/image/product.product/"
-#~ "${product_id}/image_1920\" style=\"max-width: 100%; object-fit: contain;"
-#~ "\" alt=\"Imagen del producto\"/>\n"
-#~ "                            </div>\n"
-#~ "                        </div>\n"
-#~ "                    </div>\n"
-#~ "                </div>"
-
-#, python-format
-#~ msgid ""
-#~ "\n"
-#~ "                <div class=\"modal o_legacy_dialog o_technical_modal\" id="
-#~ "\"picker-multiline-modal\" role=\"dialog\">\n"
-#~ "                    <div class=\"modal-dialog modal-lg ui-draggable\">\n"
-#~ "                        <!-- Modal content-->\n"
-#~ "                        <div class=\"modal-content\">\n"
-#~ "                            <div class=\"modal-header ui-draggable-handle"
-#~ "\">\n"
-#~ "                                <h4 class=\"modal-title\">Select witch "
-#~ "line you want to modify</h4>\n"
-#~ "                                <button type=\"button\" class=\"close\" "
-#~ "data-dismiss=\"modal\">&times;</button>\n"
-#~ "                            </div>\n"
-#~ "                            <div class=\"modal-body\" />\n"
-#~ "                            <div class=\"modal-footer\">\n"
-#~ "                                <button type=\"button\" class=\"btn btn-"
-#~ "primary\" data-dismiss=\"modal\">Close</button>\n"
-#~ "                            </div>\n"
-#~ "                        </div>\n"
-#~ "                    </div>\n"
-#~ "                </div>"
-#~ msgstr ""
-#~ "\n"
-#~ "                <div class=\"modal o_legacy_dialog o_technical_modal\" id="
-#~ "\"picker-multiline-modal\" role=\"dialog\">\n"
-#~ "                    <div class=\"modal-dialog modal-lg ui-draggable\">\n"
-#~ "                        <!-- Modal content-->\n"
-#~ "                        <div class=\"modal-content\">\n"
-#~ "                            <div class=\"modal-header ui-draggable-handle"
-#~ "\">\n"
-#~ "                                <h4 class=\"modal-title\">Seleccione la "
-#~ "línea que quiera modificar</h4>\n"
-#~ "                                <button type=\"button\" class=\"close\" "
-#~ "data-dismiss=\"modal\">&times;</button>\n"
-#~ "                            </div>\n"
-#~ "                            <div class=\"modal-body\" />\n"
-#~ "                            <div class=\"modal-footer\">\n"
-#~ "                                <button type=\"button\" class=\"btn btn-"
-#~ "primary\" data-dismiss=\"modal\">Close</button>\n"
-#~ "                            </div>\n"
-#~ "                        </div>\n"
-#~ "                    </div>\n"
-#~ "                </div>"
-
-#~ msgid "<strong style=\"font-size: 1.2em\">+1</strong>"
-#~ msgstr "<strong style=\"font-size: 1.2em\">+1</strong>"
-
-#~ msgid "Cancelled"
-#~ msgstr "Cancelado"
-
-#~ msgid ""
-#~ "Current quantity of products.\n"
-#~ "In a context with a single Stock Location, this includes goods stored at "
-#~ "this Location, or any of its children.\n"
-#~ "In a context with a single Warehouse, this includes goods stored in the "
-#~ "Stock Location of this Warehouse, or any of its children.\n"
-#~ "stored in the Stock Location of the Warehouse of this Shop, or any of its "
-#~ "children.\n"
-#~ "Otherwise, this includes goods stored in any Stock Location with "
-#~ "'internal' type."
-#~ msgstr ""
-#~ "Cantidad actual de los productos.\n"
-#~ "En un contexto de una sola ubicación de existencias, esto incluye los "
-#~ "bienes almacenados en esta ubicación, o cualquiera de sus hijas.\n"
-#~ "En un contexto de un solo almacén, esto incluye los bienes almacenados en "
-#~ "la ubicación de existencias de ese almacén, o cualquiera de sus hijas.\n"
-#~ "En cualquier otro caso, esto incluye los bienes almacenados en cualquier "
-#~ "ubicación de existencias de tipo 'Interna'."
-
-#~ msgid "Display Qty Widget"
-#~ msgstr "Mostrar widget de cantidad"
-
-#~ msgid "Forecast Expected Date"
-#~ msgstr "Fecha prevista"
-
-#~ msgid "Free Qty Today"
-#~ msgstr "Cant. libre hoy"
-
-#~ msgid "Is Mto"
-#~ msgstr "Es MTO"
-
-#~ msgid "Locked"
-#~ msgstr "Bloqueado"
-
-#~ msgid "Move"
-#~ msgstr "Movimiento"
-
-#~ msgid "Qty Available Today"
-#~ msgstr "Cant. Disponible Hoy"
-
-#~ msgid "Qty To Deliver"
-#~ msgstr "Cant. a entregar"
-
-#~ msgid "Quantity:"
-#~ msgstr "Cantidad:"
-
-#~ msgid "Quotation"
-#~ msgstr "Presupuesto"
-
-#~ msgid "Quotation Sent"
-#~ msgstr "Presupuesto enviado"
-
-#~ msgid "Scheduled Date"
-#~ msgstr "Fecha prevista"
-
-#~ msgid "State"
-#~ msgstr "Estado"
-
-#~ msgid "Virtual Available At Date"
-#~ msgstr "Virtual disponible en la fecha"
-
-#~ msgid "Warehouse"
-#~ msgstr "Almacén"

--- a/sale_order_product_picker/i18n/sale_order_product_picker.pot
+++ b/sale_order_product_picker/i18n/sale_order_product_picker.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-12-01 11:32+0000\n"
+"PO-Revision-Date: 2023-12-01 11:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -61,6 +63,11 @@ msgstr ""
 #. module: sale_order_product_picker
 #: model:ir.actions.act_window,name:sale_order_product_picker.action_open_picker_views
 msgid "Commercial Quotations"
+msgstr ""
+
+#. module: sale_order_product_picker
+#: model:ir.model.fields,field_description:sale_order_product_picker.field_sale_order_picker__qty_per_packaging
+msgid "Contained Quantity"
 msgstr ""
 
 #. module: sale_order_product_picker
@@ -177,6 +184,11 @@ msgid "Origin"
 msgstr ""
 
 #. module: sale_order_product_picker
+#: model:ir.model.fields,field_description:sale_order_product_picker.field_sale_order_picker__product_packaging_id
+msgid "Packaging"
+msgstr ""
+
+#. module: sale_order_product_picker
 #: model:ir.model.fields,field_description:sale_order_product_picker.field_sale_order__picker_ids
 #: model_terms:ir.ui.view,arch_db:sale_order_product_picker.view_order_form
 msgid "Picker"
@@ -232,6 +244,11 @@ msgstr ""
 #. module: sale_order_product_picker
 #: model:ir.model.fields,field_description:sale_order_product_picker.field_sale_order_picker__product_uom_qty
 msgid "Quantity"
+msgstr ""
+
+#. module: sale_order_product_picker
+#: model:ir.model.fields,help:sale_order_product_picker.field_sale_order_picker__qty_per_packaging
+msgid "Quantity of products contained in the packaging."
 msgstr ""
 
 #. module: sale_order_product_picker

--- a/sale_order_product_picker/readme/CONTRIBUTORS.rst
+++ b/sale_order_product_picker/readme/CONTRIBUTORS.rst
@@ -3,3 +3,5 @@
   * Sergio Teruel
   * Carlos Dauden
   * Carlos Roca
+
+* Jairo Llopis (`Moduon <https://www.moduon.team/>`__)

--- a/sale_order_product_picker/readme/USAGE.rst
+++ b/sale_order_product_picker/readme/USAGE.rst
@@ -4,6 +4,12 @@
    * On page Picker you can search for products.
    * You can:
       * Add a line by clicking on +1 button.
+      * Add a packaging by clicking on +1 button.
+
+        For this to work, product packagings must be enabled in settings, and
+        the product must have at least one packaging configured for sales.
+
+        Only the 1st one for sales will be used for the picker shortcut.
       * Add/edit/delete a line by clicking the kanban card.
       * Show image on fullscreen by clicking it.
 

--- a/sale_order_product_picker/static/description/index.html
+++ b/sale_order_product_picker/static/description/index.html
@@ -401,16 +401,27 @@ or create a new one if not exists.</li>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
-<ol class="arabic simple">
-<li>Go to <em>Sales &gt; Orders &gt; Salesman Quotations</em><ul>
-<li>Create or edit an order.</li>
-<li>On page Picker you can search for products.</li>
+<ol class="arabic">
+<li><p class="first">Go to <em>Sales &gt; Orders &gt; Salesman Quotations</em></p>
+<ul>
+<li><p class="first">Create or edit an order.</p>
+</li>
+<li><p class="first">On page Picker you can search for products.</p>
+</li>
 <li><dl class="first docutils">
 <dt>You can:</dt>
 <dd><ul class="first last">
-<li>Add a line by clicking on +1 button.</li>
-<li>Add/edit/delete a line by clicking the kanban card.</li>
-<li>Show image on fullscreen by clicking it.</li>
+<li><p class="first">Add a line by clicking on +1 button.</p>
+</li>
+<li><p class="first">Add a packaging by clicking on +1 button.</p>
+<p>For this to work, product packagings must be enabled in settings, and
+the product must have at least one packaging configured for sales.</p>
+<p>Only the 1st one for sales will be used for the picker shortcut.</p>
+</li>
+<li><p class="first">Add/edit/delete a line by clicking the kanban card.</p>
+</li>
+<li><p class="first">Show image on fullscreen by clicking it.</p>
+</li>
 </ul>
 </dd>
 </dl>
@@ -448,6 +459,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Carlos Roca</li>
 </ul>
 </li>
+<li>Jairo Llopis (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/sale_order_product_picker/views/sale_order_views.xml
+++ b/sale_order_product_picker/views/sale_order_views.xml
@@ -327,6 +327,30 @@
                                                                     />
                                                                 </strong>
                                                             </a>
+                                                            <a
+                                                                role="button"
+                                                                class="btn btn-secondary o_picker_quick_add_packaging w-100"
+                                                                style="padding-left:0px; padding-right:0px;"
+                                                                groups="product.group_stock_packaging"
+                                                                attrs="{'invisible': [('product_packaging_id', '=', False)]}"
+                                                            >
+                                                                <strong
+                                                                    style="font-size: 1.2em"
+                                                                >+1
+                                                                </strong>
+                                                                <strong
+                                                                    style="font-size: 0.8em"
+                                                                >
+                                                                    <field
+                                                                        name="product_packaging_id"
+                                                                        readonly="1"
+                                                                    />
+                                                                    <field
+                                                                        name="qty_per_packaging"
+                                                                        invisible="1"
+                                                                    />
+                                                                </strong>
+                                                            </a>
                                                         </div>
                                                     </div>
                                                     <div class="row">


### PR DESCRIPTION
When enabling packaging standard Odoo system, now the picker allows you to add +1 package.
![imagen](https://github.com/OCA/sale-workflow/assets/973709/a444a853-2222-4fae-8476-04aa31363246)


For this to work, product packagings must be enabled in settings, and the product must have at least one packaging configured for sales.

Only the 1st one for sales will be used for the picker shortcut.

@moduon MT-4396