### PR TITLE
[17.0][FIX] sale_blanket_order: filter default taxes by company for all users

### DIFF
--- a/sale_blanket_order/views/sale_blanket_order_views.xml
+++ b/sale_blanket_order/views/sale_blanket_order_views.xml
@@ -205,8 +205,8 @@
                                     <field
                                         name="taxes_id"
                                         widget="many2many_tags"
-                                        domain="[('type_tax_use','=','sale')]"
-                                        context="{'default_type_tax_use': 'sale'}"
+                                        domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id)]"
+                                        context="{'search_view_ref': 'account.account_tax_view_search'}"
                                         options="{'no_create': True}"
                                         required="not display_type"
                                         invisible="display_type"


### PR DESCRIPTION
**Before this commit**
    
When adding a product on a sale blanket order line, all the taxes of the product from all accessible companies were added to the blanket order line.
    
**After this commit**
    
When adding a product on a sale blanket order line, only the taxes of the product from the company on the blanket order are added to the blanket order line. This mimics the treatment of taxes on sale order lines when adding a new product.

Also, some field and view attributes were updated in analogy to sale.order.line.
