### PR TITLE
Replace author 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/sale_manual_delivery/__manifest__.py
+++ b/sale_manual_delivery/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Sale Manual Delivery",
     "category": "Sale",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "version": "16.0.1.0.1",
     "website": "https://github.com/OCA/sale-workflow",

--- a/sale_wishlist/__manifest__.py
+++ b/sale_wishlist/__manifest__.py
@@ -7,7 +7,7 @@
         Handle sale wishlist for partners""",
     "version": "16.0.1.0.0",
     "license": "AGPL-3",
-    "author": "Camptocamp SA,Odoo Community Association (OCA)",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "depends": ["sale_product_set"],
     "data": ["views/product_set.xml", "views/partner.xml"],


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 16.0.