### PR TITLE
[14.0][FIX] sale_stock_return_request: Exclude section and notes from _get_returnable_lines

### DIFF
--- a/sale_stock_return_request/models/sale_order.py
+++ b/sale_stock_return_request/models/sale_order.py
@@ -15,7 +15,8 @@ class SaleOrder(models.Model):
 
     def _get_returnable_lines(self):
         return self.order_line.filtered(
-            lambda x: x.product_id.type != "service"
+            lambda x: not x.display_type
+            and x.product_id.type != "service"
             and float_compare(
                 x.qty_delivered, 0.0, precision_rounding=x.product_uom.rounding
             )


### PR DESCRIPTION
Backport of #2846 