### PR TITLE
[FIX][CL] Keep selected account

### DIFF
--- a/sale_order_type/models/__init__.py
+++ b/sale_order_type/models/__init__.py
@@ -5,3 +5,4 @@ from . import sale
 from . import res_partner
 from . import account_move
 from . import res_currency
+from . import account_payment

--- a/sale_order_type/models/account_payment.py
+++ b/sale_order_type/models/account_payment.py
@@ -15,10 +15,10 @@ class AccountPayment(models.Model):
         res = super(AccountPayment, self)._compute_partner_bank_id()
         for payment in self:
             if (
-                partner_bank_by_pay.get(payment.id, False) 
-                and partner_bank_by_pay.get(payment.id) 
+                partner_bank_by_pay.get(payment.id, False)
+                and partner_bank_by_pay.get(payment.id)
                 in payment.available_partner_bank_ids
             ):
                 payment.partner_bank_id = partner_bank_by_pay.get(payment.id)
-                
+
         return res

--- a/sale_order_type/models/account_payment.py
+++ b/sale_order_type/models/account_payment.py
@@ -16,7 +16,7 @@ class AccountPayment(models.Model):
         for payment in self:
             if (partner_bank_by_pay.get(payment.id, False) 
                 and partner_bank_by_pay.get(payment.id) 
-                in payment.available_partner_bank_ids):
+                in payment.available_partner_bank_ids
+            ):
                 payment.partner_bank_id = partner_bank_by_pay.get(payment.id)
         return res
-    

--- a/sale_order_type/models/account_payment.py
+++ b/sale_order_type/models/account_payment.py
@@ -1,20 +1,22 @@
-# -*- coding: utf-8 -*-
-from odoo import models, fields, api, _
+from odoo import api, models
 
 
 class AccountPayment(models.Model):
-    _inherit = 'account.payment'
+    _inherit = "account.payment"
 
-    @api.depends('available_partner_bank_ids', 'journal_id')
+    @api.depends("available_partner_bank_ids", "journal_id")
     def _compute_partner_bank_id(self):
-        '''
+        """
         If the selected account is in the available accounts then the change is not made.
-        '''
+        """
         partner_bank_by_pay = {}
         for payment in self:
-                partner_bank_by_pay[payment.id] = payment.partner_bank_id
+            partner_bank_by_pay[payment.id] = payment.partner_bank_id
         res = super(AccountPayment, self)._compute_partner_bank_id()
         for payment in self:
-            if partner_bank_by_pay.get(payment.id, False) and partner_bank_by_pay.get(payment.id) in payment.available_partner_bank_ids:
+            if (partner_bank_by_pay.get(payment.id, False) 
+                and partner_bank_by_pay.get(payment.id) 
+                in payment.available_partner_bank_ids):
                 payment.partner_bank_id = partner_bank_by_pay.get(payment.id)
         return res
+    

--- a/sale_order_type/models/account_payment.py
+++ b/sale_order_type/models/account_payment.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields, api, _
+
+
+class AccountPayment(models.Model):
+    _inherit = 'account.payment'
+
+    @api.depends('available_partner_bank_ids', 'journal_id')
+    def _compute_partner_bank_id(self):
+        '''
+        If the selected account is in the available accounts then the change is not made.
+        '''
+        partner_bank_by_pay = {}
+        for payment in self:
+                partner_bank_by_pay[payment.id] = payment.partner_bank_id
+        res = super(AccountPayment, self)._compute_partner_bank_id()
+        for payment in self:
+            if partner_bank_by_pay.get(payment.id, False) and partner_bank_by_pay.get(payment.id) in payment.available_partner_bank_ids:
+                payment.partner_bank_id = partner_bank_by_pay.get(payment.id)
+        return res

--- a/sale_order_type/models/account_payment.py
+++ b/sale_order_type/models/account_payment.py
@@ -14,9 +14,11 @@ class AccountPayment(models.Model):
             partner_bank_by_pay[payment.id] = payment.partner_bank_id
         res = super(AccountPayment, self)._compute_partner_bank_id()
         for payment in self:
-            if (partner_bank_by_pay.get(payment.id, False) 
+            if (
+                partner_bank_by_pay.get(payment.id, False) 
                 and partner_bank_by_pay.get(payment.id) 
                 in payment.available_partner_bank_ids
             ):
                 payment.partner_bank_id = partner_bank_by_pay.get(payment.id)
+                
         return res


### PR DESCRIPTION
When trying to select a different accounting account in payments, savings returns the first account
 For more details: https://github.com/OCA/sale-workflow/issues/3074