### PR TITLE
[IMP] sale_order_product_recommendation: favorites, categories

### DIFF
--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -220,11 +220,17 @@ class SaleOrderRecommendation(models.TransientModel):
 class SaleOrderRecommendationLine(models.TransientModel):
     _name = "sale.order.recommendation.line"
     _description = "Recommended product for current sale order"
-    _order = "id"
+    _order = "product_priority desc, id"
 
     currency_id = fields.Many2one(related="product_id.currency_id")
     partner_id = fields.Many2one(related="wizard_id.order_id.partner_id")
     product_id = fields.Many2one("product.product", string="Product")
+    product_categ_id = fields.Many2one(
+        related="product_id.categ_id", readonly=True, store=True
+    )
+    product_priority = fields.Selection(
+        related="product_id.priority", store=True, readonly=False
+    )
     price_unit = fields.Monetary(compute="_compute_price_unit")
     pricelist_id = fields.Many2one(related="wizard_id.order_id.pricelist_id")
     times_delivered = fields.Integer(readonly=True)

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
@@ -25,9 +25,21 @@
                             colspan="2"
                             attrs="{'invisible': [('line_ids', '=', [])]}"
                         >
-                            <tree create="0" delete="0" editable="top">
+                            <tree
+                                create="0"
+                                delete="0"
+                                editable="top"
+                                context="{'group_by': 'product_categ_id'}"
+                            >
+                                <field
+                                    name="product_priority"
+                                    widget="priority"
+                                    optional="show"
+                                    nolabel="1"
+                                />
                                 <field name="currency_id" invisible="1" />
                                 <field name="sale_line_id" invisible="1" />
+                                <field name="product_categ_id" optional="show" />
                                 <field name="product_id" readonly="1" force_save="1" />
                                 <field name="price_unit" />
                                 <field name="times_delivered" />
@@ -57,19 +69,34 @@
                                 <templates>
                                     <t t-name="kanban-box">
                                         <div class="oe_kanban_global_click">
-                                            <div class="o_kanban_image">
+                                            <div class="o_kanban_image me-1">
                                                 <img
                                                     t-att-src="kanban_image('product.product', 'image_128', record.product_id.raw_value)"
                                                     alt="Product"
+                                                    class="o_image_64_contain"
                                                 />
                                             </div>
                                             <div class="oe_kanban_details">
-                                                <div><field name="product_id" /></div>
+                                                <div class="o_kanban_record_top mb-0">
+                                                    <div
+                                                        class="o_kanban_record_headings"
+                                                    >
+                                                        <field
+                                                            name="product_id"
+                                                            class="o_kanban_record_title"
+                                                        />
+                                                    </div>
+                                                    <field
+                                                        class="w-auto mb-0"
+                                                        name="product_priority"
+                                                        widget="priority"
+                                                    />
+                                                </div>
                                                 <div>Price: <field
                                                         name="price_unit"
                                                         widget="monetary"
                                                         options="{'currency_field': 'currency_id', 'field_digits': True}"
-                                                        class="mt-0 mb-0"
+                                                        class="oe_inline mt-0 mb-0"
                                                     /></div>
                                                 <div>Delivered: <field
                                                         name="times_delivered"


### PR DESCRIPTION
New shiny feature: you can un/favorite products, and those will appear first in the list of recommendations.

![imagen](https://github.com/OCA/sale-workflow/assets/973709/1437ce8f-a4d1-47e3-97a0-09244fc7d79c)


New not-so-shiny feature: recommendations will be sortable by product category.

![imagen](https://github.com/OCA/sale-workflow/assets/973709/067ba712-65ef-412e-a943-2f6d21bee173)


While testing the module in the field, it turned out that salespeople often use recommendations based on the product category. Other than that, the favorites option still helps.

@moduon MT-4472