### PR TITLE
[15.0][IMP] sale_automatic_workflow: Confirm pickings with delivery_package_number module installed

### DIFF
--- a/sale_automatic_workflow/models/stock_picking.py
+++ b/sale_automatic_workflow/models/stock_picking.py
@@ -32,5 +32,10 @@ class StockPicking(models.Model):
                 ):
                     for move_line in move.move_line_ids:
                         move_line.qty_done = move_line.product_uom_qty
-            picking.with_context(skip_immediate=True, skip_sms=True).button_validate()
+            picking.with_context(
+                skip_immediate=True,
+                skip_sms=True,
+                # Necessary in case module delivery_package_number is in use
+                bypass_set_number_of_packages=True,
+            ).button_validate()
         return True


### PR DESCRIPTION
When the module delivery_package_number is installed, the cron that confirm pickings do not work when the following conditions in the file stock_picking.py in delivery_package_number are met, as it tries to open the number of packages selection wizard:

`
if (res and test_condition and isinstance(res, bool) and any(picking.ask_number_of_packages for picking in self) and not self.env.context.get("bypass_set_number_of_packages"))
`
Including delivery_package_number as a dependency of sale_automatic_workflow would not make much sense, but considering the "bypass_set_number_of_packages" context parameter seems logic as both modules can be used together.

I-6003