### PR TITLE
[FIX] sale_order_product_recommendation: don't destroy choices when criteria changes

### DIFF
--- a/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
@@ -10,7 +10,7 @@
         <field name="arch" type="xml">
             <form>
                 <sheet>
-                    <group>
+                    <group attrs="{'invisible': [('line_ids', '!=', [])]}">
                         <group>
                             <field name="order_id" invisible="1" />
                             <field name="months" widget="numeric_step" />
@@ -154,6 +154,13 @@
                         type="object"
                         string="Accept"
                         class="oe_highlight"
+                    />
+                    <button
+                        attrs="{'invisible': [('line_ids', '=', [])]}"
+                        confirm="You will lose any changes you have made. Are you sure?"
+                        name="action_reset"
+                        string="Change criteria"
+                        type="object"
                     />
                     <button special="cancel" string="Cancel" />
                 </footer>


### PR DESCRIPTION
Before this patch:
1. Open the recommendations wizard.
2. Generate recommendations.
3. Use those recommendation lines to add some products to the SO.
4. Change some filter parameter.
5. 💣 All changes you made are lost.

Now, to change filter criteria, you have to click on a button that will warn you about changes being lost. Then, you can choose to not do that, and instead save before opening a new recommendations wizard.

@moduon MT-4472