### PR TITLE
[16.0][IMP][sale_order_lot_selection] allow or not change of lot_id 

### DIFF
--- a/sale_order_lot_selection/__manifest__.py
+++ b/sale_order_lot_selection/__manifest__.py
@@ -6,7 +6,7 @@
     "website": "https://github.com/OCA/sale-workflow",
     "license": "AGPL-3",
     "depends": ["sale_stock", "stock_restrict_lot"],
-    "data": ["view/sale_view.xml"],
+    "data": ["view/sale_view.xml", "view/res_config_settings_views.xml"],
     "demo": ["demo/sale_demo.xml"],
     "maintainers": ["bodedra"],
     "installable": True,

--- a/sale_order_lot_selection/models/__init__.py
+++ b/sale_order_lot_selection/models/__init__.py
@@ -1,1 +1,3 @@
 from . import sale_order_line
+from . import res_company
+from . import res_config_settings

--- a/sale_order_lot_selection/models/res_company.py
+++ b/sale_order_lot_selection/models/res_company.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2024 Akretion (<http://www.akretion.com>).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    allow_to_change_lot_on_confirmed_so = fields.Boolean(
+        "Allow to change lot on confirmed sale order",
+        help="If checked, it will allow to change the lot on the confirmed sale order.",
+    )

--- a/sale_order_lot_selection/models/res_config_settings.py
+++ b/sale_order_lot_selection/models/res_config_settings.py
@@ -1,0 +1,15 @@
+# Copyright (C) 2024 Akretion (<http://www.akretion.com>).
+# @author Kévin Roche <kevin.roche@akretion.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    allow_to_change_lot_on_confirmed_so = fields.Boolean(
+        string="Allow to change lot on confirmed sale order",
+        related="company_id.allow_to_change_lot_on_confirmed_so",
+        readonly=False,
+    )

--- a/sale_order_lot_selection/static/description/index.html
+++ b/sale_order_lot_selection/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -436,7 +436,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_order_lot_selection/view/res_config_settings_views.xml
+++ b/sale_order_lot_selection/view/res_config_settings_views.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.stock</field>
+        <field name="model">res.config.settings</field>
+        <field name="priority" eval="500" />
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='production_lot_info']" position="inside">
+                <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="allow_to_change_lot_on_confirmed_so"
+                    attrs="{'invisible': [('group_stock_production_lot', '=', False)]}"
+                    title="Allow Lot/Serial Numbers changes after sale confirmation"
+                >
+                    <div class="o_setting_left_pane">
+                        <field name="allow_to_change_lot_on_confirmed_so" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="allow_to_change_lot_on_confirmed_so" />
+                        <span
+                            class="fa fa-lg fa-building-o"
+                            title="Values set here are company-specific."
+                            role="img"
+                            aria-label="Values set here are company-specific."
+                            groups="base.group_multi_company"
+                        />
+                        <div class="text-muted">
+                            Choose between two strategies :
+                            <ul>
+                                <li>Lock lot/serial numbers in sales orders lines after
+                            confirmation</li>
+                                <li>Allow lot/serial numbers to be updated after
+                            confirmation and propagate changes to stock moves</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_order_lot_selection/view/sale_view.xml
+++ b/sale_order_lot_selection/view/sale_view.xml
@@ -8,9 +8,11 @@
                 expr="//field[@name='order_line']/tree/field[@name='product_template_id']"
                 position="after"
             >
+                <field name="lot_id_readonly" invisible="1" />
                 <field
                     name="lot_id"
                     domain="[('product_id','=', product_id)]"
+                    attrs="{'readonly': [('lot_id_readonly', '=', True)]}"
                     context="{'default_product_id': product_id}"
                     groups="stock.group_production_lot"
                 />
@@ -19,9 +21,11 @@
                 expr="//field[@name='order_line']/form/group/group/field[@name='product_id']"
                 position="after"
             >
+                <field name="lot_id_readonly" invisible="1" />
                 <field
                     name="lot_id"
                     domain="[('product_id','=', product_id)]"
+                    attrs="{'readonly': [('lot_id_readonly', '=', True)]}"
                     context="{'default_product_id': product_id}"
                     groups="stock.group_production_lot"
                 />


### PR DESCRIPTION
A lot / serial number can be selected on a sale order line and is propagated to related stock moves when the order is confirmed (through procurements)
But this lot / serial number can be modified after confirmation without propagation to stock moves.

We think we should make the lot / serial number field read-only after confirmation OR propagate the modification to related stock moves (if not already done)

The current PR add a config parameter to choose between these two strategies.

The "propagation" strategy implies another PR for the stock_restrict_lot module : https://github.com/OCA/stock-logistics-workflow/pull/1560

Both @metaminux and me worked on this PR.