### PR TITLE
[14.0] [FIX] sale_product_set_packaging_qty: Fix quantity update on product.set.line

### DIFF
--- a/sale_product_set_packaging_qty/models/product_set.py
+++ b/sale_product_set_packaging_qty/models/product_set.py
@@ -17,7 +17,12 @@ class ProductSetLine(models.Model):
         digits="Product Unit of Measure",
     )
 
-    @api.depends("quantity", "product_packaging_id", "product_packaging_id.qty")
+    @api.depends(
+        "quantity",
+        "product_packaging_id",
+        "product_packaging_id.qty",
+        "product_id.packaging_ids",
+    )
     def _compute_product_packaging_qty(self):
         for line in self:
             uom_rounding = line.product_id.uom_id.rounding
@@ -31,6 +36,7 @@ class ProductSetLine(models.Model):
                 line.product_packaging_qty = 0
                 continue
             line.product_packaging_qty = line.quantity / line.product_packaging_id.qty
+            line.update(line._prepare_product_packaging_qty_values())
 
     def _inverse_product_packaging_qty(self):
         for line in self:

--- a/sale_product_set_packaging_qty/tests/test_product_set_packaging.py
+++ b/sale_product_set_packaging_qty/tests/test_product_set_packaging.py
@@ -39,3 +39,24 @@ class TestProductSetPackaging(common.SavepointCase):
         self.packaging.qty = 0
         with self.assertRaises(exceptions.UserError):
             line.product_packaging_qty = 10
+
+    def test_packaging_qty_update(self):
+        line = self.line
+        line.product_packaging_id = self.packaging
+
+        # set packaging qty and check product.set.line quantity is correctly updated
+        line.product_packaging_qty = 2
+        self.assertEqual(self.packaging.qty, 10)
+        # qty on line is 20: 2 packages of 10 units each
+        self.assertEqual(line.quantity, 20)
+
+        # change qty on packaging and check product.set.line quantity is correctly updated
+        self.packaging.qty = 5
+        self.line.product_packaging_qty = 2
+
+        self.assertEqual(self.packaging.qty, 5)
+        self.assertEqual(line.product_id.packaging_ids.qty, 5)
+        self.assertEqual(line.product_id.product_tmpl_id.packaging_ids.qty, 5)
+
+        # qty on line is 10: 2 packages of 5 units each
+        self.assertEqual(line.quantity, 10)


### PR DESCRIPTION
Changing qty on packaging in product form is not reflected on product.set.line record having this package set. To avoid this situation, we should recompute packaging_qty and update values on the product.set.line whenever packaging_ids changes on product.