### PR TITLE
[14.0][IMP] sale_delivery_state: improve xpath in view inheritance

### DIFF
--- a/sale_delivery_state/views/sale_order_views.xml
+++ b/sale_delivery_state/views/sale_order_views.xml
@@ -26,7 +26,7 @@
                 <field name="delivery_state" readonly="True" />
                 <field name="force_delivery_state" invisible="True" />
             </field>
-            <xpath expr="//field[@name='order_line']//tree" position="inside">
+            <xpath expr="//field[@name='order_line']/tree" position="inside">
                 <field name="skip_sale_delivery_state" optional="hide" />
             </xpath>
         </field>


### PR DESCRIPTION
The current xpath used in the inherit of the form view of sale.order could match a tree view embedded in the form view of sale.order.line. This commit fixes this.