### PR TITLE
[16.0][REF] sale_triple_discount: Consolidate discount in std field

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -18,6 +18,8 @@ org_name: Odoo Community Association (OCA)
 org_slug: OCA
 rebel_module_groups:
 - sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration
+- sale_triple_discount
+- sale_fixed_discount
 repo_description: 'TODO: add repo description.'
 repo_name: sale-workflow
 repo_slug: sale-workflow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,17 +36,31 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
-            include: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration"
+            include: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_triple_discount,sale_order_general_discount_triple"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
-            include: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration"
+            include: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_triple_discount,sale_order_general_discount_triple"
             name: test with OCB
             makepot: "true"
           - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
-            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration"
+            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_triple_discount,sale_order_general_discount_triple"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
-            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration"
+            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_triple_discount,sale_order_general_discount_triple"
+            name: test with OCB
+            makepot: "true"
+          - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
+            include: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_global_discount"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
+            include: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_global_discount"
+            name: test with OCB
+            makepot: "true"
+          - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
+            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_global_discount"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
+            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_global_discount"
             name: test with OCB
             makepot: "true"
     services:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,31 +36,31 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
-            include: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_triple_discount,sale_order_general_discount_triple"
+            include: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
-            include: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_triple_discount,sale_order_general_discount_triple"
+            include: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration"
             name: test with OCB
             makepot: "true"
           - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
-            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_triple_discount,sale_order_general_discount_triple"
+            include: "sale_triple_discount"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
-            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_triple_discount,sale_order_general_discount_triple"
+            include: "sale_triple_discount"
             name: test with OCB
             makepot: "true"
           - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
-            include: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_global_discount"
+            include: "sale_fixed_discount"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
-            include: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_global_discount"
+            include: "sale_fixed_discount"
             name: test with OCB
             makepot: "true"
           - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
-            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_global_discount"
+            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_triple_discount,sale_fixed_discount"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
-            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_global_discount"
+            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_triple_discount,sale_fixed_discount"
             name: test with OCB
             makepot: "true"
     services:

--- a/sale_fixed_discount/__manifest__.py
+++ b/sale_fixed_discount/__manifest__.py
@@ -11,6 +11,7 @@
     "application": False,
     "installable": True,
     "depends": ["sale", "account_invoice_fixed_discount"],
+    "excludes": ["sale_triple_discount"],
     "data": [
         "security/res_groups.xml",
         "reports/report_sale_order.xml",

--- a/sale_fixed_discount/static/description/index.html
+++ b/sale_fixed_discount/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -436,7 +437,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_order_general_discount/models/sale_order_line.py
+++ b/sale_order_general_discount/models/sale_order_line.py
@@ -15,5 +15,9 @@ class SaleOrderLine(models.Model):
             # set again to 0 to remove the discount on all the lines at the same
             # time
             if line.order_id.general_discount or line.order_id._origin.general_discount:
-                line.discount = line.order_id.general_discount
+                if "discount1" in self._fields:
+                    # Compatibility with sale_triple_discount module
+                    line.discount1 = line.order_id.general_discount
+                else:
+                    line.discount = line.order_id.general_discount
         return res

--- a/sale_order_general_discount_triple/models/res_config_settings.py
+++ b/sale_order_general_discount_triple/models/res_config_settings.py
@@ -6,7 +6,7 @@ class ResConfigSettings(models.TransientModel):
 
     general_discount = fields.Selection(
         [
-            ("discount", "Discount"),
+            ("discount1", "Discount 1"),
             ("discount2", "Discount 2"),
             ("discount3", "Discount 3"),
         ],
@@ -15,7 +15,7 @@ class ResConfigSettings(models.TransientModel):
     )
     pricelist_discount = fields.Selection(
         [
-            ("discount", "Discount"),
+            ("discount1", "Discount 1"),
             ("discount2", "Discount 2"),
             ("discount3", "Discount 3"),
         ],

--- a/sale_order_general_discount_triple/models/sale_order.py
+++ b/sale_order_general_discount_triple/models/sale_order.py
@@ -10,7 +10,7 @@ class SaleOrder(models.Model):
             self.env["ir.config_parameter"]
             .sudo()
             .get_param(
-                "sale_order_general_discount_triple.general_discount", "discount"
+                "sale_order_general_discount_triple.general_discount", "discount1"
             )
         )
         if general_discount != "no_apply":
@@ -20,7 +20,7 @@ class SaleOrder(models.Model):
     def _create_delivery_line(self, carrier, price_unit):
         res = super()._create_delivery_line(carrier, price_unit)
         for line in self.order_line:
-            line._compute_discount()
+            line._compute_discount1()
             line._compute_discount2()
             line._compute_discount3()
         return res

--- a/sale_order_general_discount_triple/models/sale_order_line.py
+++ b/sale_order_general_discount_triple/models/sale_order_line.py
@@ -4,21 +4,22 @@ from odoo import api, fields, models
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
+    discount1 = fields.Float(compute="_compute_discount1", store=True, readonly=False)
     discount2 = fields.Float(compute="_compute_discount2", store=True, readonly=False)
     discount3 = fields.Float(compute="_compute_discount3", store=True, readonly=False)
 
     @api.depends("product_id", "product_uom", "product_uom_qty")
-    def _compute_discount(self):
+    def _compute_discount1(self):
         pricelist_discount = self._get_discount_field_position("pricelist_discount")
         general_discount = self._get_discount_field_position("general_discount")
-        if "discount" not in [pricelist_discount, general_discount]:
-            self.update({"discount": 0.0})
+        if "discount1" not in [pricelist_discount, general_discount]:
+            self.update({"discount1": 0.0})
             return
         for line in self:
-            if pricelist_discount == "discount":
-                line.update({"discount": line._get_pricelist_discount()})
-            elif general_discount == "discount":
-                line.update({"discount": line.order_id.general_discount})
+            if pricelist_discount == "discount1":
+                line.update({"discount1": line._get_pricelist_discount()})
+            elif general_discount == "discount1":
+                line.update({"discount1": line.order_id.general_discount})
         return
 
     @api.depends("product_id", "product_uom", "product_uom_qty")
@@ -71,6 +72,6 @@ class SaleOrderLine(models.Model):
             self.env["ir.config_parameter"]
             .sudo()
             .get_param(
-                "sale_order_general_discount_triple.{}".format(field_name), "discount"
+                "sale_order_general_discount_triple.{}".format(field_name), "discount1"
             )
         )

--- a/sale_order_general_discount_triple/tests/test_module.py
+++ b/sale_order_general_discount_triple/tests/test_module.py
@@ -29,7 +29,7 @@ class TestModule(TransactionCase):
         )
         setting_form = Form(cls.env["res.config.settings"])
         setting_form.general_discount = "discount2"
-        setting_form.pricelist_discount = "discount"
+        setting_form.pricelist_discount = "discount1"
         setting_form.group_discount_per_so_line = True
         setting_form.save().set_values()
 
@@ -41,4 +41,4 @@ class TestModule(TransactionCase):
             line.product_id = self.product
         sale = sale_form.save()
         self.assertEqual(sale.order_line.discount2, 10)
-        self.assertEqual(sale.order_line.discount, 20)
+        self.assertEqual(sale.order_line.discount1, 20)

--- a/sale_triple_discount/README.rst
+++ b/sale_triple_discount/README.rst
@@ -109,6 +109,7 @@ Contributors
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
 * Denis Leemann <denis.leemann@camptocamp.com>
 * Manuel Regidor <manuel.regidor@sygel.es>
+* Akim Juillerat <akim.juillerat@camptocamp.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_triple_discount/__init__.py
+++ b/sale_triple_discount/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import post_load

--- a/sale_triple_discount/__manifest__.py
+++ b/sale_triple_discount/__manifest__.py
@@ -16,4 +16,5 @@
     "depends": ["sale_management", "account_invoice_triple_discount"],
     "data": ["views/sale_order_report.xml", "views/sale_order_view.xml"],
     "installable": True,
+    "post_load": "post_load",
 }

--- a/sale_triple_discount/__manifest__.py
+++ b/sale_triple_discount/__manifest__.py
@@ -14,6 +14,7 @@
     "license": "AGPL-3",
     "summary": "Manage triple discount on sale order lines",
     "depends": ["sale_management", "account_invoice_triple_discount"],
+    "excludes": ["sale_fixed_discount"],
     "data": ["views/sale_order_report.xml", "views/sale_order_view.xml"],
     "installable": True,
     "post_load": "post_load",

--- a/sale_triple_discount/__manifest__.py
+++ b/sale_triple_discount/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "Sale Triple Discount",
-    "version": "16.0.1.0.4",
+    "version": "16.0.2.0.0",
     "category": "Sales",
     "author": "ADHOC SA, Agile Business Group, Tecnativa, "
     "Odoo Community Association (OCA)",

--- a/sale_triple_discount/hooks.py
+++ b/sale_triple_discount/hooks.py
@@ -1,0 +1,24 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+import logging
+
+import pkg_resources
+
+from odoo.modules.module import get_manifest
+
+_logger = logging.getLogger(__name__)
+
+
+def post_load():
+    account_invoice_triple_discount_manifest = get_manifest(
+        "account_invoice_triple_discount"
+    )
+    if not pkg_resources.parse_version(
+        account_invoice_triple_discount_manifest["version"]
+    ) >= pkg_resources.parse_version("16.0.2.0.0"):
+        msg = (
+            "Module sale_triple_discount requires module "
+            "account_invoice_triple_discount >= 16.0.2.0.0"
+        )
+        _logger.error(msg)
+        raise Exception(msg)

--- a/sale_triple_discount/migrations/16.0.2.0.0/post-migrate.py
+++ b/sale_triple_discount/migrations/16.0.2.0.0/post-migrate.py
@@ -1,0 +1,23 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+import openupgrade
+
+
+@openupgrade.logging()
+def compute_discount(env):
+    env["sale.order.line"].search(
+        [
+            "|",
+            "|",
+            ("discount1", "!=", 0),
+            ("discount2", "!=", 0),
+            ("discount3", "!=", 0),
+        ]
+    )
+    env["sale.order.line"]._compute_discount()
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    compute_discount(env)

--- a/sale_triple_discount/migrations/16.0.2.0.0/post-migrate.py
+++ b/sale_triple_discount/migrations/16.0.2.0.0/post-migrate.py
@@ -1,12 +1,12 @@
 # Copyright 2024 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
-import openupgrade
+from openupgradelib import openupgrade
 
 
 @openupgrade.logging()
 def compute_discount(env):
-    env["sale.order.line"].search(
+    lines_with_discount = env["sale.order.line"].search(
         [
             "|",
             "|",
@@ -15,7 +15,7 @@ def compute_discount(env):
             ("discount3", "!=", 0),
         ]
     )
-    env["sale.order.line"]._compute_discount()
+    lines_with_discount._compute_discount_consolidated()
 
 
 @openupgrade.migrate()

--- a/sale_triple_discount/migrations/16.0.2.0.0/pre-migrate.py
+++ b/sale_triple_discount/migrations/16.0.2.0.0/pre-migrate.py
@@ -1,0 +1,29 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+import openupgrade
+
+
+def migrate_discount_to_discount1():
+    openupgrade.add_fields(
+        [
+            (
+                "discount1",
+                "sale.order.line",
+                "sale_order_line",
+                "float",
+                "numeric",
+                "sale_triple_discount",
+                0.0,
+            )
+        ]
+    )
+    openupgrade.logged_query(
+        """
+        UPDATE sale_order_line
+        SET discount1 = discount;
+        """
+    )
+
+
+def migrate(cr, version):
+    migrate_discount_to_discount1()

--- a/sale_triple_discount/migrations/16.0.2.0.0/pre-migrate.py
+++ b/sale_triple_discount/migrations/16.0.2.0.0/pre-migrate.py
@@ -1,10 +1,11 @@
 # Copyright 2024 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-import openupgrade
+from openupgradelib import openupgrade
 
 
-def migrate_discount_to_discount1():
+def migrate_discount_to_discount1(env):
     openupgrade.add_fields(
+        env,
         [
             (
                 "discount1",
@@ -15,15 +16,17 @@ def migrate_discount_to_discount1():
                 "sale_triple_discount",
                 0.0,
             )
-        ]
+        ],
     )
     openupgrade.logged_query(
+        env.cr,
         """
         UPDATE sale_order_line
         SET discount1 = discount;
-        """
+        """,
     )
 
 
-def migrate(cr, version):
-    migrate_discount_to_discount1()
+@openupgrade.migrate()
+def migrate(env, version):
+    migrate_discount_to_discount1(env)

--- a/sale_triple_discount/models/sale_order_line.py
+++ b/sale_triple_discount/models/sale_order_line.py
@@ -15,12 +15,21 @@ class SaleOrderLine(models.Model):
 
     discount = fields.Float(
         string="Total discount",
+        store=True,
+        compute="_compute_discount_consolidated",
+        compute_sudo=True,
+        precompute=True,
         readonly=True,
     )
     discount1 = fields.Float(
         string="Disc. 1 (%)",
         digits="Discount",
+        store=True,
         default=0.0,
+        compute="_compute_discount",
+        compute_sudo=True,
+        precompute=True,
+        readonly=False,
     )
     discount2 = fields.Float(
         string="Disc. 2 (%)",
@@ -69,24 +78,54 @@ class SaleOrderLine(models.Model):
         final_discount = 1
         for discount in discounts:
             final_discount *= discount
-        return 100 - final_discount * 100
+        result = 100 - final_discount * 100
+        dp = self.env.ref("product.decimal_discount").precision_get("Discount")
+        return round(result, dp)
 
     @api.model
     def _discount_fields(self):
         return ["discount1", "discount2", "discount3"]
 
-    # pylint: disable=W8110
-    @api.depends("discount1", "discount2", "discount3", "discounting_type")
+    # Copy of Odoo function to change field being assigned from discount to discount1
+    @api.depends("product_id", "product_uom", "product_uom_qty")
     def _compute_discount(self):
-        super()._compute_discount()
         for line in self:
-            # Reset discount if not done in super
+            if not line.product_id or line.display_type:
+                line.discount1 = 0.0
+
             if not (
                 line.order_id.pricelist_id
                 and line.order_id.pricelist_id.discount_policy == "without_discount"
             ):
-                line.discount = 0.0
-            line.discount += line._get_final_discount()
+                continue
+
+            line.discount1 = 0.0
+
+            if not line.pricelist_item_id:
+                # No pricelist rule was found for the product
+                # therefore, the pricelist didn't apply any discount/change
+                # to the existing sales price.
+                continue
+
+            line.discount1 = line._calc_discount_from_pricelist()
+
+    def _calc_discount_from_pricelist(self):
+        self.ensure_one()
+        self = self.with_company(self.company_id)
+        pricelist_price = self._get_pricelist_price()
+        base_price = self._get_pricelist_price_before_discount()
+
+        if base_price != 0:  # Avoid division by zero
+            discount = (base_price - pricelist_price) / base_price * 100
+            if (discount > 0 and base_price > 0) or (discount < 0 and base_price < 0):
+                # only show negative discounts if price is negative
+                # otherwise it's a surcharge which shouldn't be shown to the customer
+                return discount
+
+    @api.depends("discount1", "discount2", "discount3", "discounting_type")
+    def _compute_discount_consolidated(self):
+        for line in self:
+            line.discount = line._get_final_discount()
 
     _sql_constraints = [
         (

--- a/sale_triple_discount/models/sale_order_line.py
+++ b/sale_triple_discount/models/sale_order_line.py
@@ -151,6 +151,7 @@ class SaleOrderLine(models.Model):
         more discount fields to the invoice lines
         """
         res = super()._prepare_invoice_line(**kwargs)
+        res.pop("discount", None)
         if self.discounting_type == "multiplicative":
             res.update(
                 {

--- a/sale_triple_discount/models/sale_order_line.py
+++ b/sale_triple_discount/models/sale_order_line.py
@@ -13,6 +13,15 @@ from odoo.exceptions import ValidationError
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
+    discount = fields.Float(
+        string="Total discount",
+        readonly=True,
+    )
+    discount1 = fields.Float(
+        string="Disc. 1 (%)",
+        digits="Discount",
+        default=0.0,
+    )
     discount2 = fields.Float(
         string="Disc. 2 (%)",
         digits="Discount",
@@ -64,15 +73,27 @@ class SaleOrderLine(models.Model):
 
     @api.model
     def _discount_fields(self):
-        return ["discount", "discount2", "discount3"]
+        return ["discount1", "discount2", "discount3"]
 
-    @api.depends("discount2", "discount3", "discounting_type")
-    def _compute_amount(self):
-        with self._aggregated_discount() as lines:
-            res = super(SaleOrderLine, lines)._compute_amount()
-        return res
+    # pylint: disable=W8110
+    @api.depends("discount1", "discount2", "discount3", "discounting_type")
+    def _compute_discount(self):
+        super()._compute_discount()
+        for line in self:
+            # Reset discount if not done in super
+            if not (
+                line.order_id.pricelist_id
+                and line.order_id.pricelist_id.discount_policy == "without_discount"
+            ):
+                line.discount = 0.0
+            line.discount += line._get_final_discount()
 
     _sql_constraints = [
+        (
+            "discount1_limit",
+            "CHECK (discount1 <= 100.0)",
+            "Discount 1 must be lower or equal than 100%.",
+        ),
         (
             "discount2_limit",
             "CHECK (discount2 <= 100.0)",
@@ -91,51 +112,14 @@ class SaleOrderLine(models.Model):
         more discount fields to the invoice lines
         """
         res = super()._prepare_invoice_line(**kwargs)
-        res.update({"discount2": self.discount2, "discount3": self.discount3})
+        if self.discounting_type == "multiplicative":
+            res.update(
+                {
+                    "discount1": self.discount1,
+                    "discount2": self.discount2,
+                    "discount3": self.discount3,
+                }
+            )
+        else:
+            res.update({"discount1": self.discount})
         return res
-
-    @contextmanager
-    def _aggregated_discount(self):
-        """A context manager to temporarily change the discount value on the
-        records and restore it after the context is exited. It temporarily
-        changes the discount value to the aggregated discount value so that
-        methods that depend on the discount value will use the aggregated
-        discount value instead of the original one.
-        """
-        discount_field = self._fields["discount"]
-        # Protect discount field from triggering recompute of totals. We don't want
-        # to invalidate the cache to avoid to flush the records to the database.
-        # This is safe because we are going to restore the original value at the end
-        # of the method.
-        with self.env.protecting([discount_field], self):
-            old_values = {}
-            for line in self:
-                old_values[line.id] = line.discount
-                aggregated_discount = line._get_final_discount()
-                line.update({"discount": aggregated_discount})
-            yield self.with_context(discount_is_aggregated=True)
-            for line in self:
-                if line.id not in old_values:
-                    continue
-                line.with_context(
-                    restoring_triple_discount=True,
-                ).update({"discount": old_values[line.id]})
-
-    def _convert_to_tax_base_line_dict(self):
-        self.ensure_one()
-        discount = (
-            self.discount
-            if self.env.context.get("discount_is_aggregated")
-            else self._get_final_discount()
-        )
-        return self.env["account.tax"]._convert_to_tax_base_line_dict(
-            self,
-            partner=self.order_id.partner_id,
-            currency=self.order_id.currency_id,
-            product=self.product_id,
-            taxes=self.tax_id,
-            price_unit=self.price_unit,
-            quantity=self.product_uom_qty,
-            discount=discount,
-            price_subtotal=self.price_subtotal,
-        )

--- a/sale_triple_discount/models/sale_order_line.py
+++ b/sale_triple_discount/models/sale_order_line.py
@@ -3,9 +3,6 @@
 # Copyright 2017 Tecnativa - David Vidal
 # Copyright 2018 Simone Rubino - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
-from contextlib import contextmanager
-
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 

--- a/sale_triple_discount/readme/CONTRIBUTORS.rst
+++ b/sale_triple_discount/readme/CONTRIBUTORS.rst
@@ -7,3 +7,4 @@
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
 * Denis Leemann <denis.leemann@camptocamp.com>
 * Manuel Regidor <manuel.regidor@sygel.es>
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/sale_triple_discount/static/description/index.html
+++ b/sale_triple_discount/static/description/index.html
@@ -457,6 +457,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Pimolnat Suntian &lt;<a class="reference external" href="mailto:pimolnats&#64;ecosoft.co.th">pimolnats&#64;ecosoft.co.th</a>&gt;</li>
 <li>Denis Leemann &lt;<a class="reference external" href="mailto:denis.leemann&#64;camptocamp.com">denis.leemann&#64;camptocamp.com</a>&gt;</li>
 <li>Manuel Regidor &lt;<a class="reference external" href="mailto:manuel.regidor&#64;sygel.es">manuel.regidor&#64;sygel.es</a>&gt;</li>
+<li>Akim Juillerat &lt;<a class="reference external" href="mailto:akim.juillerat&#64;camptocamp.com">akim.juillerat&#64;camptocamp.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/sale_triple_discount/tests/test_sale_triple_discount.py
+++ b/sale_triple_discount/tests/test_sale_triple_discount.py
@@ -53,6 +53,36 @@ class TestSaleOrder(common.TransactionCase):
         """Tests with single discount"""
         self.so_line1.discount1 = 50.0
         self.so_line2.discount1 = 75.0
+        self.assertAlmostEqual(self.so_line1.discount, 50.0)
+        self.assertAlmostEqual(self.so_line2.discount, 75.0)
+        self.assertAlmostEqual(self.so_line1.price_subtotal, 300.0)
+        self.assertAlmostEqual(self.so_line2.price_subtotal, 150.0)
+        self.assertAlmostEqual(self.order.amount_untaxed, 450.0)
+        self.assertAlmostEqual(self.order.amount_tax, 67.5)
+        # Mix taxed and untaxed:
+        self.so_line1.tax_id = False
+        self.assertAlmostEqual(self.order.amount_tax, 22.5)
+
+    def test_01_2_sale_order_classic_discount(self):
+        """Tests with single discount"""
+        self.so_line1.discount2 = 50.0
+        self.so_line2.discount2 = 75.0
+        self.assertAlmostEqual(self.so_line1.discount, 50.0)
+        self.assertAlmostEqual(self.so_line2.discount, 75.0)
+        self.assertAlmostEqual(self.so_line1.price_subtotal, 300.0)
+        self.assertAlmostEqual(self.so_line2.price_subtotal, 150.0)
+        self.assertAlmostEqual(self.order.amount_untaxed, 450.0)
+        self.assertAlmostEqual(self.order.amount_tax, 67.5)
+        # Mix taxed and untaxed:
+        self.so_line1.tax_id = False
+        self.assertAlmostEqual(self.order.amount_tax, 22.5)
+
+    def test_01_3_sale_order_classic_discount(self):
+        """Tests with single discount"""
+        self.so_line1.discount3 = 50.0
+        self.so_line2.discount3 = 75.0
+        self.assertAlmostEqual(self.so_line1.discount, 50.0)
+        self.assertAlmostEqual(self.so_line2.discount, 75.0)
         self.assertAlmostEqual(self.so_line1.price_subtotal, 300.0)
         self.assertAlmostEqual(self.so_line2.price_subtotal, 150.0)
         self.assertAlmostEqual(self.order.amount_untaxed, 450.0)

--- a/sale_triple_discount/tests/test_sale_triple_discount.py
+++ b/sale_triple_discount/tests/test_sale_triple_discount.py
@@ -51,8 +51,8 @@ class TestSaleOrder(common.TransactionCase):
 
     def test_01_sale_order_classic_discount(self):
         """Tests with single discount"""
-        self.so_line1.discount = 50.0
-        self.so_line2.discount = 75.0
+        self.so_line1.discount1 = 50.0
+        self.so_line2.discount1 = 75.0
         self.assertAlmostEqual(self.so_line1.price_subtotal, 300.0)
         self.assertAlmostEqual(self.so_line2.price_subtotal, 150.0)
         self.assertAlmostEqual(self.order.amount_untaxed, 450.0)
@@ -65,19 +65,22 @@ class TestSaleOrder(common.TransactionCase):
         """Tests on a single line"""
         self.so_line2.unlink()
         # Divide by two on every discount:
-        self.so_line1.discount = 50.0
+        self.so_line1.discount1 = 50.0
         self.so_line1.discount2 = 50.0
         self.so_line1.discount3 = 50.0
+        self.assertAlmostEqual(self.so_line1.discount, 87.5)
         self.assertAlmostEqual(self.so_line1.price_subtotal, 75.0)
         self.assertAlmostEqual(self.order.amount_untaxed, 75.0)
         self.assertAlmostEqual(self.order.amount_tax, 11.25)
         # Unset first discount:
-        self.so_line1.discount = 0.0
+        self.so_line1.discount1 = 0.0
+        self.assertAlmostEqual(self.so_line1.discount, 75)
         self.assertAlmostEqual(self.so_line1.price_subtotal, 150.0)
         self.assertAlmostEqual(self.order.amount_untaxed, 150.0)
         self.assertAlmostEqual(self.order.amount_tax, 22.5)
         # Set a charge instead:
         self.so_line1.discount2 = -50.0
+        self.assertAlmostEqual(self.so_line1.discount, 25)
         self.assertAlmostEqual(self.so_line1.price_subtotal, 450.0)
         self.assertAlmostEqual(self.order.amount_untaxed, 450.0)
         self.assertAlmostEqual(self.order.amount_tax, 67.5)
@@ -88,10 +91,11 @@ class TestSaleOrder(common.TransactionCase):
             67.5,
         )
         # set discount_type to additive
-        self.so_line1.discount = 10.0
+        self.so_line1.discount1 = 10.0
         self.so_line1.discount2 = 10.0
         self.so_line1.discount3 = 10.0
         self.so_line1.discounting_type = "additive"
+        self.assertAlmostEqual(self.so_line1.discount, 30.0)
         self.assertAlmostEqual(self.so_line1.price_subtotal, 420.0)
         self.assertAlmostEqual(self.order.amount_untaxed, 420.0)
         self.assertAlmostEqual(self.order.amount_tax, 63.0)
@@ -102,47 +106,54 @@ class TestSaleOrder(common.TransactionCase):
             63.0,
         )
         # set discount over 100%
-        self.so_line1.discount = 30.0
+        self.so_line1.discount1 = 30.0
         self.so_line1.discount2 = 70.0
         self.so_line1.discount3 = 50.0
+        self.assertAlmostEqual(self.so_line1.discount, 100.0)
         self.assertAlmostEqual(self.so_line1.price_subtotal, 0.0)
         self.assertAlmostEqual(self.order.amount_untaxed, 0.0)
         self.assertAlmostEqual(self.order.amount_tax, 0.0)
         # set discount_type to multiplicative
-        self.so_line1.discount = 50.0
+        self.so_line1.discount1 = 50.0
         self.so_line1.discount2 = 50.0
         self.so_line1.discount3 = 50.0
         self.so_line1.discounting_type = "multiplicative"
+        self.assertAlmostEqual(self.so_line1.discount, 87.5)
         self.assertAlmostEqual(self.so_line1.price_subtotal, 75.0)
         self.assertAlmostEqual(self.order.amount_untaxed, 75.0)
         self.assertAlmostEqual(self.order.amount_tax, 11.25)
 
     def test_03_sale_order_complex_triple_discount(self):
         """Tests on multiple lines"""
-        self.so_line1.discount = 50.0
+        self.so_line1.discount1 = 50.0
         self.so_line1.discount2 = 50.0
         self.so_line1.discount3 = 50.0
+        self.assertAlmostEqual(self.so_line1.discount, 87.5)
         self.assertAlmostEqual(self.so_line1.price_subtotal, 75.0)
         self.assertAlmostEqual(self.order.amount_untaxed, 675.0)
         self.assertAlmostEqual(self.order.amount_tax, 101.25)
         # additive discount
         self.so_line2.discount3 = 50.0
+        self.assertAlmostEqual(self.so_line2.discount, 50.0)
         self.assertAlmostEqual(self.so_line2.price_subtotal, 300.0)
         self.assertAlmostEqual(self.order.amount_untaxed, 375.0)
         self.assertAlmostEqual(self.order.amount_tax, 56.25)
         self.so_line2.discounting_type = "additive"
         self.so_line2.discount2 = 10.0
+        self.assertAlmostEqual(self.so_line2.discount, 60.0)
         self.assertAlmostEqual(self.so_line2.price_subtotal, 240.0)
         self.assertAlmostEqual(self.order.amount_untaxed, 315.0)
         self.assertAlmostEqual(self.order.amount_tax, 47.25)
         # multiplicative discount
         self.so_line2.discount2 = 0.0
         self.so_line2.discount3 = 50.0
+        self.assertAlmostEqual(self.so_line2.discount, 50.0)
         self.assertAlmostEqual(self.so_line2.price_subtotal, 300.0)
         self.assertAlmostEqual(self.order.amount_untaxed, 375.0)
         self.assertAlmostEqual(self.order.amount_tax, 56.25)
         self.so_line2.discounting_type = "multiplicative"
         self.so_line2.discount2 = 10.0
+        self.assertAlmostEqual(self.so_line1.discount, 87.5)
         self.assertAlmostEqual(self.so_line2.price_subtotal, 270.0)
         self.assertAlmostEqual(self.order.amount_untaxed, 345.0)
         self.assertAlmostEqual(self.order.amount_tax, 51.75)
@@ -155,6 +166,7 @@ class TestSaleOrder(common.TransactionCase):
         self.so_line1.discount3 = 50.0
         self.so_line2.discount3 = 50.0
         self.order.action_confirm()
+        # FIXME: AFAIK this is another module messing and shouldn't be in this test
         if self.order.state == "waiting_approval":
             self.order.action_approve()
             self.assertAlmostEqual(self.order.state, "approved")
@@ -165,6 +177,9 @@ class TestSaleOrder(common.TransactionCase):
             self.so_line1.discount, invoice.invoice_line_ids[0].discount
         )
         self.assertAlmostEqual(
+            self.so_line1.discount1, invoice.invoice_line_ids[0].discount1
+        )
+        self.assertAlmostEqual(
             self.so_line1.discount2, invoice.invoice_line_ids[0].discount2
         )
         self.assertAlmostEqual(
@@ -172,6 +187,9 @@ class TestSaleOrder(common.TransactionCase):
         )
         self.assertAlmostEqual(
             self.so_line1.price_subtotal, invoice.invoice_line_ids[0].price_subtotal
+        )
+        self.assertAlmostEqual(
+            self.so_line2.discount, invoice.invoice_line_ids[1].discount
         )
         self.assertAlmostEqual(
             self.so_line2.discount3, invoice.invoice_line_ids[1].discount3
@@ -184,7 +202,7 @@ class TestSaleOrder(common.TransactionCase):
     def test_05_round_globally(self):
         """Tests on multiple lines when 'round_globally' is active"""
         self.env.user.company_id.tax_calculation_rounding_method = "round_globally"
-        self.so_line1.discount = 50.0
+        self.so_line1.discount1 = 50.0
         self.so_line1.discount2 = 50.0
         self.so_line1.discount3 = 50.0
         self.assertEqual(self.so_line1.price_subtotal, 75.0)
@@ -197,11 +215,11 @@ class TestSaleOrder(common.TransactionCase):
 
     def test_06_discount_0(self):
         self.so_line1.discounting_type = "additive"
-        self.so_line1.discount = 0.0
+        self.so_line1.discount1 = 0.0
         self.so_line1.discount2 = 0.0
         self.so_line1.discount3 = 0.0
         self.so_line2.discounting_type = "additive"
-        self.so_line2.discount = 0.0
+        self.so_line2.discount1 = 0.0
         self.so_line2.discount2 = 0.0
         self.so_line2.discount3 = 0.0
         self.assertAlmostEqual(self.so_line1.price_subtotal, 600.0)

--- a/sale_triple_discount/views/sale_order_report.xml
+++ b/sale_triple_discount/views/sale_order_report.xml
@@ -4,7 +4,15 @@
         id="report_saleorder_document_triple_discount"
         inherit_id="sale.report_saleorder_document"
     >
+
+        <xpath expr="//t[@t-set='display_discount']" position="attributes">
+            <attribute name="t-value">False</attribute>
+        </xpath>
         <xpath expr="//t[@t-set='display_discount']" position="after">
+            <t
+                t-set="display_discount1"
+                t-value="any([l.discount1 for l in doc.order_line])"
+            />
             <t
                 t-set="display_discount2"
                 t-value="any([l.discount2 for l in doc.order_line])"
@@ -15,6 +23,13 @@
             />
         </xpath>
         <xpath expr="//table/thead/tr/th[@name='th_discount']" position="after">
+            <th
+                t-if="display_discount1"
+                class="text-right"
+                groups="product.group_discount_per_so_line"
+            >
+                <span>Disc. 1 (%)</span>
+            </th>
             <th
                 t-if="display_discount2"
                 class="text-right"
@@ -31,6 +46,13 @@
             </th>
         </xpath>
         <xpath expr="//table/tbody//tr//td[@t-if='display_discount']" position="after">
+            <td
+                t-if="display_discount1"
+                class="text-right"
+                groups="product.group_discount_per_so_line"
+            >
+                <span t-field="line.discount1" />
+            </td>
             <td
                 t-if="display_discount2"
                 class="text-right"

--- a/sale_triple_discount/views/sale_order_view.xml
+++ b/sale_triple_discount/views/sale_order_view.xml
@@ -7,8 +7,20 @@
         <field name="arch" type="xml">
             <xpath
                 expr="//field[@name='order_line']//tree//field[@name='discount']"
+                position="attributes"
+            >
+                <attribute name="string">Total discount</attribute>
+                <attribute name="optional">hide</attribute>
+            </xpath>
+            <xpath
+                expr="//field[@name='order_line']//tree//field[@name='discount']"
                 position="after"
             >
+                <field
+                    name="discount1"
+                    optional="show"
+                    groups="product.group_discount_per_so_line"
+                />
                 <field
                     name="discount2"
                     optional="show"
@@ -29,6 +41,10 @@
                 expr="//field[@name='order_line']//form//div[@name='discount']"
                 position="after"
             >
+                <label for="discount1" groups="product.group_discount_per_so_line" />
+                <div name="discount1" groups="product.group_discount_per_so_line">
+                    <field name="discount1" class="oe_inline" /> %
+                </div>
                 <label for="discount2" groups="product.group_discount_per_so_line" />
                 <div name="discount2" groups="product.group_discount_per_so_line">
                     <field name="discount2" class="oe_inline" /> %


### PR DESCRIPTION
Until now, the triple discount feature did use the standard Odoo field as the first discount field, adding only extra fields for the second and the third discount. This implied we had to override any function using discount to consider the other discounts properly.

By adding an extra field discount1 to store the first discount, it allows to redefine the standard discount field to a computed field that will consolidate the triple discount from the other fields, and avoid the need to redefine anything relying on the discount field as it will already consider the triple discounts.

Relates to:
 - [ ] https://github.com/OCA/account-invoicing/pull/1638