### PR TITLE
[17.0][FIX] sale_blanket_order: not require taxes on blanket orders

### DIFF
--- a/sale_blanket_order/views/sale_blanket_order_views.xml
+++ b/sale_blanket_order/views/sale_blanket_order_views.xml
@@ -208,7 +208,6 @@
                                         domain="[('type_tax_use','=','sale')]"
                                         context="{'default_type_tax_use': 'sale'}"
                                         options="{'no_create': True}"
-                                        required="not display_type"
                                         invisible="display_type"
                                     />
                                     <field


### PR DESCRIPTION
This module following from https://github.com/OCA/sale-workflow/pull/3172