### PR TITLE
[17.0][FIX] sale_discount_display_amount: field attributes

### DIFF
--- a/sale_discount_display_amount/models/res_company.py
+++ b/sale_discount_display_amount/models/res_company.py
@@ -4,4 +4,4 @@ from odoo import fields, models
 class ResCompany(models.Model):
     _inherit = "res.company"
 
-    display_discount_with_tax = fields.Boolean(Name="Show the Discount with TAX")
+    display_discount_with_tax = fields.Boolean(string="Show the Discount with TAX")

--- a/sale_discount_display_amount/models/res_config_settings.py
+++ b/sale_discount_display_amount/models/res_config_settings.py
@@ -5,7 +5,7 @@ class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
     display_discount_with_tax = fields.Boolean(
-        Name="Show the Discount with TAX",
+        string="Show the Discount with TAX",
         help="Check this field to show the Discount with TAX",
         related="company_id.display_discount_with_tax",
         readonly=False,

--- a/sale_discount_display_amount/models/sale_order.py
+++ b/sale_discount_display_amount/models/sale_order.py
@@ -8,31 +8,29 @@ class SaleOrder(models.Model):
     _inherit = "sale.order"
 
     display_discount_with_tax = fields.Boolean(
-        name="Show the Discount with TAX",
+        string="Show the Discount with TAX",
         help="Check this field to show the Discount with TAX",
         related="company_id.display_discount_with_tax",
     )
     discount_total = fields.Monetary(
         compute="_compute_discount_total",
-        name="Discount total",
         currency_field="currency_id",
         store=True,
     )
     discount_subtotal = fields.Monetary(
         compute="_compute_discount_total",
-        name="Discount Subtotal",
         currency_field="currency_id",
         store=True,
     )
     price_subtotal_no_discount = fields.Monetary(
         compute="_compute_discount_total",
-        name="Subtotal Without Discount",
+        string="Subtotal Without Discount",
         currency_field="currency_id",
         store=True,
     )
     price_total_no_discount = fields.Monetary(
         compute="_compute_discount_total",
-        name="Total Without Discount",
+        string="Total Without Discount",
         currency_field="currency_id",
         store=True,
     )

--- a/sale_discount_display_amount/models/sale_order_line.py
+++ b/sale_discount_display_amount/models/sale_order_line.py
@@ -9,25 +9,23 @@ class SaleOrderLine(models.Model):
 
     discount_total = fields.Monetary(
         compute="_compute_amount",
-        Name="Discount Subtotal",
         store=True,
         precompute=True,
     )
     discount_subtotal = fields.Monetary(
         compute="_compute_amount",
-        Name="Discount Subtotal",
         store=True,
         precompute=True,
     )
     price_subtotal_no_discount = fields.Monetary(
         compute="_compute_amount",
-        Name="Subtotal Without Discount",
+        string="Subtotal Without Discount",
         store=True,
         precompute=True,
     )
     price_total_no_discount = fields.Monetary(
         compute="_compute_amount",
-        Name="Total Without Discount",
+        string="Total Without Discount",
         store=True,
         precompute=True,
     )


### PR DESCRIPTION
Replace non-existent `name` and `Name` attributes in field declarations to `string`.

Fixes field labels and log warnings:
```
2024-09-12 13:49:38,055 570 WARNING x odoo.fields: Field res.config.settings.display_discount_with_tax: unknown parameter 'Name', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it 
2024-09-12 13:49:38,056 570 WARNING x odoo.fields: Field res.company.display_discount_with_tax: unknown parameter 'Name', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it 
2024-09-12 13:49:38,117 570 WARNING x odoo.fields: Field sale.order.line.discount_total: unknown parameter 'Name', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it 
2024-09-12 13:49:38,117 570 WARNING x odoo.fields: Field sale.order.line.discount_subtotal: unknown parameter 'Name', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it 
2024-09-12 13:49:38,117 570 WARNING x odoo.fields: Field sale.order.line.price_subtotal_no_discount: unknown parameter 'Name', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it 
2024-09-12 13:49:38,117 570 WARNING x odoo.fields: Field sale.order.line.price_total_no_discount: unknown parameter 'Name', if this is an actual parameter you may want to override the method _valid_field_parameter on the relevant model in order to allow it 
```