### PR TITLE
[16.0][FIX] sale_packaging_default: Keep packaging order in SO lines

### DIFF
--- a/sale_packaging_default/models/sale_order_line.py
+++ b/sale_packaging_default/models/sale_order_line.py
@@ -27,7 +27,7 @@ class SaleOrderLine(models.Model):
                 line.product_packaging_id = (
                     line.product_id.packaging_ids.filtered_domain(
                         [("sales", "=", True)]
-                    )[:1]
+                    ).sorted("sequence")[:1]
                 )
         result = super()._compute_product_packaging_id()
         # If there's no way to package the desired qty, remove the packaging.

--- a/sale_packaging_default/tests/test_sale_packaging_default.py
+++ b/sale_packaging_default/tests/test_sale_packaging_default.py
@@ -75,6 +75,20 @@ class SalePackagingDefaultCase(ProductCommon):
             self.assertEqual(line_f.product_packaging_qty, 0)
             self.assertEqual(line_f.product_uom_qty, 0)
 
+    def test_default_packaging_order_on_sale_order(self):
+        """Check if changing packaging order on product is reflected"""
+        # Create a sale order with the product
+        so_f = Form(self.env["sale.order"])
+        so_f.partner_id = self.partner
+        # Change the sequence of the 2nd packaging to be the first
+        self.dozen.sequence = 1
+        with so_f.order_line.new() as line_f:
+            line_f.product_id = self.product
+            # Automatically set the default packaging and the quantity
+            self.assertEqual(line_f.product_packaging_id, self.dozen)
+            self.assertEqual(line_f.product_packaging_qty, 1)
+            self.assertEqual(line_f.product_uom_qty, 12)
+
     def test_sale_order_product_picker_compatibility(self):
         """Emulate a call done by the product picker module and see it works.
 


### PR DESCRIPTION
When multiple packaging are set on a product, during the SO creation, the default package is sometime not the first one in the list :

1. Have a product with 2 packagings
2. Drag and drop the first packaging to be the second to change its sequence
3. Create a SO and add a line with the product

Before : package A is selected instead of package B
After : package B is selected