### PR TITLE
[IMP] sale_order_product_recommendation: choose order on mobile

### DIFF
--- a/sale_order_product_recommendation/README.rst
+++ b/sale_order_product_recommendation/README.rst
@@ -88,6 +88,8 @@ To use this module, you need to:
 #. Create a new sale order.
 #. Assign its customer.
 #. Press *Recommended Products* button.
+#. Configure the recommendations parameters.
+#. Press *Get recommendations* button.
 #. Add products into the opened wizard.
 #. Press *Accept*.
 

--- a/sale_order_product_recommendation/readme/USAGE.rst
+++ b/sale_order_product_recommendation/readme/USAGE.rst
@@ -3,5 +3,7 @@ To use this module, you need to:
 #. Create a new sale order.
 #. Assign its customer.
 #. Press *Recommended Products* button.
+#. Configure the recommendations parameters.
+#. Press *Get recommendations* button.
 #. Add products into the opened wizard.
 #. Press *Accept*.

--- a/sale_order_product_recommendation/static/description/index.html
+++ b/sale_order_product_recommendation/static/description/index.html
@@ -433,6 +433,8 @@ You can then edit the desired quantities directly in the sale order.</p>
 <li>Create a new sale order.</li>
 <li>Assign its customer.</li>
 <li>Press <em>Recommended Products</em> button.</li>
+<li>Configure the recommendations parameters.</li>
+<li>Press <em>Get recommendations</em> button.</li>
 <li>Add products into the opened wizard.</li>
 <li>Press <em>Accept</em>.</li>
 </ol>

--- a/sale_order_product_recommendation/tests/test_recommendation_common.py
+++ b/sale_order_product_recommendation/tests/test_recommendation_common.py
@@ -28,12 +28,16 @@ class RecommendationCase(TransactionCase):
                 "property_product_pricelist": cls.pricelist.id,
             }
         )
+        cls.cat_a, cls.cat_b = cls.env["product.category"].create(
+            [{"name": "A"}, {"name": "B"}]
+        )
         cls.product_obj = cls.env["product.product"]
         cls.prod_1 = cls.product_obj.create(
             {
                 "name": "Test Product 1",
                 "detailed_type": "service",
                 "list_price": 25.00,
+                "categ_id": cls.cat_b.id,
             }
         )
         cls.prod_2 = cls.product_obj.create(
@@ -41,6 +45,7 @@ class RecommendationCase(TransactionCase):
                 "name": "Test Product 2",
                 "detailed_type": "service",
                 "list_price": 50.00,
+                "categ_id": cls.cat_b.id,
             }
         )
         cls.prod_3 = cls.product_obj.create(
@@ -48,6 +53,7 @@ class RecommendationCase(TransactionCase):
                 "name": "Test Product 3",
                 "detailed_type": "service",
                 "list_price": 75.00,
+                "categ_id": cls.cat_a.id,
             }
         )
         # Create old sale orders to have searchable history

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
@@ -19,6 +19,7 @@
                         <group>
                             <field name="sale_recommendation_price_origin" />
                             <field name="use_delivery_address" />
+                            <field name="recommendations_order" />
                         </group>
                     </group>
                     <group col="2">
@@ -29,12 +30,7 @@
                             colspan="2"
                             attrs="{'invisible': [('line_ids', '=', [])]}"
                         >
-                            <tree
-                                create="0"
-                                delete="0"
-                                editable="top"
-                                context="{'group_by': 'product_categ_id'}"
-                            >
+                            <tree create="0" delete="0" editable="top">
                                 <field
                                     name="product_priority"
                                     widget="priority"
@@ -43,7 +39,10 @@
                                 />
                                 <field name="currency_id" invisible="1" />
                                 <field name="sale_line_id" invisible="1" />
-                                <field name="product_categ_id" optional="show" />
+                                <field
+                                    name="product_categ_complete_name"
+                                    optional="show"
+                                />
                                 <field name="product_id" readonly="1" force_save="1" />
                                 <field name="price_unit" />
                                 <field name="times_delivered" />


### PR DESCRIPTION
Before, recommendations on mobile screens couldn't be sorted because they are using the kanban widget, which doesn't allow it.

Recommendation lines order is particularly important to improve salesperson efficiency, so a special feature is added here so that it can be done while using the module in mobile.

The previous default behavior is respected.

@moduon MT-4472