### PR TITLE
[15.0][IMP] sale_order_invoice_amount: not count over-invoicing lines for uninvoicing amount

### DIFF
--- a/sale_order_invoice_amount/models/sale_order.py
+++ b/sale_order_invoice_amount/models/sale_order.py
@@ -53,6 +53,7 @@ class SaleOrder(models.Model):
                         * (line.price_total / line.product_uom_qty)
                         for line in rec.order_line.filtered(
                             lambda sl: sl.product_uom_qty > 0
+                            and sl.product_uom_qty > sl.qty_invoiced
                         )
                     ),
                 )


### PR DESCRIPTION
@ForgeFlow 