### PR TITLE
[16.0][IMP] sale_discount_display_amount: Show total discount on sale report.

### DIFF
--- a/sale_discount_display_amount/README.rst
+++ b/sale_discount_display_amount/README.rst
@@ -81,6 +81,7 @@ Contributors
 * Chafique Delli <chafique.delli@akretion.com>
 * Ruchir Shukla <ruchir@bizzappdev.com>
 * Manuel Regidor <manuel.regidor@sygel.es>
+* Ángel García de la Chica Herrera <angel.garcia@sygel.es>
 
 * `Pesol <https://www.pesol.es>`__:
 

--- a/sale_discount_display_amount/__manifest__.py
+++ b/sale_discount_display_amount/__manifest__.py
@@ -11,7 +11,10 @@
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "depends": ["sale_management"],
-    "data": ["views/sale_view.xml"],
+    "data": [
+        "views/sale_view.xml",
+        "report/sale_report_template.xml",
+    ],
     "pre_init_hook": "pre_init_hook",
     "post_init_hook": "post_init_hook",
 }

--- a/sale_discount_display_amount/readme/CONTRIBUTORS.rst
+++ b/sale_discount_display_amount/readme/CONTRIBUTORS.rst
@@ -3,6 +3,7 @@
 * Chafique Delli <chafique.delli@akretion.com>
 * Ruchir Shukla <ruchir@bizzappdev.com>
 * Manuel Regidor <manuel.regidor@sygel.es>
+* Ángel García de la Chica Herrera <angel.garcia@sygel.es>
 
 * `Pesol <https://www.pesol.es>`__:
 

--- a/sale_discount_display_amount/report/sale_report_template.xml
+++ b/sale_discount_display_amount/report/sale_report_template.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <template
+        id="sale_discount_display_amount_document"
+        inherit_id="sale.report_saleorder_document"
+    >
+        <xpath expr="//t[@t-call='account.document_tax_totals']" position="after">
+            <tr t-if="doc.discount_total" groups="product.group_discount_per_so_line">
+                <td name="td_discount_total_label"><span>Total Discount</span></td>
+                <td name="td_discount_total" class="text-end">
+                    <span t-field="doc.discount_total" />
+                </td>
+            </tr>
+        </xpath>
+    </template>
+</odoo>

--- a/sale_discount_display_amount/static/description/index.html
+++ b/sale_discount_display_amount/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -428,6 +427,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Chafique Delli &lt;<a class="reference external" href="mailto:chafique.delli&#64;akretion.com">chafique.delli&#64;akretion.com</a>&gt;</li>
 <li>Ruchir Shukla &lt;<a class="reference external" href="mailto:ruchir&#64;bizzappdev.com">ruchir&#64;bizzappdev.com</a>&gt;</li>
 <li>Manuel Regidor &lt;<a class="reference external" href="mailto:manuel.regidor&#64;sygel.es">manuel.regidor&#64;sygel.es</a>&gt;</li>
+<li>Ángel García de la Chica Herrera &lt;<a class="reference external" href="mailto:angel.garcia&#64;sygel.es">angel.garcia&#64;sygel.es</a>&gt;</li>
 <li><a class="reference external" href="https://www.pesol.es">Pesol</a>:<ul>
 <li>Jonathan Oscategui Taza &lt;<a class="reference external" href="mailto:info&#64;pesol.es">info&#64;pesol.es</a>&gt;</li>
 </ul>


### PR DESCRIPTION
This improvement is the same as the PRs https://github.com/OCA/sale-workflow/pull/2957 and https://github.com/OCA/sale-workflow/pull/3114 in v15.

[T-6001]