### PR TITLE
[IMP] sale_loyalty_exclude: Avoid to  select excluded products in rul…

### DIFF
--- a/sale_loyalty_exclude/models/__init__.py
+++ b/sale_loyalty_exclude/models/__init__.py
@@ -1,2 +1,3 @@
+from . import loyalty_reward
 from . import product_template
 from . import sale_order

--- a/sale_loyalty_exclude/models/loyalty_reward.py
+++ b/sale_loyalty_exclude/models/loyalty_reward.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class LoyaltyReward(models.Model):
+    _inherit = "loyalty.reward"
+
+    discount_product_ids = fields.Many2many(
+        "product.product", domain=[("loyalty_exclude", "=", False)]
+    )

--- a/sale_loyalty_exclude/views/product_views.xml
+++ b/sale_loyalty_exclude/views/product_views.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="product_template_form_view" model="ir.ui.view">
         <field name="model">product.template</field>
-        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="inherit_id" ref="product.product_template_only_form_view" />
         <field name="arch" type="xml">
             <xpath expr="//page[@name='sales']" position="inside">
                 <group>


### PR DESCRIPTION
Avoid to  select excluded products in rewards

The excluded products can be selected at loyalty rewards. This is pointless and only makes confussion because the rewards would be ignored.

Besides, the "loyalty_exclude" check will no longer appear at product variant views.

[Grabación de pantalla desde 09-09-24 09:18:52.webm](https://github.com/user-attachments/assets/744bd60e-3316-4f2c-b146-9dc5fc6d3644)

FL-556-3740
