### PR TITLE
[14.0][FIX] sale_mrp_bom: accept BoMs without variant

### DIFF
--- a/sale_mrp_bom/models/sale_order_line.py
+++ b/sale_mrp_bom/models/sale_order_line.py
@@ -19,16 +19,18 @@ class SaleOrderLine(models.Model):
     @api.constrains("bom_id", "product_id")
     def _check_match_product_variant_ids(self):
         for line in self:
-            if line.bom_id:
-                bom_product_tmpl = line.bom_id.product_tmpl_id
-                bom_product = bom_product_tmpl.product_variant_ids
-            else:
-                bom_product_tmpl, bom_product = None, None
-            line_product = line.product_id
-            if not bom_product or line_product == bom_product:
+            if not line.bom_id:
+                continue
+            bom_product = line.bom_id.product_id
+            bom_product_tmpl = line.bom_id.product_tmpl_id
+
+            if bom_product and bom_product == line.product_id:
+                continue
+            if not bom_product and bom_product_tmpl == line.product_template_id:
                 continue
             raise ValidationError(
                 _(
-                    "Please select BoM that has matched product with the line `{}`"
-                ).format(line_product.name)
+                    "Please select a BoM that matches the product %(product)s",
+                    product=line.product_id.display_name,
+                )
             )


### PR DESCRIPTION
This commit fixes a bug where the module would not accept a BoM on a Sale Order Line if the product in question had multiple variants and the BoM did not specify a variant.

Now, regardless of whether a product has multiple variants or not,  if the variant is specified on the BoM, it must match the product on the Sale Order Line (like before), but if it's not specified, matching on the product template is enough.