### PR TITLE
[Fix] sale_triple_discount untaxed_amount_to_invoice

### DIFF
--- a/sale_triple_discount/tests/test_sale_triple_discount.py
+++ b/sale_triple_discount/tests/test_sale_triple_discount.py
@@ -209,3 +209,27 @@ class TestSaleOrder(common.TransactionCase):
         self.assertAlmostEqual(self.so_line2.price_subtotal, 600.0)
         self.assertAlmostEqual(self.order.amount_untaxed, 1200.0)
         self.assertAlmostEqual(self.order.amount_tax, 180.0)
+
+    def test_untaxed_amount_to_invoice_computed_with_all_discounts(self):
+        """Tests that the untaxed amount to invoice is computed correctly when
+        all discounts are applied (discount, discount2, discount3)"""
+        self.assertEqual(self.so_line1.untaxed_amount_to_invoice, 0)
+        self.assertEqual(self.so_line2.untaxed_amount_to_invoice, 0)
+
+        self.order.action_confirm()
+
+        self.assertEqual(self.so_line1.untaxed_amount_to_invoice, 600)
+        self.assertEqual(self.so_line2.untaxed_amount_to_invoice, 600)
+
+        sale_order_copy = self.order.copy()
+        sale_order_copy.order_line[0].discount = 50
+        sale_order_copy.order_line[0].discount2 = 50
+        sale_order_copy.order_line[0].discount3 = 50
+        sale_order_copy.order_line[1].discount = 50
+        sale_order_copy.order_line[1].discount2 = 10
+        sale_order_copy.order_line[1].discount3 = 0
+
+        sale_order_copy.action_confirm()
+
+        self.assertEqual(sale_order_copy.order_line[0].untaxed_amount_to_invoice, 75)
+        self.assertEqual(sale_order_copy.order_line[1].untaxed_amount_to_invoice, 270)


### PR DESCRIPTION
**AS-IS**
`untaxed_amount_to_invoice = fields.Monetary("Untaxed Amount To Invoice", compute='_compute_untaxed_amount_to_invoice', store=True)` field is computed by  `def _compute_untaxed_amount_to_invoice(self):`  in sale addon 
 > https://github.com/odoo/odoo/blob/15.0/addons/sale/models/sale_order_line.py#L472

However, the `untaxed_amount_to_invoice` result will only be based on the native discount field, missing discount2 and discount3 for a proper value

**TO-BE**
Almost full-override of `_compute_untaxed_amount_to_invoice` method in order to compute the `untaxed_amount_to_invoice` field value with triple discounting fields (discount2 & discount3)