### PR TITLE
[16.0] sale_product_packaging_container_deposit: fix qty delivered update

### DIFF
--- a/sale_product_packaging_container_deposit/models/__init__.py
+++ b/sale_product_packaging_container_deposit/models/__init__.py
@@ -1,2 +1,3 @@
 from . import sale_order
 from . import sale_order_line
+from . import stock_move

--- a/sale_product_packaging_container_deposit/models/sale_order_line.py
+++ b/sale_product_packaging_container_deposit/models/sale_order_line.py
@@ -13,8 +13,3 @@ class SaleOrderLine(models.Model):
 
     def _get_product_qty_delivered_received_field(self):
         return "qty_delivered"
-
-    def _compute_qty_delivered(self):
-        res = super()._compute_qty_delivered()
-        self.mapped("order_id").update_order_container_deposit_quantity()
-        return res

--- a/sale_product_packaging_container_deposit/models/stock_move.py
+++ b/sale_product_packaging_container_deposit/models/stock_move.py
@@ -1,0 +1,15 @@
+# Copyright 2023 Camptocamp (<https://www.camptocamp.com>).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _action_done(self, cancel_backorder=False):
+        todo_moves = super()._action_done(cancel_backorder=cancel_backorder)
+        # ensure container deposit qty are updated on related SOs
+        if todo_moves:
+            todo_moves.sale_line_id.order_id.update_order_container_deposit_quantity()
+        return todo_moves

--- a/sale_product_packaging_container_deposit/readme/CONTRIBUTORS.rst
+++ b/sale_product_packaging_container_deposit/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Telmo Santos <telmo.santos@camptocamp.com>
 * Jacques-Etienne Baudoux <je@bcim.be>
+* Simone Orsi <simone.orsi@camptocamp.com>

--- a/sale_product_packaging_container_deposit/tests/test_sale_product_packaging_container_deposit.py
+++ b/sale_product_packaging_container_deposit/tests/test_sale_product_packaging_container_deposit.py
@@ -274,3 +274,20 @@ class TestSaleProductPackagingContainerDeposit(Common):
         order_line.qty_delivered = 200
         self.assertEqual(pallet_line.qty_delivered, 0)
         self.assertEqual(box_line.qty_delivered, 8)
+
+    def test_sale_product_packaging_container_deposit_quantities_case8(self):
+        """Test add and delete container deposit lines"""
+        sale_form = Form(self.env["sale.order"])
+        sale_form.partner_id = self.sale_order.partner_id
+        with sale_form.order_line.new() as line:
+            line.product_id = self.product_a
+            line.product_uom_qty = 280
+        sale = sale_form.save()
+        with sale_form.order_line.edit(0) as line:
+            line.product_uom_qty = 10
+
+        lines_to_delete = sale.order_line.filtered(
+            lambda ol: ol.product_id == self.pallet or ol.product_id == self.box
+        )
+        with self._check_delete_after_commit(lines_to_delete):
+            sale_form.save()


### PR DESCRIPTION
We should never write on related records in a computed field.
Now to detect the update of delivered qty we hook to the stock move update.

Depends on https://github.com/OCA/product-attribute/pull/1475

The same fix should be applied to the purchase module.
