### PR TITLE
[16.0][FIX] sale_order_line_input: New id for the _get_lang method

### DIFF
--- a/sale_order_line_input/models/sale_order.py
+++ b/sale_order_line_input/models/sale_order.py
@@ -24,6 +24,15 @@ class SaleOrderLine(models.Model):
         for line in self:
             line.force_company_id = line.order_id.company_id or self.env.company
 
+    def _compute_name(self):
+        # A NewId is needed to set the product for the parent method to set
+        # the language correctly. Empty id leads to error in ‘_get_lang’.
+        for line in self:
+            if not line.order_id and line.product_id:
+                SaleOrder = self.env["sale.order"]
+                line.order_id = SaleOrder.new({})
+        return super()._compute_name()
+
     @api.onchange("force_company_id")
     def _onchange_force_company_id(self):
         """Assign company_id because is used in domains as partner,

--- a/sale_order_line_input/tests/test_sale_order_line_input.py
+++ b/sale_order_line_input/tests/test_sale_order_line_input.py
@@ -29,3 +29,12 @@ class TestSaleOrderLineInput(TransactionCase):
         action_dict = line.action_sale_order_form()
         self.assertEqual(action_dict["res_id"], line.order_id.id)
         self.assertEqual(action_dict["res_model"], "sale.order")
+
+    def test_sale_order_line_compute_name(self):
+        # Ensure that when calculating the line name, the new sales order id has
+        # already been created as it is done in the order form view.
+        line_form = Form(
+            self.env["sale.order.line"],
+            view="sale_order_line_input.view_sales_order_line_input_tree",
+        )
+        line_form.product_id = self.product


### PR DESCRIPTION
When a line is defined in the sales order it calculates the name of the description with the language of the order using the new id of the new order being created. If this is done from the order lines view there is no order created and that is why you need to create a new id to avoid the error in the parent method.

@chienandalu  @carlos-lopez-tecnativa please review