### PR TITLE
[FIX] sale_order_line_date: bugfix unwanted procurement groups

### DIFF
--- a/sale_order_line_date/models/sale_order_line.py
+++ b/sale_order_line_date/models/sale_order_line.py
@@ -19,7 +19,7 @@ class SaleOrderLine(models.Model):
     def _prepare_procurement_values(self, group_id=False):
         vals = super()._prepare_procurement_values(group_id)
         # has ensure_one already
-        if self.commitment_date:
+        if self.commitment_date and not self.move_ids:
             vals.update(
                 {
                     "date_planned": self.commitment_date


### PR DESCRIPTION
Updating both quantities and date created different procurement groups. After this fix the same behavior of standard Odoo is followed.