### PR TITLE
[15.0][IMP] sale_order_secondary_unit: make the secondary unit and secondary y quantity fields optional

### DIFF
--- a/sale_order_secondary_unit/views/sale_order_views.xml
+++ b/sale_order_secondary_unit/views/sale_order_views.xml
@@ -39,6 +39,7 @@
                 <field
                     name="secondary_uom_qty"
                     attrs="{'readonly': [('parent.state', 'in', ('done', 'cancel'))]}"
+                    optional="show"
                 />
                 <field
                     name="secondary_uom_id"
@@ -47,6 +48,7 @@
                                          ('product_id', '=', False)]"
                     options="{'no_create': True}"
                     attrs="{'readonly': [('product_uom_readonly', '=', True)], 'required': [('secondary_uom_qty', '!=', 0.0)]}"
+                    optional="show"
                 />
             </xpath>
             <xpath


### PR DESCRIPTION
cc @Tecnativa TT49686

@CarlosRoca13 @sergio-teruel please review