### PR TITLE
[17.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/sale_manual_delivery/__manifest__.py
+++ b/sale_manual_delivery/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Sale Manual Delivery",
     "category": "Sale",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "version": "17.0.1.0.0",
     "website": "https://github.com/OCA/sale-workflow",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 17.0.