### PR TITLE
[15.0][IMP] sale_order_product_recommendation_secondary_unit: make the secondary unit and secondary quantity fields optional

### DIFF
--- a/sale_order_product_recommendation_secondary_unit/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation_secondary_unit/wizards/sale_order_recommendation_view.xml
@@ -19,11 +19,13 @@
                     name="secondary_uom_id"
                     domain="[('product_tmpl_id', '=', product_tmpl_id)]"
                     attrs="{'readonly': [('product_uom_readonly', '=', True)]}"
+                    optional="show"
                 />
                 <field
                     name="secondary_uom_qty"
                     attrs="{'invisible': [('secondary_uom_id', '=', False)]}"
                     widget="numeric_step"
+                    optional="show"
                 />
             </xpath>
             <xpath


### PR DESCRIPTION
cc @tecnativa TT49686

@CarlosRoca13 @sergio-teruel please review