### PR TITLE
[FIX] pricelist_cache: item expiration fix

### DIFF
--- a/pricelist_cache/models/product_pricelist.py
+++ b/pricelist_cache/models/product_pricelist.py
@@ -141,15 +141,20 @@ class Pricelist(models.Model):
         globally, and based on another pricelist
         """
         self.ensure_one()
+        today = str(date.today())
+        self.flush()
         query = """
             SELECT base_pricelist_id
             FROM product_pricelist_item
             WHERE applied_on = '3_global'
+            AND active = TRUE
             AND base = 'pricelist'
             AND base_pricelist_id IS NOT NULL
             AND pricelist_id = %(pricelist_id)s
+            AND (date_end IS NULL OR date_end >= %(today)s)
+            AND (date_start IS NULL OR date_start <= %(today)s)
         """
-        self.env.cr.execute(query, {"pricelist_id": self.id})
+        self.env.cr.execute(query, {"pricelist_id": self.id, "today": today})
         return self.browse([row[0] for row in self.env.cr.fetchall()])
 
     def _is_factor_pricelist(self):

--- a/pricelist_cache/models/product_pricelist_cache.py
+++ b/pricelist_cache/models/product_pricelist_cache.py
@@ -103,7 +103,7 @@ class PricelistCache(models.Model):
 
         Args:
             - pricelist: a product.pricelist record
-            - product_prices: A dictionnary,
+            - product_prices: A dictionary,
               with product.product id as keys, and prices as values
         """
         product_ids = list(product_prices.keys())

--- a/pricelist_cache/tests/common.py
+++ b/pricelist_cache/tests/common.py
@@ -157,3 +157,9 @@ class TestPricelistCacheCommon(SavepointCase):
 
     def assert_cache_not_computed(self, lists):
         self.assertFalse(any(lists.mapped("is_pricelist_cache_computed")))
+
+    def assert_price_equal(self, pricelist, product, expected_price):
+        self.cache_model.cron_reset_pricelist_cache()
+        self.cache_model.invalidate_cache(["price"])
+        prices = self.cache_model.get_cached_prices_for_pricelist(pricelist, product)
+        self.assertEqual(prices.price, expected_price)

--- a/pricelist_cache/tests/test_methods.py
+++ b/pricelist_cache/tests/test_methods.py
@@ -36,3 +36,17 @@ class TestPricelistCacheModels(TestPricelistCacheCommon):
         list5_parents_tree = list5._get_parent_list_tree()
         expected_list5_tree = expected_list3_tree | list5
         self.assertEqual(list5_parents_tree, expected_list5_tree)
+
+    def test_get_parent_pricelists(self):
+        # test that list2 finds the parent pricelist list1
+        self.assertEqual(self.list2._get_parent_pricelists(), self.list1)
+        # test that list1 is not returned when item is expired
+        item = self.list2.item_ids.filtered(
+            lambda item: (
+                item.applied_on == "3_global"
+                and item.base == "pricelist"
+                and item.base_pricelist_id
+            )
+        )
+        item.write({"date_end": "2021-03-14"})
+        self.assertFalse(self.list2._get_parent_pricelists())


### PR DESCRIPTION
The pricelist cache was not taking into account the `date_end` and `date_start` of items when calculating the prices. This caused outdated prices to be shown in the pricelist cache.

Fixed by modifying the SQL query that finds the parent pricelists to check the item expiration.