### PR TITLE
[17.0][FIX] sale_order_type: Ensure sale_type_id is computed correctly

### DIFF
--- a/sale_order_type/models/account_move.py
+++ b/sale_order_type/models/account_move.py
@@ -18,16 +18,9 @@ class AccountMove(models.Model):
         precompute=True,
     )
 
-    @api.depends("partner_id", "company_id")
-    @api.depends_context("default_move_type", "active_model", "company")
+    @api.depends("partner_id", "company_id", "move_type")
     def _compute_sale_type_id(self):
-        # If create invoice from sale order, sale type will not computed.
-        if not self.env.context.get("default_move_type", False) or self.env.context.get(
-            "active_model", False
-        ) in ["sale.order", "sale.advance.payment.inv"]:
-            return
         sale_type = self.env["sale.order.type"].browse()
-        self.sale_type_id = sale_type
         for record in self:
             if record.move_type not in ["out_invoice", "out_refund"]:
                 record.sale_type_id = sale_type


### PR DESCRIPTION
When a sale_type is set for a partner, it was not correctly applied when creating an invoice for that partner. This resulted in invoices not reflecting the correct sale_order_type`during creation, leading to potential inconsistencies in how invoices were processed.

This commit fixes the issue by ensuring that the context is preserved and properly applied during invoice creation.

Steps to reproduce:

1. Set a sale_order_type for a partner.
2. Create an invoice for that partner.
3. Observe that the created invoice does not display the correct sale_type_id.

Video with the issue --> https://drive.google.com/file/d/1tupgsxmEttOUC3qq0PZFMNRb68DquOjJ/view