### PR TITLE
[15.0][IMP] sale_order_product_recommendation_secondary_unit: Change position of secondary uom qty field to maintain coherence with the lines of the order

### DIFF
--- a/sale_order_product_recommendation_secondary_unit/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation_secondary_unit/wizards/sale_order_recommendation_view.xml
@@ -16,15 +16,15 @@
                 <field name="product_tmpl_id" invisible="1" />
                 <field name="product_uom_readonly" invisible="1" />
                 <field
-                    name="secondary_uom_id"
-                    domain="[('product_tmpl_id', '=', product_tmpl_id)]"
-                    attrs="{'readonly': [('product_uom_readonly', '=', True)]}"
-                    optional="show"
-                />
-                <field
                     name="secondary_uom_qty"
                     attrs="{'invisible': [('secondary_uom_id', '=', False)]}"
                     widget="numeric_step"
+                    optional="show"
+                />
+                <field
+                    name="secondary_uom_id"
+                    domain="[('product_tmpl_id', '=', product_tmpl_id)]"
+                    attrs="{'readonly': [('product_uom_readonly', '=', True)]}"
                     optional="show"
                 />
             </xpath>
@@ -58,14 +58,14 @@
                 <field name="product_tmpl_id" invisible="1" />
                 <field name="product_uom_readonly" invisible="1" />
                 <field
-                    name="secondary_uom_id"
-                    attrs="{'readonly': [('product_uom_readonly', '=', True)], 'invisible': [('secondary_uom_id', '=', False)]}"
-                    domain="[('product_tmpl_id', '=', product_tmpl_id)]"
-                />
-                <field
                     name="secondary_uom_qty"
                     attrs="{'invisible': [('secondary_uom_id', '=', False)]}"
                     widget="numeric_step"
+                />
+                <field
+                    name="secondary_uom_id"
+                    attrs="{'readonly': [('product_uom_readonly', '=', True)], 'invisible': [('secondary_uom_id', '=', False)]}"
+                    domain="[('product_tmpl_id', '=', product_tmpl_id)]"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
cc @Tecnativa TT50022

ping @carlosdauden  @pilarvargas-tecnativa 