### PR TITLE
[15.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/sale_invoice_no_mail/__manifest__.py
+++ b/sale_invoice_no_mail/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Sale Invoice No Mail",
     "version": "15.0.1.0.1",
     "category": "Sales Management",
-    "author": "Camptocamp SA," "Odoo Community Association (OCA)",
+    "author": "Camptocamp," "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "license": "AGPL-3",
     "depends": ["sale"],

--- a/sale_wishlist/__manifest__.py
+++ b/sale_wishlist/__manifest__.py
@@ -7,7 +7,7 @@
         Handle sale wishlist for partners""",
     "version": "15.0.1.0.0",
     "license": "AGPL-3",
-    "author": "Camptocamp SA,Odoo Community Association (OCA)",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "depends": ["sale_product_set"],
     "data": ["views/product_set.xml", "views/partner.xml"],


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 15.0.