### PR TITLE
[IMP] sale_packaging_default: keep packaging qty when changing product

### DIFF
--- a/sale_packaging_default/README.rst
+++ b/sale_packaging_default/README.rst
@@ -94,6 +94,9 @@ You will notice that:
 -  The packaging quantity is set to 1 packaging unit.
 -  The product UoM quantity is set to the amount of units contained in 1
    packaging.
+-  When changing to another product, instead of keeping the amount of
+   UoM units, we now keep the packaging qty, and the UoM qty is
+   recomputed accordingly.
 
 Bug Tracker
 ===========

--- a/sale_packaging_default/readme/USAGE.md
+++ b/sale_packaging_default/readme/USAGE.md
@@ -17,3 +17,5 @@ You will notice that:
 - The product is added with the default sale packaging.
 - The packaging quantity is set to 1 packaging unit.
 - The product UoM quantity is set to the amount of units contained in 1 packaging.
+- When changing to another product, instead of keeping the amount of UoM units,
+  we now keep the packaging qty, and the UoM qty is recomputed accordingly.

--- a/sale_packaging_default/static/description/index.html
+++ b/sale_packaging_default/static/description/index.html
@@ -442,6 +442,9 @@ will be considered the default one.</li>
 <li>The packaging quantity is set to 1 packaging unit.</li>
 <li>The product UoM quantity is set to the amount of units contained in 1
 packaging.</li>
+<li>When changing to another product, instead of keeping the amount of
+UoM units, we now keep the packaging qty, and the UoM qty is
+recomputed accordingly.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">

--- a/sale_packaging_default/tests/test_sale_packaging_default.py
+++ b/sale_packaging_default/tests/test_sale_packaging_default.py
@@ -1,5 +1,6 @@
 # Copyright 2023 Moduon Team S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+from odoo import fields
 from odoo.tests.common import Form
 
 from odoo.addons.product.tests.common import ProductCommon
@@ -13,19 +14,35 @@ class SalePackagingDefaultCase(ProductCommon):
         with Form(cls.product) as product_f:
             with product_f.packaging_ids.new() as packaging_f:
                 packaging_f.name = "Dozen"
-                packaging_f.sequence = 10
                 packaging_f.qty = 12
                 packaging_f.sales = True
                 packaging_f.sequence = 20
             with product_f.packaging_ids.new() as packaging_f:
                 packaging_f.name = "Big box"
-                packaging_f.sequence = 20
                 packaging_f.qty = 100
                 packaging_f.sales = True
                 packaging_f.sequence = 10  # This is the default one
         cls.big_box, cls.dozen = cls.product.packaging_ids
         assert cls.dozen.name == "Dozen"
         assert cls.big_box.name == "Big box"
+        cls.product2 = cls.env["product.product"].create(
+            {
+                "name": "Product 2",
+                "type": "consu",
+                "packaging_ids": [
+                    fields.Command.create(
+                        {
+                            "name": "3-pack",
+                            "qty": 3,
+                            "sales": True,
+                            "sequence": 10,
+                        }
+                    ),
+                ],
+            }
+        )
+        cls.p2_three_pack = cls.product2.packaging_ids[0]
+        assert cls.p2_three_pack.name == "3-pack"
 
     def test_default_packaging_sale_order(self):
         """Check is packaging usage in sale order."""
@@ -91,3 +108,21 @@ class SalePackagingDefaultCase(ProductCommon):
         with so_f.order_line.new() as line_f:
             self.assertEqual(line_f.product_uom_qty, 1)
             self.assertFalse(line_f.product_packaging_id)
+
+    def test_product_change(self):
+        """Set one product, alter qtys, change product, qtys are reset."""
+        so_f = Form(self.env["sale.order"])
+        so_f.partner_id = self.partner
+        with so_f.order_line.new() as line_f:
+            line_f.product_id = self.product
+            self.assertEqual(line_f.product_packaging_id, self.big_box)
+            self.assertEqual(line_f.product_packaging_qty, 1)
+            self.assertEqual(line_f.product_uom_qty, 100)
+            line_f.product_uom_qty = 120
+            self.assertEqual(line_f.product_packaging_id, self.dozen)
+            self.assertEqual(line_f.product_packaging_qty, 10)
+            self.assertEqual(line_f.product_uom_qty, 120)
+            line_f.product_id = self.product2
+            self.assertEqual(line_f.product_packaging_id, self.p2_three_pack)
+            self.assertEqual(line_f.product_packaging_qty, 10)
+            self.assertEqual(line_f.product_uom_qty, 30)


### PR DESCRIPTION
When changing the line product, before this patch we had upstream Odoo behavior unchanged: keep the uom qty and recompute the packaging qty accordingly.

This gave a poor UX because, when using this addon, you expect packaging qty to have priority over uom qty. Thus, if you changed from selling 2 packagings of one product packaged by default in 6-packs (thus 12 units) to another product with a default sales packaging of 3-packs, you expect to be still selling 2 packagings (thus 6 units).

@moduon MT-5444