### PR TITLE
[FIX] sale_elaboration: compatible with delivery (don't compute notes)

### DIFF
--- a/sale_elaboration/__manifest__.py
+++ b/sale_elaboration/__manifest__.py
@@ -23,6 +23,7 @@
         "views/sale_elaboration_report_views.xml",
         "views/stock_move_line_views.xml",
         "views/stock_picking_views.xml",
+        "reports/report_base.xml",
         "reports/report_deliveryslip.xml",
         "reports/report_picking_operations.xml",
     ],

--- a/sale_elaboration/models/product_elaboration_mixin.py
+++ b/sale_elaboration/models/product_elaboration_mixin.py
@@ -14,19 +14,12 @@ class ProductElaborationMixin(models.AbstractModel):
     )
     elaboration_note = fields.Char(
         store=True,
-        compute="_compute_elaboration_note",
-        readonly=False,
     )
     is_elaboration = fields.Boolean(
         store=True,
         compute="_compute_is_elaboration",
         readonly=False,
     )
-
-    @api.depends("elaboration_ids")
-    def _compute_elaboration_note(self):
-        for line in self:
-            line.elaboration_note = ", ".join(line.elaboration_ids.mapped("name"))
 
     @api.depends("product_id")
     def _compute_is_elaboration(self):

--- a/sale_elaboration/reports/report_base.xml
+++ b/sale_elaboration/reports/report_base.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 Moduon Team S.L. <info@moduon.team>
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<data>
+    <!-- Reusable template for printing elaborations and notes -->
+    <template id="elaboration_notes">
+        <div
+            class="fst-italic"
+            groups="sale_elaboration.group_elaboration_note_on_delivery_slip"
+            t-if="record.elaboration_ids or record.elaboration_note"
+        >
+            <i class="fa fa-comment-o " />
+            <span t-field="record.elaboration_ids" /><t
+                t-if="record.elaboration_ids and record.elaboration_note"
+            >.</t>
+            <span t-field="record.elaboration_note" />
+        </div>
+    </template>
+</data>

--- a/sale_elaboration/reports/report_deliveryslip.xml
+++ b/sale_elaboration/reports/report_deliveryslip.xml
@@ -20,7 +20,7 @@
         >
             <attribute
                 name="t-value"
-                add="or (o.move_ids.filtered('elaboration_note'))"
+                add="or (o.move_ids.filtered('elaboration_ids') | o.move_ids.filtered('elaboration_note'))"
                 separator=" "
             />
             <attribute
@@ -30,14 +30,12 @@
             />
         </xpath>
         <xpath expr="//p[span[@t-field='move.description_picking']]" position="after">
-            <div
-                class="fst-italic"
-                groups="sale_elaboration.group_elaboration_note_on_delivery_slip"
-                t-if="move.picking_code != 'incoming' and move.elaboration_note"
+            <t
+                t-if="move.picking_code != 'incoming'"
+                t-call="sale_elaboration.elaboration_notes"
             >
-                <i class="fa fa-comment-o " />
-                <span t-field="move.elaboration_note" />
-            </div>
+                <t t-set="record" t-value="move" />
+            </t>
         </xpath>
     </template>
 
@@ -46,14 +44,12 @@
         inherit_id="stock.stock_report_delivery_has_serial_move_line"
     >
         <xpath expr="//span[@t-field='move_line.product_id']" position="after">
-            <div
-                class="fst-italic"
-                groups="sale_elaboration.group_elaboration_note_on_delivery_slip"
-                t-if="move_line.picking_code != 'incoming' and move_line.elaboration_note"
+            <t
+                t-if="move.picking_code != 'incoming'"
+                t-call="sale_elaboration.elaboration_notes"
             >
-                <i class="fa fa-comment-o" />
-                <span t-field="move_line.elaboration_note" />
-            </div>
+                <t t-set="record" t-value="move" />
+            </t>
         </xpath>
     </template>
 </odoo>

--- a/sale_elaboration/static/description/index.html
+++ b/sale_elaboration/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -445,7 +446,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_elaboration/tests/test_sale_elaboration.py
+++ b/sale_elaboration/tests/test_sale_elaboration.py
@@ -86,9 +86,10 @@ class TestSaleElaboration(AccountTestInvoicingCommon):
         elaboration = self.Elaboration.name_search("AA")
         self.assertEqual(len(elaboration), 1)
 
-    def test_sale_elaboration_change(self):
+    def test_sale_elaboration_doesnt_change(self):
+        self.order.order_line.elaboration_note = "Some details"
         self.order.order_line.elaboration_ids = self.elaboration_b
-        self.assertEqual(self.order.order_line.elaboration_note, "Elaboration B")
+        self.assertEqual(self.order.order_line.elaboration_note, "Some details")
 
     def test_sale_elaboration(self):
         self.order.action_confirm()

--- a/sale_order_product_recommendation_elaboration/tests/test_sale_order_recommendation.py
+++ b/sale_order_product_recommendation_elaboration/tests/test_sale_order_recommendation.py
@@ -59,7 +59,7 @@ class RecommendationCaseTests(test_recommendation_common.RecommendationCase):
         )
         wiz_line.ensure_one()
         self.assertEqual(wiz_line.elaboration_ids, self.elab_1 | self.elab_2)
-        self.assertEqual(wiz_line.elaboration_note, "Elaboration 1, Elaboration 2")
+        self.assertFalse(wiz_line.elaboration_note)
         wiz_line.elaboration_note = "Elaborations 1 and 2"
         # Include 1 of those
         wiz_line.units_included = 1
@@ -87,7 +87,7 @@ class RecommendationCaseTests(test_recommendation_common.RecommendationCase):
             )
         ]
         self.assertEqual(len(self.new_so.order_line), 1)
-        self.assertEqual(self.new_so.order_line.elaboration_note, "Elaboration 2")
+        self.assertFalse(self.new_so.order_line.elaboration_note)
         self.new_so.order_line.elaboration_note = "custom"
         wiz = self.wizard()
         wiz_line = wiz.line_ids.filtered_domain([("product_id", "=", self.prod_2.id)])


### PR DESCRIPTION
Under certain circumstances, elaboration notes were deleted. For example, when adding or removing an elaboration.

That's more or less OK, but also when delivery is installed along with this module, then the notes removal is unpredictable.

Here I fix https://github.com/OCA/sale-workflow/issues/3154 by removing the computation on notes.

Until now, notes were just repeating the same as we had in elaborations. Since the information was duplicated, the `elaboration_ids` field never appeared in reports.

Now the notes are just a normal text field that does nothing if empty. Since it will be usually empty, now reports need to include `elaboration_ids` too.

@moduon MT-6164