### PR TITLE
[12.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/sale_manual_delivery/__manifest__.py
+++ b/sale_manual_delivery/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Sale Manual Delivery",
     "category": "Sale",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "version": "12.0.2.0.2",
     "website": "https://github.com/OCA/sale-workflow",

--- a/sale_milestone_profile_invoicing/__manifest__.py
+++ b/sale_milestone_profile_invoicing/__manifest__.py
@@ -3,7 +3,7 @@
     'summary': """Inform on delivered and invoiced work by sale order line.""",
     'version': '12.0.1.0.1',
     'license': 'AGPL-3',
-    'author': 'Camptocamp SA, Odoo Community Association (OCA)',
+    'author': 'Camptocamp, Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/sale-workflow',
     'depends': [
         'sale',

--- a/sale_wishlist/__manifest__.py
+++ b/sale_wishlist/__manifest__.py
@@ -7,7 +7,7 @@
         Handle sale wishlist for partners""",
     'version': '12.0.1.0.0',
     'license': 'AGPL-3',
-    'author': 'Camptocamp SA,Odoo Community Association (OCA)',
+    'author': 'Camptocamp,Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/sale-workflow',
     'depends': [
         'sale_product_set',


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 12.0.