### PR TITLE
[16.0][IMP] sale_stock_picking_note: Notes from partner shipping

### DIFF
--- a/sale_stock_picking_note/models/sale_order.py
+++ b/sale_stock_picking_note/models/sale_order.py
@@ -22,9 +22,15 @@ class SaleOrder(models.Model):
         readonly=False,
     )
 
-    @api.depends("partner_id")
+    @api.depends("partner_id", "partner_shipping_id")
     def _compute_picking_notes(self):
         for order in self:
             if order.state not in {"sale", "done", "cancel"}:
-                order.picking_note = order.partner_id.picking_note
-                order.picking_customer_note = order.partner_id.picking_customer_note
+                order.picking_note = (
+                    order.partner_shipping_id.picking_note
+                    or order.partner_id.picking_note
+                )
+                order.picking_customer_note = (
+                    order.partner_shipping_id.picking_customer_note
+                    or order.partner_id.picking_customer_note
+                )


### PR DESCRIPTION
When choosing delivery address in sale order, notes are taken from delivery address.
If the delivery address has no notes, they are taken from the customer.

https://www.loom.com/share/d1051894a29b42909ba075d35408964c

@yajo, @Gelojr, @rafaelbn, @Shide or @chienandalu please review.

MT-4381 @moduon