### PR TITLE
[16.0][IMP] sale_global_discount: refactor _compute_amounts

### DIFF
--- a/sale_global_discount/README.rst
+++ b/sale_global_discount/README.rst
@@ -88,6 +88,10 @@ Contributors
   * David Vidal
   * Pedro M. Baeza
 * Omar Castiñeira <omar@comunitea.com>
+* `Trobz <https://www.trobz.com>`_
+
+  * Quoc Duong
+  * Tris Doan
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_global_discount/models/sale_order.py
+++ b/sale_global_discount/models/sale_order.py
@@ -112,9 +112,13 @@ class SaleOrder(models.Model):
                     product=line.product_id,
                     partner=line.order_id.partner_shipping_id,
                 )
-                amount_discounted_tax += sum(
-                    t.get("amount", 0.0) for t in discounted_tax.get("taxes", [])
-                )
+                for tax in discounted_tax.get("taxes", []):
+                    if line.tax_id.browse(tax["id"]).amount_type == "fixed":
+                        amount_discounted_tax += (
+                            tax.get("amount", 0.0) * line.product_uom_qty
+                        )
+                        continue
+                    amount_discounted_tax += tax.get("amount", 0.0)
             order.update(
                 {
                     "amount_untaxed_before_global_discounts": (

--- a/sale_global_discount/models/sale_order.py
+++ b/sale_global_discount/models/sale_order.py
@@ -94,48 +94,51 @@ class SaleOrder(models.Model):
         res = super()._compute_amounts()
         for order in self:
             order._check_global_discounts_sanity()
-            amount_untaxed_before_global_discounts = order.amount_untaxed
-            amount_total_before_global_discounts = order.amount_total
+            vals = {
+                "amount_untaxed_before_global_discounts": order.amount_untaxed,
+                "amount_total_before_global_discounts": order.amount_total,
+            }
             discounts = order.global_discount_ids.mapped("discount")
-            amount_discounted_untaxed = amount_discounted_tax = 0
-            for line in order.order_line:
-                discounted_subtotal = line.price_subtotal
-                if not line.product_id.bypass_global_discount:
-                    discounted_subtotal = self.get_discounted_global(
-                        line.price_subtotal, discounts.copy()
-                    )
-                amount_discounted_untaxed += discounted_subtotal
-                discounted_tax = line.tax_id.compute_all(
-                    discounted_subtotal,
-                    line.order_id.currency_id,
-                    1.0,
-                    product=line.product_id,
-                    partner=line.order_id.partner_shipping_id,
-                )
-                for tax in discounted_tax.get("taxes", []):
-                    if line.tax_id.browse(tax["id"]).amount_type == "fixed":
-                        amount_discounted_tax += (
-                            tax.get("amount", 0.0) * line.product_uom_qty
+            if discounts:
+                amount_discounted_untaxed = amount_discounted_tax = 0
+                order_lines = order.order_line.filtered(lambda x: not x.display_type)
+                for line in order_lines:
+                    discounted_subtotal = line.price_subtotal
+                    if not line.product_id.bypass_global_discount:
+                        discounted_subtotal = self.get_discounted_global(
+                            line.price_subtotal, discounts.copy()
                         )
-                        continue
-                    amount_discounted_tax += tax.get("amount", 0.0)
-            order.update(
-                {
-                    "amount_untaxed_before_global_discounts": (
-                        amount_untaxed_before_global_discounts
-                    ),
-                    "amount_total_before_global_discounts": (
-                        amount_total_before_global_discounts
-                    ),
-                    "amount_global_discount": (
-                        amount_untaxed_before_global_discounts
-                        - amount_discounted_untaxed
-                    ),
-                    "amount_untaxed": amount_discounted_untaxed,
-                    "amount_tax": amount_discounted_tax,
-                    "amount_total": (amount_discounted_untaxed + amount_discounted_tax),
-                }
-            )
+                    amount_discounted_untaxed += discounted_subtotal
+
+                    # tax calculation
+                    tax_results = (
+                        self.env["account.tax"]
+                        .with_company(line.company_id)
+                        ._compute_taxes(
+                            [
+                                line.with_context(
+                                    from_tax_calculation=True
+                                )._convert_to_tax_base_line_dict()
+                            ]
+                        )
+                    )
+                    totals = list(tax_results["totals"].values())[0]
+                    amount_discounted_tax += totals["amount_tax"]
+
+                vals.update(
+                    {
+                        "amount_global_discount": (
+                            vals["amount_untaxed_before_global_discounts"]
+                            - amount_discounted_untaxed
+                        ),
+                        "amount_untaxed": amount_discounted_untaxed,
+                        "amount_tax": amount_discounted_tax,
+                        "amount_total": (
+                            amount_discounted_untaxed + amount_discounted_tax
+                        ),
+                    }
+                )
+            order.update(vals)
         return res
 
     def _compute_tax_totals(self):

--- a/sale_global_discount/readme/CONTRIBUTORS.rst
+++ b/sale_global_discount/readme/CONTRIBUTORS.rst
@@ -3,3 +3,7 @@
   * David Vidal
   * Pedro M. Baeza
 * Omar Castiñeira <omar@comunitea.com>
+* `Trobz <https://www.trobz.com>`_
+
+  * Quoc Duong
+  * Tris Doan

--- a/sale_global_discount/static/description/index.html
+++ b/sale_global_discount/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -437,12 +438,19 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </li>
 <li>Omar Castiñeira &lt;<a class="reference external" href="mailto:omar&#64;comunitea.com">omar&#64;comunitea.com</a>&gt;</li>
+<li><a class="reference external" href="https://www.trobz.com">Trobz</a><ul>
+<li>Quoc Duong</li>
+<li>Tris Doan</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_global_discount/tests/test_sale_global_discount.py
+++ b/sale_global_discount/tests/test_sale_global_discount.py
@@ -228,3 +228,40 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         self.assertAlmostEqual(line.price_subtotal, 135)
         self.assertAlmostEqual(self.sale.amount_untaxed_before_global_discounts, 234.99)
         self.assertAlmostEqual(self.sale.amount_untaxed, 187.99)
+
+    def test_07_discount_line_with_fixed_taxes(self):
+        # Create a fixed tax and apply on lines
+        fixed_tax = self.safe_copy(self.company_data["default_tax_sale"])
+        fixed_tax.write(
+            {
+                "amount": 5.0,
+                "amount_type": "fixed",
+            }
+        )
+        lines = self.sale.order_line
+        lines.tax_id = [(6, 0, (fixed_tax + self.tax_1 + self.tax_2).ids)]
+        # Based on test_01
+        # 299.99 + (5 * 2) + (5 * 3)
+        self.assertAlmostEqual(self.sale.amount_total, 324.99)
+        # Based on test_01
+        # 60 + (5 * 2) + (5 * 3)
+        self.assertAlmostEqual(self.sale.amount_tax, 75)
+        self.assertAlmostEqual(
+            self.get_taxes_widget_total_tax(self.sale), self.sale.amount_tax
+        )
+        self.assertAlmostEqual(self.sale.amount_untaxed, 249.99)
+        # Apply a single 20% global discount
+        self.sale.global_discount_ids = self.global_discount_1
+        # Discount is computed over the base and global taxes are computed
+        # according to it line by line with the core method
+        self.assertAlmostEqual(self.sale.amount_global_discount, 50)
+        # Based on test_01
+        # 40 + (5 * 2) + (5 * 3)
+        self.assertAlmostEqual(self.sale.amount_tax, 65.0)
+        self.assertAlmostEqual(self.sale.amount_untaxed_before_global_discounts, 249.99)
+        self.assertAlmostEqual(self.sale.amount_untaxed, 199.99)
+        self.assertAlmostEqual(self.sale.amount_total_before_global_discounts, 324.99)
+        self.assertAlmostEqual(self.sale.amount_total, 264.99)
+        self.assertAlmostEqual(
+            self.get_taxes_widget_total_tax(self.sale), self.sale.amount_tax
+        )

--- a/sale_global_discount/tests/test_sale_global_discount.py
+++ b/sale_global_discount/tests/test_sale_global_discount.py
@@ -265,3 +265,37 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         self.assertAlmostEqual(
             self.get_taxes_widget_total_tax(self.sale), self.sale.amount_tax
         )
+
+    def test_08_global_discount_w_included_tax(self):
+        """
+        In case tax is configured as included-in-price,
+        amount_tax should be calculated based on discounted amount
+        """
+        self.tax_1.price_include = True
+        sale_form = Form(self.env["sale.order"])
+        sale_form.partner_id = self.partner_1
+        with sale_form.order_line.new() as order_line:
+            order_line.product_id = self.product_1
+            order_line.tax_id.clear()
+            order_line.tax_id.add(self.tax_1)
+            order_line.product_uom_qty = 2
+            order_line.price_unit = 75
+        test_sale = sale_form.save()
+        self.assertAlmostEqual(test_sale.amount_untaxed, 130.43)
+        self.assertAlmostEqual(test_sale.amount_tax, 19.57)
+        self.assertAlmostEqual(test_sale.amount_total, 150)
+        self.assertAlmostEqual(
+            self.get_taxes_widget_total_tax(test_sale), test_sale.amount_tax
+        )
+        # Apply a single 20% global discount
+        test_sale.global_discount_ids = self.global_discount_1
+        self.assertAlmostEqual(test_sale.amount_untaxed_before_global_discounts, 130.43)
+        self.assertAlmostEqual(test_sale.amount_total_before_global_discounts, 150)
+        self.assertAlmostEqual(test_sale.amount_global_discount, 26.09)
+        self.assertAlmostEqual(test_sale.amount_untaxed, 104.34)
+        # amount_tax is calculated based on discounted amount
+        self.assertAlmostEqual(test_sale.amount_tax, 15.65)
+        self.assertAlmostEqual(test_sale.amount_total, 119.99)
+        self.assertAlmostEqual(
+            self.get_taxes_widget_total_tax(test_sale), test_sale.amount_tax
+        )


### PR DESCRIPTION
### Context

In simple case (tax is not included in price), flow of the module as follow:
   - Let tax is computed as usual, as odoo native supports
   - Afterwards, checking if global discount is applied on Sale order:
      1. If not, only add amt_untaxed_before_global_discount and amt_total_before_global_discount,
      2. If yes, precompute tax

**A example of Sale order is below:**
- Tax is not included in price
- With 20% global discount

<div style="display: flex;">

<div style="flex: 1;">

| **Product Name** | **Quantity** | **Unit Price** | **SubTotal** |
|------------------|--------------|----------------|-----------------|
| Example Product  | 2            | $75        | $150        |

</div>

<div style="flex: 0; margin-left: 20px;">

| **Untaxed Amt** |
|------------------|
| $120      |

| **Tax** |
|------------------|
| $18.0      |

| **Total** |
|------------------|
| $138.0      |

**=> So tax is recalculated based on Final price (after global discount)**


- Before this change, if enabling included-in-price tax, it breaks the intended flow as it triggers the part 'handling price include' again with the new price

### This change
- pass param: `handle_price_include=False` because it was handle in super(), by default `handle_price_include=True` . Now, as we recalculate tax to apply global discount, there is no need to handle price included or not.

- With above example, now it is:
   **- but this time, Tax is included in price**

<div style="display: flex;">

<div style="flex: 1;">

| **Product Name** | **Quantity** | **Unit Price** | **SubTotal** |
|------------------|--------------|----------------|-----------------|
| Example Product  | 2            | $75        | $130.43       |

</div>

<div style="flex: 0; margin-left: 20px;">

| **Untaxed Amt** |
|------------------|
| $104.34      |

| **Tax** |
|------------------|
| $15.65      |

| **Total** |
|------------------|
| $119.9900      |


- Add a check to only recompute tax when global discount is applied on the sale order. Before this change, it results in rounding issue. It happens when products are configured as tax-included in price. For example:

![sample_sale_global_discount](https://github.com/trisdoan/sale-workflow/assets/88806544/513d414d-c0d3-49ad-ad53-17fe66731792)

