### PR TITLE
[FIX] sale_product_multi_add: fix discount

### DIFF
--- a/sale_product_multi_add/wizards/sale_import_products.py
+++ b/sale_product_multi_add/wizards/sale_import_products.py
@@ -46,7 +46,10 @@ class SaleImportProducts(models.TransientModel):
             }
         )
         line_values = sale_line._convert_to_write(sale_line._cache)
-        line_values = sol_obj.play_onchanges(line_values, [])
+        line_values = sol_obj.play_onchanges(
+            line_values,
+            ["product_id", "price_unit", "product_uom", "product_uom_qty", "tax_id"],
+        )
         return line_values
 
     def select_products(self):


### PR DESCRIPTION
Previously, when the 'Discount Policy' on the Price list was configured to 'Show public price & discount to customer,' the inclusion of multiple products in the sales order line did not take the price list into account. Now, this functionality is compatible with the specified price list configuration.