### PR TITLE
[FIX] sale_product_multi_add: fix discount

### DIFF
--- a/sale_product_multi_add/__manifest__.py
+++ b/sale_product_multi_add/__manifest__.py
@@ -9,7 +9,7 @@
     "category": "Sale Management",
     "version": "14.0.1.0.1",
     "license": "AGPL-3",
-    "depends": ["sale"],
+    "depends": ["sale", "onchange_helper"],
     "data": [
         "security/ir.model.access.csv",
         "wizards/sale_import_products_view.xml",

--- a/sale_product_multi_add/wizards/sale_import_products.py
+++ b/sale_product_multi_add/wizards/sale_import_products.py
@@ -34,7 +34,8 @@ class SaleImportProducts(models.TransientModel):
 
     @api.model
     def _get_line_values(self, sale, item):
-        sale_line = self.env["sale.order.line"].new(
+        sol_obj = self.env["sale.order.line"]
+        sale_line = sol_obj.new(
             {
                 "order_id": sale.id,
                 "name": item.product_id.name,
@@ -44,8 +45,8 @@ class SaleImportProducts(models.TransientModel):
                 "price_unit": item.product_id.list_price,
             }
         )
-        sale_line.product_id_change()
         line_values = sale_line._convert_to_write(sale_line._cache)
+        line_values = sol_obj.play_onchanges(line_values, [])
         return line_values
 
     def select_products(self):


### PR DESCRIPTION
Previously, when the 'Discount Policy' on the Price list was configured to 'Show public price & discount to customer,' the inclusion of multiple products in the sales order line did not take the price list into account. 
Now, this functionality is compatible with the specified price list configuration.