### PR TITLE
[IMP]sale_quoatation_number: New sequence after change in state

### DIFF
--- a/sale_quotation_number/models/sale_order.py
+++ b/sale_quotation_number/models/sale_order.py
@@ -48,16 +48,19 @@ class SaleOrder(models.Model):
         self.ensure_one()
         return self.env["ir.sequence"].next_by_code("sale.order")
 
-    def action_confirm(self):
+    def _action_confirm(self):
         for order in self:
-            if not self.quotation_seq_used:
+            if not (
+                order.state == "sale"
+                and order.quotation_seq_used
+                and not order.company_id.keep_name_so
+            ):
                 continue
-            if order.state not in ("draft", "sent") or order.company_id.keep_name_so:
-                continue
+            quo = ""
             if order.origin and order.origin != "":
                 quo = order.origin + ", " + order.name
             else:
                 quo = order.name
             sequence = order.get_sale_order_seq()
             order.write({"origin": quo, "name": sequence, "quotation_seq_used": False})
-        return super().action_confirm()
+        return super()._action_confirm()


### PR DESCRIPTION
In the current version of the module, the change in the sequence, from the quotation sequence to the confirmed order sequence, is performed before the actual change of the state in the sale order.

With this improvement, the change in the sequence is dones after the change of the state in the sale order. The aim is to avoid a write action (the one to change the sequence and other attributes related to it) if the change of the state fails or cannot be completed for any reason.