### PR TITLE
[16.0][FIX] sale_planner_calendar: Remove partner name from default location address

### DIFF
--- a/sale_planner_calendar/models/res_partner.py
+++ b/sale_planner_calendar/models/res_partner.py
@@ -22,7 +22,8 @@ class ResPartner(models.Model):
         action["context"] = {
             "default_target_partner_id": self.id,
             "default_categ_ids": [(4, categ.id)],
-            "default_location": self._display_address(),
+            # Passing True omits the partner name, ensuring precise calculation of GPS location.
+            "default_location": self._display_address(True).replace("\n", " "),
             "default_duration": categ.duration,
             "default_name": categ.name,
             "default_start": fields.Datetime.now(),

--- a/sale_planner_calendar/tests/test_sale_planner_calendar.py
+++ b/sale_planner_calendar/tests/test_sale_planner_calendar.py
@@ -197,7 +197,10 @@ class TestSalePlannerCalendar(TransactionCase):
         event = self.planned_events[0]
         self.assertTrue(event.user_id in self.commercial_users)
         self.assertEqual(event.rrule_type, "weekly")
-        self.assertEqual(event.location, event.target_partner_id._display_address())
+        self.assertEqual(
+            event.location,
+            event.target_partner_id._display_address(True).replace("\n", " "),
+        )
 
     def test_planner_calendar_wizard(self):
         wiz_form = Form(self.env["sale.planner.calendar.wizard"])


### PR DESCRIPTION
By passing `True` to the `_display_address` method, the company/partner name is omitted from the address format, ensuring that only address details are displayed. This change was to calculate the GPS location exactly.

cc @Tecnativa TT51008

@CarlosRoca13 @sergio-teruel please review