### PR TITLE
[IMP] sale_order_revision: new revision Sale Orders keep link to related Invoices

### DIFF
--- a/sale_order_revision/models/sale_order.py
+++ b/sale_order_revision/models/sale_order.py
@@ -42,3 +42,11 @@ class SaleOrder(models.Model):
             "default_current_revision_id": self.id,
         }
         return result
+
+    def action_cancel_create_revision(self):
+        for sale in self:
+            sale.action_cancel()
+            action = sale.create_revision()
+        if len(self) == 1:
+            return action
+        return {}

--- a/sale_order_revision/models/sale_order.py
+++ b/sale_order_revision/models/sale_order.py
@@ -43,6 +43,16 @@ class SaleOrder(models.Model):
         }
         return result
 
+    def create_revision(self):
+        # Extends base_revision module
+        action = super().create_revision()
+        # Keep links to Invoices on the new Sale Order
+        old_lines = self.order_line
+        new_lines = self.current_revision_id.order_line
+        for old_line, new_line in zip(old_lines, new_lines):
+            new_line.invoice_lines = old_line.invoice_lines
+        return action
+
     def action_cancel_create_revision(self):
         for sale in self:
             sale.action_cancel()

--- a/sale_order_revision/readme/CONTRIBUTORS.rst
+++ b/sale_order_revision/readme/CONTRIBUTORS.rst
@@ -7,3 +7,4 @@
 * Raf Ven <raf.ven@dynapps.be>
 * Jeroen Evens <jeroen.evens@dynapps.be>
 * Kitti U. <kittiu@ecosoft.co.th>
+* Daniel Reis <dreis@opensourceintegrators.com>

--- a/sale_order_revision/readme/DESCRIPTION.rst
+++ b/sale_order_revision/readme/DESCRIPTION.rst
@@ -1,2 +1,4 @@
 Create new revisions or versions for Sales Orders,
 keeping the history of previous revisions.
+
+The revision Sales Order preserves the link to the related Invoices.

--- a/sale_order_revision/readme/DESCRIPTION.rst
+++ b/sale_order_revision/readme/DESCRIPTION.rst
@@ -1,10 +1,2 @@
-On cancelled orders, you can click on the "New copy of Quotation" button. This
-will create a new revision of the quotation, with the same base number and a
-'-revno' suffix appended. A message is added in the chatter saying that a new
-revision was created.
-
-In the form view, a new tab is added that lists the previous revisions, with
-the date they were made obsolete and the user who performed the action.
-
-The old revisions of a sale order are flagged as inactive, so they don't
-clutter up searches.
+Create new revisions or versions for Sales Orders,
+keeping the history of previous revisions.

--- a/sale_order_revision/readme/USAGE.rst
+++ b/sale_order_revision/readme/USAGE.rst
@@ -1,0 +1,12 @@
+On Sales Orders, click on the "New Revision" button.
+This creates a new revision of the quotation,
+with the same base number and a '-revno' suffix appended.
+
+A message is added in the chatter saying that a new
+revision was created.
+
+In the form view, a new tab is added that lists the previous revisions, with
+the date they were made obsolete and the user who performed the action.
+
+The old revisions of a sale order are flagged as inactive, so they don't
+clutter up searches.

--- a/sale_order_revision/tests/test_sale_order_revision.py
+++ b/sale_order_revision/tests/test_sale_order_revision.py
@@ -20,3 +20,9 @@ class TestSaleOrderRevision(test_base_revision.TestBaseRevision):
         with sale_form.order_line.new() as line_form:
             line_form.product_id = self.product
         return sale_form.save()
+
+    def test_action_cancel_create_revision(self):
+        sale = self._create_tester()
+        sale.action_cancel_create_revision()
+        self.assertEqual(sale.state, "cancel", "Original SO was cancelled")
+        self.assertTrue(sale.current_revision_id, "A new SO version was created")

--- a/sale_order_revision/tests/test_sale_order_revision.py
+++ b/sale_order_revision/tests/test_sale_order_revision.py
@@ -12,17 +12,33 @@ class TestSaleOrderRevision(test_base_revision.TestBaseRevision):
         super().setUpClass()
         cls.revision_model = cls.env["sale.order"]
         cls.partner = cls.env["res.partner"].create({"name": "Mr Odoo"})
-        cls.product = cls.env["product.product"].create({"name": "Test product"})
+        cls.product = cls.env["product.product"].create(
+            {"name": "Test product", "invoice_policy": "order"}
+        )
 
     def _create_tester(self):
         sale_form = Form(self.revision_model)
         sale_form.partner_id = self.partner
         with sale_form.order_line.new() as line_form:
             line_form.product_id = self.product
+            line_form.product_uom_qty = 10
+            line_form.price_unit = 10
         return sale_form.save()
+
+    def _create_sale_invoice(self, sale):
+        SaleInv = self.env["sale.advance.payment.inv"].with_context(active_ids=sale.ids)
+        popup = SaleInv.create({"advance_payment_method": "delivered"})
+        popup.create_invoices()
 
     def test_action_cancel_create_revision(self):
         sale = self._create_tester()
+        sale.action_confirm()
+        self._create_sale_invoice(sale)
         sale.action_cancel_create_revision()
         self.assertEqual(sale.state, "cancel", "Original SO was cancelled")
         self.assertTrue(sale.current_revision_id, "A new SO version was created")
+        self.assertEqual(
+            sale.current_revision_id.invoice_ids,
+            sale.invoice_ids,
+            "The Sale Order revision keeps a link to the original invoices",
+        )

--- a/sale_order_revision/view/sale_order.xml
+++ b/sale_order_revision/view/sale_order.xml
@@ -23,6 +23,12 @@
                     string="New Revision of Quotation"
                     type="object"
                 />
+                <button
+                    name="action_cancel_create_revision"
+                    states="sale"
+                    string="New Revision"
+                    type="object"
+                />
             </xpath>
             <xpath expr="//button[@name='action_view_invoice']" position="after">
                 <button


### PR DESCRIPTION
- [IMP] sale_order_revision: 'New Revision' quick button on confirmed Sales Orders
- [IMP] sale_order_revision: carry Invoice links to new revision Sales Orders
