### PR TITLE
[fix] sale_manual_delivery: wrong route_id model

### DIFF
--- a/sale_manual_delivery/wizard/manual_delivery.py
+++ b/sale_manual_delivery/wizard/manual_delivery.py
@@ -73,7 +73,7 @@ class ManualDelivery(models.TransientModel):
         ondelete="cascade",
     )
     route_id = fields.Many2one(
-        "stock.location.route",
+        "stock.route",
         string="Use specific Route",
         domain=[("sale_selectable", "=", True)],
         ondelete="cascade",


### PR DESCRIPTION
``stock.location.route`` is no more available.

It is replaced with stock.route

Exception Occurs when trying to Popup Create Manual Delivery Due to route_id relational model is not available.

Fixes #2702
Replaces #2703 
