### PR TITLE
[16.0][FIX] sale_triple_discount: Remove call to deprecated

### DIFF
--- a/sale_triple_discount/models/sale_order_line.py
+++ b/sale_triple_discount/models/sale_order_line.py
@@ -102,7 +102,7 @@ class SaleOrderLine(models.Model):
         this method is called multiple times.
         Updating the cache provides consistency through re-computations."""
         prev_values = dict()
-        self.invalidate_cache(fnames=self._discount_fields(), ids=self.ids)
+        self.invalidate_recordset(self._discount_fields())
         for line in self:
             prev_values[line] = {
                 fname: line[fname] for fname in self._discount_fields()
@@ -118,10 +118,7 @@ class SaleOrderLine(models.Model):
     def triple_discount_postprocess(self, prev_values):
         """Restore the discounts of the lines in the dictionary prev_values.
         Updating the cache provides consistency through re-computations."""
-        self.invalidate_cache(
-            fnames=self._discount_fields(),
-            ids=[line.id for line in list(prev_values.keys())],
-        )
+        self.invalidate_recordset(self._discount_fields())
         for line, prev_vals_dict in list(prev_values.items()):
             line.update(prev_vals_dict)
 


### PR DESCRIPTION
Method 'invalidate_cache' is deprecated. To invalidate specific field's value into the cache for a recordset we must use the 'invalidate_recordset' method on the recordset itself.