### PR TITLE
[16.0][IMP] sale_elaboration: Elaborations and elaboration note in move line tree detailed

### DIFF
--- a/sale_elaboration/__manifest__.py
+++ b/sale_elaboration/__manifest__.py
@@ -21,7 +21,7 @@
         "views/sale_elaboration_views.xml",
         "views/sale_order_views.xml",
         "views/sale_elaboration_report_views.xml",
-        "views/stock_move_views.xml",
+        "views/stock_move_line_views.xml",
         "views/stock_picking_views.xml",
         "reports/report_deliveryslip.xml",
         "reports/report_picking_operations.xml",

--- a/sale_elaboration/reports/report_deliveryslip.xml
+++ b/sale_elaboration/reports/report_deliveryslip.xml
@@ -35,7 +35,7 @@
                 groups="sale_elaboration.group_elaboration_note_on_delivery_slip"
                 t-if="move.picking_code != 'incoming' and move.elaboration_note"
             >
-                <strong>Elab.</strong>
+                <i class="fa fa-comment-o " />
                 <span t-field="move.elaboration_note" />
             </div>
         </xpath>
@@ -51,7 +51,7 @@
                 groups="sale_elaboration.group_elaboration_note_on_delivery_slip"
                 t-if="move_line.picking_code != 'incoming' and move_line.elaboration_note"
             >
-                <strong>Elab.</strong>
+                <i class="fa fa-comment-o" />
                 <span t-field="move_line.elaboration_note" />
             </div>
         </xpath>

--- a/sale_elaboration/reports/report_picking_operations.xml
+++ b/sale_elaboration/reports/report_picking_operations.xml
@@ -9,7 +9,7 @@
                 groups="sale_elaboration.group_elaboration_note_on_picking_operations"
                 t-if="ml.picking_code != 'incoming' and ml.elaboration_note"
             >
-                <strong>Elab.</strong>
+                <i class="fa fa-comment-o" />
                 <span t-field="ml.elaboration_note" />
             </div>
         </xpath>

--- a/sale_elaboration/views/stock_move_line_views.xml
+++ b/sale_elaboration/views/stock_move_line_views.xml
@@ -17,13 +17,27 @@
             </field>
         </field>
     </record>
-
     <record id="view_stock_move_line_detailed_operation_tree" model="ir.ui.view">
         <field name="model">stock.move.line</field>
         <field
             name="inherit_id"
             ref="stock.view_stock_move_line_detailed_operation_tree"
         />
+        <field name="arch" type="xml">
+            <field name="product_uom_id" position="after">
+                <field
+                    name="elaboration_ids"
+                    widget="many2many_tags"
+                    options="{'no_create': True}"
+                    optional="hide"
+                />
+                <field name="elaboration_note" optional="hide" />
+            </field>
+        </field>
+    </record>
+    <record id="view_move_line_tree_detailed" model="ir.ui.view">
+        <field name="model">stock.move.line</field>
+        <field name="inherit_id" ref="stock.view_move_line_tree_detailed" />
         <field name="arch" type="xml">
             <field name="product_uom_id" position="after">
                 <field


### PR DESCRIPTION
Add elaborations and elaboration note in view: view_move_line_tree_detailed.

https://www.loom.com/share/06a46d3a08414af9b113b1e49ffb09a2

Also add icon fa-comment-o to report to replace word elab.
![image](https://github.com/OCA/sale-workflow/assets/53056345/01e27621-2f06-4a47-bee5-9d538493554e)


@yajo @Shide @rafaelbn @Gelojr  please review.

@moduon MT-5810