### PR TITLE
[16.0][IMP] sale_product_set: Move the base logic of the transient model to product_set

### DIFF
--- a/sale_product_set/README.rst
+++ b/sale_product_set/README.rst
@@ -91,6 +91,9 @@ Contributors
 * Adria Gil Sorribes <adria.gil@forgeflow.com>
 * Phuc (Tran Thanh) <phuc@trobz.com>
 * Manuel Regidor <manuel.regidor@sygel.es>
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Pilar Vargas
 
 Other credits
 ~~~~~~~~~~~~~

--- a/sale_product_set/__manifest__.py
+++ b/sale_product_set/__manifest__.py
@@ -13,7 +13,7 @@
         "security/ir.model.access.csv",
         "views/product_set.xml",
         "views/product_set_line.xml",
-        "wizard/product_set_add.xml",
+        "wizard/sale_product_set_wizard_view.xml",
         "views/sale_order.xml",
     ],
     "demo": ["demo/product_set_line.xml"],

--- a/sale_product_set/readme/CONTRIBUTORS.rst
+++ b/sale_product_set/readme/CONTRIBUTORS.rst
@@ -6,3 +6,6 @@
 * Adria Gil Sorribes <adria.gil@forgeflow.com>
 * Phuc (Tran Thanh) <phuc@trobz.com>
 * Manuel Regidor <manuel.regidor@sygel.es>
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Pilar Vargas

--- a/sale_product_set/security/ir.model.access.csv
+++ b/sale_product_set/security/ir.model.access.csv
@@ -1,4 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 sale_product_set_manager,Read-Write-Create access on product.set to Sale Manager,product_set.model_product_set,sales_team.group_sale_manager,1,1,1,1
 sale_product_set_line_manager,Read-Write-Create access on product.set.line to Sale Manager,product_set.model_product_set_line,sales_team.group_sale_manager,1,1,1,1
-product_set_add_wizard_user,Read-Write-Create-Delete access on product.set.add to users,model_product_set_add,base.group_user,1,1,1,1
+sale_product_set.access_sale_product_set_wizard,access_sale_product_set_wizard,sale_product_set.model_sale_product_set_wizard,base.group_user,1,1,1,1

--- a/sale_product_set/static/description/index.html
+++ b/sale_product_set/static/description/index.html
@@ -438,6 +438,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Adria Gil Sorribes &lt;<a class="reference external" href="mailto:adria.gil&#64;forgeflow.com">adria.gil&#64;forgeflow.com</a>&gt;</li>
 <li>Phuc (Tran Thanh) &lt;<a class="reference external" href="mailto:phuc&#64;trobz.com">phuc&#64;trobz.com</a>&gt;</li>
 <li>Manuel Regidor &lt;<a class="reference external" href="mailto:manuel.regidor&#64;sygel.es">manuel.regidor&#64;sygel.es</a>&gt;</li>
+<li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
+<li>Pilar Vargas</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="other-credits">

--- a/sale_product_set/tests/test_product_set.py
+++ b/sale_product_set/tests/test_product_set.py
@@ -14,7 +14,7 @@ class TestProductSet(common.TransactionCase):
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.so_model = cls.env["sale.order"]
         cls.so = cls.env.ref("sale.sale_order_6")
-        cls.product_set_add = cls.env["product.set.add"]
+        cls.product_set_add = cls.env["sale.product.set.wizard"]
         cls.product_set = cls.env.ref("product_set.product_set_i5_computer")
 
     def _get_wiz(self, ctx=None, **kw):

--- a/sale_product_set/wizard/__init__.py
+++ b/sale_product_set/wizard/__init__.py
@@ -1,1 +1,1 @@
-from . import product_set_add
+from . import sale_product_set_wizard

--- a/sale_product_set/wizard/sale_product_set_wizard_view.xml
+++ b/sale_product_set/wizard/sale_product_set_wizard_view.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <record id="product_set_add_form_view" model="ir.ui.view">
-        <field name="name">product.set.add.form.view</field>
-        <field name="model">product.set.add</field>
+        <field name="name">sale.product.set.wizard.form.view</field>
+        <field name="model">sale.product.set.wizard</field>
         <field name="arch" type="xml">
             <form string="Add set in sale order line">
                 <group name="main" colspan="4">
@@ -68,7 +68,7 @@
         model="ir.actions.act_window"
     >
         <field name="name">Add set in sale order</field>
-        <field name="res_model">product.set.add</field>
+        <field name="res_model">sale.product.set.wizard</field>
         <field name="view_mode">form</field>
         <field name="view_id" ref="product_set_add_form_view" />
         <field name="domain">[]</field>
@@ -77,7 +77,7 @@
     </record>
     <record id="act_open_wizard_product_set_add_from_set" model="ir.actions.act_window">
         <field name="name">Add set to sale order</field>
-        <field name="res_model">product.set.add</field>
+        <field name="res_model">sale.product.set.wizard</field>
         <field name="binding_model_id" ref="product_set.model_product_set" />
         <field name="view_mode">form</field>
         <field name="view_id" ref="product_set_add_form_view" />


### PR DESCRIPTION
Pending from:

- [x] https://github.com/OCA/product-attribute/pull/1548

The reason to move this logic is that there are other modules that extend
product_set as for example stock_product_set but at the same time make use
of the transient model to define a wizard. For this reason it is better to
have the logic available in product_set module and avoid duplicating code or
inheriting from sale_product_set and what this implies in their respective
dependencies with the only need to extend the transient model.
In addition, the transient model is renamed to make it clearer to identify
that it is this type of model.

cc @Tecnativa TT48100

@pedrobaeza @victoralmau please review