### PR TITLE
[16.0][FIX] sale_blanket_order: not require taxes on blanket orders

### DIFF
--- a/sale_blanket_order/views/sale_blanket_order_views.xml
+++ b/sale_blanket_order/views/sale_blanket_order_views.xml
@@ -215,7 +215,6 @@
                                         context="{'default_type_tax_use': 'sale'}"
                                         options="{'no_create': True}"
                                         attrs="{
-                                            'required': [('display_type', '=', False)],
                                             'invisible': [('display_type', '=', True)],
                                         }"
                                     />


### PR DESCRIPTION
I remove taxes required on blanket orders.