### PR TITLE
[FIX] sale_order_line_price_history: OWL component with onchange

### DIFF
--- a/sale_order_line_price_history/static/src/js/sale_line_price_history_widget.js
+++ b/sale_order_line_price_history/static/src/js/sale_line_price_history_widget.js
@@ -31,7 +31,11 @@ export class PriceHistoryWidget extends Component {
 }
 
 PriceHistoryWidget.template = "sale_order_line_price_history.price_history_widget";
-PriceHistoryWidget.props = standardFieldProps;
+PriceHistoryWidget.props = {
+    ...standardFieldProps,
+    // Onchange decorator returns an undefined value for the id instead of false
+    value: {optional: true},
+};
 
 // Add the field to the correct category
 registry.category("fields").add("sale_line_price_history_widget", PriceHistoryWidget);


### PR DESCRIPTION
Fixed owl error  "Invalid props for component 'PriceHistoryWidget': 'value' is undefined (should be a value)" when order lines are created by onchange.

Fix Issue:  https://github.com/OCA/sale-workflow/issues/2908