### PR TITLE
[FIX] sale_order_product_recommendation: product category field string

### DIFF
--- a/sale_order_product_recommendation/i18n/sale_order_product_recommendation.pot
+++ b/sale_order_product_recommendation/i18n/sale_order_product_recommendation.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 16.0\n"
+"Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-03-11 08:56+0000\n"
+"PO-Revision-Date: 2024-03-11 08:56+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -81,11 +83,6 @@ msgstr ""
 #. module: sale_order_product_recommendation
 #: model:ir.model,name:sale_order_product_recommendation.model_res_company
 msgid "Companies"
-msgstr ""
-
-#. module: sale_order_product_recommendation
-#: model:ir.model.fields,field_description:sale_order_product_recommendation.field_sale_order_recommendation_line__product_categ_complete_name
-msgid "Complete Name"
 msgstr ""
 
 #. module: sale_order_product_recommendation
@@ -279,6 +276,7 @@ msgid "Product Uom Readonly"
 msgstr ""
 
 #. module: sale_order_product_recommendation
+#: model:ir.model.fields,field_description:sale_order_product_recommendation.field_sale_order_recommendation_line__product_categ_complete_name
 #: model:ir.model.fields.selection,name:sale_order_product_recommendation.selection__sale_order_recommendation__recommendations_order__product_categ_complete_name_asc
 msgid "Product category"
 msgstr ""

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -249,7 +249,7 @@ class SaleOrderRecommendationLine(models.TransientModel):
         name="Product name", related="product_id.name", readonly=True, store=True
     )
     product_categ_complete_name = fields.Char(
-        name="Product category",
+        string="Product category",
         related="product_id.categ_id.complete_name",
         readonly=True,
         store=True,


### PR DESCRIPTION
Product category was labeled as "Complete name" due to a typo in field definition, which didn't make any sense.

@moduon MT-5404