### PR TITLE
Added setting on partner

### DIFF
--- a/sale_invoice_policy/__manifest__.py
+++ b/sale_invoice_policy/__manifest__.py
@@ -10,9 +10,10 @@
     "category": "Sales Management",
     "version": "16.0.2.0.0",
     "license": "AGPL-3",
-    "depends": ["sale_stock"],
+    "depends": ["base","sale_stock","sale","account"],
     "data": [
         "views/res_config_settings_view.xml",
         "views/sale_view.xml",
+        "views/res_partner_views.xml",
     ],
 }

--- a/sale_invoice_policy/i18n/sv.po
+++ b/sale_invoice_policy/i18n/sv.po
@@ -1,0 +1,124 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sale_invoice_policy
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e-20240607\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-03 19:32+0000\n"
+"PO-Revision-Date: 2024-07-03 21:33+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: sv_SE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.4\n"
+
+#. module: sale_invoice_policy
+#. odoo-python
+#: code:addons/sale_invoice_policy/models/res_partner.py:0
+#, python-format
+msgid "%d partners have been updated with the default invoice policy (%s)."
+msgstr "%d-partners har uppdaterats med standardfakturapolicyn (%s)."
+
+#. module: sale_invoice_policy
+#: model:ir.model,name:sale_invoice_policy.model_res_config_settings
+msgid "Config Settings"
+msgstr "Inställningar"
+
+#. module: sale_invoice_policy
+#: model:ir.model,name:sale_invoice_policy.model_res_partner
+msgid "Contact"
+msgstr "Kontakt"
+
+#. module: sale_invoice_policy
+#: model:ir.model.fields,field_description:sale_invoice_policy.field_res_partner__default_invoice_policy
+#: model:ir.model.fields,field_description:sale_invoice_policy.field_res_users__default_invoice_policy
+msgid "Default Invoicing Policy"
+msgstr "Standardfaktureringspolicy"
+
+#. module: sale_invoice_policy
+#: model:ir.model.fields.selection,name:sale_invoice_policy.selection__res_partner__default_invoice_policy__delivery
+#: model:ir.model.fields.selection,name:sale_invoice_policy.selection__sale_order__invoice_policy__delivery
+msgid "Delivered quantities"
+msgstr "Levererade kvantiteter"
+
+#. module: sale_invoice_policy
+#: model:ir.model.fields,field_description:sale_invoice_policy.field_sale_order__invoice_policy
+msgid "Invoice Policy"
+msgstr "Fakturapolicy"
+
+#. module: sale_invoice_policy
+#: model:ir.model.fields,field_description:sale_invoice_policy.field_sale_order__invoice_policy_required
+msgid "Invoice Policy Required"
+msgstr "Fakturapolicy krävs"
+
+#. module: sale_invoice_policy
+#: model_terms:ir.ui.view,arch_db:sale_invoice_policy.view_sales_config
+msgid "Invoice Policy required in Sale Orders"
+msgstr "Fakturapolicy krävs i försäljningsorder"
+
+#. module: sale_invoice_policy
+#: model:ir.model.fields,help:sale_invoice_policy.field_sale_order__invoice_policy
+msgid ""
+"Ordered Quantity: Invoice based on the quantity the customer ordered.\n"
+"Delivered Quantity: Invoiced based on the quantity the vendor delivered (time or deliveries)."
+msgstr ""
+"Beställd Kvantitet: Fakturera baserat på den kvantitet kunden beställt\n"
+"Levererad Kvantitet: Faktureras baserat på den kvantitet leverantören levererat (tid eller leveranser)."
+
+#. module: sale_invoice_policy
+#: model:ir.model.fields.selection,name:sale_invoice_policy.selection__res_partner__default_invoice_policy__order
+#: model:ir.model.fields.selection,name:sale_invoice_policy.selection__sale_order__invoice_policy__order
+msgid "Ordered quantities"
+msgstr "Beställda kvantiteter"
+
+#. module: sale_invoice_policy
+#: model_terms:ir.ui.view,arch_db:sale_invoice_policy.view_sales_config
+msgid "Sale Invoice Policy"
+msgstr "Försäljningsfaktureringspolicy"
+
+#. module: sale_invoice_policy
+#: model:ir.model.fields,field_description:sale_invoice_policy.field_res_config_settings__sale_invoice_policy_required
+msgid "Sale Invoice Policy Required"
+msgstr "Krav på försäljningsfaktureringspolicy"
+
+#. module: sale_invoice_policy
+#: model:ir.model,name:sale_invoice_policy.model_sale_order
+msgid "Sales Order"
+msgstr "Order"
+
+#. module: sale_invoice_policy
+#: model:ir.model,name:sale_invoice_policy.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Orderrad"
+
+#. module: sale_invoice_policy
+#: model:ir.actions.server,name:sale_invoice_policy.action_set_default_invoice_policy
+msgid "Set Default Invoice Policy"
+msgstr "Ange standardfaktureringspolicy"
+
+#. module: sale_invoice_policy
+#. odoo-python
+#: code:addons/sale_invoice_policy/models/res_config_settings.py:0
+#: model:ir.model.fields,help:sale_invoice_policy.field_res_config_settings__sale_invoice_policy_required
+#, python-format
+msgid "This makes Invoice Policy required on Sale Orders"
+msgstr "Detta gör faktureringspolicy obligatorisk för försäljningsorder"
+
+#. module: sale_invoice_policy
+#: model:ir.model.fields,help:sale_invoice_policy.field_res_partner__default_invoice_policy
+#: model:ir.model.fields,help:sale_invoice_policy.field_res_users__default_invoice_policy
+msgid "This will be the default invoicing policy for this partner when creating new sales orders."
+msgstr ""
+"Detta kommer att vara standardfaktureringspolicyn för denna partner när nya försäljningsorder skapas."
+
+#. module: sale_invoice_policy
+#. odoo-python
+#: code:addons/sale_invoice_policy/models/res_partner.py:0
+#, python-format
+msgid "Update Complete"
+msgstr "Uppdateringen har slutförts"

--- a/sale_invoice_policy/models/__init__.py
+++ b/sale_invoice_policy/models/__init__.py
@@ -1,3 +1,4 @@
 from . import res_config_settings
+from . import res_partner
 from . import sale_order
 from . import sale_order_line

--- a/sale_invoice_policy/models/res_config_settings.py
+++ b/sale_invoice_policy/models/res_config_settings.py
@@ -1,15 +1,14 @@
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 
 
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
     sale_invoice_policy_required = fields.Boolean(
-        help="This makes Invoice Policy required on Sale Orders"
-    )
+        help=_("This makes Invoice Policy required on Sale Orders"))
 
     @api.model
     def get_values(self):

--- a/sale_invoice_policy/models/res_partner.py
+++ b/sale_invoice_policy/models/res_partner.py
@@ -1,0 +1,63 @@
+from odoo import fields, models, api, _
+import logging
+
+_logger = logging.getLogger(__name__)
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    @api.model
+    def _get_default_invoice_policy(self):
+        company = self.env.company
+        default_policy = company.default_invoice_policy if hasattr(company, 'default_invoice_policy') else None
+
+        if not default_policy:
+            Config = self.env['ir.config_parameter'].sudo()
+            default_policy = Config.get_param('sale.default_invoice_policy')
+
+        if not default_policy or default_policy not in ['order', 'delivery']:
+            default_policy = 'order'
+
+        _logger.info(f"Default invoice policy from settings: {default_policy}")
+        return default_policy
+
+    default_invoice_policy = fields.Selection([
+        ('order', 'Ordered quantities'),
+        ('delivery', 'Delivered quantities')],
+        string='Default Invoicing Policy',
+        default=_get_default_invoice_policy,
+        help="This will be the default invoicing policy for this partner when creating new sales orders.")
+
+    @api.depends('is_company', 'parent_id')
+    def _compute_company_type(self):
+        super()._compute_company_type()
+        for partner in self:
+            if not partner.is_company and partner.default_invoice_policy:
+                partner.default_invoice_policy = False
+
+    @api.model
+    def set_default_invoice_policy(self):
+        default_policy = self._get_default_invoice_policy()
+        partners_to_update = self.env['res.partner'].search([
+            ('is_company', '=', True),
+            '|',
+            ('default_invoice_policy', '=', False),
+            ('default_invoice_policy', '=', None)
+        ])
+
+        if partners_to_update:
+            partners_to_update.write({'default_invoice_policy': default_policy})
+            _logger.info(f"Updated {len(partners_to_update)} partners with default invoice policy: {default_policy}")
+        else:
+            _logger.info("No partners found to update")
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': _('Update Complete'),
+                'message': _('%d partners have been updated with the default invoice policy (%s).') % (len(partners_to_update), default_policy),
+                'sticky': False,
+                'type': 'success',
+            }
+        }

--- a/sale_invoice_policy/models/sale_order.py
+++ b/sale_invoice_policy/models/sale_order.py
@@ -1,8 +1,7 @@
 # Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
-
+from odoo import api, fields, models, _
 
 class SaleOrder(models.Model):
 
@@ -10,7 +9,7 @@ class SaleOrder(models.Model):
 
     invoice_policy = fields.Selection(
         [("order", "Ordered quantities"), ("delivery", "Delivered quantities")],
-        readonly=True,
+        readonly=False,
         states={"draft": [("readonly", False)], "sent": [("readonly", False)]},
         help="Ordered Quantity: Invoice based on the quantity the customer "
         "ordered.\n"
@@ -47,3 +46,8 @@ class SaleOrder(models.Model):
         )
         for sale in self:
             sale.invoice_policy_required = invoice_policy_required
+
+    @api.onchange('partner_id')
+    def _onchange_partner_invoice_policy(self):
+        if self.partner_id and self.partner_id.default_invoice_policy:
+            self.invoice_policy = self.partner_id.default_invoice_policy

--- a/sale_invoice_policy/views/res_partner_views.xml
+++ b/sale_invoice_policy/views/res_partner_views.xml
@@ -1,0 +1,21 @@
+<odoo>
+    <record id="view_partner_property_form" model="ir.ui.view">
+        <field name="name">res.partner.property.form.inherit.sale.invoice.policy</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="account.view_partner_property_form"/>
+        <field name="arch" type="xml">
+            <group name="sale" position="inside">
+                <field name="default_invoice_policy" attrs="{'invisible': [('is_company', '=', False)]}"/>
+            </group>
+        </field>
+    </record>
+    <record id="action_set_default_invoice_policy" model="ir.actions.server">
+        <field name="name">Set Default Invoice Policy</field>
+        <field name="model_id" ref="base.model_res_partner"/>
+        <field name="binding_model_id" ref="base.model_res_partner"/>
+        <field name="state">code</field>
+        <field name="code">
+            action = model.set_default_invoice_policy()
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Added the ability to set a standard invoice policy for a partner so that it will always be sett on the sales order. It will select the default setting from Sales->Settings->Invoice->Invoice Policy as the default setting when a new partner is created. Also added an extra menu item in the Action menu that can update all partners with the default setting if no setting is set from the beginning.