### PR TITLE
[16.0][IMP] sale_stock_picking_blocking: add blocking reason to payment terms

### DIFF
--- a/sale_stock_picking_blocking/README.rst
+++ b/sale_stock_picking_blocking/README.rst
@@ -54,6 +54,16 @@ policy to add that delivery block to his sales by default:
 #. The 'Default Delivery Block Reason' will be added
    automatically when creating a new sales order for the customer.
 
+You can also set a payment term with a 'Default Delivery Block Reason'
+policy to add that delivery block to his sales by default (only if the
+customer does not have one set), in a similar way to the customers:
+
+#. Go to 'Invoicing > Configuration > Invoicing > Payment Terms'.
+#. Add a 'Default Delivery Block Reason'.
+#. The 'Default Delivery Block Reason' will be added
+   automatically when creating a new sales order for the payment term,
+   in case the customer does not have one.
+
 Usage
 =====
 
@@ -80,12 +90,12 @@ Credits
 Authors
 ~~~~~~~
 
-* Eficent
+* ForgeFlow
 
 Contributors
 ~~~~~~~~~~~~
 
-* Lois Rilo <lois.rilo@eficent.com>
+* Lois Rilo <lois.rilo@forgeflow.com>
 * Sudhir Arya <sudhir@erpharbor.com>
 * Julien Coux <julien.coux@camptocamp.com>
 

--- a/sale_stock_picking_blocking/__manifest__.py
+++ b/sale_stock_picking_blocking/__manifest__.py
@@ -1,12 +1,12 @@
-# Copyright 2019 Eficent Business and IT Consulting Services S.L.
-#   (http://www.eficent.com)
+# Copyright 2019 ForgeFlow S.L.
+#   (http://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Sale Stock Picking Blocking",
     "summary": "Allow you to block the creation of deliveries from a sale order.",
-    "version": "16.0.1.0.1",
-    "author": "Eficent, Odoo Community Association (OCA)",
+    "version": "16.0.1.1.0",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "category": "Sales",
     "depends": ["sale_stock"],
@@ -17,6 +17,7 @@
         "views/sale_stock_picking_blocking_reason_view.xml",
         "views/sale_order_view.xml",
         "views/res_partner_view.xml",
+        "views/account_payment_term_view.xml",
     ],
     "license": "AGPL-3",
     "installable": True,

--- a/sale_stock_picking_blocking/migrations/16.0.1.1.0/pre-migration.py
+++ b/sale_stock_picking_blocking/migrations/16.0.1.1.0/pre-migration.py
@@ -1,0 +1,15 @@
+from openupgradelib import openupgrade
+
+column_renames = {
+    "account_payment_term": [
+        ("default_delivery_block", "default_delivery_block_reason_id")
+    ],
+}
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if openupgrade.column_exists(
+        env.cr, "account_payment_term", "default_delivery_block"
+    ):
+        openupgrade.rename_columns(env.cr, column_renames)

--- a/sale_stock_picking_blocking/models/__init__.py
+++ b/sale_stock_picking_blocking/models/__init__.py
@@ -4,3 +4,4 @@ from . import sale_order
 from . import sale_order_line
 from . import sale_stock_picking_blocking_reason
 from . import res_partner
+from . import account_payment_term

--- a/sale_stock_picking_blocking/models/account_payment_term.py
+++ b/sale_stock_picking_blocking/models/account_payment_term.py
@@ -1,0 +1,16 @@
+# Copyright 2024 ForgeFlow S.L.
+#   (http://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class AccountPaymentTerm(models.Model):
+    _inherit = "account.payment.term"
+
+    default_delivery_block_reason_id = fields.Many2one(
+        comodel_name="sale.delivery.block.reason",
+        string="Default Delivery Block Reason",
+        help="Set a reason to block by default the deliveries in this "
+        "payment term sales orders.",
+    )

--- a/sale_stock_picking_blocking/models/res_partner.py
+++ b/sale_stock_picking_blocking/models/res_partner.py
@@ -1,5 +1,5 @@
-# Copyright 2019 Eficent Business and IT Consulting Services S.L.
-#   (http://www.eficent.com)
+# Copyright 2019 ForgeFlow S.L.
+#   (http://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models

--- a/sale_stock_picking_blocking/models/sale_order_line.py
+++ b/sale_stock_picking_blocking/models/sale_order_line.py
@@ -1,5 +1,5 @@
-# Copyright 2019 Eficent Business and IT Consulting Services S.L.
-#   (http://www.eficent.com)
+# Copyright 2019 ForgeFlow S.L.
+#   (http://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import models

--- a/sale_stock_picking_blocking/models/sale_stock_picking_blocking_reason.py
+++ b/sale_stock_picking_blocking/models/sale_stock_picking_blocking_reason.py
@@ -1,5 +1,5 @@
-# Copyright 2019 Eficent Business and IT Consulting Services S.L.
-#   (http://www.eficent.com)
+# Copyright 2019 ForgeFlow S.L.
+#   (http://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models

--- a/sale_stock_picking_blocking/readme/CONFIGURE.rst
+++ b/sale_stock_picking_blocking/readme/CONFIGURE.rst
@@ -12,3 +12,13 @@ policy to add that delivery block to his sales by default:
 #. In the 'Sales & Purchases' add a 'Default Delivery Block Reason'.
 #. The 'Default Delivery Block Reason' will be added
    automatically when creating a new sales order for the customer.
+
+You can also set a payment term with a 'Default Delivery Block Reason'
+policy to add that delivery block to his sales by default (only if the
+customer does not have one set), in a similar way to the customers:
+
+#. Go to 'Invoicing > Configuration > Invoicing > Payment Terms'.
+#. Add a 'Default Delivery Block Reason'.
+#. The 'Default Delivery Block Reason' will be added
+   automatically when creating a new sales order for the payment term,
+   in case the customer does not have one.

--- a/sale_stock_picking_blocking/readme/CONTRIBUTORS.rst
+++ b/sale_stock_picking_blocking/readme/CONTRIBUTORS.rst
@@ -1,3 +1,3 @@
-* Lois Rilo <lois.rilo@eficent.com>
+* Lois Rilo <lois.rilo@forgeflow.com>
 * Sudhir Arya <sudhir@erpharbor.com>
 * Julien Coux <julien.coux@camptocamp.com>

--- a/sale_stock_picking_blocking/static/description/index.html
+++ b/sale_stock_picking_blocking/static/description/index.html
@@ -402,6 +402,16 @@ policy to add that delivery block to his sales by default:</p>
 <li>The ‘Default Delivery Block Reason’ will be added
 automatically when creating a new sales order for the customer.</li>
 </ol>
+<p>You can also set a payment term with a ‘Default Delivery Block Reason’
+policy to add that delivery block to his sales by default (only if the
+customer does not have one set), in a similar way to the customers:</p>
+<ol class="arabic simple">
+<li>Go to ‘Invoicing &gt; Configuration &gt; Invoicing &gt; Payment Terms’.</li>
+<li>Add a ‘Default Delivery Block Reason’.</li>
+<li>The ‘Default Delivery Block Reason’ will be added
+automatically when creating a new sales order for the payment term,
+in case the customer does not have one.</li>
+</ol>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
@@ -426,13 +436,13 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="authors">
 <h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
-<li>Eficent</li>
+<li>ForgeFlow</li>
 </ul>
 </div>
 <div class="section" id="contributors">
 <h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
-<li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;eficent.com">lois.rilo&#64;eficent.com</a>&gt;</li>
+<li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
 <li>Sudhir Arya &lt;<a class="reference external" href="mailto:sudhir&#64;erpharbor.com">sudhir&#64;erpharbor.com</a>&gt;</li>
 <li>Julien Coux &lt;<a class="reference external" href="mailto:julien.coux&#64;camptocamp.com">julien.coux&#64;camptocamp.com</a>&gt;</li>
 </ul>

--- a/sale_stock_picking_blocking/tests/test_sale_stock_picking_blocking.py
+++ b/sale_stock_picking_blocking/tests/test_sale_stock_picking_blocking.py
@@ -1,5 +1,5 @@
-# Copyright 2019 Eficent Business and IT Consulting Services S.L.
-#   (http://www.eficent.com)
+# Copyright 2019 ForgeFlow S.L.
+#   (http://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from odoo.tests import Form, common
 
@@ -77,7 +77,7 @@ class TestSaleDeliveryBlock(common.TransactionCase):
         pick = self._picking_comp(so)
         self.assertNotEqual(pick, 0, "A delivery should have been made")
 
-    def test_default_delivery_block(self):
+    def test_default_delivery_block_partner(self):
         block_reason = self.block_model.with_user(self.user_test).create(
             {"name": "Test Block."}
         )
@@ -89,6 +89,28 @@ class TestSaleDeliveryBlock(common.TransactionCase):
         )
         so_form = Form(self.env["sale.order"])
         so_form.partner_id = partner_block
+        so = so_form.save()
+        self.assertEqual(so.delivery_block_id, block_reason)
+        self.assertEqual(so.copy().delivery_block_id, block_reason)
+
+    def test_default_delivery_block_payment_term(self):
+        block_reason = self.block_model.with_user(self.user_test).create(
+            {"name": "Test Block."}
+        )
+        partner_block = self.env["res.partner"].create(
+            {
+                "name": "Foo",
+            }
+        )
+        payment_term_block = self.env["account.payment.term"].create(
+            {
+                "name": "Foo",
+                "default_delivery_block_reason_id": block_reason.id,
+            }
+        )
+        so_form = Form(self.env["sale.order"])
+        so_form.partner_id = partner_block
+        so_form.payment_term_id = payment_term_block
         so = so_form.save()
         self.assertEqual(so.delivery_block_id, block_reason)
         self.assertEqual(so.copy().delivery_block_id, block_reason)

--- a/sale_stock_picking_blocking/views/account_payment_term_view.xml
+++ b/sale_stock_picking_blocking/views/account_payment_term_view.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <!--Copyright 2024 ForgeFlow S.L.-->
+    <!--(http://www.forgeflow.com)-->
+    <!--License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).-->
+    <data>
+        <record id="view_payment_term_form" model="ir.ui.view">
+            <field name="name">account.payment.term.form</field>
+            <field name="model">account.payment.term</field>
+            <field name="inherit_id" ref="account.view_payment_term_form" />
+            <field name="arch" type="xml">
+                <xpath
+                    expr="//form//sheet//field[@name='display_on_invoice']"
+                    position="attributes"
+                >
+                    <attribute name="invisible">1</attribute>
+                </xpath>
+                <xpath
+                    expr="//form//sheet//label[@for='display_on_invoice']"
+                    position="attributes"
+                >
+                    <attribute name="invisible">1</attribute>
+                </xpath>
+                <xpath
+                    expr="//form//sheet//group[field[@name='note']]"
+                    position="after"
+                >
+                    <group>
+                        <group>
+                            <field name="default_delivery_block_reason_id" />
+                        </group>
+                        <group>
+                            <field name="display_on_invoice" />
+                        </group>
+                    </group>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Add the Default Delivery Block fields to Payment Terms, to be used in the Sale Orders in case the customer does not have one set.