### PR TITLE
[16.0][FIX] sale_fixed_discount

### DIFF
--- a/sale_fixed_discount/models/sale_order_line.py
+++ b/sale_fixed_discount/models/sale_order_line.py
@@ -18,19 +18,18 @@ class SaleOrderLine(models.Model):
     @api.constrains("discount_fixed", "discount")
     def _check_discounts(self):
         """Check that the fixed discount and the discount percentage are consistent."""
+        precision = self.env["decimal.precision"].precision_get("Discount")
         for line in self:
             if line.discount_fixed and line.discount:
-                currency = line.currency_id
                 calculated_fixed_discount = float_round(
                     line._get_discount_from_fixed_discount(),
-                    precision_rounding=currency.rounding,
+                    precision_digits=precision,
                 )
-
                 if (
                     float_compare(
                         calculated_fixed_discount,
                         line.discount,
-                        precision_rounding=currency.rounding,
+                        precision_digits=precision,
                     )
                     != 0
                 ):


### PR DESCRIPTION
When you are fixing a new discount, the constain is not doing properly the rounding and it's showing all decimal values, producing the validation error due to the mentioned issue