### PR TITLE
[16.0] [FIX] sale_elaboration: Do not print Elaboration on incoming pickings

### DIFF
--- a/sale_elaboration/README.rst
+++ b/sale_elaboration/README.rst
@@ -91,6 +91,8 @@ Contributors
   * Carlos Roca
   * Ernesto Tejeda
 
+* Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/sale_elaboration/readme/CONTRIBUTORS.rst
+++ b/sale_elaboration/readme/CONTRIBUTORS.rst
@@ -4,3 +4,5 @@
   * Pedro M. Baeza
   * Carlos Roca
   * Ernesto Tejeda
+
+* Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)

--- a/sale_elaboration/reports/report_deliveryslip.xml
+++ b/sale_elaboration/reports/report_deliveryslip.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2018 Tecnativa - Sergio Teruel
+     Copyright 2024 Moduon Team S.L. <info@moduon.team>
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
     <template
@@ -29,19 +30,19 @@
             />
         </xpath>
         <xpath expr="//th[@name='th_sm_quantity']" position="after">
-            <th name="th_sm_elaboration">
+            <th t-if="o.picking_type_id.code != 'incoming'" name="th_sm_elaboration">
                 <strong>Elab.</strong>
             </th>
         </xpath>
         <xpath expr="//span[@t-field='move.quantity_done']/.." position="after">
-            <td>
+            <td t-if="o.picking_type_id.code != 'incoming'">
                 <span
                     t-esc="', '.join(move.sale_line_id.elaboration_ids.mapped('code'))"
                 />
             </td>
         </xpath>
         <xpath expr="//th[@name='th_sml_quantity']" position="after">
-            <th name="th_sml_elaboration">
+            <th t-if="o.picking_type_id.code != 'incoming'" name="th_sml_elaboration">
                 <strong>Elaboration</strong>
             </th>
         </xpath>
@@ -52,7 +53,7 @@
         inherit_id="stock.stock_report_delivery_has_serial_move_line"
     >
         <xpath expr="//td[@name='move_line_lot_qty_done']" position="after">
-            <td>
+            <td t-if="o.picking_type_id.code != 'incoming'">
                 <span
                     t-esc="', '.join(move_line.move_id.sale_line_id.elaboration_ids.mapped('code'))"
                 />

--- a/sale_elaboration/static/description/index.html
+++ b/sale_elaboration/static/description/index.html
@@ -438,6 +438,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Ernesto Tejeda</li>
 </ul>
 </li>
+<li>Eduardo de Miguel (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Incoming shipments doesn't have elaborations because there is no elaboration on the Purchase module.

MT-5393 @moduon @rafaelbn @EmilioPascual @yajo @fcvalgar @Gelojr please review if you want :)