### PR TITLE
[IMP] sale_elaboration: display elaboration notes in picking operations report

### DIFF
--- a/sale_elaboration/__manifest__.py
+++ b/sale_elaboration/__manifest__.py
@@ -24,6 +24,7 @@
         "views/stock_move_views.xml",
         "views/stock_picking_views.xml",
         "reports/report_deliveryslip.xml",
+        "reports/report_picking_operations.xml",
     ],
     "pre_init_hook": "pre_init_hook",
     "maintainers": ["rafaelbn", "yajo"],

--- a/sale_elaboration/models/res_config_settings.py
+++ b/sale_elaboration/models/res_config_settings.py
@@ -11,3 +11,7 @@ class ResConfigSettings(models.TransientModel):
         "Display Elaboration notes on Delivery Slips",
         implied_group="sale_elaboration.group_elaboration_note_on_delivery_slip",
     )
+    group_elaboration_note_on_picking_operations = fields.Boolean(
+        "Display Elaboration notes on Picking Operations",
+        implied_group="sale_elaboration.group_elaboration_note_on_picking_operations",
+    )

--- a/sale_elaboration/reports/report_picking_operations.xml
+++ b/sale_elaboration/reports/report_picking_operations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 Moduon Team S.L.
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0) -->
+<data>
+    <template id="report_picking" inherit_id="stock.report_picking">
+        <xpath expr="//td[span[@t-field='ml.product_id.display_name']]">
+            <div
+                class="fst-italic"
+                groups="sale_elaboration.group_elaboration_note_on_picking_operations"
+                t-if="ml.picking_code != 'incoming' and ml.elaboration_note"
+            >
+                <strong>Elab.</strong>
+                <span t-field="ml.elaboration_note" />
+            </div>
+        </xpath>
+    </template>
+</data>

--- a/sale_elaboration/security/security.xml
+++ b/sale_elaboration/security/security.xml
@@ -4,4 +4,9 @@
         <field name="name">Include elaboration notes on delivery slip</field>
         <field name="category_id" ref="base.module_category_hidden" />
     </record>
+
+    <record id="group_elaboration_note_on_picking_operations" model="res.groups">
+        <field name="name">Include elaboration notes on picking operations</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+    </record>
 </odoo>

--- a/sale_elaboration/static/description/index.html
+++ b/sale_elaboration/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -445,7 +446,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_elaboration/views/res_config_settings_views.xml
+++ b/sale_elaboration/views/res_config_settings_views.xml
@@ -19,6 +19,20 @@
                         </div>
                     </div>
                 </div>
+                <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="group_elaboration_note_on_picking_operations"
+                >
+                    <div class="o_setting_left_pane">
+                        <field name="group_elaboration_note_on_picking_operations" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="group_elaboration_note_on_picking_operations" />
+                        <div class="text-muted">
+                            Elaboration notes will appear on the picking operations report
+                        </div>
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
~If the option to print elaboration data on delivery slips is enabled, they also will appear now in the picking operations report.~

~The XML ID of that security group is kept for historical reasons, but it is re-labeled now.~

@moduon MT-5508