### PR TITLE
[17.0][IMP] linting changes to .rst files

### DIFF
--- a/sale_discount_display_amount/README.rst
+++ b/sale_discount_display_amount/README.rst
@@ -28,11 +28,12 @@ Sale Discount Display Amount
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-In standard Odoo only display the rate of the discount applied, never the
-amount. It could be great to be able to tell the customer how much he spares.
-This is the goal of this addons, it will show on a sale
-order the total without the discount and the value of the discount.
-You can choose if you want the discount on the Total with or the Total without TAX.
+In standard Odoo only display the rate of the discount applied, never
+the amount. It could be great to be able to tell the customer how much
+he spares. This is the goal of this addons, it will show on a sale order
+the total without the discount and the value of the discount. You can
+choose if you want the discount on the Total with or the Total without
+TAX.
 
 **Table of contents**
 
@@ -44,17 +45,19 @@ Configuration
 
 To configure this module, you need to:
 
-#. Go to Sales/Settings and check "Allow discounts on sales order lines"
-#. Go to Sales/Settings and check or uncheck "Show the Discount with TAX" depending on your needs
+1. Go to Sales/Settings and check "Allow discounts on sales order lines"
+2. Go to Sales/Settings and check or uncheck "Show the Discount with
+   TAX" depending on your needs
 
 Usage
 =====
 
 To use this module, you need to:
 
-#. Go on a sale order
-#. Set a discount on a line
-#. The value of the discount is dislayed in the total section as well as the total without it.
+1. Go on a sale order
+2. Set a discount on a line
+3. The value of the discount is dislayed in the total section as well as
+   the total without it.
 
 Bug Tracker
 ===========
@@ -70,25 +73,24 @@ Credits
 =======
 
 Authors
-~~~~~~~
+-------
 
 * ACSONE SA/NV
 
 Contributors
-~~~~~~~~~~~~
+------------
 
-* Cédric Pigeon <cedric.pigeon@acsone.eu>
-* Abraham Anes <abrahamanes@gmail.com>
-* Chafique Delli <chafique.delli@akretion.com>
-* Ruchir Shukla <ruchir@bizzappdev.com>
-* Manuel Regidor <manuel.regidor@sygel.es>
+-  Cédric Pigeon <cedric.pigeon@acsone.eu>
+-  Abraham Anes <abrahamanes@gmail.com>
+-  Chafique Delli <chafique.delli@akretion.com>
+-  Ruchir Shukla <ruchir@bizzappdev.com>
+-  Manuel Regidor <manuel.regidor@sygel.es>
+-  `Pesol <https://www.pesol.es>`__:
 
-* `Pesol <https://www.pesol.es>`__:
-
-  * Jonathan Oscategui Taza <info@pesol.es>
+   -  Jonathan Oscategui Taza <info@pesol.es>
 
 Maintainers
-~~~~~~~~~~~
+-----------
 
 This module is maintained by the OCA.
 

--- a/sale_discount_display_amount/readme/CONFIGURE.md
+++ b/sale_discount_display_amount/readme/CONFIGURE.md
@@ -1,0 +1,6 @@
+To configure this module, you need to:
+
+1.  Go to Sales/Settings and check "Allow discounts on sales order
+    lines"
+2.  Go to Sales/Settings and check or uncheck "Show the Discount with
+    TAX" depending on your needs

--- a/sale_discount_display_amount/readme/CONFIGURE.rst
+++ b/sale_discount_display_amount/readme/CONFIGURE.rst
@@ -1,4 +1,0 @@
-To configure this module, you need to:
-
-#. Go to Sales/Settings and check "Allow discounts on sales order lines"
-#. Go to Sales/Settings and check or uncheck "Show the Discount with TAX" depending on your needs

--- a/sale_discount_display_amount/readme/CONTRIBUTORS.md
+++ b/sale_discount_display_amount/readme/CONTRIBUTORS.md
@@ -1,0 +1,7 @@
+- Cédric Pigeon \<<cedric.pigeon@acsone.eu>\>
+- Abraham Anes \<<abrahamanes@gmail.com>\>
+- Chafique Delli \<<chafique.delli@akretion.com>\>
+- Ruchir Shukla \<<ruchir@bizzappdev.com>\>
+- Manuel Regidor \<<manuel.regidor@sygel.es>\>
+- [Pesol](https://www.pesol.es):
+  - Jonathan Oscategui Taza \<<info@pesol.es>\>

--- a/sale_discount_display_amount/readme/CONTRIBUTORS.rst
+++ b/sale_discount_display_amount/readme/CONTRIBUTORS.rst
@@ -1,9 +1,0 @@
-* Cédric Pigeon <cedric.pigeon@acsone.eu>
-* Abraham Anes <abrahamanes@gmail.com>
-* Chafique Delli <chafique.delli@akretion.com>
-* Ruchir Shukla <ruchir@bizzappdev.com>
-* Manuel Regidor <manuel.regidor@sygel.es>
-
-* `Pesol <https://www.pesol.es>`__:
-
-  * Jonathan Oscategui Taza <info@pesol.es>

--- a/sale_discount_display_amount/readme/DESCRIPTION.md
+++ b/sale_discount_display_amount/readme/DESCRIPTION.md
@@ -1,0 +1,6 @@
+In standard Odoo only display the rate of the discount applied, never
+the amount. It could be great to be able to tell the customer how much
+he spares. This is the goal of this addons, it will show on a sale order
+the total without the discount and the value of the discount. You can
+choose if you want the discount on the Total with or the Total without
+TAX.

--- a/sale_discount_display_amount/readme/DESCRIPTION.rst
+++ b/sale_discount_display_amount/readme/DESCRIPTION.rst
@@ -1,5 +1,0 @@
-In standard Odoo only display the rate of the discount applied, never the
-amount. It could be great to be able to tell the customer how much he spares.
-This is the goal of this addons, it will show on a sale
-order the total without the discount and the value of the discount.
-You can choose if you want the discount on the Total with or the Total without TAX.

--- a/sale_discount_display_amount/readme/USAGE.md
+++ b/sale_discount_display_amount/readme/USAGE.md
@@ -1,0 +1,6 @@
+To use this module, you need to:
+
+1.  Go on a sale order
+2.  Set a discount on a line
+3.  The value of the discount is dislayed in the total section as well
+    as the total without it.

--- a/sale_discount_display_amount/readme/USAGE.rst
+++ b/sale_discount_display_amount/readme/USAGE.rst
@@ -1,5 +1,0 @@
-To use this module, you need to:
-
-#. Go on a sale order
-#. Set a discount on a line
-#. The value of the discount is dislayed in the total section as well as the total without it.

--- a/sale_discount_display_amount/static/description/index.html
+++ b/sale_discount_display_amount/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -369,11 +370,12 @@ ul.auto-toc {
 !! source digest: sha256:bbe170573a7271befeaef85ccb150ab7766de57da3e4c8c02fb6eb954c7f0fe3
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/sale-workflow/tree/17.0/sale_discount_display_amount"><img alt="OCA/sale-workflow" src="https://img.shields.io/badge/github-OCA%2Fsale--workflow-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/sale-workflow-17-0/sale-workflow-17-0-sale_discount_display_amount"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/sale-workflow&amp;target_branch=17.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>In standard Odoo only display the rate of the discount applied, never the
-amount. It could be great to be able to tell the customer how much he spares.
-This is the goal of this addons, it will show on a sale
-order the total without the discount and the value of the discount.
-You can choose if you want the discount on the Total with or the Total without TAX.</p>
+<p>In standard Odoo only display the rate of the discount applied, never
+the amount. It could be great to be able to tell the customer how much
+he spares. This is the goal of this addons, it will show on a sale order
+the total without the discount and the value of the discount. You can
+choose if you want the discount on the Total with or the Total without
+TAX.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -393,7 +395,8 @@ You can choose if you want the discount on the Total with or the Total without T
 <p>To configure this module, you need to:</p>
 <ol class="arabic simple">
 <li>Go to Sales/Settings and check “Allow discounts on sales order lines”</li>
-<li>Go to Sales/Settings and check or uncheck “Show the Discount with TAX” depending on your needs</li>
+<li>Go to Sales/Settings and check or uncheck “Show the Discount with
+TAX” depending on your needs</li>
 </ol>
 </div>
 <div class="section" id="usage">
@@ -402,7 +405,8 @@ You can choose if you want the discount on the Total with or the Total without T
 <ol class="arabic simple">
 <li>Go on a sale order</li>
 <li>Set a discount on a line</li>
-<li>The value of the discount is dislayed in the total section as well as the total without it.</li>
+<li>The value of the discount is dislayed in the total section as well as
+the total without it.</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">
@@ -438,7 +442,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_order_line_sequence/README.rst
+++ b/sale_order_line_sequence/README.rst
@@ -28,8 +28,8 @@ Sale Order Line Sequence
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-Displays the sequence of Sale order line and helps to maintain the order.
-The line sequence number is also displayed in sale order reports.
+Displays the sequence of Sale order line and helps to maintain the
+order. The line sequence number is also displayed in sale order reports.
 
 **Table of contents**
 
@@ -50,28 +50,29 @@ Credits
 =======
 
 Authors
-~~~~~~~
+-------
 
 * ForgeFlow
 * Serpent CS
 
 Contributors
-~~~~~~~~~~~~
+------------
 
-* ForgeFlow S.L. <contact@forgeflow.com>
-* Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
-* Rattapong Chokmasermkul <rattapongc@ecosoft.co.th>
+-  ForgeFlow S.L. <contact@forgeflow.com>
+-  Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+-  Rattapong Chokmasermkul <rattapongc@ecosoft.co.th>
 
 Other credits
-~~~~~~~~~~~~~
+-------------
 
 Images
-------
+~~~~~~
 
-* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+-  Odoo Community Association:
+   `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`__.
 
 Maintainers
-~~~~~~~~~~~
+-----------
 
 This module is maintained by the OCA.
 

--- a/sale_order_line_sequence/readme/CONTRIBUTORS.md
+++ b/sale_order_line_sequence/readme/CONTRIBUTORS.md
@@ -1,0 +1,3 @@
+- ForgeFlow S.L. \<<contact@forgeflow.com>\>
+- Serpent Consulting Services Pvt. Ltd. \<<support@serpentcs.com>\>
+- Rattapong Chokmasermkul \<<rattapongc@ecosoft.co.th>\>

--- a/sale_order_line_sequence/readme/CONTRIBUTORS.rst
+++ b/sale_order_line_sequence/readme/CONTRIBUTORS.rst
@@ -1,3 +1,0 @@
-* ForgeFlow S.L. <contact@forgeflow.com>
-* Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
-* Rattapong Chokmasermkul <rattapongc@ecosoft.co.th>

--- a/sale_order_line_sequence/readme/CREDITS.md
+++ b/sale_order_line_sequence/readme/CREDITS.md
@@ -1,0 +1,4 @@
+## Images
+
+- Odoo Community Association:
+  [Icon](https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg).

--- a/sale_order_line_sequence/readme/CREDITS.rst
+++ b/sale_order_line_sequence/readme/CREDITS.rst
@@ -1,4 +1,0 @@
-Images
-------
-
-* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.

--- a/sale_order_line_sequence/readme/DESCRIPTION.md
+++ b/sale_order_line_sequence/readme/DESCRIPTION.md
@@ -1,0 +1,2 @@
+Displays the sequence of Sale order line and helps to maintain the
+order. The line sequence number is also displayed in sale order reports.

--- a/sale_order_line_sequence/readme/DESCRIPTION.rst
+++ b/sale_order_line_sequence/readme/DESCRIPTION.rst
@@ -1,2 +1,0 @@
-Displays the sequence of Sale order line and helps to maintain the order.
-The line sequence number is also displayed in sale order reports.

--- a/sale_order_line_sequence/static/description/index.html
+++ b/sale_order_line_sequence/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -369,8 +370,8 @@ ul.auto-toc {
 !! source digest: sha256:28c2b71b2bead701a630215f957970e26891eaaea3e224fac54efb5654ead807
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/sale-workflow/tree/17.0/sale_order_line_sequence"><img alt="OCA/sale-workflow" src="https://img.shields.io/badge/github-OCA%2Fsale--workflow-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/sale-workflow-17-0/sale-workflow-17-0-sale_order_line_sequence"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/sale-workflow&amp;target_branch=17.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>Displays the sequence of Sale order line and helps to maintain the order.
-The line sequence number is also displayed in sale order reports.</p>
+<p>Displays the sequence of Sale order line and helps to maintain the
+order. The line sequence number is also displayed in sale order reports.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -417,14 +418,17 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="images">
 <h3><a class="toc-backref" href="#toc-entry-6">Images</a></h3>
 <ul class="simple">
-<li>Odoo Community Association: <a class="reference external" href="https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg">Icon</a>.</li>
+<li>Odoo Community Association:
+<a class="reference external" href="https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg">Icon</a>.</li>
 </ul>
 </div>
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_order_line_tag/README.rst
+++ b/sale_order_line_tag/README.rst
@@ -28,7 +28,8 @@ Sale Order Line Tag
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module allows the user to tag sales order lines in order to classify them.
+This module allows the user to tag sales order lines in order to
+classify them.
 
 **Table of contents**
 
@@ -49,17 +50,17 @@ Credits
 =======
 
 Authors
-~~~~~~~
+-------
 
 * Open Source Integrators
 
 Contributors
-~~~~~~~~~~~~
+------------
 
-* Samuel Macias <smacias@opensourceintegrators.com>
+-  Samuel Macias <smacias@opensourceintegrators.com>
 
 Maintainers
-~~~~~~~~~~~
+-----------
 
 This module is maintained by the OCA.
 

--- a/sale_order_line_tag/readme/CONTRIBUTORS.md
+++ b/sale_order_line_tag/readme/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+- Samuel Macias \<<smacias@opensourceintegrators.com>\>

--- a/sale_order_line_tag/readme/CONTRIBUTORS.rst
+++ b/sale_order_line_tag/readme/CONTRIBUTORS.rst
@@ -1,1 +1,0 @@
-* Samuel Macias <smacias@opensourceintegrators.com>

--- a/sale_order_line_tag/readme/DESCRIPTION.md
+++ b/sale_order_line_tag/readme/DESCRIPTION.md
@@ -1,0 +1,2 @@
+This module allows the user to tag sales order lines in order to
+classify them.

--- a/sale_order_line_tag/readme/DESCRIPTION.rst
+++ b/sale_order_line_tag/readme/DESCRIPTION.rst
@@ -1,1 +1,0 @@
-This module allows the user to tag sales order lines in order to classify them.

--- a/sale_order_line_tag/static/description/index.html
+++ b/sale_order_line_tag/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -369,7 +370,8 @@ ul.auto-toc {
 !! source digest: sha256:57fb96fc9ffb1d907e47f09026486a1bdb2fdaa5d0cc7152de6773f2f4aaa555
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/sale-workflow/tree/17.0/sale_order_line_tag"><img alt="OCA/sale-workflow" src="https://img.shields.io/badge/github-OCA%2Fsale--workflow-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/sale-workflow-17-0/sale-workflow-17-0-sale_order_line_tag"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/sale-workflow&amp;target_branch=17.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module allows the user to tag sales order lines in order to classify them.</p>
+<p>This module allows the user to tag sales order lines in order to
+classify them.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -407,7 +409,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
includes linting changes to .rst files of `sale_discount_display_amount`,  `sale_order_line_sequence` and `sale_order_line_tag` as handled by pre-commit, in case we should tackle this separately in this way

as uncovered in a discussion in https://github.com/OCA/sale-workflow/pull/3262