### PR TITLE
[IMP] sale_discount_display_amount: hide total discount on reports when it is equal to zero.

### DIFF
--- a/sale_discount_display_amount/report/sale_report_template.xml
+++ b/sale_discount_display_amount/report/sale_report_template.xml
@@ -5,7 +5,7 @@
         inherit_id="sale.report_saleorder_document"
     >
         <xpath expr="//t[@t-call='account.document_tax_totals']" position="after">
-            <tr groups="product.group_discount_per_so_line">
+            <tr t-if="doc.discount_total" groups="product.group_discount_per_so_line">
                 <td name="td_discount_total_label"><span>Total Discount</span></td>
                 <td name="td_discount_total" class="text-right">
                     <span t-field="doc.discount_total" />


### PR DESCRIPTION
This improvement hides the total discount in the sales reports when it is equal to zero.
Here are a couple of screenshots with/without the improvement:

- Without the improvement:
![Captura desde 2024-05-02 12-41-15](https://github.com/OCA/sale-workflow/assets/101106685/c45db8cd-fc1a-4017-8622-4edd36e7f805)


- With the improvement:
![Captura desde 2024-05-02 12-39-50](https://github.com/OCA/sale-workflow/assets/101106685/92ce4a9b-d638-449d-98f6-e1603809d720)



[T-6001]