### PR TITLE
[FIX] sale_order_currency_rate : Change curency_rate calculation

### DIFF
--- a/sale_order_currency_rate/models/sale_order.py
+++ b/sale_order_currency_rate/models/sale_order.py
@@ -7,13 +7,8 @@ from odoo import api, fields, models
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    currency_rate = fields.Float(
-        compute="_compute_currency_rate",
-        digits="Currency Rate Precision",
-    )
-
     inverse_currency_rate = fields.Float(
-        compute="_compute_currency_rate",
+        compute="_compute_inverse_currency_rate",
         digits="Currency Rate Precision",
     )
 
@@ -23,23 +18,15 @@ class SaleOrder(models.Model):
     )
 
     @api.depends("currency_id", "company_id.currency_id")
-    def _compute_currency_rate(self):
+    def _compute_inverse_currency_rate(self):
         for order in self:
             if order.currency_id != order.company_id.currency_id:
-                order.currency_rate = order.currency_id._convert(
+                order.inverse_currency_rate = order.currency_id._convert(
                     1.0,
                     order.company_id.currency_id,
                     order.company_id,
                     order.date_order,
                     round=False,
                 )
-                order.inverse_currency_rate = order.company_id.currency_id._convert(
-                    1.0,
-                    order.currency_id,
-                    order.company_id,
-                    order.date_order,
-                    round=False,
-                )
             else:
-                order.currency_rate = 1.0
                 order.inverse_currency_rate = 1.0

--- a/sale_order_currency_rate/tests/__init__.py
+++ b/sale_order_currency_rate/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_order_currency_rate

--- a/sale_order_currency_rate/tests/test_sale_order_currency_rate.py
+++ b/sale_order_currency_rate/tests/test_sale_order_currency_rate.py
@@ -1,0 +1,40 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.fields import Command
+from odoo.tests.common import TransactionCase
+
+
+class TestSaleOrderCurrencyRate(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        partner_id = cls.env.ref("base.res_partner_1")
+        product_1 = cls.env.ref("product.product_product_4")
+        product_2 = cls.env.ref("product.product_product_5")
+        pricelist = cls.env.ref("product.list0")
+        pricelist_data = pricelist.copy_data()[0]
+        currency_eur = cls.env.ref("base.EUR")
+        pricelist_data.update({"currency_id": currency_eur.id})
+        cls.pricelist_eur = cls.env["product.pricelist"].create(pricelist_data)
+        order_lines = [
+            {"product_id": product_1.id, "product_uom_qty": 1},
+            {"product_id": product_2.id, "product_uom_qty": 1},
+        ]
+        cls.order = cls.env["sale.order"].create(
+            {
+                "name": "SO Test",
+                "partner_id": partner_id.id,
+                "pricelist_id": pricelist.id,
+                "order_line": [Command.create(line) for line in order_lines],
+            }
+        )
+
+    def test_sale_order_currency_rate(self):
+        # Setting the configuration to "both" in order to show currency rate and inverse
+        # currency rate, when the pricelist of the order changes, it corresponds to
+        # currency set in the pricelist.
+        self.env["res.config.settings"].create({"sale_show_currency_rate": "both"})
+        self.assertEqual(self.order.currency_rate, 1.0)
+        self.assertEqual(self.order.inverse_currency_rate, 1.0)
+        self.order.write({"pricelist_id": self.pricelist_eur.id})
+        self.assertAlmostEqual(self.order.currency_rate, 0.65, places=2)
+        self.assertAlmostEqual(self.order.inverse_currency_rate, 1.53, places=2)


### PR DESCRIPTION
### Module

sale_order_currency_rate

### Describe the bug

The currency rate applied is not correct and the value in report is incorrect too

### To Reproduce

1. Create a sale order and confirm
2. Check the value in sale report

(image from runboat OCA)

![image](https://github.com/user-attachments/assets/b164dff0-0f86-498c-abd5-1a5bd6002a92)

![Captura desde 2024-08-02 16-01-00](https://github.com/user-attachments/assets/b1b7253f-4348-4748-9730-065f0e3916f2)

Instead of divining by the unit per USD is using the USD per unit and the value is incorect. Because this reason, the best option is using the base odoo calculation of currency_rate.

![image](https://github.com/user-attachments/assets/c20350ac-45af-4766-bfef-df6a260e19be)

**Affected versions:**

16.0