### PR TITLE
[FIX] sale_order_product_recommendation_elaboration: don't assume the current product is the same than the one in the elaboration

### DIFF
--- a/sale_order_product_recommendation_elaboration/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation_elaboration/wizards/sale_order_recommendation_view.xml
@@ -12,11 +12,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='line_ids']/form" position="inside">
                 <group string="Elaborations" name="elaboration">
-                    <field
-                        name="elaboration_ids"
-                        widget="many2many_tags"
-                        context="{'default_product_id': product_id}"
-                    />
+                    <field name="elaboration_ids" widget="many2many_tags" />
                     <field name="elaboration_note" />
                 </group>
             </xpath>
@@ -24,12 +20,7 @@
                 expr="//field[@name='line_ids']/tree//field[@name='units_included']"
                 position="after"
             >
-                <field
-                    name="elaboration_ids"
-                    widget="many2many_tags"
-                    optional="show"
-                    context="{'default_product_id': product_id}"
-                />
+                <field name="elaboration_ids" widget="many2many_tags" optional="show" />
                 <field name="elaboration_note" optional="show" />
             </xpath>
         </field>


### PR DESCRIPTION
Correcting some mistakes due to a misconception on my side, I designed the module and tests assuming the product linked in the elaboration should be the one we're currently selling.

Instead, as the README on `sale_elaboration` says, the elaboration product is an additional product to be added to the SO when delivered, producing a price increase.

@moduon MT-4472