### PR TITLE
[FIX] sale_triple_discount: apply rounding 

### DIFF
--- a/sale_triple_discount/models/sale_order_line.py
+++ b/sale_triple_discount/models/sale_order_line.py
@@ -58,7 +58,9 @@ class SaleOrderLine(models.Model):
         final_discount = 1
         for discount in discounts:
             final_discount *= discount
-        return 100 - final_discount * 100
+        result = 100 - final_discount * 100
+        dp = self.env.ref("product.decimal_discount").precision_get("Discount")
+        return round(result, dp)
 
     def _discount_fields(self):
         return ["discount", "discount2", "discount3"]


### PR DESCRIPTION
sometimes in case of multiplicative discount, subtotal on the line is not same as untaxed amount. Seems due to rounding as so far result returned by method could be something like: `284.64151515`

before:
![Screenshot from 2024-04-09 13-11-50](https://github.com/OCA/sale-workflow/assets/59824990/503a6ab8-c36d-42c6-8c77-2eebe35f95f1)

after:
![image](https://github.com/OCA/sale-workflow/assets/59824990/ceec89aa-22ea-4bd8-a3cb-d83ed6d77a80)


