### PR TITLE
[FIX] [16.0] sale_elaboration: Fix report call

### DIFF
--- a/sale_elaboration/reports/report_deliveryslip.xml
+++ b/sale_elaboration/reports/report_deliveryslip.xml
@@ -45,10 +45,10 @@
     >
         <xpath expr="//span[@t-field='move_line.product_id']" position="after">
             <t
-                t-if="move.picking_code != 'incoming'"
+                t-if="move_line.picking_code != 'incoming'"
                 t-call="sale_elaboration.elaboration_notes"
             >
-                <t t-set="record" t-value="move" />
+                <t t-set="record" t-value="move_line.move_id" />
             </t>
         </xpath>
     </template>


### PR DESCRIPTION
Fast fix

Can assign move_line to record, but to maintain consitency with the other calls, I've used move_line.move_id

MT-6388 @moduon @EmilioPascual @fcvalgar @rafaelbn please review if you want