### PR TITLE
[FIX] sale_order_product_recommendation: smaller heading on wizard

### DIFF
--- a/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
@@ -11,11 +11,15 @@
             <form>
                 <sheet>
                     <group>
-                        <field name="order_id" invisible="1" />
-                        <field name="months" widget="numeric_step" />
-                        <field name="line_amount" widget="numeric_step" />
-                        <field name="sale_recommendation_price_origin" />
-                        <field name="use_delivery_address" />
+                        <group>
+                            <field name="order_id" invisible="1" />
+                            <field name="months" widget="numeric_step" />
+                            <field name="line_amount" widget="numeric_step" />
+                        </group>
+                        <group>
+                            <field name="sale_recommendation_price_origin" />
+                            <field name="use_delivery_address" />
+                        </group>
                     </group>
                     <group col="2">
                         <field


### PR DESCRIPTION
Before this patch, the wizard header had too much height on desktop computers.

Besides, the +/- buttons that appear when `web_numeric_step` is installed were too far apart on tablets.

![imagen](https://github.com/OCA/sale-workflow/assets/973709/f5fc5789-cc8a-4129-96d8-450429397eb6)

Now:

![imagen](https://github.com/OCA/sale-workflow/assets/973709/fed75f63-1f1c-43b5-8880-5f53a110b50a)




@moduon MT-4472