### PR TITLE
[17.0][IMP] sale_fixed_discount: prevent using replace in xml view extension

### DIFF
--- a/sale_fixed_discount/views/sale_portal_templates.xml
+++ b/sale_fixed_discount/views/sale_portal_templates.xml
@@ -3,7 +3,6 @@
     <template
         id="sale_order_portal_content"
         inherit_id="sale.sale_order_portal_content"
-        priority="100"
     >
         <xpath
             expr="//section[@id='details']//t[@t-set='display_discount']"
@@ -25,22 +24,19 @@
                 <span>Disc. Fixed Amount</span>
             </th>
         </xpath>
-        <xpath
-            expr="//section[@id='details']//tbody[hasclass('sale_tbody')]//t[@t-foreach='lines_to_report']/tr//t[@t-if='not line.display_type']//td[3]/div"
-            position="replace"
-        >
-            <div
-                t-if="line.discount &gt;= 0 or line.fixed_discount &gt;= 0"
-                t-field="line.price_unit"
-                t-att-style="(line.discount or line.discount_fixed) and 'text-decoration: line-through' or None"
-                t-att-class="((line.discount or line.discount_fixed) and 'text-danger' or '') + ' text-right'"
-            />
-            <div t-if="line.discount_fixed">
-                <t
-                    t-esc="line.price_unit - line.discount_fixed"
-                    t-options='{"widget": "float", "decimal_precision": "Product Price"}'
-                />
-            </div>
+        <xpath expr="//div[@t-field='line.price_unit']" position="attributes">
+            <attribute
+                name="t-if"
+            >line.discount &gt;= 0 or line.fixed_discount &gt;= 0</attribute>
+            <attribute
+                name="t-att-style"
+            >(line.discount or line.discount_fixed) and 'text-decoration: line-through' or None</attribute>
+            <attribute
+                name="t-att-class"
+            >((line.discount or line.discount_fixed) and 'text-danger' or '') + ' text-right'</attribute>
+        </xpath>
+        <xpath expr="//div[@t-if='line.discount']/t" position="attributes">
+            <attribute name="t-out">line.price_unit - line.discount_fixed</attribute>
         </xpath>
         <xpath
             expr="//section[@id='details']//table/tbody//t[@t-foreach='lines_to_report']/tr//t[@t-if='not line.display_type']//td[@t-if='display_discount']"


### PR DESCRIPTION
My initial issue was that another addon adds an td node in the front, so that td[3] wasn't hitting the correct node anymore:
//section[@id='details']//tbody[hasclass('sale_tbody')]//t[@t-foreach='lines_to_report']/tr//t[@t-if='not line.display_type']//td[3]/div

Therefore I've removed this xpath and replaced it with setting attributes, which is to prefer anyway.