### PR TITLE
[IMP] sale_order_product_recommendation: sort separately by product name or code

### DIFF
--- a/sale_order_product_recommendation/tests/test_recommendation.py
+++ b/sale_order_product_recommendation/tests/test_recommendation.py
@@ -89,6 +89,41 @@ class RecommendationCaseTests(RecommendationCase):
             ],
         )
 
+    def test_recommendations_ordered_by_code(self):
+        wiz_f = Form(
+            self.env["sale.order.recommendation"].with_context(active_id=self.new_so.id)
+        )
+        wiz_f.recommendations_order = "product_default_code asc"
+        wizard = wiz_f.save()
+        wizard.generate_recommendations()
+        # Prod 3 is 1st because its code is "A"
+        self.assertRecordValues(
+            wizard.line_ids,
+            [
+                {
+                    "product_id": self.prod_2.id,
+                    "product_default_code": False,
+                    "times_delivered": 2,
+                    "units_delivered": 100,
+                    "units_included": 0,
+                },
+                {
+                    "product_id": self.prod_1.id,
+                    "product_default_code": False,
+                    "times_delivered": 1,
+                    "units_delivered": 25,
+                    "units_included": 0,
+                },
+                {
+                    "product_id": self.prod_3.id,
+                    "product_default_code": "TEST-PROD-3",
+                    "times_delivered": 1,
+                    "units_delivered": 100,
+                    "units_included": 0,
+                },
+            ],
+        )
+
     def test_recommendations_archived_product(self):
         self.env["sale.order"].create(
             {

--- a/sale_order_product_recommendation/tests/test_recommendation_common.py
+++ b/sale_order_product_recommendation/tests/test_recommendation_common.py
@@ -54,6 +54,7 @@ class RecommendationCase(TransactionCase):
                 "detailed_type": "service",
                 "list_price": 75.00,
                 "categ_id": cls.cat_a.id,
+                "default_code": "TEST-PROD-3",
             }
         )
         # Create old sale orders to have searchable history

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -52,6 +52,7 @@ class SaleOrderRecommendation(models.TransientModel):
             ("times_delivered desc", "Times delivered"),
             ("units_delivered desc", "Units delivered"),
             ("product_categ_complete_name asc", "Product category"),
+            ("product_default_code asc", "Product code"),
             ("product_name asc", "Product name"),
         ],
         required=True,
@@ -192,7 +193,7 @@ class SaleOrderRecommendation(models.TransientModel):
         priority_multiplier = 1 if order_dir == "desc" else -1
         self.line_ids = recommendation_lines.sorted(
             key=lambda line: (
-                line[order_field],
+                "" if line[order_field] is False else line[order_field],
                 int(line.product_priority) * priority_multiplier,
             ),
             reverse=order_dir == "desc",
@@ -247,6 +248,9 @@ class SaleOrderRecommendationLine(models.TransientModel):
         related="product_id.categ_id.complete_name",
         readonly=True,
         store=True,
+    )
+    product_default_code = fields.Char(
+        related="product_id.default_code", readonly=True, store=True
     )
     product_priority = fields.Selection(
         related="product_id.priority", store=True, readonly=False

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
@@ -43,10 +43,17 @@
                                     name="product_categ_complete_name"
                                     optional="show"
                                 />
-                                <field name="product_id" readonly="1" force_save="1" />
-                                <field name="price_unit" />
-                                <field name="times_delivered" />
-                                <field name="units_delivered" />
+                                <field
+                                    name="product_id"
+                                    readonly="1"
+                                    force_save="1"
+                                    optional="hide"
+                                />
+                                <field name="product_default_code" optional="show" />
+                                <field name="product_name" optional="show" />
+                                <field name="price_unit" optional="show" />
+                                <field name="times_delivered" optional="show" />
+                                <field name="units_delivered" optional="show" />
                                 <field name="units_included" widget="numeric_step" />
                                 <field
                                     name="sale_uom_id"


### PR DESCRIPTION
Before this patch, only one column was displayed for product. Thus, sorting by its name was giving unexpected results if some had code and others didn't.

Now that column is hidden by default, and product name and code are split in 2 columns that can be sorted separately in list view.

![imagen](https://github.com/OCA/sale-workflow/assets/973709/be30196d-e1d6-4d81-b987-1edcf2f68f56)


As the amount of list columns grows, I added `optional="show"` to more of them.

For mobile kanban, product code order is added to the settings before generating recommendations.

@moduon MT-4472