### PR TITLE
[FIX] sale_block_no_stock: Add notes to sale orders when adjusting or moving quantities

### DIFF
--- a/sale_block_no_stock/README.rst
+++ b/sale_block_no_stock/README.rst
@@ -46,6 +46,9 @@ extra option to confirm the Order with errors will appear on the Wizard.
 This module only can block lines with product type 'product' (storable
 products).
 
+Internal notes will be posted on sales when adjusting quantities or
+moving to another orders.
+
 .. IMPORTANT::
    This is an alpha version, the data model and design can change at any time without warning.
    Only for development or testing purpose, do not use in production.

--- a/sale_block_no_stock/__manifest__.py
+++ b/sale_block_no_stock/__manifest__.py
@@ -13,9 +13,7 @@
     "license": "LGPL-3",
     "application": False,
     "installable": True,
-    "depends": [
-        "sale_stock",
-    ],
+    "depends": ["sale_stock", "mail_message_destiny_link_template"],
     "data": [
         "security/ir.model.access.csv",
         "views/res_config_settings_views.xml",

--- a/sale_block_no_stock/i18n/es.po
+++ b/sale_block_no_stock/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-03 14:16+0000\n"
-"PO-Revision-Date: 2024-06-03 16:22+0200\n"
+"POT-Creation-Date: 2024-06-28 09:31+0000\n"
+"PO-Revision-Date: 2024-06-28 11:32+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -23,8 +23,8 @@ msgid ""
 "<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
 "specific.\" groups=\"base.group_multi_company\"/>"
 msgstr ""
-"<span class=\"fa fa-lg fa-building-o\" title=\"Los valores configurados aquí "
-"son específicos de la empresa.\" groups=\"base.group_multi_company\"/>"
+"<span class=\"fa fa-lg fa-building-o\" title=\"Los valores configurados "
+"aquí son específicos de la empresa.\" groups=\"base.group_multi_company\"/>"
 
 #. module: sale_block_no_stock
 #: model_terms:ir.ui.view,arch_db:sale_block_no_stock.sale_order_block_wizard_view
@@ -63,7 +63,8 @@ msgstr "Bloqueo de ventas por falta de stock"
 #, python-format
 msgid "Cannot launch wizard from sale orders from different companies."
 msgstr ""
-"No se puede abrir el asistente para Pedidos de Venta de diferentes compañías."
+"No se puede abrir el asistente para Pedidos de Venta de diferentes "
+"compañías."
 
 #. module: sale_block_no_stock
 #: model_terms:ir.ui.view,arch_db:sale_block_no_stock.sale_order_block_wizard_view
@@ -133,12 +134,12 @@ msgstr ""
 #. module: sale_block_no_stock
 #: model:ir.model.fields,field_description:sale_block_no_stock.field_sale_order_block_wizard__is_packaging_adjustable
 msgid "Is Packaging Adjustable"
-msgstr ""
+msgstr "Es ajustable por Paquetes"
 
 #. module: sale_block_no_stock
 #: model:ir.model.fields,field_description:sale_block_no_stock.field_sale_order_block_wizard__is_uom_adjustable
 msgid "Is Uom Adjustable"
-msgstr ""
+msgstr "Es ajustable por UdM"
 
 #. module: sale_block_no_stock
 #: model:ir.model.fields,field_description:sale_block_no_stock.field_sale_order_block_wizard____last_update
@@ -189,6 +190,17 @@ msgstr "Envase"
 #: model:ir.model.fields,field_description:sale_block_no_stock.field_sale_order_block_wizard_line__product_id
 msgid "Product"
 msgstr "Producto"
+
+#. module: sale_block_no_stock
+#. odoo-python
+#: code:addons/sale_block_no_stock/wizard/sale_order_block_wizard.py:0
+#, python-format
+msgid ""
+"Product <b>%(product)s</b> adjusted from <b>%(init_qty)s</b> %(uom)s to "
+"<b>%(final_qty)s</b> %(uom)s."
+msgstr ""
+"Producto <b>%(product)s</b> ajustado de <b>%(init_qty)s</b> %(uom)s a "
+"<b>%(final_qty)s</b> %(uom)s."
 
 #. module: sale_block_no_stock
 #: model:ir.model.fields,field_description:sale_block_no_stock.field_sale_order_block_wizard_line__product_packaging_qty
@@ -244,8 +256,8 @@ msgstr "Pedido de venta"
 #: model:ir.model.fields,help:sale_block_no_stock.field_res_company__sale_line_block_allowed_groups
 #: model:ir.model.fields,help:sale_block_no_stock.field_res_config_settings__sale_line_block_allowed_groups
 msgid ""
-"These groups will be able to bypass the block on the Sale Order Lines if the "
-"quantity is not enough"
+"These groups will be able to bypass the block on the Sale Order Lines if "
+"the quantity is not enough"
 msgstr ""
 "Estos grupos podrán evitar el bloqueo en las Líneas de Orden de Venta si la "
 "cantidad no es suficiente"
@@ -267,8 +279,8 @@ msgid ""
 "stock. Please manage the following products before confirming the order."
 msgstr ""
 "Este pedido no puede ser confirmado porque contiene productos que no están "
-"en stock. Por favor, gestiona los siguientes productos antes de confirmar el "
-"pedido."
+"en stock. Por favor, gestiona los siguientes productos antes de confirmar "
+"el pedido."
 
 #. module: sale_block_no_stock
 #: model:ir.model.fields,field_description:sale_block_no_stock.field_sale_order_block_wizard_line__product_uom
@@ -300,14 +312,4 @@ msgstr "No tienes permitido confirmar estos pedidos."
 #. module: sale_block_no_stock
 #: model_terms:ir.ui.view,arch_db:sale_block_no_stock.sale_order_block_wizard_view
 msgid "or"
-msgstr ""
-
-#~ msgid ""
-#~ "You are going to adjust Qty. (Pkg.) to Max. Qty. (Pkg.). Only lines with "
-#~ "Packagings will be modified"
-#~ msgstr ""
-#~ "Vas a ajustar Cant. (Env.) a la Cant. Máx. (Env.). Sólo las líneas con "
-#~ "Envases serán modificadas"
-
-#~ msgid "You are going to adjust Qty. (UoM) to Max. Qty. (UoM)"
-#~ msgstr "Vas a ajustar Cant. (UdM.) a la Cant. Máx. (UdM.)"
+msgstr "o"

--- a/sale_block_no_stock/i18n/sale_block_no_stock.pot
+++ b/sale_block_no_stock/i18n/sale_block_no_stock.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-06-28 09:31+0000\n"
+"PO-Revision-Date: 2024-06-28 09:31+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -181,6 +183,15 @@ msgstr ""
 #. module: sale_block_no_stock
 #: model:ir.model.fields,field_description:sale_block_no_stock.field_sale_order_block_wizard_line__product_id
 msgid "Product"
+msgstr ""
+
+#. module: sale_block_no_stock
+#. odoo-python
+#: code:addons/sale_block_no_stock/wizard/sale_order_block_wizard.py:0
+#, python-format
+msgid ""
+"Product <b>%(product)s</b> adjusted from <b>%(init_qty)s</b> %(uom)s to "
+"<b>%(final_qty)s</b> %(uom)s."
 msgstr ""
 
 #. module: sale_block_no_stock

--- a/sale_block_no_stock/readme/DESCRIPTION.md
+++ b/sale_block_no_stock/readme/DESCRIPTION.md
@@ -7,3 +7,5 @@ Then, you can adjust UoM quantities, Packaging quantities or move remaining unfi
 If the user who is confirming an order has a group that is allowed, an extra option to confirm the Order with errors will appear on the Wizard.
 
 This module only can block lines with product type 'product' (storable products).
+
+Internal notes will be posted on sales when adjusting quantities or moving to another orders.

--- a/sale_block_no_stock/static/description/index.html
+++ b/sale_block_no_stock/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -382,6 +383,8 @@ remaining unfixed lines to a new order.</p>
 extra option to confirm the Order with errors will appear on the Wizard.</p>
 <p>This module only can block lines with product type ‘product’ (storable
 products).</p>
+<p>Internal notes will be posted on sales when adjusting quantities or
+moving to another orders.</p>
 <div class="admonition important">
 <p class="first admonition-title">Important</p>
 <p class="last">This is an alpha version, the data model and design can change at any time without warning.
@@ -486,7 +489,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-9">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_block_no_stock/tests/test_sale_block_no_stock.py
+++ b/sale_block_no_stock/tests/test_sale_block_no_stock.py
@@ -239,6 +239,15 @@ class TestSaleBlockNoStock(TransactionCase):
         # No Block: 1 Unit in stock
         self.sale.with_user(self.saleblock_user.id).action_confirm()
         self.assertNotEqual(self.sale.state, "draft")
+        # Check messages
+        self.assertTrue(
+            any(
+                [
+                    "adjusted from" in body
+                    for body in self.sale.message_ids.mapped("body")
+                ]
+            )
+        )
 
     def test_sale_adjust_packaging_quantity(self):
         """Test Wizard Adjusting Packaging Quantity."""
@@ -261,6 +270,15 @@ class TestSaleBlockNoStock(TransactionCase):
         # No Block: 1 Unit (2 Packagings) in stock
         self.sale.with_user(self.saleblock_user.id).action_confirm()
         self.assertNotEqual(self.sale.state, "draft")
+        # Check messages
+        self.assertTrue(
+            any(
+                [
+                    "adjusted from" in body
+                    for body in self.sale.message_ids.mapped("body")
+                ]
+            )
+        )
 
     def test_sale_move_to_new_order(self):
         """Test Wizard Moving to New Order."""
@@ -278,3 +296,20 @@ class TestSaleBlockNoStock(TransactionCase):
         new_orders = wizard.action_move_to_new_order()
         self.assertEqual(len(self.sale.order_line), 0)
         self.assertEqual(len(new_orders.order_line), 1)
+        # Check messages
+        self.assertTrue(
+            any(
+                [
+                    "This sales order has created" in body
+                    for body in self.sale.message_ids.mapped("body")
+                ]
+            )
+        )
+        self.assertTrue(
+            any(
+                [
+                    "This sales order has been modified from" in body
+                    for body in new_orders.message_ids.mapped("body")
+                ]
+            )
+        )


### PR DESCRIPTION
Add notes to sale orders when moving or adjusting quantities.

Uses new module [mail_message_destiny_link_template](https://github.com/OCA/server-ux/pull/904) that must be merge before this one.

Images of the result:
![adjust_notifs](https://github.com/OCA/sale-workflow/assets/1162050/adb80c1d-ead1-4c04-8389-cecc8571c4ba)

MT-6090 @moduon @rafaelbn  @Gelojr @fcvalgar please review if you want :)