### PR TITLE
[FIX] [16.0] sale_tier_validation: Group to bypass Validation rules (Sale)

### DIFF
--- a/sale_tier_validation/README.rst
+++ b/sale_tier_validation/README.rst
@@ -31,6 +31,9 @@ Sale Tier Validation
 This module extends the functionality of Sale Orders to support a tier
 validation process.
 
+Also adds *Skip Sale Tier Validations* security group to allow users
+skip validation process only for Sale Tiers.
+
 **Table of contents**
 
 .. contents::
@@ -103,6 +106,7 @@ Contributors
    -  Sergio Teruel
 
 -  Tharathip Chaweewongphan <tharathipc@ecosoft.co.th>
+-  Eduardo de Miguel <info@moduon.team>
 
 Maintainers
 -----------

--- a/sale_tier_validation/__manifest__.py
+++ b/sale_tier_validation/__manifest__.py
@@ -12,5 +12,9 @@
     "application": False,
     "installable": True,
     "depends": ["sale", "base_tier_validation"],
-    "data": ["data/mail_data.xml", "views/sale_order_view.xml"],
+    "data": [
+        "security/tier_validation_security.xml",
+        "data/mail_data.xml",
+        "views/sale_order_view.xml",
+    ],
 }

--- a/sale_tier_validation/i18n/es.po
+++ b/sale_tier_validation/i18n/es.po
@@ -4,19 +4,23 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 12.0\n"
+"Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-07 11:28+0000\n"
-"PO-Revision-Date: 2023-11-08 13:40+0000\n"
-"Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
-"Language-Team: none\n"
+"POT-Creation-Date: 2024-07-04 08:59+0000\n"
+"PO-Revision-Date: 2024-07-04 10:59+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
-"SO-Revision-Date: 2019-05-08 12:03+0000\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.4\n"
+
+#. module: sale_tier_validation
+#: model:ir.model.fields,help:sale_tier_validation.field_sale_order__user_can_skip_validation
+msgid "Allow user to skip validation process and allows to edit the record."
+msgstr "Permite al usuario saltarse el proceso de validación y editar el registro."
 
 #. module: sale_tier_validation
 #: model:ir.model.fields,field_description:sale_tier_validation.field_sale_order__can_review
@@ -71,12 +75,17 @@ msgstr "SOs validadas y preparadas para ser confirmadas"
 #. module: sale_tier_validation
 #: model:ir.model,name:sale_tier_validation.model_sale_order
 msgid "Sales Order"
-msgstr "Pedidos"
+msgstr "Pedido de venta"
+
+#. module: sale_tier_validation
+#: model:res.groups,name:sale_tier_validation.skip_sale_validations_group
+msgid "Skip Sale Tier Validations"
+msgstr "Evitar los Niveles de Validación de Ventas"
 
 #. module: sale_tier_validation
 #: model:ir.model,name:sale_tier_validation.model_tier_definition
 msgid "Tier Definition"
-msgstr "Definición de nivel"
+msgstr "Definición de Nivel"
 
 #. module: sale_tier_validation
 #: model:mail.message.subtype,name:sale_tier_validation.crm_team_tier_validation_accepted
@@ -102,6 +111,11 @@ msgid "To Validate Message"
 msgstr "Para validar el mensaje"
 
 #. module: sale_tier_validation
+#: model:ir.model.fields,field_description:sale_tier_validation.field_sale_order__user_can_skip_validation
+msgid "User can skip validation"
+msgstr "El usuario puede evitar validaciones"
+
+#. module: sale_tier_validation
 #: model:ir.model.fields,field_description:sale_tier_validation.field_sale_order__validated
 #: model_terms:ir.ui.view,arch_db:sale_tier_validation.view_sale_order_filter
 msgid "Validated"
@@ -121,29 +135,3 @@ msgstr "Estado de la Validación"
 #: model:ir.model.fields,field_description:sale_tier_validation.field_sale_order__review_ids
 msgid "Validations"
 msgstr "Validaciones"
-
-#~ msgid ""
-#~ "<i class=\"fa fa-info-circle\"/>This SO needs to be\n"
-#~ "                        validated."
-#~ msgstr ""
-#~ "<i class=\"fa fa-info-circle\"/>Esta SO debe ser\n"
-#~ "                        validada."
-
-#~ msgid "<i class=\"fa fa-thumbs-down\"/> Operation has been <b>rejected</b>."
-#~ msgstr ""
-#~ "<i class=\"fa fa-thumbs-down\"/>La operación ha sido <b>rechazada</b>."
-
-#~ msgid "<i class=\"fa fa-thumbs-up\"/> Operation has been <b>validated</b>!"
-#~ msgstr "<i class=\"fa fa-thumbs-up\"/>La operación ha sido <b>validada</b>!"
-
-#~ msgid "Reject"
-#~ msgstr "Rechazar"
-
-#~ msgid "Request Validation"
-#~ msgstr "Solicitar Validación"
-
-#~ msgid "Restart Validation"
-#~ msgstr "Reiniciar Validación"
-
-#~ msgid "Validate"
-#~ msgstr "Validar"

--- a/sale_tier_validation/i18n/sale_tier_validation.pot
+++ b/sale_tier_validation/i18n/sale_tier_validation.pot
@@ -6,12 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-07-04 08:58+0000\n"
+"PO-Revision-Date: 2024-07-04 08:58+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: sale_tier_validation
+#: model:ir.model.fields,help:sale_tier_validation.field_sale_order__user_can_skip_validation
+msgid "Allow user to skip validation process and allows to edit the record."
+msgstr ""
 
 #. module: sale_tier_validation
 #: model:ir.model.fields,field_description:sale_tier_validation.field_sale_order__can_review
@@ -69,6 +76,11 @@ msgid "Sales Order"
 msgstr ""
 
 #. module: sale_tier_validation
+#: model:res.groups,name:sale_tier_validation.skip_sale_validations_group
+msgid "Skip Sale Tier Validations"
+msgstr ""
+
+#. module: sale_tier_validation
 #: model:ir.model,name:sale_tier_validation.model_tier_definition
 msgid "Tier Definition"
 msgstr ""
@@ -94,6 +106,11 @@ msgstr ""
 #. module: sale_tier_validation
 #: model:ir.model.fields,field_description:sale_tier_validation.field_sale_order__to_validate_message
 msgid "To Validate Message"
+msgstr ""
+
+#. module: sale_tier_validation
+#: model:ir.model.fields,field_description:sale_tier_validation.field_sale_order__user_can_skip_validation
+msgid "User can skip validation"
 msgstr ""
 
 #. module: sale_tier_validation

--- a/sale_tier_validation/models/sale_order.py
+++ b/sale_tier_validation/models/sale_order.py
@@ -1,7 +1,8 @@
 # Copyright 2019 Open Source Integrators
+# Copyright 2024 Moduon Team
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class SaleOrder(models.Model):
@@ -20,3 +21,10 @@ class SaleOrder(models.Model):
 
     def _get_rejected_notification_subtype(self):
         return "sale_tier_validation.sale_order_tier_validation_rejected"
+
+    @api.model
+    def _user_can_skip_validation(self):
+        res = super()._user_can_skip_validation()
+        return res or self.env.user.has_group(
+            "sale_tier_validation.skip_sale_validations_group"
+        )

--- a/sale_tier_validation/readme/CONTRIBUTORS.md
+++ b/sale_tier_validation/readme/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
 - [Tecnativa](https://www.tecnativa.com):
   - Sergio Teruel
 - Tharathip Chaweewongphan \<<tharathipc@ecosoft.co.th>\>
+- Eduardo de Miguel \<<info@moduon.team>\>

--- a/sale_tier_validation/readme/DESCRIPTION.md
+++ b/sale_tier_validation/readme/DESCRIPTION.md
@@ -1,2 +1,5 @@
 This module extends the functionality of Sale Orders to support a tier
 validation process.
+
+Also adds *Skip Sale Tier Validations* security group to allow users
+skip validation process only for Sale Tiers.

--- a/sale_tier_validation/security/tier_validation_security.xml
+++ b/sale_tier_validation/security/tier_validation_security.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="0">
+    <!-- Allows the user to skip Sale Tier Validations -->
+    <record id="skip_sale_validations_group" model="res.groups">
+        <field name="name">Skip Sale Tier Validations</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+    </record>
+</odoo>

--- a/sale_tier_validation/static/description/index.html
+++ b/sale_tier_validation/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -371,6 +372,8 @@ ul.auto-toc {
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/sale-workflow/tree/16.0/sale_tier_validation"><img alt="OCA/sale-workflow" src="https://img.shields.io/badge/github-OCA%2Fsale--workflow-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/sale-workflow-16-0/sale-workflow-16-0-sale_tier_validation"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/sale-workflow&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module extends the functionality of Sale Orders to support a tier
 validation process.</p>
+<p>Also adds <em>Skip Sale Tier Validations</em> security group to allow users
+skip validation process only for Sale Tiers.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -452,12 +455,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </li>
 <li>Tharathip Chaweewongphan &lt;<a class="reference external" href="mailto:tharathipc&#64;ecosoft.co.th">tharathipc&#64;ecosoft.co.th</a>&gt;</li>
+<li>Eduardo de Miguel &lt;<a class="reference external" href="mailto:info&#64;moduon.team">info&#64;moduon.team</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-9">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Added a new group to bypass only Sale Tier Validations.

PR Series: 

- https://github.com/OCA/server-ux/pull/913 (Merge before this one)
- https://github.com/OCA/sale-workflow/pull/3222 (This one)


MT-6238 @moduon @rafaelbn @Gelojr @yajo @fcvalgar @LoisRForgeFlow please reivew if you want :)