### PR TITLE
[17.0][FIX] sale_quotation_number: fix numbering to be compatible with sale_order_revision

### DIFF
--- a/sale_quotation_number/models/sale_order.py
+++ b/sale_quotation_number/models/sale_order.py
@@ -13,20 +13,21 @@ class SaleOrder(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
-            if self.is_using_quotation_number(vals):
-                company_id = vals.get("company_id", self.env.company.id)
-                sequence = (
-                    self.with_company(company_id)
-                    .env["ir.sequence"]
-                    .next_by_code("sale.quotation")
-                )
-                vals["name"] = sequence or "/"
+            if not vals.get("name"):
+                if self.is_using_quotation_number(vals):
+                    company_id = vals.get("company_id", self.env.company.id)
+                    sequence = (
+                        self.with_company(company_id)
+                        .env["ir.sequence"]
+                        .next_by_code("sale.quotation")
+                    )
+                    vals["name"] = sequence or "/"
         return super().create(vals_list)
 
     @api.model
     def is_using_quotation_number(self, vals):
         company = False
-        if "company_id" in vals:
+        if vals.get("company_id"):
             company = self.env["res.company"].browse(vals.get("company_id"))
         else:
             company = self.env.company

--- a/sale_quotation_number/tests/test_sale_order.py
+++ b/sale_quotation_number/tests/test_sale_order.py
@@ -106,3 +106,9 @@ class TestSaleOrder(TransactionCase):
         next_name = sequence_id.get_next_char(sequence_id.number_next_actual)
         self.order_company1.action_confirm()
         self.assertEqual(next_name, self.order_company1.name)
+
+    def test_create_with_specific_name(self):
+        order = self.sale_order_model.create(
+            {"name": "CustomName", "partner_id": self.env.ref("base.res_partner_1").id}
+        )
+        self.assertEqual(order.name, "CustomName")


### PR DESCRIPTION
This module is incompatible with sale_order_revision. New revision got always the next number instead of -02 suppliment.

