### PR TITLE
[15.0][FIX] sale_invoice_plan: add permission menu invoice plan

### DIFF
--- a/sale_invoice_plan/views/sale_view.xml
+++ b/sale_invoice_plan/views/sale_view.xml
@@ -236,6 +236,7 @@
         action="action_sale_invoice_plan"
         id="menu_sale_invoice_plan"
         parent="sale.sale_order_menu"
+        groups="sales_team.group_sale_salesman"
         sequence="2"
     />
 </odoo>


### PR DESCRIPTION
This PR fixed user is not sale can visible menu sale because `sale invoice plan` don't have permission.
They shouldn't see this menu, if not sale.

![Selection_002](https://github.com/OCA/sale-workflow/assets/20896369/953da61c-364c-43f7-bd8d-dadd1acd727e)
