### PR TITLE
[FIX] sale_discount_display_amount: fix inifinite loop at in,it hook

### DIFF
--- a/sale_discount_display_amount/hooks.py
+++ b/sale_discount_display_amount/hooks.py
@@ -48,4 +48,4 @@ def post_init_hook(cr, registry):
     order_ids = cr.fetchall()
 
     orders = env["sale.order"].search([("id", "in", order_ids)])
-    orders.mapped("order_line")._update_discount_display_fields()
+    orders.mapped("order_line")._compute_amount()


### PR DESCRIPTION
`_update_discount_display_fields` is called in  `_compute_amount`  and uses computed fields from it. This leads to an infinite loop during module initialization