### PR TITLE
[15.0][FIX] sale_planner_calendar: 'calendar.event' object has no attribute 'start_datetime'

### DIFF
--- a/sale_planner_calendar/models/sale_order.py
+++ b/sale_planner_calendar/models/sale_order.py
@@ -28,7 +28,7 @@ class SaleOrder(models.Model):
                 limit=1,
             )
             if delivery_event:
-                order.commitment_date = delivery_event.start_datetime
+                order.commitment_date = delivery_event.start
         return super()._action_confirm()
 
     def _prepare_calendar_event_planner(self):


### PR DESCRIPTION
- With the router we can establish a recurring calendar event of type "Delivery" that means that when a sales order is confirmed that generates a delivery, it establishes the delivery date on the order on the next day that has been defined in the event. calendar.
- Before this fix, when trying to confirm a sale order got this error message:

<img width="993" alt="image" src="https://github.com/OCA/sale-workflow/assets/143796894/50106bf5-334e-4325-9b0a-f187fd3eeeb1">

@Tecnativa
TT49977
@pedrobaeza @sergio-teruel 