### PR TITLE
[FIX] sale_elaboration: propagate note-only lines to stock moves

### DIFF
--- a/sale_elaboration/README.rst
+++ b/sale_elaboration/README.rst
@@ -92,6 +92,7 @@ Contributors
   * Ernesto Tejeda
 
 * Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)
+* Jairo Llopis (`Moduon <https://www.moduon.team/>`__)
 
 Maintainers
 ~~~~~~~~~~~
@@ -105,6 +106,17 @@ This module is maintained by the OCA.
 OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
+
+.. |maintainer-rafaelbn| image:: https://github.com/rafaelbn.png?size=40px
+    :target: https://github.com/rafaelbn
+    :alt: rafaelbn
+.. |maintainer-yajo| image:: https://github.com/yajo.png?size=40px
+    :target: https://github.com/yajo
+    :alt: yajo
+
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-rafaelbn| |maintainer-yajo| 
 
 This module is part of the `OCA/sale-workflow <https://github.com/OCA/sale-workflow/tree/16.0/sale_elaboration>`_ project on GitHub.
 

--- a/sale_elaboration/__manifest__.py
+++ b/sale_elaboration/__manifest__.py
@@ -26,4 +26,5 @@
         "reports/report_deliveryslip.xml",
     ],
     "pre_init_hook": "pre_init_hook",
+    "maintainers": ["rafaelbn", "yajo"],
 }

--- a/sale_elaboration/models/stock_rule.py
+++ b/sale_elaboration/models/stock_rule.py
@@ -34,7 +34,7 @@ class StockRule(models.Model):
             record = self.env["sale.order.line"].browse(sale_line_id)
         else:
             record = values.get("move_dest_ids", self.env["stock.move"].browse())[:1]
-        if record and record.elaboration_ids:
+        if record and (record.elaboration_ids or record.elaboration_note):
             res.update(
                 {
                     "elaboration_ids": [(6, 0, record.elaboration_ids.ids)],

--- a/sale_elaboration/readme/CONTRIBUTORS.rst
+++ b/sale_elaboration/readme/CONTRIBUTORS.rst
@@ -6,3 +6,4 @@
   * Ernesto Tejeda
 
 * Eduardo de Miguel (`Moduon <https://www.moduon.team/>`__)
+* Jairo Llopis (`Moduon <https://www.moduon.team/>`__)

--- a/sale_elaboration/static/description/index.html
+++ b/sale_elaboration/static/description/index.html
@@ -439,6 +439,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </li>
 <li>Eduardo de Miguel (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
+<li>Jairo Llopis (<a class="reference external" href="https://www.moduon.team/">Moduon</a>)</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
@@ -448,6 +449,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/rafaelbn"><img alt="rafaelbn" src="https://github.com/rafaelbn.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/yajo"><img alt="yajo" src="https://github.com/yajo.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/sale-workflow/tree/16.0/sale_elaboration">OCA/sale-workflow</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>


### PR DESCRIPTION
Before this patch, if a sale order line had no elaborations selected, but had elaboration notes, those notes didn't land in the created `stock.move` records when confirming the SO.

@moduon MT-5511