### PR TITLE
[FIX] sale_product_rating_verified: Don't set computed method to required

### DIFF
--- a/sale_product_rating_verified/models/rating.py
+++ b/sale_product_rating_verified/models/rating.py
@@ -7,9 +7,7 @@ from odoo import api, fields, models
 class Rating(models.Model):
     _inherit = "rating.rating"
 
-    purchase_verified = fields.Boolean(
-        required=True, default=False, compute="_compute_purchase_verified", store=True
-    )
+    purchase_verified = fields.Boolean(compute="_compute_purchase_verified", store=True)
 
     @api.depends("partner_id", "res_id", "res_model")
     def _compute_purchase_verified(self):


### PR DESCRIPTION
As the False value is set for all records at the beginning of the compute method, don't set it to required as previous created records before this module install will avoid to set the NOT NULL constraint at module install


This is due to project module install before this one in this PR: https://github.com/OCA/sale-workflow/pull/1436