### PR TITLE
[14.0][IMP] sale_product_multi_add: pricelist compatibility

### DIFF
--- a/sale_product_multi_add/wizards/sale_import_products.py
+++ b/sale_product_multi_add/wizards/sale_import_products.py
@@ -42,7 +42,9 @@ class SaleImportProducts(models.TransientModel):
                 "product_id": item.product_id.id,
                 "product_uom_qty": item.quantity,
                 "product_uom": item.product_id.uom_id.id,
-                "price_unit": item.product_id.list_price,
+                "price_unit": item.product_id.with_context(
+                    pricelist=sale.pricelist_id.id
+                ).price,
             }
         )
         line_values = sale_line._convert_to_write(sale_line._cache)


### PR DESCRIPTION
Before commit:

Adding sale order lines from `sale.import.products` assign `list_price`
as so line `price_unit`

After commit:

Adding sale order lines from `sale.import.products` will fetch the price
accordingly to the selected pricelist. Pricelist price will be assigned
as so line `price_unit` if a pricelist item matches so line `product_id`.
If no pricelist items matches so line `product_id`, the `list_price` will
be assigned as sale order line `price_unit`