### PR TITLE
[15.0][IMP] sale_planner_calendar: Open links Whatsapp and Location in new window

### DIFF
--- a/sale_planner_calendar/views/sale_planner_calendar_event_view.xml
+++ b/sale_planner_calendar/views/sale_planner_calendar_event_view.xml
@@ -458,6 +458,8 @@
                                                 t-att-href="'https://wa.me/' + record.sanitized_partner_mobile.value"
                                                 class="btn btn-primary w-100 h-80 text-white"
                                                 title="Whatsapp"
+                                                target="_blank"
+                                                aria-label="Whatsapp"
                                             >
                                                 <i class="fa fa-whatsapp fa-fw fa-2x" />
                                                 <div class="o_stat_text">Whatsapp</div>
@@ -472,6 +474,8 @@
                                                 t-att-href="'https://www.google.com/maps/search/?api=1&amp;query=' + record.location_url.value"
                                                 class="btn btn-primary w-100 h-80"
                                                 title="Location"
+                                                target="_blank"
+                                                aria-label="Location"
                                             >
                                                 <i
                                                     class="fa fa fa-map-marker fa-fw fa-2x"


### PR DESCRIPTION
Currently the Whatsapp and Location links open in the same window. Once you click on one of these links, it overwrites the current window and opens the whatsapp or google maps website.
When you go back, you have lost all context, you are back to the generic routing screen. To avoid this, we have added the option to open the links in a new window that can be closed and not lose the information from the routing screen.

cc @Tecnativa TT50045

@CarlosRoca13 @sergio-teruel please review