### PR TITLE
[FIX] sale_company_currency: Changes on currency rate application

### DIFF
--- a/sale_company_currency/models/sale_order.py
+++ b/sale_company_currency/models/sale_order.py
@@ -29,5 +29,5 @@ class SaleOrder(models.Model):
             if order.currency_id.id == order.company_id.currency_id.id:
                 to_amount = order.amount_total
             else:
-                to_amount = order.amount_total / order.currency_rate
+                to_amount = order.amount_total * order.currency_rate
             order.amount_total_curr = to_amount


### PR DESCRIPTION
### Module

sale_company_currency

### Describe the bug

The calculation of Total (Company Currency) field is not correct, it is diving currency rate instead of multiplying

### To Reproduce

1. Create a sale order
2. Use a pricealist with the same currency as the company and check the field
3. Change the pricelist for one with different currency of the company

(image from runboat OCA)

Settings

![Captura desde 2024-07-19 09-15-38](https://github.com/user-attachments/assets/9ca7d53a-0d4c-46cf-bbcc-520ba87e43c2)

USD

![image](https://github.com/user-attachments/assets/381c8816-be7e-420c-8176-76e59f2ac276)

![image](https://github.com/user-attachments/assets/efae27e9-3ed2-4df7-9806-0a975d0f04e9)

EUR

![Captura desde 2024-07-19 09-16-58](https://github.com/user-attachments/assets/f5a56eec-0edd-46e6-ad6d-e4c0f6435c6e)

![Captura desde 2024-07-19 09-17-54](https://github.com/user-attachments/assets/56ad4fd6-510c-4550-a70a-8f771cd962b2)

The 36.37 is not correct because it is dividing the total in the currency of the order (in this case €) by the rate of the company's currency (which is USD) when it should be multiplying it to get the real value of the company's currency (55.60€ * 1.528900 = 85.00$) which is the value it gives at the beginning without currency changes. This applies for all the **Show Currency Rate** types in the configuration.

**Affected versions:**

16.0
