### PR TITLE
[FIX] sale_order_product_recommendation: make UoM work

### DIFF
--- a/sale_order_product_recommendation/README.rst
+++ b/sale_order_product_recommendation/README.rst
@@ -128,6 +128,12 @@ Contributors
 
   * Telmo Santos
 
+* `Moduon <https://www.moduon.team>`_:
+
+  * Rafael Blasco
+  * Gelo Joga
+  * Jairo Llopis
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/sale_order_product_recommendation/readme/CONTRIBUTORS.rst
+++ b/sale_order_product_recommendation/readme/CONTRIBUTORS.rst
@@ -11,3 +11,9 @@
 * `Camptocamp SA <https://www.camptocamp.com>`_:
 
   * Telmo Santos
+
+* `Moduon <https://www.moduon.team>`_:
+
+  * Rafael Blasco
+  * Gelo Joga
+  * Jairo Llopis

--- a/sale_order_product_recommendation/static/description/index.html
+++ b/sale_order_product_recommendation/static/description/index.html
@@ -472,6 +472,12 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Telmo Santos</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.moduon.team">Moduon</a>:<ul>
+<li>Rafael Blasco</li>
+<li>Gelo Joga</li>
+<li>Jairo Llopis</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -260,6 +260,10 @@ class SaleOrderRecommendationLine(models.TransientModel):
     product_priority = fields.Selection(
         related="product_id.priority", store=True, readonly=False
     )
+    product_uom_readonly = fields.Boolean(related="sale_line_id.product_uom_readonly")
+    product_uom_category_id = fields.Many2one(
+        related="product_id.uom_id.category_id", depends=["product_id"]
+    )
     price_unit = fields.Monetary(compute="_compute_price_unit")
     pricelist_id = fields.Many2one(related="wizard_id.order_id.pricelist_id")
     times_delivered = fields.Integer(readonly=True)
@@ -273,7 +277,19 @@ class SaleOrderRecommendationLine(models.TransientModel):
         readonly=True,
     )
     sale_line_id = fields.Many2one(comodel_name="sale.order.line")
-    sale_uom_id = fields.Many2one(related="sale_line_id.product_uom")
+    sale_uom_id = fields.Many2one(
+        comodel_name="uom.uom",
+        string="Unit of Measure",
+        compute="_compute_sale_uom_id",
+        store=True,
+        readonly=False,
+        domain="[('category_id', '=', product_uom_category_id)]",
+    )
+
+    @api.depends("sale_line_id", "product_id")
+    def _compute_sale_uom_id(self):
+        for line in self:
+            line.sale_uom_id = line.sale_line_id.product_uom or line.product_id.uom_id
 
     @api.depends(
         "partner_id",
@@ -297,12 +313,16 @@ class SaleOrderRecommendationLine(models.TransientModel):
 
     def _prepare_update_so_line(self, line_form):
         """So we can extend SO update"""
+        if not self.product_uom_readonly:
+            line_form.product_uom = self.sale_uom_id
         line_form.product_uom_qty = self.units_included
 
     def _prepare_new_so_line(self, line_form, sequence):
         """So we can extend SO create"""
         line_form.product_id = self.product_id
         line_form.sequence = sequence
+        if not self.product_uom_readonly:
+            line_form.product_uom = self.sale_uom_id
         line_form.product_uom_qty = self.units_included
         if self.wizard_id.sale_recommendation_price_origin == "last_sale_price":
             line_form.price_unit = self.price_unit

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation_view.xml
@@ -55,10 +55,13 @@
                                 <field name="times_delivered" optional="show" />
                                 <field name="units_delivered" optional="show" />
                                 <field name="units_included" widget="numeric_step" />
+                                <field name="product_uom_category_id" invisible="1" />
+                                <field name="product_uom_readonly" invisible="1" />
                                 <field
                                     name="sale_uom_id"
                                     optional="show"
                                     groups="uom.group_uom"
+                                    attrs="{'readonly': [('product_uom_readonly', '=', True)]}"
                                 />
                             </tree>
                             <kanban


### PR DESCRIPTION
Before this patch, UoM wasn't being properly inherited into generated lines when those lines didn't exist previously in the SO:

![image](https://github.com/OCA/sale-workflow/assets/973709/4b7d9db6-c508-462b-9605-9b37c3a7ea32)


Also, changing it manually didn't work as expected in that same case.

This is because the UoM was related to the SOL UoM. But if there was no SOL, it did nothing.

Now it's properly computed. UoM comes from the product if there's no SOL or it can't provide it. The user can change it to other UoM of the same category. The change is propagated when applying the wizard, both when creating lines and updating them. Tests added.

@moduon MT-4472