### PR TITLE
[15.0][FIX] sale_payment_sheet: Don't set name on stamement lines

### DIFF
--- a/sale_payment_sheet/models/sale_payment_sheet.py
+++ b/sale_payment_sheet/models/sale_payment_sheet.py
@@ -153,7 +153,6 @@ class SalePaymentSheet(models.Model):
 
                 if key not in vals_dic:
                     vals_dic[key] = {
-                        "name": line.name,
                         "date": line.date,
                         "amount": amount_line,
                         "partner_id": line.partner_id.id,
@@ -164,7 +163,6 @@ class SalePaymentSheet(models.Model):
                     }
                 else:
                     vals_dic[key]["amount"] += amount_line
-                    vals_dic[key]["name"] += " {}".format(line.invoice_id.name)
                     vals_dic[key]["payment_sheet_line_ids"] += line
             for vals in vals_dic.values():
                 payment_sheet_line_ids = vals.pop("payment_sheet_line_ids", None)


### PR DESCRIPTION
Since v14, statement lines are extensions of journal entries, so its fields are the move fields. Setting `name` field of the line means setting the journal entry number, which is not desired and provokes incorrect numbering scheme.

@Tecnativa TT46659