### PR TITLE
[13.0][FIX] sale_order_line_packaging_qty

### DIFF
--- a/sale_order_line_packaging_qty/models/sale_order_line.py
+++ b/sale_order_line_packaging_qty/models/sale_order_line.py
@@ -35,16 +35,19 @@ class SaleOrderLine(models.Model):
                 )
             else:
                 product_qty = sol.product_uom_qty
+            uom = (
+                sol.product_packaging.product_uom_id
+                or sol.product_uom
+                or sol.product_id.uom_id
+            )
+            rounding = uom.rounding or 2
             qty_mod = float_round(
-                product_qty % sol.product_packaging.qty,
-                precision_rounding=sol.product_packaging.product_uom_id.rounding,
+                product_qty % sol.product_packaging.qty, precision_rounding=rounding,
             )
             # After the rounding, the value could be equals to sol.product_packaging.qty
             # So just re-apply the '%'
             qty_mod = qty_mod % sol.product_packaging.qty
-            if not float_is_zero(
-                qty_mod, precision_digits=sol.product_packaging.product_uom_id.rounding,
-            ):
+            if not float_is_zero(qty_mod, precision_rounding=rounding):
                 # If qty does not fit in package reset package qty
                 sol.product_packaging_qty = 0
             else:


### PR DESCRIPTION
In some case, the `product_packaging` is empty so the `product_uom_id` too and the rounding is not possible.
This fix force a default value (`2`) for the `rounding`.