### PR TITLE
[16.0][IMP-FIX] sale_payment_sheet: Archive all reconciliation models to avoid them interfering with the tests

### DIFF
--- a/sale_payment_sheet/tests/test_sale_payment_sheet.py
+++ b/sale_payment_sheet/tests/test_sale_payment_sheet.py
@@ -16,6 +16,8 @@ class TestSaleInvoicePayment(TransactionCase):
         super().setUpClass()
         # Remove time zone from user to avoid to time local representation
         cls.env.user.partner_id.tz = False
+        # Archive all reconciliation models to avoid them interfering with the tests
+        cls.env["account.reconcile.model"].search([]).active = False
         account_group = cls.env.ref("account.group_account_user")
         cls.env.user.write({"groups_id": [(4, account_group.id)]})
         no_one_group = cls.env.ref("base.group_no_one")


### PR DESCRIPTION
When in an instance this module coincides with the bank reconciliation module account_reconcile_oca it causes the tests to fail as the statement lines are automatically reconciled. For this reason it is necessary to archive all records of the reconciliation models.

cc @tecnativa TT44331

@carolinafernandez-tecnativa @victoralmau please review

ping @pedrobaeza 