### PR TITLE
[17.0][FIX] sale_fixed_discount: SOL discount propagation to invoice line

### DIFF
--- a/sale_fixed_discount/models/sale_order_line.py
+++ b/sale_fixed_discount/models/sale_order_line.py
@@ -78,9 +78,12 @@ class SaleOrderLine(models.Model):
 
         return super()._convert_to_tax_base_line_dict()
 
-    @api.onchange("discount_fixed", "price_unit")
-    def _onchange_discount_fixed(self):
-        self.discount = self._get_discount_from_fixed_discount()
+    @api.depends("discount_fixed", "price_unit")
+    def _compute_discount(self):
+        lines_with_discount_fixed = self.filtered(lambda sol: sol.discount_fixed)
+        for line in lines_with_discount_fixed:
+            line.discount = line._get_discount_from_fixed_discount()
+        return super(SaleOrderLine, self - lines_with_discount_fixed)
 
     def _get_discount_from_fixed_discount(self):
         """Calculate the discount percentage from the fixed discount amount."""


### PR DESCRIPTION
**Context:**
when creating or editing a sale order line by using the UI, the `_onchange_discount_fixed()` ensures that the `discount` field is computed based on the value of `discount_fixed` and `price_unit` fields. Keeping the `discount` updated is important because this value will be propagated to the invoice line at the moment the invoice is generated.

**Description of the issue:**
The onchange method is not triggered in case we create or modify the sale order line by using an API (and so without using the UI) or when we update `discount_fixed` and `price_unit` field in custom code.
This means that the wrong `discount` value (that stays `0.0`) will be propagated to the invoice line at the moment the invoice is generated.

**Proposed fix:**
with this PR the onchange method is replaced by extending the `_compute_discount()` method, ensuring that the `discount` field is consistent with `discount_fixed`

