### PR TITLE
[14.0][FIX]sale_blanket_order_revision: enable module

### DIFF
--- a/sale_blanket_order_revision/__manifest__.py
+++ b/sale_blanket_order_revision/__manifest__.py
@@ -11,5 +11,5 @@
     "data": [
         "views/sale_blanket_order_view.xml",
     ],
-    "installable": False,
+    "installable": True,
 }

--- a/setup/sale_blanket_order_revision/odoo/addons/sale_blanket_order_revision
+++ b/setup/sale_blanket_order_revision/odoo/addons/sale_blanket_order_revision
@@ -1,0 +1,1 @@
+../../../../sale_blanket_order_revision

--- a/setup/sale_blanket_order_revision/setup.py
+++ b/setup/sale_blanket_order_revision/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Activation of `sale_blanket_order_revision`, initially introduced in https://github.com/OCA/sale-workflow/pull/2925 but later disabled in https://github.com/OCA/sale-workflow/pull/2942 for a premature merge.