### PR TITLE
[15.0][FIX] sale_custom_rounding: Do not call super with empty recordset

### DIFF
--- a/sale_custom_rounding/models/sale_order.py
+++ b/sale_custom_rounding/models/sale_order.py
@@ -34,21 +34,31 @@ class SaleOrder(models.Model):
 
     @api.depends("tax_calculation_rounding_method")
     def _compute_tax_totals_json(self):
-        super(
-            SaleOrder,
-            self.filtered(
-                lambda a: a.tax_calculation_rounding_method == "round_per_line"
-            ).with_context(round=True),
-        )._compute_tax_totals_json()
-        super(
-            SaleOrder,
-            self.filtered(
-                lambda a: a.tax_calculation_rounding_method == "round_globally"
-            ).with_context(round=False),
-        )._compute_tax_totals_json()
-        return super(
-            SaleOrder, self.filtered(lambda a: not a.tax_calculation_rounding_method)
-        )._compute_tax_totals_json()
+        ret = True
+        if self.filtered(
+            lambda a: a.tax_calculation_rounding_method == "round_per_line"
+        ):
+            ret = super(
+                SaleOrder,
+                self.filtered(
+                    lambda a: a.tax_calculation_rounding_method == "round_per_line"
+                ).with_context(round=True),
+            )._compute_tax_totals_json()
+        if self.filtered(
+            lambda a: a.tax_calculation_rounding_method == "round_globally"
+        ):
+            ret = super(
+                SaleOrder,
+                self.filtered(
+                    lambda a: a.tax_calculation_rounding_method == "round_globally"
+                ).with_context(round=False),
+            )._compute_tax_totals_json()
+        if self.filtered(lambda a: not a.tax_calculation_rounding_method):
+            ret = super(
+                SaleOrder,
+                self.filtered(lambda a: not a.tax_calculation_rounding_method),
+            )._compute_tax_totals_json()
+        return ret
 
     def _prepare_invoice(self):
         vals = super()._prepare_invoice()
@@ -69,19 +79,30 @@ class SaleOrderLine(models.Model):
 
     @api.depends("order_id.tax_calculation_rounding_method")
     def _compute_amount(self):
-        super(
-            SaleOrderLine,
-            self.filtered(
-                lambda a: a.order_id.tax_calculation_rounding_method == "round_per_line"
-            ),
-        )._compute_amount()
-        super(
-            SaleOrderLine,
-            self.filtered(
-                lambda a: a.order_id.tax_calculation_rounding_method == "round_globally"
-            ),
-        )._compute_amount()
-        return super(
-            SaleOrderLine,
-            self.filtered(lambda a: not a.order_id.tax_calculation_rounding_method),
-        )._compute_amount()
+        ret = True
+        if self.filtered(
+            lambda a: a.order_id.tax_calculation_rounding_method == "round_per_line"
+        ):
+            ret = super(
+                SaleOrderLine,
+                self.filtered(
+                    lambda a: a.order_id.tax_calculation_rounding_method
+                    == "round_per_line"
+                ).with_context(round=True),
+            )._compute_amount()
+        if self.filtered(
+            lambda a: a.order_id.tax_calculation_rounding_method == "round_globally"
+        ):
+            ret = super(
+                SaleOrderLine,
+                self.filtered(
+                    lambda a: a.order_id.tax_calculation_rounding_method
+                    == "round_globally"
+                ).with_context(round=False),
+            )._compute_amount()
+        if self.filtered(lambda a: not a.order_id.tax_calculation_rounding_method):
+            ret = super(
+                SaleOrderLine,
+                self.filtered(lambda a: not a.order_id.tax_calculation_rounding_method),
+            )._compute_amount()
+        return ret

--- a/sale_custom_rounding/tests/test_sale_custom_rounding.py
+++ b/sale_custom_rounding/tests/test_sale_custom_rounding.py
@@ -1,12 +1,12 @@
 # Copyright 2024 Manuel Regidor <manuel.regidor@sygel.es>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo.addons.invoice_custom_rounding.tests.common import (
-    TestInvoiceCustomRoundingCommon,
+from odoo.addons.account_invoice_custom_rounding.tests.common import (
+    TestAccountInvoiceCustomRoundingCommon,
 )
 
 
-class TestSaleCustomRounding(TestInvoiceCustomRoundingCommon):
+class TestSaleCustomRounding(TestAccountInvoiceCustomRoundingCommon):
     def create_sale_order(self):
         sale_order = self.env["sale.order"].create(
             {


### PR DESCRIPTION
Before this fix, super method could be called with an empty recordset, which can cause errors depending on the order that methods execute.

After this fix, super methods are called only when some of the records meet certain criteria to avoid calling methods with empty recordsets.

It also fixes the imports and names of tests.