### PR TITLE
[IMP] sale_order_revision: 'New Revision' quick button on confirmed Sales Orders

### DIFF
--- a/sale_order_revision/models/sale_order.py
+++ b/sale_order_revision/models/sale_order.py
@@ -43,3 +43,11 @@ class SaleOrder(models.Model):
             "default_current_revision_id": self.id,
         }
         return result
+
+    def action_cancel_create_revision(self):
+        for sale in self:
+            sale.action_cancel()
+            action = sale.create_revision()
+        if len(self) == 1:
+            return action
+        return {}

--- a/sale_order_revision/readme/CONTRIBUTORS.rst
+++ b/sale_order_revision/readme/CONTRIBUTORS.rst
@@ -8,3 +8,4 @@
 * Jeroen Evens <jeroen.evens@dynapps.be>
 * Kitti U. <kittiu@ecosoft.co.th>
 * Denis Leemann <denis.leemann@camptocamp.com>
+* Daniel Reis <dreis@opensourceintegrators.com>

--- a/sale_order_revision/readme/DESCRIPTION.rst
+++ b/sale_order_revision/readme/DESCRIPTION.rst
@@ -1,10 +1,2 @@
-On cancelled orders, you can click on the "New copy of Quotation" button. This
-will create a new revision of the quotation, with the same base number and a
-'-revno' suffix appended. A message is added in the chatter saying that a new
-revision was created.
-
-In the form view, a new tab is added that lists the previous revisions, with
-the date they were made obsolete and the user who performed the action.
-
-The old revisions of a sale order are flagged as inactive, so they don't
-clutter up searches.
+Create new revisions or versions for Sales Orders,
+keeping the history of previous revisions.

--- a/sale_order_revision/readme/USAGE.rst
+++ b/sale_order_revision/readme/USAGE.rst
@@ -1,0 +1,12 @@
+On Sales Orders, click on the "New Revision" button.
+This creates a new revision of the quotation,
+with the same base number and a '-revno' suffix appended.
+
+A message is added in the chatter saying that a new
+revision was created.
+
+In the form view, a new tab is added that lists the previous revisions, with
+the date they were made obsolete and the user who performed the action.
+
+The old revisions of a sale order are flagged as inactive, so they don't
+clutter up searches.

--- a/sale_order_revision/tests/test_sale_order_revision.py
+++ b/sale_order_revision/tests/test_sale_order_revision.py
@@ -65,3 +65,9 @@ class TestSaleOrderRevision(test_base_revision.TestBaseRevision):
         self.assertEqual(revision_2.revision_number, 2)
         self.assertEqual(revision_2.name.endswith("-02"), True)
         self.assertEqual(revision_2.has_old_revisions, True)
+
+    def test_action_cancel_create_revision(self):
+        sale = self._create_tester()
+        sale.action_cancel_create_revision()
+        self.assertEqual(sale.state, "cancel", "Original SO was cancelled")
+        self.assertTrue(sale.current_revision_id, "A new SO version was created")

--- a/sale_order_revision/view/sale_order.xml
+++ b/sale_order_revision/view/sale_order.xml
@@ -23,6 +23,12 @@
                     string="New Revision of Quotation"
                     type="object"
                 />
+                <button
+                    name="action_cancel_create_revision"
+                    states="sale"
+                    string="New Revision"
+                    type="object"
+                />
             </xpath>
             <xpath expr="//button[@name='action_view_invoice']" position="after">
                 <button


### PR DESCRIPTION
Forward port of https://github.com/OCA/sale-workflow/pull/2346