### PR TITLE
[FIX] sale_order_type: Fix when changing the currency in a customer payment

### DIFF
--- a/sale_order_type/models/__init__.py
+++ b/sale_order_type/models/__init__.py
@@ -5,3 +5,4 @@ from . import sale
 from . import res_partner
 from . import account_move
 from . import res_currency
+from . import account_payment

--- a/sale_order_type/models/account_payment.py
+++ b/sale_order_type/models/account_payment.py
@@ -1,0 +1,14 @@
+from odoo import api, models
+
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    @api.depends("journal_id")
+    def _compute_currency_id(self):
+        for rec in self:
+            currency = rec.currency_id
+            res = super()._compute_currency_id()
+            if currency and currency != rec.journal_id.company_id.currency_id:
+                rec.currency_id = currency
+        return res

--- a/sale_order_type/tests/__init__.py
+++ b/sale_order_type/tests/__init__.py
@@ -3,3 +3,4 @@
 from . import test_account_invoice_report
 from . import test_sale_order_report
 from . import test_sale_order_type
+from . import test_account_payment

--- a/sale_order_type/tests/test_account_payment.py
+++ b/sale_order_type/tests/test_account_payment.py
@@ -1,0 +1,58 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestAccountPayment(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.AccountPayment = self.env["account.payment"]
+        self.Journal = self.env["account.journal"]
+
+        self.env["res.currency"].search(
+            [("active", "=", False), ("name", "=", "EUR")]
+        ).write({"active": True})
+
+        self.company_currency = self.env.company.currency_id
+        self.currency_eur = self.env["res.currency"].search([("name", "=", "EUR")])
+
+        self.journal_usd = self.Journal.create(
+            {
+                "name": "USD Journal",
+                "type": "bank",
+                "currency_id": self.company_currency.id,
+            }
+        )
+
+        self.journal_eur = self.Journal.create(
+            {"name": "EUR Journal", "type": "bank", "currency_id": self.currency_eur.id}
+        )
+
+        self.payment = self.AccountPayment.create(
+            {
+                "journal_id": self.journal_usd.id,
+                "payment_type": "inbound",
+                "amount": 10.0,
+                "currency_id": self.company_currency.id,
+            }
+        )
+
+    def test_compute_currency_id(self):
+        # Test the scenario when currency is the same as company's currency
+        self.assertEqual(self.payment.currency_id, self.company_currency)
+
+        # Test that currency is computed correctly when it differs
+        # from the company's currency
+        self.payment.write({"currency_id": self.currency_eur.id})
+        self.payment._compute_currency_id()
+        self.assertEqual(self.payment.currency_id, self.currency_eur)
+
+        # Test that currency remains the same if it differs from the journal's currency
+        self.payment.journal_id = self.journal_eur
+        self.payment._compute_currency_id()
+        self.assertEqual(self.payment.currency_id, self.currency_eur)
+
+        # Scenario to replicate the error condition: journal company currency different
+        # from payment currency
+        self.payment._compute_currency_id()
+        self.assertNotEqual(
+            self.payment.currency_id, self.payment.journal_id.company_id.currency_id
+        )


### PR DESCRIPTION
When you change the currency of a customer payment, the currency of the payment gets changed to the company's set currency. 

For example:
When you are changing from ARS to EUR and the company's currency is set to USD, the payment currency changes to USD.

I attach a video to represent the error.
https://drive.google.com/file/d/1xsZmIiFM5-bOAV8oFZw_vieeUTe0p7oS/view
