### PR TITLE
[16.0][IMP] sale_stock_picking_blocking: allow lock state on sale order

### DIFF
--- a/sale_stock_picking_blocking/models/sale_order.py
+++ b/sale_stock_picking_blocking/models/sale_order.py
@@ -2,8 +2,7 @@
 #   (http://www.eficent.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo import api, fields, models
 
 
 class SaleOrder(models.Model):
@@ -17,14 +16,6 @@ class SaleOrder(models.Model):
         store=True,
         states={"draft": [("readonly", False)], "sent": [("readonly", False)]},
     )
-
-    @api.constrains("delivery_block_id")
-    def _check_not_auto_done(self):
-        auto_done = self.user_has_groups("sale.group_auto_done_setting")
-        if auto_done and any(so.delivery_block_id for so in self):
-            raise ValidationError(
-                _('You cannot block a sale order with "auto_done_setting" ' "active.")
-            )
 
     @api.depends("partner_id")
     def _compute_delivery_block_id(self):

--- a/sale_stock_picking_blocking/tests/test_sale_stock_picking_blocking.py
+++ b/sale_stock_picking_blocking/tests/test_sale_stock_picking_blocking.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Eficent Business and IT Consulting Services S.L.
 #   (http://www.eficent.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-from odoo.exceptions import ValidationError
 from odoo.tests import Form, common
 
 
@@ -49,20 +48,6 @@ class TestSaleDeliveryBlock(common.TransactionCase):
             "product_uom_qty": 1.0,
         }
         cls.sale_order_line = cls.sol_model.with_user(cls.user_test).create(sol_dict)
-
-    def test_check_auto_done(self):
-        # Set active auto done configuration
-        config = self.env["res.config.settings"].create(
-            {"group_auto_done_setting": True}
-        )
-        config.execute()
-        block_reason = self.block_model.with_user(self.user_test).create(
-            {"name": "Test Block."}
-        )
-        so = self.sale_order
-        # Check settings constraints
-        with self.assertRaises(ValidationError):
-            so.write({"delivery_block_id": block_reason.id})
 
     def _picking_comp(self, so):
         """count created pickings"""


### PR DESCRIPTION
### Steps to reproduce:

1. Activate "Lock Confirmed Sales"
2. Create a new sale order, add a product and configure a Delivery Block Reason
3. Save the sale order / confirm, you get this error message : `You cannot block a sale order with "auto_done_setting" active`.

### This change

- Remove `_check_not_auto_done` to allow feature sale order lock.
