### PR TITLE
[17.0][IMP] sale_quotation_number: allow customizable quotation sequence

### DIFF
--- a/sale_quotation_number/models/sale_order.py
+++ b/sale_quotation_number/models/sale_order.py
@@ -43,8 +43,11 @@ class SaleOrder(models.Model):
         return super().copy(default)
 
     def action_confirm(self):
+        sequence = self.env["ir.sequence"].search(
+            [("code", "=", "sale.quotation")], limit=1
+        )
         for order in self:
-            if self.name[:2] != "SQ":
+            if sequence and self.name[: len(sequence.prefix)] != sequence.prefix:
                 continue
             if order.state not in ("draft", "sent") or order.company_id.keep_name_so:
                 continue


### PR DESCRIPTION
Enable users to customize the sale.quotation sequence prefix, instead of it being restricted to the default 'SQ'.

Solution from version 14: https://github.com/OCA/sale-workflow/pull/2126

(PR 16: #3309 )
(PR 15: #3311 )

(Follow-up PR: https://github.com/OCA/sale-workflow/pull/3213)