### PR TITLE
[16.0][IMP] sale_packaging_default: Add context to support bypass setting default packaging

### DIFF
--- a/sale_packaging_default/models/sale_order_line.py
+++ b/sale_packaging_default/models/sale_order_line.py
@@ -22,6 +22,9 @@ class SaleOrderLine(models.Model):
     @api.depends("product_id", "product_uom_qty", "product_uom")
     def _compute_product_packaging_id(self):
         """Set a default packaging for sales if possible."""
+        if not self.env.context.get("apply_default_packaging", True):
+            return super()._compute_product_packaging_id()
+
         for line in self:
             if line.product_id != line.product_packaging_id.product_id:
                 line.product_packaging_id = line._get_default_packaging(line.product_id)


### PR DESCRIPTION
In some cases, we don't want to get the default for packaging. This PR will provide a context to use for those cases.