### PR TITLE
[17.0][FIX] sale_blanket_order: set analytic distribution on created sale lines

### DIFF
--- a/sale_blanket_order/tests/test_blanket_orders.py
+++ b/sale_blanket_order/tests/test_blanket_orders.py
@@ -76,9 +76,7 @@ class TestSaleBlanketOrders(common.TransactionCase):
                 "payment_term_id": self.payment_term.id,
                 "pricelist_id": self.sale_pricelist.id,
                 "line_ids": [
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": self.product.id,
                             "product_uom": self.product.uom_id.id,
@@ -86,9 +84,7 @@ class TestSaleBlanketOrders(common.TransactionCase):
                             "price_unit": 0.0,  # will be updated later
                         },
                     ),
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "name": "My section",
                             "display_type": "line_section",
@@ -131,9 +127,7 @@ class TestSaleBlanketOrders(common.TransactionCase):
                 "payment_term_id": self.payment_term.id,
                 "pricelist_id": self.sale_pricelist.id,
                 "line_ids": [
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": False,
                             "product_uom": False,
@@ -141,9 +135,7 @@ class TestSaleBlanketOrders(common.TransactionCase):
                             "display_type": "line_section",
                         },
                     ),
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "analytic_distribution": self.analytic_distribution,
                             "product_id": self.product.id,
@@ -198,9 +190,7 @@ class TestSaleBlanketOrders(common.TransactionCase):
                 "payment_term_id": self.payment_term.id,
                 "pricelist_id": self.sale_pricelist.id,
                 "line_ids": [
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": self.product.id,
                             "product_uom": self.product.uom_id.id,
@@ -208,9 +198,7 @@ class TestSaleBlanketOrders(common.TransactionCase):
                             "price_unit": 30.0,
                         },
                     ),
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": self.product2.id,
                             "product_uom": self.product2.uom_id.id,
@@ -249,9 +237,7 @@ class TestSaleBlanketOrders(common.TransactionCase):
                 "pricelist_id": self.sale_pricelist.id,
                 "currency_id": self.sale_pricelist.currency_id.id,
                 "line_ids": [
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": self.product.id,
                             "product_uom": self.product.uom_id.id,
@@ -259,9 +245,7 @@ class TestSaleBlanketOrders(common.TransactionCase):
                             "price_unit": 30.0,
                         },
                     ),
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": self.product2.id,
                             "product_uom": self.product2.uom_id.id,
@@ -283,9 +267,7 @@ class TestSaleBlanketOrders(common.TransactionCase):
                 "payment_term_id": self.payment_term.id,
                 "pricelist_id": self.sale_pricelist.id,
                 "order_line": [
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": self.product.id,
                             "product_uom": self.product.uom_id.id,
@@ -293,9 +275,7 @@ class TestSaleBlanketOrders(common.TransactionCase):
                             "price_unit": 30.0,
                         },
                     ),
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": self.product2.id,
                             "product_uom": self.product2.uom_id.id,
@@ -320,9 +300,7 @@ class TestSaleBlanketOrders(common.TransactionCase):
                 "payment_term_id": self.payment_term.id,
                 "pricelist_id": self.sale_pricelist.id,
                 "line_ids": [
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": self.product.id,
                             "product_uom": self.uom_dozen.id,
@@ -342,9 +320,7 @@ class TestSaleBlanketOrders(common.TransactionCase):
                 "payment_term_id": self.payment_term.id,
                 "pricelist_id": self.sale_pricelist.id,
                 "order_line": [
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": self.product.id,
                             "product_uom": self.product.uom_id.id,
@@ -371,9 +347,7 @@ class TestSaleBlanketOrders(common.TransactionCase):
                 "payment_term_id": self.payment_term.id,
                 "pricelist_id": self.sale_pricelist.id,
                 "line_ids": [
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": self.product.id,
                             "product_uom": self.product.uom_id.id,
@@ -381,9 +355,7 @@ class TestSaleBlanketOrders(common.TransactionCase):
                             "price_unit": 30.0,
                         },
                     ),
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": self.product2.id,
                             "product_uom": self.product2.uom_id.id,

--- a/sale_blanket_order/tests/test_blanket_orders.py
+++ b/sale_blanket_order/tests/test_blanket_orders.py
@@ -63,6 +63,9 @@ class TestSaleBlanketOrders(common.TransactionCase):
 
         cls.yesterday = date.today() - timedelta(days=1)
         cls.tomorrow = date.today() + timedelta(days=1)
+        cls.analytic_distribution = {
+            str(cls.env.ref("analytic.analytic_internal").id): 100,
+        }
 
     def test_01_create_blanket_order(self):
         """We create a blanket order and check constrains to confirm BO"""
@@ -142,6 +145,7 @@ class TestSaleBlanketOrders(common.TransactionCase):
                         0,
                         0,
                         {
+                            "analytic_distribution": self.analytic_distribution,
                             "product_id": self.product.id,
                             "product_uom": self.product.uom_id.id,
                             "original_uom_qty": 20.0,
@@ -177,6 +181,12 @@ class TestSaleBlanketOrders(common.TransactionCase):
         sos = self.so_obj.browse(domain_ids)
         for so in sos:
             self.assertEqual(so.origin, blanket_order.name)
+
+        # Analytic distribution is propagated to the sale line
+        self.assertEqual(
+            sos[0].order_line.filtered("product_id").analytic_distribution,
+            self.analytic_distribution,
+        )
 
     def test_03_create_sale_orders_from_blanket_order_line(self):
         """We create a blanket order and create two sale orders

--- a/sale_blanket_order/tests/test_sale_order.py
+++ b/sale_blanket_order/tests/test_sale_order.py
@@ -52,9 +52,7 @@ class TestSaleOrder(common.TransactionCase):
                 "payment_term_id": self.payment_term.id,
                 "pricelist_id": self.sale_pricelist.id,
                 "line_ids": [
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": self.product.id,
                             "product_uom": self.product.uom_id.id,
@@ -65,9 +63,7 @@ class TestSaleOrder(common.TransactionCase):
                             "price_unit": 30.0,
                         },
                     ),
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": self.product.id,
                             "product_uom": self.product.uom_id.id,
@@ -92,9 +88,7 @@ class TestSaleOrder(common.TransactionCase):
                 "payment_term_id": self.payment_term.id,
                 "pricelist_id": self.sale_pricelist.id,
                 "line_ids": [
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": self.product.id,
                             "product_uom": self.product.uom_id.id,
@@ -102,9 +96,7 @@ class TestSaleOrder(common.TransactionCase):
                             "price_unit": 30.0,
                         },
                     ),
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "product_id": self.product_2.id,
                             "product_uom": self.product.uom_id.id,
@@ -130,9 +122,7 @@ class TestSaleOrder(common.TransactionCase):
             {
                 "partner_id": self.partner.id,
                 "order_line": [
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "name": self.product.name,
                             "product_id": self.product.id,
@@ -164,9 +154,7 @@ class TestSaleOrder(common.TransactionCase):
             {
                 "partner_id": self.partner.id,
                 "order_line": [
-                    (
-                        0,
-                        0,
+                    fields.Command.create(
                         {
                             "name": self.product.name,
                             "product_id": self.product.id,

--- a/sale_blanket_order/wizard/create_sale_orders.py
+++ b/sale_blanket_order/wizard/create_sale_orders.py
@@ -66,15 +66,9 @@ class BlanketOrderWizard(models.TransientModel):
         lines = [
             fields.Command.create(
                 {
-                    "analytic_distribution": bol.analytic_distribution,
                     "blanket_line_id": bol.id,
-                    "product_id": bol.product_id.id,
                     "date_schedule": bol.date_schedule,
-                    "remaining_uom_qty": bol.remaining_uom_qty,
-                    "price_unit": bol.price_unit,
-                    "product_uom": bol.product_uom,
                     "qty": bol.remaining_uom_qty,
-                    "partner_id": bol.partner_id,
                 },
             )
             for bol in bo_lines.filtered(

--- a/sale_blanket_order/wizard/create_sale_orders.py
+++ b/sale_blanket_order/wizard/create_sale_orders.py
@@ -64,9 +64,7 @@ class BlanketOrderWizard(models.TransientModel):
         self._check_valid_blanket_order_line(bo_lines)
 
         lines = [
-            (
-                0,
-                0,
+            fields.Command.create(
                 {
                     "analytic_distribution": bol.analytic_distribution,
                     "blanket_line_id": bol.id,
@@ -111,7 +109,7 @@ class BlanketOrderWizard(models.TransientModel):
             "price_unit": line.blanket_line_id.price_unit,
             "blanket_order_line": line.blanket_line_id.id,
             "product_uom_qty": line.qty,
-            "tax_id": [(6, 0, line.taxes_id.ids)],
+            "tax_id": [fields.Command.set(line.taxes_id.ids)],
         }
 
     def _prepare_so_vals(

--- a/sale_blanket_order/wizard/create_sale_orders.py
+++ b/sale_blanket_order/wizard/create_sale_orders.py
@@ -68,6 +68,7 @@ class BlanketOrderWizard(models.TransientModel):
                 0,
                 0,
                 {
+                    "analytic_distribution": bol.analytic_distribution,
                     "blanket_line_id": bol.id,
                     "product_id": bol.product_id.id,
                     "date_schedule": bol.date_schedule,
@@ -102,6 +103,7 @@ class BlanketOrderWizard(models.TransientModel):
 
     def _prepare_so_line_vals(self, line):
         return {
+            "analytic_distribution": line.analytic_distribution,
             "product_id": line.product_id.id,
             "name": line.product_id.name,
             "product_uom": line.product_uom.id,
@@ -199,11 +201,13 @@ class BlanketOrderWizard(models.TransientModel):
 
 
 class BlanketOrderWizardLine(models.TransientModel):
+    _inherit = "analytic.mixin"
     _name = "sale.blanket.order.wizard.line"
     _description = "Blanket order wizard line"
 
     wizard_id = fields.Many2one("sale.blanket.order.wizard")
     blanket_line_id = fields.Many2one("sale.blanket.order.line")
+    analytic_distribution = fields.Json(related="blanket_line_id.analytic_distribution")
     product_id = fields.Many2one(
         "product.product", related="blanket_line_id.product_id", string="Product"
     )

--- a/sale_blanket_order/wizard/create_sale_orders.xml
+++ b/sale_blanket_order/wizard/create_sale_orders.xml
@@ -20,6 +20,16 @@
                             <field name="remaining_uom_qty" />
                             <field name="product_uom" groups="uom.group_uom" />
                             <field name="qty" />
+                            <field
+                                name="analytic_distribution"
+                                widget="analytic_distribution"
+                                optional="hide"
+                                groups="analytic.group_analytic_accounting"
+                                options="{
+                                         'product_field': 'product_id',
+                                         'business_domain': 'sale_order'
+                                         }"
+                            />
                         </tree>
                     </field>
                 </group>


### PR DESCRIPTION
## Describe the bug
Analytic distributions recorded on blanket order lines are not set on the sale lines created from those blanket order lines

## To Reproduce

Steps to reproduce the behavior:
1. Create a sale blanket order with a sale line with an analytic distribution
2. Create a sale order from the blanket order

**Expected behavior**
The created sale line has the same analytic distribution as the blanket order line from which it was created.
