### PR TITLE
[15.0][FIX] sale_elaboration, product_supplierinfo_for_customer_elaboration: Set elaboration note with a onchange instead of compute method

### DIFF
--- a/sale_elaboration/models/product_elaboration_mixin.py
+++ b/sale_elaboration/models/product_elaboration_mixin.py
@@ -12,19 +12,18 @@ class ProductElaborationMixin(models.AbstractModel):
         comodel_name="product.elaboration",
         string="Elaborations",
     )
-    elaboration_note = fields.Char(
-        store=True,
-        compute="_compute_elaboration_note",
-        readonly=False,
-    )
+    elaboration_note = fields.Char()
     is_elaboration = fields.Boolean(
         store=True,
         compute="_compute_is_elaboration",
         readonly=False,
     )
 
-    @api.depends("elaboration_ids")
-    def _compute_elaboration_note(self):
+    @api.onchange("elaboration_ids")
+    def onchange_elaboration_ids(self):
+        """Use onchange method instead of compute because if any other data of any line
+        force a recompute of all lines and the elaboration custom notes are reset.
+        """
         for line in self:
             line.elaboration_note = ", ".join(line.elaboration_ids.mapped("name"))
 

--- a/sale_elaboration/tests/test_sale_elaboration.py
+++ b/sale_elaboration/tests/test_sale_elaboration.py
@@ -95,7 +95,11 @@ class TestSaleElaboration(TransactionCase):
         self.assertEqual(len(elaboration), 1)
 
     def test_sale_elaboration_change(self):
-        self.order.order_line.elaboration_ids = self.elaboration_b
+        order_form = Form(self.order)
+        with order_form.order_line.edit(0) as line:
+            line.elaboration_ids.clear()
+            line.elaboration_ids.add(self.elaboration_b)
+        order_form.save()
         self.assertEqual(self.order.order_line.elaboration_note, "Elaboration B")
 
     def test_sale_elaboration(self):


### PR DESCRIPTION
cc @Tecnativa  TT50584

Use onchange method instead of compute because if any other data of any line force a recompute of all lines and the elaboration custom notes are reset.

ping  @carlosdauden @pilarvargas-tecnativa 