### PR TITLE
[FIX] [16.0] sale_order_line_effective_date: Add commitment date

### DIFF
--- a/sale_order_line_effective_date/README.rst
+++ b/sale_order_line_effective_date/README.rst
@@ -29,7 +29,8 @@ Sale Order Line Effective Dates
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module extends the functionality of sale stock and adds "Effective
-date" and "Last Effective date" fields in sale order line.
+date", "Last Effective date" and "Order Commitment Date" fields in sale
+order line.
 
 .. IMPORTANT::
    This is an alpha version, the data model and design can change at any time without warning.
@@ -44,8 +45,8 @@ date" and "Last Effective date" fields in sale order line.
 Installation
 ============
 
-To see field "Effective date" and "Last Effective date" you can install
-*sale_order_line_menu*
+To see field "Effective date", "Last Effective date" and "Order
+Commitment Date" you can install *sale_order_line_menu*
 
 Usage
 =====
@@ -53,11 +54,13 @@ Usage
 To use this module, you need to:
 
 1. Go to Sales > Orders > Quotation.
-2. Create a new quotation with 2 units of a storable product.
+2. Create a new quotation with 2 units of a storable product and set
+   Commitment Date.
 3. Confirm quotation.
 4. Click on Delivery Smart Button.
 5. Deliver 1 unit, validate and create backorder.
 6. Deliver the last unit from the backorder.
+7. Check Effective and Commitment Date fields on Sale Order Lines.
 
 Bug Tracker
 ===========

--- a/sale_order_line_effective_date/i18n/es.po
+++ b/sale_order_line_effective_date/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-06-12 07:27+0000\n"
-"PO-Revision-Date: 2024-06-12 09:27+0200\n"
+"POT-Creation-Date: 2024-06-28 10:27+0000\n"
+"PO-Revision-Date: 2024-06-28 12:28+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -16,6 +16,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.4\n"
+
+#. module: sale_order_line_effective_date
+#: model:ir.model.fields,field_description:sale_order_line_effective_date.field_sale_order_line__order_commitment_date
+msgid "Commitment Date"
+msgstr "Fecha de entrega"
+
+#. module: sale_order_line_effective_date
+#: model:ir.model.fields,help:sale_order_line_effective_date.field_sale_order_line__order_commitment_date
+msgid "Commitment Date set on the Order"
+msgstr "Fecha de Entrega establecida en el Pedido."
 
 #. module: sale_order_line_effective_date
 #: model:ir.model.fields,help:sale_order_line_effective_date.field_sale_order_line__effective_date

--- a/sale_order_line_effective_date/i18n/sale_order_line_effective_date.pot
+++ b/sale_order_line_effective_date/i18n/sale_order_line_effective_date.pot
@@ -6,12 +6,24 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-06-28 10:27+0000\n"
+"PO-Revision-Date: 2024-06-28 10:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: sale_order_line_effective_date
+#: model:ir.model.fields,field_description:sale_order_line_effective_date.field_sale_order_line__order_commitment_date
+msgid "Commitment Date"
+msgstr ""
+
+#. module: sale_order_line_effective_date
+#: model:ir.model.fields,help:sale_order_line_effective_date.field_sale_order_line__order_commitment_date
+msgid "Commitment Date set on the Order"
+msgstr ""
 
 #. module: sale_order_line_effective_date
 #: model:ir.model.fields,help:sale_order_line_effective_date.field_sale_order_line__effective_date

--- a/sale_order_line_effective_date/models/sale_order_line.py
+++ b/sale_order_line_effective_date/models/sale_order_line.py
@@ -19,6 +19,13 @@ class SaleOrderLine(models.Model):
         compute_sudo=True,
         help="Completion date of the last delivery order.",
     )
+    order_commitment_date = fields.Datetime(
+        related="order_id.commitment_date",
+        string="Commitment Date",
+        store=True,
+        readonly=True,
+        help="Commitment Date set on the Order",
+    )
 
     @api.depends("move_ids.date")
     def _compute_effective_dates(self):

--- a/sale_order_line_effective_date/readme/DESCRIPTION.md
+++ b/sale_order_line_effective_date/readme/DESCRIPTION.md
@@ -1,1 +1,2 @@
-This module extends the functionality of sale stock and adds "Effective date" and "Last Effective date" fields in sale order line.
+This module extends the functionality of sale stock and adds "Effective date",
+"Last Effective date" and "Order Commitment Date" fields in sale order line.

--- a/sale_order_line_effective_date/readme/INSTALL.md
+++ b/sale_order_line_effective_date/readme/INSTALL.md
@@ -1,1 +1,1 @@
-To see field "Effective date" and "Last Effective date" you can install *sale_order_line_menu*
+To see field "Effective date", "Last Effective date" and "Order Commitment Date" you can install *sale_order_line_menu*

--- a/sale_order_line_effective_date/readme/USAGE.md
+++ b/sale_order_line_effective_date/readme/USAGE.md
@@ -1,8 +1,9 @@
 To use this module, you need to:
 
 1. Go to Sales > Orders > Quotation.
-2. Create a new quotation with 2 units of a storable product.
+2. Create a new quotation with 2 units of a storable product and set Commitment Date.
 3. Confirm quotation.
 4. Click on Delivery Smart Button.
 5. Deliver 1 unit, validate and create backorder.
 6. Deliver the last unit from the backorder.
+7. Check Effective and Commitment Date fields on Sale Order Lines.

--- a/sale_order_line_effective_date/static/description/index.html
+++ b/sale_order_line_effective_date/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -370,7 +371,8 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/licence-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/sale-workflow/tree/16.0/sale_order_line_effective_date"><img alt="OCA/sale-workflow" src="https://img.shields.io/badge/github-OCA%2Fsale--workflow-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/sale-workflow-16-0/sale-workflow-16-0-sale_order_line_effective_date"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/sale-workflow&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module extends the functionality of sale stock and adds “Effective
-date” and “Last Effective date” fields in sale order line.</p>
+date”, “Last Effective date” and “Order Commitment Date” fields in sale
+order line.</p>
 <div class="admonition important">
 <p class="first admonition-title">Important</p>
 <p class="last">This is an alpha version, the data model and design can change at any time without warning.
@@ -393,19 +395,21 @@ Only for development or testing purpose, do not use in production.
 </div>
 <div class="section" id="installation">
 <h1><a class="toc-backref" href="#toc-entry-1">Installation</a></h1>
-<p>To see field “Effective date” and “Last Effective date” you can install
-<em>sale_order_line_menu</em></p>
+<p>To see field “Effective date”, “Last Effective date” and “Order
+Commitment Date” you can install <em>sale_order_line_menu</em></p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
 <p>To use this module, you need to:</p>
 <ol class="arabic simple">
 <li>Go to Sales &gt; Orders &gt; Quotation.</li>
-<li>Create a new quotation with 2 units of a storable product.</li>
+<li>Create a new quotation with 2 units of a storable product and set
+Commitment Date.</li>
 <li>Confirm quotation.</li>
 <li>Click on Delivery Smart Button.</li>
 <li>Deliver 1 unit, validate and create backorder.</li>
 <li>Deliver the last unit from the backorder.</li>
+<li>Check Effective and Commitment Date fields on Sale Order Lines.</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">
@@ -435,7 +439,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_order_line_effective_date/views/sale_order_line.xml
+++ b/sale_order_line_effective_date/views/sale_order_line.xml
@@ -11,6 +11,9 @@
                 <field name="effective_date" optional="hide" />
                 <field name="last_effective_date" optional="hide" />
             </xpath>
+            <xpath expr="//tree" position="inside">
+                <field name="order_commitment_date" optional="hide" />
+            </xpath>
         </field>
     </record>
     <record id="sale_order_line_view_form_readonly" model="ir.ui.view">
@@ -18,9 +21,10 @@
         <field name="model">sale.order.line</field>
         <field name="inherit_id" ref="sale.sale_order_line_view_form_readonly" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='order_id']/parent::group" position="after">
-                <field name="effective_date" optional="hide" />
-                <field name="last_effective_date" optional="hide" />
+            <xpath expr="//field[@name='order_id']/.." position="inside">
+                <field name="order_commitment_date" />
+                <field name="effective_date" />
+                <field name="last_effective_date" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Add real commitment date to the lines.

Is just a relation with the real commitment date.

Checked with [sale_order_line_date](https://github.com/OCA/sale-workflow/tree/16.0/sale_order_line_date) module and doesn't do the same. This only adds the real commitment date set on the order. The other one performs another operations.

MT-6075 @moduon @rafaelbn @Gelojr @fcvalgar please review if you want :)