### PR TITLE
[16.0][IMP] sale_product_packaging_container_deposit: Avoid forbidden modifying locked SO when updating order container deposit quantity

### DIFF
--- a/sale_product_packaging_container_deposit/models/sale_order_line.py
+++ b/sale_product_packaging_container_deposit/models/sale_order_line.py
@@ -13,3 +13,9 @@ class SaleOrderLine(models.Model):
 
     def _get_product_qty_delivered_received_field(self):
         return "qty_delivered"
+
+    def _get_protected_fields(self):
+        protected_fields = super()._get_protected_fields()
+        if self.env.context.get("update_order_container_deposit_quantity", False):
+            protected_fields.remove("product_uom_qty")
+        return protected_fields


### PR DESCRIPTION
Depend on:
- https://github.com/OCA/product-attribute/pull/1545

Rationale:
- `product_packaging_container_deposit` needs to update SOL
- But when a Sale Order is locked, some fields are protected (hence the error: "It is forbidden to modify the following fields in a locked order: Quantity")
- Given that this is a modification intended by the system and not by the user, we had a context key + an override to allow it.