### PR TITLE
[FIX] sale_order_product_recommendation_packaging_default: quick crea…

### DIFF
--- a/sale_order_product_recommendation_packaging_default/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation_packaging_default/wizards/sale_order_recommendation_view.xml
@@ -18,6 +18,7 @@
                     name="product_packaging_id"
                     groups="product.group_stock_packaging"
                     optional="show"
+                    context="{'default_product_id': product_id}"
                 />
                 <field
                     name="product_packaging_qty"
@@ -34,6 +35,7 @@
                 <field
                     name="product_packaging_id"
                     groups="product.group_stock_packaging"
+                    context="{'default_product_id': product_id}"
                 />
                 <field
                     name="product_packaging_qty"


### PR DESCRIPTION
…te packaging

Now it includes the default product in the context, so when you use quick creation actions, it will behave as expected.

@moduon MT-4472