### PR TITLE
[FIX] sale_order_lot_selection: remove deprecated method for domain

### DIFF
--- a/sale_order_lot_selection/models/sale_order_line.py
+++ b/sale_order_lot_selection/models/sale_order_line.py
@@ -4,7 +4,26 @@ from odoo import api, fields, models
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    lot_id = fields.Many2one("stock.production.lot", "Lot", copy=False)
+    lot_id = fields.Many2one(
+        comodel_name="stock.production.lot",
+        string="Lot",
+        domain="[('id', 'in', allowed_lot_ids)]",
+        copy=False,
+    )
+    allowed_lot_ids = fields.Many2many(
+        comodel_name="stock.production.lot",
+        compute="_compute_allowed_lot_ids",
+    )
+
+    @api.depends("product_id")
+    def _compute_allowed_lot_ids(self):
+        lot_model = self.env["stock.production.lot"]
+        for rec in self:
+            rec.allowed_lot_ids = lot_model.search(
+                [
+                    ("product_id", "=", rec.product_id.id),
+                ]
+            )
 
     def _prepare_procurement_values(self, group_id=False):
         vals = super()._prepare_procurement_values(group_id=group_id)
@@ -17,7 +36,3 @@ class SaleOrderLine(models.Model):
         res = super().product_id_change()
         self.lot_id = False
         return res
-
-    @api.onchange("product_id")
-    def _onchange_product_id_set_lot_domain(self):
-        return {"domain": {"lot_id": [("product_id", "=", self.product_id.id)]}}

--- a/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
+++ b/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
@@ -297,12 +297,7 @@ class TestSaleOrderLotSelection(test_common.SingleTransactionCase):
         picking_move_line_ids[0].location_id = self.stock_location
         picking.button_validate()
 
-        onchange_res = self.sol3._onchange_product_id_set_lot_domain()
-        self.assertEqual(
-            onchange_res["domain"]["lot_id"], [("product_id", "=", self.prd_cable.id)]
-        )
-        # put back the lot because it is removed by onchange
-        self.sol3.lot_id = lot10.id
+        self.assertEqual(self.sol3.allowed_lot_ids.product_id, self.prd_cable)
         # I'll try to confirm it to check lot reservation:
         # lot10 was delivered by order1
         lot10_qty_available = self._stock_quantity(
@@ -313,13 +308,7 @@ class TestSaleOrderLotSelection(test_common.SingleTransactionCase):
         # products are not available for reservation (lot unavailable)
         self.assertEqual(self.order3.picking_ids[0].state, "confirmed")
 
-        # also test on_change for order2
-        onchange_res = self.sol2a._onchange_product_id_set_lot_domain()
-        self.assertEqual(
-            onchange_res["domain"]["lot_id"], [("product_id", "=", self.product_46.id)]
-        )
-        # onchange remove lot_id, we put it back
-        self.sol2a.lot_id = lot11.id
+        self.assertEqual(self.sol2a.allowed_lot_ids.product_id, self.product_46)
         self.order2.action_confirm()
         picking = self.order2.picking_ids
         picking.action_assign()

--- a/sale_order_lot_selection/view/sale_view.xml
+++ b/sale_order_lot_selection/view/sale_view.xml
@@ -8,9 +8,9 @@
                 expr="//field[@name='order_line']/tree/field[@name='product_id']"
                 position="after"
             >
+                <field name="allowed_lot_ids" invisible="1" />
                 <field
                     name="lot_id"
-                    domain="[('product_id','=', product_id)]"
                     context="{'default_product_id': product_id, 'default_company_id': parent.company_id}"
                     groups="stock.group_production_lot"
                 />
@@ -19,9 +19,9 @@
                 expr="//field[@name='order_line']/form/group/group/field[@name='product_id']"
                 position="after"
             >
+                <field name="allowed_lot_ids" invisible="1" />
                 <field
                     name="lot_id"
-                    domain="[('product_id','=', product_id)]"
                     context="{'default_product_id': product_id}"
                     groups="stock.group_production_lot"
                 />


### PR DESCRIPTION
`_onchange_product_id_set_lot_domain()` causes a warning as 'domain' is deprecated as a return value, and also, doesn't work as intented, the domain is specified in the view. In short you can't customize it by overriding this method anyway, as its output is ignored.

So we take the other approach, as describe here:
https://github.com/odoo/odoo/pull/41918#issuecomment-824946980

Tests have been modified accordingly.