### PR TITLE
[FIX] product_supplierinfo_for_customer_sale: fix tests

### DIFF
--- a/product_supplierinfo_for_customer_sale/tests/test_product_supplierinfo_for_customer_sale.py
+++ b/product_supplierinfo_for_customer_sale/tests/test_product_supplierinfo_for_customer_sale.py
@@ -41,6 +41,7 @@ class TestProductSupplierinfoForCustomerSale(TransactionCase):
         self.pricelist_template = self._create_pricelist(
             "Test Pricelist Template", self.product_template.product_variant_ids[:1]
         )
+        self.env.user.groups_id |= self.env.ref("product.group_product_pricelist")
 
     def _create_customer(self, name):
         return self.env["res.partner"].create(


### PR DESCRIPTION
In #3163 the test where changed and try to set a field restricted to a group that the user used in the test don't have.