### PR TITLE
[FIX] sale_elaboration: use parent.state in domain

### DIFF
--- a/sale_elaboration/views/sale_order_views.xml
+++ b/sale_elaboration/views/sale_order_views.xml
@@ -14,12 +14,12 @@
                     <field
                         name="elaboration_ids"
                         widget="many2many_tags"
-                        attrs="{'readonly': ['|', ('product_updatable', '=', False), ('state', 'in', ('done', 'cancel'))]}"
+                        attrs="{'readonly': ['|', ('product_updatable', '=', False), ('parent.state', 'in', ('done', 'cancel'))]}"
                         domain="elaboration_profile_id and [('profile_ids', 'in', [elaboration_profile_id])] or []"
                     />
                     <field
                         name="elaboration_note"
-                        attrs="{'readonly': ['|', ('product_updatable', '=', False), ('state', 'in', ('done', 'cancel'))]}"
+                        attrs="{'readonly': ['|', ('product_updatable', '=', False), ('parent.state', 'in', ('done', 'cancel'))]}"
                     />
                     <field
                         name="elaboration_price_unit"
@@ -37,13 +37,13 @@
                 <field
                     name="elaboration_ids"
                     widget="many2many_tags"
-                    attrs="{'readonly': ['|', ('product_updatable', '=', False), ('state', 'in', ('done', 'cancel'))]}"
+                    attrs="{'readonly': ['|', ('product_updatable', '=', False), ('parent.state', 'in', ('done', 'cancel'))]}"
                     domain="elaboration_profile_id and [('profile_ids', 'in', [elaboration_profile_id])] or []"
                     optional="show"
                 />
                 <field
                     name="elaboration_note"
-                    attrs="{'readonly': ['|', ('product_updatable', '=', False), ('state', 'in', ('done', 'cancel'))]}"
+                    attrs="{'readonly': ['|', ('product_updatable', '=', False), ('parent.state', 'in', ('done', 'cancel'))]}"
                     optional="show"
                 />
                 <field


### PR DESCRIPTION
Without this patch, and with some unknown but feasible combination of sale-workflow modules, these steps were producing an exception:

1. Switch to mobile view.
2. Edit one sale order line.
3. Change packaging.
4. Save line (but not parent record).
5. Repeat steps 2-4.

The error was:

    modifier "readonly": Unknown field state in domain

I'm not sure why just `state` wasn't working reliably, but I can tell Odoo upstream uses `parent.state` since https://github.com/odoo/odoo/commit/a7883df9eac4bd93417846a44f185e6c2bc36eca and this fixes the issue.

@moduon MT-5351