### PR TITLE
[14.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/sale_delivery_date/__manifest__.py
+++ b/sale_delivery_date/__manifest__.py
@@ -9,7 +9,7 @@
     "version": "14.0.1.1.0",
     "category": "Sales",
     "website": "https://github.com/OCA/sale-workflow",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["mmequignon"],
     "license": "AGPL-3",
     "installable": True,

--- a/sale_invoice_no_mail/__manifest__.py
+++ b/sale_invoice_no_mail/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Sale Invoice No Mail",
     "version": "14.0.1.0.1",
     "category": "Sales Management",
-    "author": "Camptocamp SA," "Odoo Community Association (OCA)",
+    "author": "Camptocamp," "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "license": "AGPL-3",
     "depends": ["sale"],

--- a/sale_mail_autosubscribe/__manifest__.py
+++ b/sale_mail_autosubscribe/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Sale Mail Autosubscribe",
     "summary": "Automatically subscribe partners to their company's sale orders",
     "version": "14.0.1.0.0",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["ivantodorovich"],
     "license": "AGPL-3",
     "category": "Sale",

--- a/sale_manual_delivery/__manifest__.py
+++ b/sale_manual_delivery/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Sale Manual Delivery",
     "category": "Sale",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "version": "14.0.1.0.0",
     "website": "https://github.com/OCA/sale-workflow",

--- a/sale_order_disable_user_autosubscribe/__manifest__.py
+++ b/sale_order_disable_user_autosubscribe/__manifest__.py
@@ -7,7 +7,7 @@
     "version": "14.0.1.0.0",
     "category": "Sales",
     "website": "https://github.com/OCA/sale-workflow",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "installable": True,
     "depends": ["sale"],

--- a/sale_wishlist/__manifest__.py
+++ b/sale_wishlist/__manifest__.py
@@ -7,7 +7,7 @@
         Handle sale wishlist for partners""",
     "version": "14.0.1.0.2",
     "license": "AGPL-3",
-    "author": "Camptocamp SA,Odoo Community Association (OCA)",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "depends": ["sale_product_set"],
     "data": ["views/product_set.xml", "views/partner.xml"],


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 14.0.