### PR TITLE
[14.0][FIX]sale_blanket_order: fix button action access for salesman

### DIFF
--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -327,7 +327,7 @@ class BlanketOrder(models.Model):
 
     def action_view_sale_orders(self):
         sale_orders = self._get_sale_orders()
-        action = self.env.ref("sale.action_orders").read()[0]
+        action = self.env["ir.actions.actions"]._for_xml_id("sale.action_orders")
         if len(sale_orders) > 0:
             action["domain"] = [("id", "in", sale_orders.ids)]
             action["context"] = [("id", "in", sale_orders.ids)]
@@ -336,9 +336,9 @@ class BlanketOrder(models.Model):
         return action
 
     def action_view_sale_blanket_order_line(self):
-        action = self.env.ref(
-            "sale_blanket_order" ".act_open_sale_blanket_order_lines_view_tree"
-        ).read()[0]
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "sale_blanket_order.act_open_sale_blanket_order_lines_view_tree"
+        )
         lines = self.mapped("line_ids")
         if len(lines) > 0:
             action["domain"] = [("id", "in", lines.ids)]

--- a/sale_blanket_order/tests/test_blanket_orders.py
+++ b/sale_blanket_order/tests/test_blanket_orders.py
@@ -156,6 +156,13 @@ class TestSaleBlanketOrders(common.TransactionCase):
         for so in sos:
             self.assertEqual(so.origin, blanket_order.name)
 
+        action = blanket_order.action_view_sale_blanket_order_line()
+        self.assertEqual(
+            action["xml_id"],
+            "sale_blanket_order.act_open_sale_blanket_order_lines_view_tree",
+        )
+        self.assertEqual(action["domain"], [("id", "in", blanket_order.line_ids.ids)])
+
     def test_03_create_sale_orders_from_blanket_order_line(self):
         """We create a blanket order and create two sale orders
         from the blanket order lines"""


### PR DESCRIPTION
Previously unless you were the administrator, you couldn't access the actions from the buttons in the top right of the blanket order's form view.

I am willing to accept less drastic solutions