### PR TITLE
[IMP] sale_elaboration: remove elaboration column from delivery slip

### DIFF
--- a/sale_elaboration/reports/report_deliveryslip.xml
+++ b/sale_elaboration/reports/report_deliveryslip.xml
@@ -20,7 +20,7 @@
         >
             <attribute
                 name="t-value"
-                add="or (o.move_ids.sale_line_id.elaboration_ids)"
+                add="or (o.move_ids.filtered('elaboration_note'))"
                 separator=" "
             />
             <attribute
@@ -29,22 +29,15 @@
                 separator=", "
             />
         </xpath>
-        <xpath expr="//th[@name='th_sm_quantity']" position="after">
-            <th t-if="o.picking_type_id.code != 'incoming'" name="th_sm_elaboration">
+        <xpath expr="//p[span[@t-field='move.description_picking']]" position="after">
+            <div
+                class="fst-italic"
+                groups="sale_elaboration.group_elaboration_note_on_delivery_slip"
+                t-if="move.picking_code != 'incoming' and move.elaboration_note"
+            >
                 <strong>Elab.</strong>
-            </th>
-        </xpath>
-        <xpath expr="//span[@t-field='move.quantity_done']/.." position="after">
-            <td t-if="o.picking_type_id.code != 'incoming'">
-                <span
-                    t-esc="', '.join(move.sale_line_id.elaboration_ids.mapped('code'))"
-                />
-            </td>
-        </xpath>
-        <xpath expr="//th[@name='th_sml_quantity']" position="after">
-            <th t-if="o.picking_type_id.code != 'incoming'" name="th_sml_elaboration">
-                <strong>Elaboration</strong>
-            </th>
+                <span t-field="move.elaboration_note" />
+            </div>
         </xpath>
     </template>
 
@@ -52,12 +45,15 @@
         id="stock_report_delivery_has_serial_move_line"
         inherit_id="stock.stock_report_delivery_has_serial_move_line"
     >
-        <xpath expr="//td[@name='move_line_lot_qty_done']" position="after">
-            <td t-if="o.picking_type_id.code != 'incoming'">
-                <span
-                    t-esc="', '.join(move_line.move_id.sale_line_id.elaboration_ids.mapped('code'))"
-                />
-            </td>
+        <xpath expr="//span[@t-field='move_line.product_id']" position="after">
+            <div
+                class="fst-italic"
+                groups="sale_elaboration.group_elaboration_note_on_delivery_slip"
+                t-if="move_line.picking_code != 'incoming' and move_line.elaboration_note"
+            >
+                <strong>Elab.</strong>
+                <span t-field="move_line.elaboration_note" />
+            </div>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
Elaboration notes were not displayed in the delivery slip, but adding them in the preexisting column could make the column too big.

I removed the column and, instead, print the elaboration notes after the product name, where there's enough room for more text. As a side effect, the delivery slip is now more compact and easier to read.

@moduon MT-5508