### PR TITLE
[FIX] sale_order_line_date: format style of commitment_date

### DIFF
--- a/sale_order_line_date/reports/sale_order_report.xml
+++ b/sale_order_line_date/reports/sale_order_report.xml
@@ -5,13 +5,13 @@
         inherit_id="sale.report_saleorder_document"
     >
         <xpath expr="//table/thead//tr[1]//th[1]" position="after">
-            <th class="text-left">Commitment Date</th>
+            <th name="th_commitment_date" class="text-start">Commitment Date</th>
         </xpath>
         <xpath
             expr="//table/tbody[hasclass('sale_tbody')]//tr[1]//td[1]"
             position="after"
         >
-            <td>
+            <td name="td_commitment_date" class="text-start">
                 <span t-field="line.commitment_date" t-options="{'widget': 'date'}" />
             </td>
         </xpath>


### PR DESCRIPTION
The `text-left` label is no longer used In Odoo 16.0. Instead, `text-start` is now utilized.
I have replaced this label and also added a name to the `th` and `td` elements to improve the code when inheriting.