### PR TITLE
[16.0][FIX]sale_order_revision:fix access error

### DIFF
--- a/sale_order_revision/models/sale_order.py
+++ b/sale_order_revision/models/sale_order.py
@@ -34,8 +34,7 @@ class SaleOrder(models.Model):
 
     def action_view_revisions(self):
         self.ensure_one()
-        action = self.env.ref("sale.action_orders")
-        result = action.read()[0]
+        result = self.env["ir.actions.act_window"]._for_xml_id("sale.action_orders")
         result["domain"] = ["|", ("active", "=", False), ("active", "=", True)]
         result["context"] = {
             "active_test": 0,


### PR DESCRIPTION
Steps to reproduce error:
1. Login as "demo" User (Marc Demo)
2. Go to "Sales" and select a quotation
3. Cancel the quotation
4. Create a new revision of that quotation
5. Go to the newly created quotation revision
6. When clicking the smart button to see the old revisions an access error is thrown.
