### PR TITLE
[FIX] [16.0] sale_invoice_frequency: Add `invoice_frequency_id` to commercial fields

### DIFF
--- a/sale_invoice_frequency/README.rst
+++ b/sale_invoice_frequency/README.rst
@@ -31,6 +31,7 @@ Sale Invoice Frequency
 This module extends the functionality of sales to support group by Invoicing
 frequency and to allow you to choose the right orders to invoice based on the
 frequency defined on the customer.
+On the partner, Invoicing frequency field is propagated to its children when changed.
 
 **Table of contents**
 

--- a/sale_invoice_frequency/models/res_partner.py
+++ b/sale_invoice_frequency/models/res_partner.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
 
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -13,3 +13,7 @@ class ResPartner(models.Model):
         string="Invoicing frequency",
         help="Invoicing frequency for this customer",
     )
+
+    @api.model
+    def _commercial_fields(self):
+        return super()._commercial_fields() + ["invoice_frequency_id"]

--- a/sale_invoice_frequency/readme/DESCRIPTION.rst
+++ b/sale_invoice_frequency/readme/DESCRIPTION.rst
@@ -1,3 +1,4 @@
 This module extends the functionality of sales to support group by Invoicing
 frequency and to allow you to choose the right orders to invoice based on the
 frequency defined on the customer.
+On the partner, Invoicing frequency field is propagated to its children when changed.

--- a/sale_invoice_frequency/static/description/index.html
+++ b/sale_invoice_frequency/static/description/index.html
@@ -372,7 +372,8 @@ ul.auto-toc {
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/sale-workflow/tree/16.0/sale_invoice_frequency"><img alt="OCA/sale-workflow" src="https://img.shields.io/badge/github-OCA%2Fsale--workflow-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/sale-workflow-16-0/sale-workflow-16-0-sale_invoice_frequency"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/sale-workflow&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module extends the functionality of sales to support group by Invoicing
 frequency and to allow you to choose the right orders to invoice based on the
-frequency defined on the customer.</p>
+frequency defined on the customer.
+On the partner, Invoicing frequency field is propagated to its children when changed.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">


### PR DESCRIPTION
Add `invoice_frequency_id` to commercial fields and allow it to propagate to contact children when changed.

https://www.loom.com/share/84256d965e4448df825f7b9324fba764?sid=d5559b61-3a90-46d4-9df0-894d895237e9

MT-4428 @moduon @rafaelbn @fcvalgar @Gelo-fl plz review :)