### PR TITLE
[FIX][16.0] sale_order_line_price_history: Set history price from wizard tree

### DIFF
--- a/sale_order_line_price_history/README.rst
+++ b/sale_order_line_price_history/README.rst
@@ -42,7 +42,10 @@ Usage
 
 To use this module, you need to:
 
-#. Go to *Sales -> Quotations* and select a Quotation.
+#. Go to System Parameters and configure the
+   ``sale_order_line_price_history.order_line_limit`` parameter to limit the
+   number of Sale Order Lines to show on the Wizard.
+#. Go to *Sales -> Quotations* and select a Quotation. Default is 20 lines.
 #. Click on the new clock button in one of the sale order lines.
 #. A pop-up will open and you will see the *price history* for the product of
    the sale order line and for the customer of the sale order.
@@ -55,15 +58,7 @@ To use this module, you need to:
 Known issues / Roadmap
 ======================
 
-* The number of entries of prices history in the wizard should be configurable,
-  currently it is limited to 20.
 * A backend tour would be nice to have.
-* It is not possible to set a price from the tree view of the wizard lines,
-  currently it can only be done from the form view of those lines
-  (by clicking on one of them). This is not solved by simply putting a
-  'Set price' button in the wizard lines because that button will be
-  disabled since when the wizard is launched there is still no wizard
-  record in the database (this is an Odoo limitation).
 
 Bug Tracker
 ===========
@@ -91,10 +86,12 @@ Contributors
   * Pedro M. Baeza
   * Ernesto Tejeda
   * David Vidal
+  * Carlos Roca
 
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 * Dhara Solanki <dhara.solanki@initos.com>
 * Ruchir Shukla <ruchir@bizzappdev.com>
+* Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)
 
 Maintainers
 ~~~~~~~~~~~
@@ -108,6 +105,20 @@ This module is maintained by the OCA.
 OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
+
+.. |maintainer-ernestotejeda| image:: https://github.com/ernestotejeda.png?size=40px
+    :target: https://github.com/ernestotejeda
+    :alt: ernestotejeda
+.. |maintainer-CarlosRoca13| image:: https://github.com/CarlosRoca13.png?size=40px
+    :target: https://github.com/CarlosRoca13
+    :alt: CarlosRoca13
+.. |maintainer-Shide| image:: https://github.com/Shide.png?size=40px
+    :target: https://github.com/Shide
+    :alt: Shide
+
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-ernestotejeda| |maintainer-CarlosRoca13| |maintainer-Shide| 
 
 This module is part of the `OCA/sale-workflow <https://github.com/OCA/sale-workflow/tree/16.0/sale_order_line_price_history>`_ project on GitHub.
 

--- a/sale_order_line_price_history/__manifest__.py
+++ b/sale_order_line_price_history/__manifest__.py
@@ -19,5 +19,6 @@
             "sale_order_line_price_history/static/src/xml/*.xml",
         ],
     },
+    "maintainers": ["ernestotejeda", "CarlosRoca13", "Shide"],
     "installable": True,
 }

--- a/sale_order_line_price_history/i18n/es.po
+++ b/sale_order_line_price_history/i18n/es.po
@@ -4,18 +4,18 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-25 16:55+0000\n"
-"PO-Revision-Date: 2023-07-25 12:10+0000\n"
-"Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
+"POT-Creation-Date: 2024-01-18 12:02+0000\n"
+"PO-Revision-Date: 2024-01-18 13:02+0100\n"
+"Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4\n"
 
 #. module: sale_order_line_price_history
 #: model_terms:ir.ui.view,arch_db:sale_order_line_price_history.sale_order_line_price_history_view_form
@@ -75,7 +75,7 @@ msgstr "Líneas de historial de precios"
 #: model:ir.model.fields,field_description:sale_order_line_price_history.field_sale_order_line_price_history__id
 #: model:ir.model.fields,field_description:sale_order_line_price_history.field_sale_order_line_price_history_line__id
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: sale_order_line_price_history
 #: model:ir.model.fields,field_description:sale_order_line_price_history.field_sale_order_line_price_history__include_quotations
@@ -136,7 +136,11 @@ msgid "Order Reference"
 msgstr "Referencia del pedido"
 
 #. module: sale_order_line_price_history
+#. odoo-javascript
+#: code:addons/sale_order_line_price_history/static/src/xml/sale_line_price_history_widget.xml:0
+#: model_terms:ir.ui.view,arch_db:sale_order_line_price_history.sale_order_line_price_history_view_form
 #: model_terms:ir.ui.view,arch_db:sale_order_line_price_history.view_order_form
+#, python-format
 msgid "Price History"
 msgstr "Historial de precios"
 
@@ -163,6 +167,7 @@ msgstr "Historial de ventas"
 #. module: sale_order_line_price_history
 #: model:ir.model.fields,field_description:sale_order_line_price_history.field_sale_order_line_price_history__sale_order_line_id
 #: model:ir.model.fields,field_description:sale_order_line_price_history.field_sale_order_line_price_history_line__sale_order_line_id
+#: model:ir.model.fields,field_description:sale_order_line_price_history.field_sale_order_line_price_history_line__target_sale_order_line_id
 msgid "Sale order line"
 msgstr "Línea de pedido de venta"
 
@@ -182,30 +187,23 @@ msgid "Sales Order Line"
 msgstr "Línea de pedido de ventas"
 
 #. module: sale_order_line_price_history
-#: model_terms:ir.ui.view,arch_db:sale_order_line_price_history.sale_order_line_price_history_view_form
-msgid "Set price"
-msgstr "Establecer precio"
+#. odoo-javascript
+#: code:addons/sale_order_line_price_history/static/src/xml/set_price_to_line_widget.xml:0
+#, python-format
+msgid "Set Historic Price"
+msgstr "Establecer Precio Histórico"
+
+#. module: sale_order_line_price_history
+#: model:ir.model.fields,field_description:sale_order_line_price_history.field_sale_order_line_price_history_line__order_state
+msgid "Status"
+msgstr "Estado"
 
 #. module: sale_order_line_price_history
 #: model:ir.model.fields,field_description:sale_order_line_price_history.field_sale_order_line_price_history_line__price_unit
 msgid "Unit Price"
-msgstr "Precio de Unidad"
+msgstr "Precio Unitario"
 
 #. module: sale_order_line_price_history
 #: model:ir.model.fields,field_description:sale_order_line_price_history.field_sale_order_line_price_history_line__history_sale_order_line_id
 msgid "history sale order line"
 msgstr "Línea de orden de venta del historial"
-
-#~ msgid "Include quotations"
-#~ msgstr "Incluir presupuestos"
-
-#~ msgid "Ordered Quantity"
-#~ msgstr "Cantidad pedida"
-
-#~ msgid "Price history"
-#~ msgstr "Historial de precios"
-
-#~ msgid ""
-#~ "You can find a customer by its Name, TIN, Email or Internal Reference."
-#~ msgstr ""
-#~ "Puede encontrar un campo por su Nombre, TIN, Email o Referencia Interna."

--- a/sale_order_line_price_history/i18n/sale_order_line_price_history.pot
+++ b/sale_order_line_price_history/i18n/sale_order_line_price_history.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-18 12:01+0000\n"
+"PO-Revision-Date: 2024-01-18 12:01+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -127,7 +129,11 @@ msgid "Order Reference"
 msgstr ""
 
 #. module: sale_order_line_price_history
+#. odoo-javascript
+#: code:addons/sale_order_line_price_history/static/src/xml/sale_line_price_history_widget.xml:0
+#: model_terms:ir.ui.view,arch_db:sale_order_line_price_history.sale_order_line_price_history_view_form
 #: model_terms:ir.ui.view,arch_db:sale_order_line_price_history.view_order_form
+#, python-format
 msgid "Price History"
 msgstr ""
 
@@ -154,6 +160,7 @@ msgstr ""
 #. module: sale_order_line_price_history
 #: model:ir.model.fields,field_description:sale_order_line_price_history.field_sale_order_line_price_history__sale_order_line_id
 #: model:ir.model.fields,field_description:sale_order_line_price_history.field_sale_order_line_price_history_line__sale_order_line_id
+#: model:ir.model.fields,field_description:sale_order_line_price_history.field_sale_order_line_price_history_line__target_sale_order_line_id
 msgid "Sale order line"
 msgstr ""
 
@@ -173,8 +180,15 @@ msgid "Sales Order Line"
 msgstr ""
 
 #. module: sale_order_line_price_history
-#: model_terms:ir.ui.view,arch_db:sale_order_line_price_history.sale_order_line_price_history_view_form
-msgid "Set price"
+#. odoo-javascript
+#: code:addons/sale_order_line_price_history/static/src/xml/set_price_to_line_widget.xml:0
+#, python-format
+msgid "Set Historic Price"
+msgstr ""
+
+#. module: sale_order_line_price_history
+#: model:ir.model.fields,field_description:sale_order_line_price_history.field_sale_order_line_price_history_line__order_state
+msgid "Status"
 msgstr ""
 
 #. module: sale_order_line_price_history

--- a/sale_order_line_price_history/readme/CONTRIBUTORS.rst
+++ b/sale_order_line_price_history/readme/CONTRIBUTORS.rst
@@ -3,7 +3,9 @@
   * Pedro M. Baeza
   * Ernesto Tejeda
   * David Vidal
+  * Carlos Roca
 
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 * Dhara Solanki <dhara.solanki@initos.com>
 * Ruchir Shukla <ruchir@bizzappdev.com>
+* Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)

--- a/sale_order_line_price_history/readme/ROADMAP.rst
+++ b/sale_order_line_price_history/readme/ROADMAP.rst
@@ -1,9 +1,1 @@
-* The number of entries of prices history in the wizard should be configurable,
-  currently it is limited to 20.
 * A backend tour would be nice to have.
-* It is not possible to set a price from the tree view of the wizard lines,
-  currently it can only be done from the form view of those lines
-  (by clicking on one of them). This is not solved by simply putting a
-  'Set price' button in the wizard lines because that button will be
-  disabled since when the wizard is launched there is still no wizard
-  record in the database (this is an Odoo limitation).

--- a/sale_order_line_price_history/readme/USAGE.rst
+++ b/sale_order_line_price_history/readme/USAGE.rst
@@ -1,6 +1,9 @@
 To use this module, you need to:
 
-#. Go to *Sales -> Quotations* and select a Quotation.
+#. Go to System Parameters and configure the
+   ``sale_order_line_price_history.order_line_limit`` parameter to limit the
+   number of Sale Order Lines to show on the Wizard.
+#. Go to *Sales -> Quotations* and select a Quotation. Default is 20 lines.
 #. Click on the new clock button in one of the sale order lines.
 #. A pop-up will open and you will see the *price history* for the product of
    the sale order line and for the customer of the sale order.

--- a/sale_order_line_price_history/static/description/index.html
+++ b/sale_order_line_price_history/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -391,7 +390,10 @@ the sale order line.</p>
 <h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
 <p>To use this module, you need to:</p>
 <ol class="arabic simple">
-<li>Go to <em>Sales -&gt; Quotations</em> and select a Quotation.</li>
+<li>Go to System Parameters and configure the
+<tt class="docutils literal">sale_order_line_price_history.order_line_limit</tt> parameter to limit the
+number of Sale Order Lines to show on the Wizard.</li>
+<li>Go to <em>Sales -&gt; Quotations</em> and select a Quotation. Default is 20 lines.</li>
 <li>Click on the new clock button in one of the sale order lines.</li>
 <li>A pop-up will open and you will see the <em>price history</em> for the product of
 the sale order line and for the customer of the sale order.</li>
@@ -405,15 +407,7 @@ click the smart button named <em>Set price</em>.</li>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
 <ul class="simple">
-<li>The number of entries of prices history in the wizard should be configurable,
-currently it is limited to 20.</li>
 <li>A backend tour would be nice to have.</li>
-<li>It is not possible to set a price from the tree view of the wizard lines,
-currently it can only be done from the form view of those lines
-(by clicking on one of them). This is not solved by simply putting a
-‘Set price’ button in the wizard lines because that button will be
-disabled since when the wizard is launched there is still no wizard
-record in the database (this is an Odoo limitation).</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
@@ -439,11 +433,13 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Pedro M. Baeza</li>
 <li>Ernesto Tejeda</li>
 <li>David Vidal</li>
+<li>Carlos Roca</li>
 </ul>
 </li>
 <li>Serpent Consulting Services Pvt. Ltd. &lt;<a class="reference external" href="mailto:support&#64;serpentcs.com">support&#64;serpentcs.com</a>&gt;</li>
 <li>Dhara Solanki &lt;<a class="reference external" href="mailto:dhara.solanki&#64;initos.com">dhara.solanki&#64;initos.com</a>&gt;</li>
 <li>Ruchir Shukla &lt;<a class="reference external" href="mailto:ruchir&#64;bizzappdev.com">ruchir&#64;bizzappdev.com</a>&gt;</li>
+<li>Eduardo de Miguel (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
@@ -453,6 +449,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/ernestotejeda"><img alt="ernestotejeda" src="https://github.com/ernestotejeda.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/CarlosRoca13"><img alt="CarlosRoca13" src="https://github.com/CarlosRoca13.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/Shide"><img alt="Shide" src="https://github.com/Shide.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/sale-workflow/tree/16.0/sale_order_line_price_history">OCA/sale-workflow</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/sale_order_line_price_history/static/src/js/sale_line_price_history_widget.js
+++ b/sale_order_line_price_history/static/src/js/sale_line_price_history_widget.js
@@ -1,6 +1,5 @@
 /** @odoo-module **/
 const {Component} = owl;
-// Import the registry
 import {registry} from "@web/core/registry";
 import {standardFieldProps} from "@web/views/fields/standard_field_props";
 import {useService} from "@web/core/utils/hooks";
@@ -20,6 +19,11 @@ export class PriceHistoryWidget extends Component {
                     default_partner_id: this.props.record.data.order_partner_id[0],
                     default_active_id: this.props.value,
                     default_sale_order_line_id: this.props.value,
+                },
+                onClose: (value) => {
+                    if (value && "price_unit" in value) {
+                        this.props.record.update(value);
+                    }
                 },
             }
         );

--- a/sale_order_line_price_history/static/src/js/set_price_to_line_widget.js
+++ b/sale_order_line_price_history/static/src/js/set_price_to_line_widget.js
@@ -1,0 +1,29 @@
+/** @odoo-module **/
+const {Component} = owl;
+import {registry} from "@web/core/registry";
+import {standardFieldProps} from "@web/views/fields/standard_field_props";
+import {useService} from "@web/core/utils/hooks";
+
+export class SetPriceToLineWidget extends Component {
+    setup() {
+        super.setup();
+        this.actionService = useService("action");
+    }
+
+    setPriceHistory() {
+        this.actionService.doAction({
+            type: "ir.actions.act_window_close",
+            infos: {
+                price_unit: this.props.record.data.price_unit,
+                discount: this.props.record.data.discount,
+            },
+        });
+    }
+}
+
+SetPriceToLineWidget.template =
+    "sale_order_line_price_history.price_to_line_history_widget";
+SetPriceToLineWidget.props = standardFieldProps;
+
+// Add the field to the correct category
+registry.category("fields").add("set_price_to_line_widget", SetPriceToLineWidget);

--- a/sale_order_line_price_history/static/src/xml/sale_line_price_history_widget.xml
+++ b/sale_order_line_price_history/static/src/xml/sale_line_price_history_widget.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2021 Tecnativa - David Vidal
-     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html). -->
+     Copyright 2024 Moduon Team S.L. <info@moduon.team>
+     License AGLP-3.0 or later (https://www.gnu.org/licenses/agpl.html). -->
 <templates>
     <t t-name="sale_order_line_price_history.price_history_widget" owl="1">
         <div>
-            <a tabindex="0" t-on-click="viewPriceHistory" class="fa fa-history" />
+            <a
+                tabindex="0"
+                t-on-click="viewPriceHistory"
+                class="fa fa-history"
+                title="Price History"
+            />
         </div>
     </t>
 </templates>

--- a/sale_order_line_price_history/static/src/xml/set_price_to_line_widget.xml
+++ b/sale_order_line_price_history/static/src/xml/set_price_to_line_widget.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 Tecnativa - Carlos Roca
+     Copyright 2024 Moduon Team S.L. <info@moduon.team>
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html). -->
+<templates>
+    <div t-name="sale_order_line_price_history.price_to_line_history_widget" owl="1">
+        <div>
+            <a
+                tabindex="0"
+                t-on-click="setPriceHistory"
+                class="fa fa-check p-1"
+                title="Set Historic Price"
+            />
+        </div>
+    </div>
+</templates>

--- a/sale_order_line_price_history/views/sale_views.xml
+++ b/sale_order_line_price_history/views/sale_views.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2019 Tecnativa - Ernesto Tejeda
+     Copyright 2024 Moduon Team S.L. <info@moduon.team>
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
     <record id="view_order_form" model="ir.ui.view">
@@ -7,13 +8,17 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='order_line']/tree">
+            <xpath
+                expr="//field[@name='order_line']/tree/field[@name='price_unit']"
+                position="after"
+            >
                 <field name="order_partner_id" invisible="1" />
                 <field
                     name="id"
-                    string="Price History"
+                    string=" "
                     context="{'active_id': id, 'active_ids': [id]}"
                     widget="sale_line_price_history_widget"
+                    help="Price History"
                 />
             </xpath>
         </field>

--- a/sale_order_line_price_history/wizards/sale_order_line_price_history.xml
+++ b/sale_order_line_price_history/wizards/sale_order_line_price_history.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2019 Tecnativa - Ernesto Tejeda
+     Copyright 2024 Moduon Team S.L. <info@moduon.team>
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
     <record id="sale_order_line_price_history_view_form" model="ir.ui.view">
@@ -7,68 +8,76 @@
         <field name="model">sale.order.line.price.history</field>
         <field name="arch" type="xml">
             <form>
-                <group col="4">
-                    <field name="partner_id" />
-                    <field name="product_id" readonly="1" />
-                    <field name="include_commercial_partner" />
-                    <field name="include_quotations" />
-                </group>
-                <group string="Sale history" col="2">
-                    <field name="line_ids" nolabel="1" readonly="1" colspan="2">
-                        <form>
-                            <div
-                                class="oe_button_box"
-                                name="button_box"
-                                attrs="{'invisible': [('history_sale_order_line_id', '=', False)]}"
-                            >
-                                <button
-                                    class="oe_stat_button"
-                                    string="Set price"
-                                    type="object"
-                                    name="action_set_price"
-                                    icon="fa-check"
-                                />
-                            </div>
-                            <group>
-                                <field name="sale_order_line_id" invisible="1" />
-                                <field
-                                    name="history_sale_order_line_id"
-                                    invisible="1"
-                                />
+                <sheet>
+                    <group>
+                        <field name="partner_id" />
+                        <field name="product_id" readonly="1" />
+                        <field name="include_commercial_partner" />
+                        <field name="include_quotations" />
+                        <field name="sale_order_line_id" invisible="1" />
+                    </group>
+                    <group string="Sale history">
+                        <field name="line_ids" nolabel="1" readonly="1" colspan="2">
+                            <form>
+                                <header>
+                                    <field name="order_state" widget="statusbar" />
+                                </header>
+                                <sheet>
+                                    <group>
+                                        <field
+                                            name="sale_order_line_id"
+                                            invisible="1"
+                                        />
+                                        <field
+                                            name="history_sale_order_line_id"
+                                            invisible="1"
+                                        />
+                                        <field name="order_id" />
+                                        <field name="partner_id" />
+                                        <field name="sale_order_date_order" />
+                                        <field name="product_uom_qty" />
+                                        <field name="price_unit" />
+                                        <label
+                                            for="discount"
+                                            groups="product.group_discount_per_so_line"
+                                        />
+                                        <div
+                                            name="discount"
+                                            groups="product.group_discount_per_so_line"
+                                        >
+                                            <field
+                                                name="discount"
+                                                class="oe_inline"
+                                            /> %%
+                                        </div>
+                                    </group>
+                                </sheet>
+                                <footer />
+                            </form>
+                            <tree decoration-info="order_state in ('draft', 'sent')">
                                 <field name="order_id" />
-                                <field name="partner_id" />
+                                <field name="order_state" invisible="1" />
+                                <field
+                                    name="partner_id"
+                                    attrs="{'column_invisible': [('parent.partner_id', '!=', False)]}"
+                                />
                                 <field name="sale_order_date_order" />
                                 <field name="product_uom_qty" />
                                 <field name="price_unit" />
-                                <label
-                                    for="discount"
-                                    groups="product.group_discount_per_so_line"
-                                />
-                                <div
+                                <field
                                     name="discount"
                                     groups="product.group_discount_per_so_line"
-                                >
-                                    <field name="discount" class="oe_inline" /> %%
-                                </div>
-                            </group>
-                        </form>
-                        <tree>
-                            <field name="order_id" />
-                            <field
-                                name="partner_id"
-                                attrs="{'column_invisible': [('parent.partner_id', '!=', False)]}"
-                            />
-                            <field name="sale_order_date_order" />
-                            <field name="product_uom_qty" />
-                            <field name="price_unit" />
-                            <field
-                                name="discount"
-                                groups="product.group_discount_per_so_line"
-                            />
-                        </tree>
-                    </field>
-                </group>
-                <field name="sale_order_line_id" invisible="1" />
+                                />
+                                <field
+                                    name="target_sale_order_line_id"
+                                    string=" "
+                                    widget="set_price_to_line_widget"
+                                    help="Price History"
+                                />
+                            </tree>
+                        </field>
+                    </group>
+                </sheet>
                 <footer>
                     <button special="cancel" string="Close" />
                 </footer>


### PR DESCRIPTION
### Forwar Port, but unable to cherry-pick directly (complex refactors -> use co-authored instead cherry-pick)
[FWP] [[15.0][IMP] sale_order_line_price_history: Use just widget to display wizard and update values without saving](https://github.com/OCA/sale-workflow/pull/2800)
[FWP] [[15.0][FIX] sale_order_line_price_history: Add discount to changes](https://github.com/OCA/sale-workflow/pull/2814)

### Updated [Roadmap from v15](https://github.com/OCA/sale-workflow/blob/15.0/sale_order_line_price_history/readme/ROADMAP.rst):
[NEW] System parameter to limit number of lines
[NEW] Allow to set price from the tree view with a new widget

### UX changes:
[NEW] Improved UX
[NEW] Removed button from the wizard sale_order_line form to not allow set price and doesn't have the instant changes

Co-authored with @CarlosRoca13 because can't cherry-pick direclty the commits

https://www.loom.com/share/d101b9af2b4040ad9bdbfb2f9e77dcf0?sid=c2de8483-1be5-453e-a418-0ad2cd27a71b

MT-3593 @moduon @rafaelbn @CarlosRoca13 @pedrobaeza @yajo please review if you want :)