### PR TITLE
[16.0][IMP] sale_order_line_sequence: Improved xpath on invoice report

### DIFF
--- a/sale_order_line_sequence/views/report_invoice.xml
+++ b/sale_order_line_sequence/views/report_invoice.xml
@@ -4,16 +4,14 @@
         id="report_invoice_document_inherit_sale_sequence"
         inherit_id="account.report_invoice_document"
     >
-        <!--complicated expr to be compatible with other modules-->
-        <xpath expr="//table/thead/tr/th[1]" position="before">
+        <xpath expr="//th[@name='th_description']" position="before">
             <th
                 t-if="(o.move_type == 'out_invoice' or o.move_type == 'out_refund') and any(l.related_so_sequence for l in o.invoice_line_ids)"
             >
                 Line Number
             </th>
         </xpath>
-        <!--complicated expr to be compatible with other modules-->
-        <xpath expr="//table/tbody//span[1]/.." position="before">
+        <xpath expr="//td[@name='account_invoice_line_name']" position="before">
              <td
                 t-if="(o.move_type == 'out_invoice' or o.move_type == 'out_refund') and line.related_so_sequence"
             >


### PR DESCRIPTION
- When installed with other modules(ie `account_invoice_report_grouped_by_picking`), the layout can be inconsistent. This commit makes the xpath more specific.

Before
![image](https://github.com/user-attachments/assets/1fea10ea-3d79-4e2b-8eb3-14c23498f368)

After
![image](https://github.com/user-attachments/assets/8176da96-608e-4da3-9c48-dfdcc9cefdd8)

@tecnativa TT50196