### PR TITLE
[16.0][IMP]sale_exception: set context param for unlocking an order

### DIFF
--- a/sale_exception/models/sale_order.py
+++ b/sale_exception/models/sale_order.py
@@ -65,3 +65,8 @@ class SaleOrder(models.Model):
     @api.model
     def _get_popup_action(self):
         return self.env.ref("sale_exception.action_sale_exception_confirm")
+
+    def action_unlock(self):
+        return super(
+            SaleOrder, self.with_context(check_exception=False)
+        ).action_unlock()


### PR DESCRIPTION
Hi!

I have found the following problem.

Suppose there is an order that initially it does not have any exception or the exception is desactived and it is activated when the order has a 'done' state. If you try to unlock it, you will receive the warning message and you will not be able to unlock it.

### To Repoduce

1. Create an order

![image](https://github.com/OCA/sale-workflow/assets/134701949/cecd19be-374f-475e-ae93-b882b254b6cc)

2. Activate the sale exception rule

![image](https://github.com/OCA/sale-workflow/assets/134701949/6f3b834d-69ac-441b-80c9-ccc0132fc9d9)

3. Try to unlock the order

![image](https://github.com/OCA/sale-workflow/assets/134701949/acaac8f0-4216-4a51-98dd-e2160d75aa27)

(images from runboat OCA)

With this change, it will be possible to unlock the order. It only adds the param "check_exception" to the context in order to avoid the warning message [here](https://github.com/OCA/server-tools/blob/d799fb940d0c52d0f4b7db30c1576a53cbeb150b/base_exception/models/base_exception.py#L100)