### PR TITLE
[10.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/product_price_category/__manifest__.py
+++ b/product_price_category/__manifest__.py
@@ -7,7 +7,7 @@
     'summary': 'Add Price Category field on product and allow to apply '
                'a pricelist on this field.',
     'version': '10.0.1.0.1',
-    'author': 'Camptocamp SA,Odoo Community Association (OCA)',
+    'author': 'Camptocamp,Odoo Community Association (OCA)',
     'license': 'AGPL-3',
     'category': 'Product',
     'depends': [

--- a/sale_manual_delivery/__manifest__.py
+++ b/sale_manual_delivery/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Sale Manual Delivery',
     'category': 'Sales',
-    'author': 'Camptocamp SA, Odoo Community Association (OCA)',
+    'author': 'Camptocamp, Odoo Community Association (OCA)',
     "license": "AGPL-3",
     'version': '10.0.2.0.1',
     'website': 'https://github.com/OCA/sale-workflow',


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 10.0.