### PR TITLE
[16.0][IMP] sale_order_lot_selection: Default company on lot creation, consistent field label

### DIFF
--- a/sale_order_lot_selection/models/sale_order_line.py
+++ b/sale_order_lot_selection/models/sale_order_line.py
@@ -6,7 +6,7 @@ class SaleOrderLine(models.Model):
 
     lot_id = fields.Many2one(
         "stock.lot",
-        "Lot",
+        "Restrict Lot/Serial Number",
         copy=False,
         compute="_compute_lot_id",
         store=True,

--- a/sale_order_lot_selection/view/sale_view.xml
+++ b/sale_order_lot_selection/view/sale_view.xml
@@ -22,7 +22,7 @@
                 <field
                     name="lot_id"
                     domain="[('product_id','=', product_id)]"
-                    context="{'default_product_id': product_id}"
+                    context="{'default_product_id': product_id, 'default_company_id': company_id}"
                     groups="stock.group_production_lot"
                 />
             </xpath>


### PR DESCRIPTION
Current behavior:
===========

- On creating a lot from a Sale Order Line in the Sale Order form view, the company_id field has no default value, which prevents quick create
- The field label for lot_id on the Sale Order Line is not consistent with the stock_restrict_lot or stock modules

Improvement:
=========

- Make the default value for company_id on a stock.lot created from a Sale Order Line the same as the company_id for the order line
- Change the field label for lot_id on the Sale Order Line to match "Restrict Lot" from stock_restrict_lot module and "Lot/Serial Number" from stock module