### PR TITLE
[FIX] sale_stock_product_recommendation: wizard compatibility with sale_order_product_recommendation_packaging_default

### DIFF
--- a/sale_stock_product_recommendation/wizards/sale_order_recommendation_view.xml
+++ b/sale_stock_product_recommendation/wizards/sale_order_recommendation_view.xml
@@ -10,6 +10,8 @@
             name="inherit_id"
             ref="sale_order_product_recommendation.sale_order_recommendation_view_form"
         />
+        <!-- Compatibility with sale_order_product_recommendation_packaging_default -->
+        <field name="priority">30</field>
         <field name="arch" type="xml">
             <xpath
                 expr="//field[@name='line_ids']/tree/field[@name='units_included']"


### PR DESCRIPTION
Without this patch, the non-deterministic order of view replacing sometimes made the wrapping of the `units_included` field done by this module wrap other fields that it shouldn't. Those fields lost their labels and the form became awkward:
![image](https://github.com/OCA/sale-workflow/assets/973709/81b11897-fca9-4e46-beaf-0a9dd58ede84)


To test this works, both `sale_stock_product_recommendation` and `sale_order_product_recommendation_packaging_default` must be installed simultaneously in the DB, and the form should appear correctly:
![image](https://github.com/OCA/sale-workflow/assets/973709/a0a57515-57dd-4945-85b9-7a1b31dc7f2b)

@moduon MT-6109