### PR TITLE
[14.0][IMP] sale_order_invoice_amount: make sure to respect currencies

### DIFF
--- a/sale_order_invoice_amount/models/sale_order.py
+++ b/sale_order_invoice_amount/models/sale_order.py
@@ -29,12 +29,27 @@ class SaleOrder(models.Model):
     )
     def _compute_invoice_amount(self):
         for rec in self:
-            if rec.state != "cancel" and rec.invoice_ids:
+            if (
+                rec.state != "cancel"
+                and rec.invoice_ids
+                and rec.invoice_status != "invoiced"
+            ):
                 rec.invoiced_amount = 0.0
                 for invoice in rec.invoice_ids:
                     if invoice.state != "cancel":
-                        rec.invoiced_amount += invoice.amount_total_signed
+                        if invoice.currency_id != rec.currency_id:
+                            rec.invoiced_amount += invoice.currency_id._convert(
+                                invoice.amount_total,
+                                rec.currency_id,
+                                invoice.company_id,
+                                invoice.invoice_date or fields.Date.today(),
+                            )
+                        else:
+                            rec.invoiced_amount += invoice.amount_total
                 rec.uninvoiced_amount = max(0, rec.amount_total - rec.invoiced_amount)
+            elif rec.invoice_status == "invoiced":
+                rec.invoiced_amount = rec.amount_total
+                rec.uninvoiced_amount = 0.0
             else:
                 rec.invoiced_amount = 0.0
                 if rec.state in ["draft", "sent", "cancel"]:

--- a/sale_order_invoice_amount/models/sale_order.py
+++ b/sale_order_invoice_amount/models/sale_order.py
@@ -29,27 +29,36 @@ class SaleOrder(models.Model):
     )
     def _compute_invoice_amount(self):
         for rec in self:
-            if (
-                rec.state != "cancel"
-                and rec.invoice_ids
-                and rec.invoice_status != "invoiced"
-            ):
+            if rec.state != "cancel" and rec.invoice_ids:
                 rec.invoiced_amount = 0.0
                 for invoice in rec.invoice_ids:
                     if invoice.state != "cancel":
-                        if invoice.currency_id != rec.currency_id:
+                        if (
+                            invoice.currency_id != rec.currency_id
+                            and rec.currency_id != invoice.company_currency_id
+                        ):
                             rec.invoiced_amount += invoice.currency_id._convert(
-                                invoice.amount_total,
+                                invoice.amount_total_signed,
                                 rec.currency_id,
                                 invoice.company_id,
                                 invoice.invoice_date or fields.Date.today(),
                             )
                         else:
-                            rec.invoiced_amount += invoice.amount_total
-                rec.uninvoiced_amount = max(0, rec.amount_total - rec.invoiced_amount)
-            elif rec.invoice_status == "invoiced":
-                rec.invoiced_amount = rec.amount_total
-                rec.uninvoiced_amount = 0.0
+                            rec.invoiced_amount += invoice.amount_total_signed
+                # Uninvoiced amount could not be equal to total - invoiced amount.
+                # For example if the amount invoiced does not match with the price unit.
+                rec.uninvoiced_amount = max(
+                    0,
+                    sum(
+                        [
+                            (line.product_uom_qty - line.qty_invoiced)
+                            * (line.price_total / line.product_uom_qty)
+                            for line in rec.order_line.filtered(
+                                lambda sl: sl.product_uom_qty > 0
+                            )
+                        ]
+                    ),
+                )
             else:
                 rec.invoiced_amount = 0.0
                 if rec.state in ["draft", "sent", "cancel"]:

--- a/sale_order_invoice_amount/tests/test_sale_order_invoice_amount.py
+++ b/sale_order_invoice_amount/tests/test_sale_order_invoice_amount.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2021 ForgeFlow S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
+from odoo import fields
 from odoo.tests import common
 
 
@@ -14,6 +15,8 @@ class TestSaleOrderInvoiceAmount(common.SavepointCase):
         cls.res_partner_address_1 = cls.env["res.partner"].create(
             {"name": "Willie Burke", "parent_id": cls.res_partner_1.id}
         )
+        cls.currency_eur = cls.env.ref("base.EUR")
+        cls.currency_cad = cls.env.ref("base.CAD")
         cls.res_partner_2 = cls.env["res.partner"].create({"name": "Partner 12"})
 
         # Products
@@ -79,39 +82,269 @@ class TestSaleOrderInvoiceAmount(common.SavepointCase):
             }
         )
 
-    def test_sale_order_invoiced_amount(self):
+    def test_01_sale_order_invoiced_amount(self):
 
         self.assertEqual(
             self.sale_order_1.invoiced_amount,
             0.0,
             "Invoiced Amount should be 0.0",
         )
-        context_payment = {
-            "active_ids": [self.sale_order_1.id],
-            "active_id": self.sale_order_1.id,
-        }
-        payment = (
-            self.env["sale.advance.payment.inv"]
-            .with_context(context_payment)
-            .create({"advance_payment_method": "fixed", "fixed_amount": 100})
+        self.sale_order_1.action_confirm()
+        aml1 = self.order_line_1._prepare_invoice_line()
+        aml2 = self.order_line_2._prepare_invoice_line()
+        test_invoice = self.env["account.move"].create(
+            [
+                {
+                    "move_type": "out_invoice",
+                    "invoice_date": fields.Date.from_string("2024-01-01"),
+                    "date": fields.Date.from_string("2024-01-01"),
+                    "partner_id": self.res_partner_1.id,
+                    "invoice_line_ids": [aml1, aml2],
+                }
+            ]
         )
-
-        payment.create_invoices()
+        test_invoice.action_post()
         self.assertEqual(
             self.sale_order_1.invoiced_amount,
-            100.0,
-            "Invoiced Amount should be 100",
+            242.0,
+            "Invoiced Amount should be 242",
         )
         self.assertEqual(
             self.sale_order_1.uninvoiced_amount,
-            263.0,
-            "Uninvoiced Amount should be 263",
+            121.0,
+            "Uninvoiced Amount should be 121, as the lines keep uninvoiced.",
         )
-
-        self.sale_order_1.action_confirm()
+        test_invoice.button_cancel()
         self.sale_order_1._create_invoices(final=True)
         self.assertEqual(
             self.sale_order_1.invoiced_amount,
             363.0,
-            "Invoiced Amount should be calculated",
+            "Invoiced Amount should be calculated.",
+        )
+        self.assertEqual(
+            self.sale_order_1.uninvoiced_amount,
+            0.0,
+            "Uninvoiced Amount should be calculated.",
+        )
+
+    def test_02_sale_order_invoiced_amount_different_currencies_invoice(self):
+
+        self.assertEqual(
+            self.sale_order_1.invoiced_amount,
+            0.0,
+            "Invoiced Amount should be 0.0",
+        )
+        self.sale_order_1.action_confirm()
+        price_foreign_currency_1 = self.sale_order_1.currency_id._convert(
+            10.0,
+            self.currency_eur,
+            self.sale_order_1.company_id,
+            fields.Date.from_string("2024-01-01"),
+        )
+        price_foreign_currency_2 = self.sale_order_1.currency_id._convert(
+            4.0,
+            self.currency_eur,
+            self.sale_order_1.company_id,
+            fields.Date.from_string("2024-01-01"),
+        )
+        aml1 = self.order_line_1._prepare_invoice_line(
+            **{
+                "price_unit": price_foreign_currency_1,
+                "currency_id": self.currency_eur.id,
+            }
+        )
+        aml2 = self.order_line_2._prepare_invoice_line(
+            **{
+                "price_unit": price_foreign_currency_2,
+                "currency_id": self.currency_eur.id,
+            }
+        )
+        test_invoice = self.env["account.move"].create(
+            [
+                {
+                    "move_type": "out_invoice",
+                    "invoice_date": fields.Date.from_string("2024-01-01"),
+                    "date": fields.Date.from_string("2024-01-01"),
+                    "partner_id": self.res_partner_1.id,
+                    "invoice_line_ids": [aml1, aml2],
+                    "currency_id": self.currency_eur.id,
+                }
+            ]
+        )
+        test_invoice.action_post()
+        self.assertAlmostEqual(
+            self.sale_order_1.invoiced_amount,
+            242.0,
+            delta=1,
+        )
+        self.assertEqual(
+            self.sale_order_1.uninvoiced_amount,
+            121.0,
+            "Uninvoiced Amount should be 121, as the lines keep uninvoiced.",
+        )
+        test_invoice.button_cancel()
+        self.sale_order_1._create_invoices(final=True)
+        self.assertEqual(
+            self.sale_order_1.invoiced_amount,
+            363.0,
+            "Invoiced Amount should be calculated.",
+        )
+        self.assertEqual(
+            self.sale_order_1.uninvoiced_amount,
+            0.0,
+            "Uninvoiced Amount should be calculated.",
+        )
+
+    def test_03_sale_order_invoiced_amount_different_currencies_sale(self):
+
+        self.sale_order_1 = self.env["sale.order"].create(
+            {"partner_id": self.res_partner_1.id, "currency_id": self.currency_eur.id}
+        )
+        self.order_line_1 = self.env["sale.order.line"].create(
+            {
+                "order_id": self.sale_order_1.id,
+                "product_id": self.product_1.id,
+                "product_uom": self.product_1.uom_id.id,
+                "product_uom_qty": 10.0,
+                "price_unit": 10.0,
+                "tax_id": self.tax,
+                "currency_id": self.currency_eur.id,
+            }
+        )
+        self.order_line_2 = self.env["sale.order.line"].create(
+            {
+                "order_id": self.sale_order_1.id,
+                "product_id": self.product_2.id,
+                "product_uom": self.product_2.uom_id.id,
+                "product_uom_qty": 25.0,
+                "price_unit": 4.0,
+                "tax_id": self.tax,
+                "currency_id": self.currency_eur.id,
+            }
+        )
+        self.order_line_3 = self.env["sale.order.line"].create(
+            {
+                "order_id": self.sale_order_1.id,
+                "product_id": self.product_3.id,
+                "product_uom": self.product_3.uom_id.id,
+                "product_uom_qty": 20.0,
+                "price_unit": 5.0,
+                "tax_id": self.tax,
+                "currency_id": self.currency_eur.id,
+            }
+        )
+
+        self.assertEqual(
+            self.sale_order_1.invoiced_amount,
+            0.0,
+            "Invoiced Amount should be 0.0",
+        )
+        self.sale_order_1.action_confirm()
+        self.sale_order_1.currency_id = self.currency_eur
+        price_foreign_currency_1 = self.sale_order_1.currency_id._convert(
+            10.0,
+            self.currency_cad,
+            self.sale_order_1.company_id,
+            fields.Date.from_string("2024-01-01"),
+        )
+        price_foreign_currency_2 = self.sale_order_1.currency_id._convert(
+            4.0,
+            self.currency_cad,
+            self.sale_order_1.company_id,
+            fields.Date.from_string("2024-01-01"),
+        )
+        aml1 = self.order_line_1._prepare_invoice_line(
+            **{
+                "price_unit": price_foreign_currency_1,
+                "currency_id": self.currency_cad.id,
+            }
+        )
+        aml2 = self.order_line_2._prepare_invoice_line(
+            **{
+                "price_unit": price_foreign_currency_2,
+                "currency_id": self.currency_cad.id,
+            }
+        )
+        test_invoice = self.env["account.move"].create(
+            [
+                {
+                    "move_type": "out_invoice",
+                    "invoice_date": fields.Date.from_string("2024-01-01"),
+                    "date": fields.Date.from_string("2024-01-01"),
+                    "partner_id": self.res_partner_1.id,
+                    "invoice_line_ids": [aml1, aml2],
+                    "currency_id": self.currency_cad.id,
+                }
+            ]
+        )
+        test_invoice.action_post()
+        self.assertAlmostEqual(
+            self.sale_order_1.invoiced_amount,
+            242.0,
+            delta=10,
+        )
+        self.assertEqual(
+            self.sale_order_1.uninvoiced_amount,
+            121.0,
+            "Uninvoiced Amount should be 121, as the lines keep uninvoiced.",
+        )
+        test_invoice.button_cancel()
+        price_foreign_currency_1 = self.sale_order_1.currency_id._convert(
+            10.0,
+            self.currency_cad,
+            self.sale_order_1.company_id,
+            fields.Date.from_string("2024-01-01"),
+        )
+        price_foreign_currency_2 = self.sale_order_1.currency_id._convert(
+            4.0,
+            self.currency_cad,
+            self.sale_order_1.company_id,
+            fields.Date.from_string("2024-01-01"),
+        )
+        price_foreign_currency_3 = self.sale_order_1.currency_id._convert(
+            5.0,
+            self.currency_cad,
+            self.sale_order_1.company_id,
+            fields.Date.from_string("2024-01-01"),
+        )
+        aml1 = self.order_line_1._prepare_invoice_line(
+            **{
+                "price_unit": price_foreign_currency_1,
+                "currency_id": self.currency_cad.id,
+            }
+        )
+        aml2 = self.order_line_2._prepare_invoice_line(
+            **{
+                "price_unit": price_foreign_currency_2,
+                "currency_id": self.currency_cad.id,
+            }
+        )
+        aml3 = self.order_line_3._prepare_invoice_line(
+            **{
+                "price_unit": price_foreign_currency_3,
+                "currency_id": self.currency_cad.id,
+            }
+        )
+        test_invoice = self.env["account.move"].create(
+            [
+                {
+                    "move_type": "out_invoice",
+                    "invoice_date": fields.Date.from_string("2024-01-01"),
+                    "date": fields.Date.from_string("2024-01-01"),
+                    "partner_id": self.res_partner_1.id,
+                    "invoice_line_ids": [aml1, aml2, aml3],
+                    "currency_id": self.currency_cad.id,
+                }
+            ]
+        )
+        test_invoice.action_post()
+        self.assertAlmostEqual(
+            self.sale_order_1.invoiced_amount,
+            363.0,
+            delta=15,
+        )
+        self.assertEqual(
+            self.sale_order_1.uninvoiced_amount,
+            0.0,
+            "Uninvoiced Amount should be calculated.",
         )


### PR DESCRIPTION
Using this module in a system with multiple currencies I have found some issues with this ones.

When computing the amount from invoice to the sale order it will firstly convert correctly the currency.

Also when the sale order is marked as fully invoiced, the amount invoiced is automatically settled as 0.

Lastly, now the uninvoiced amount is not always total_amount - invoiced_amount. Now it checks the qty invoiced to compute the uninvoiced amount.

@ForgeFlow