### PR TITLE
[FIX] sale_company_currency: Changes on sale_order_currency_rate

### DIFF
--- a/sale_company_currency/models/sale_order.py
+++ b/sale_company_currency/models/sale_order.py
@@ -29,5 +29,5 @@ class SaleOrder(models.Model):
             if order.currency_id.id == order.company_id.currency_id.id:
                 to_amount = order.amount_total
             else:
-                to_amount = order.amount_total * order.currency_rate
+                to_amount = order.amount_total / order.currency_rate
             order.amount_total_curr = to_amount


### PR DESCRIPTION
### Module

sale_company_currency

### Describe the bug

The problem was the Total (company currency) field (`amount_total_curr`) was bad calculated as I explained in the [PR](https://github.com/OCA/sale-workflow/pull/3240). However, the field was not incorrect, the incorrect value was the currency_rate in sale_order_currency_rate that uses for amount_total_curr's calculation. 

Because this reason, I have created a new PR https://github.com/OCA/sale-workflow/pull/3260 changing the calcultaion of currency_rate as it is in odoo base and explainning the problema more detailed.

**Affected versions:**

16.0 