### PR TITLE
[16.0][IMP] sale_auto_remove_zero_quantity_lines: exclude lines that don't have a product_id

### DIFF
--- a/sale_auto_remove_zero_quantity_lines/models/sale_order.py
+++ b/sale_auto_remove_zero_quantity_lines/models/sale_order.py
@@ -11,7 +11,7 @@ class SaleOrder(models.Model):
         for order in self:
             if order.company_id.sale_auto_remove_zero_quantity_lines:
                 zero_lines = order.order_line.filtered(
-                    lambda line: line.product_uom_qty == 0
+                    lambda line: line.product_id and line.product_uom_qty == 0
                 )
                 if zero_lines:
                     body = _(

--- a/sale_auto_remove_zero_quantity_lines/tests/test_sale_auto_remove_zero_quantity_lines.py
+++ b/sale_auto_remove_zero_quantity_lines/tests/test_sale_auto_remove_zero_quantity_lines.py
@@ -42,9 +42,17 @@ class TestSaleAutoRemoveZeroQuantityLines(TransactionCase):
                             "price_unit": p.list_price,
                         },
                     ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Note test",
+                            "display_type": "line_note",
+                        },
+                    ),
                 ],
                 "pricelist_id": self.env.ref("product.list0").id,
             }
         )
         so.action_confirm()
-        self.assertEqual(len(so.order_line), 1)
+        self.assertEqual(len(so.order_line), 2)


### PR DESCRIPTION
In the action that removes zero qty lines, exclude lines that don't have a product set on them like notes and sections