### PR TITLE
[15.0][FIX] sale_order_invoicing_finished_task: invoiceable field is not updated…

### DIFF
--- a/sale_order_invoicing_finished_task/views/project_view.xml
+++ b/sale_order_invoicing_finished_task/views/project_view.xml
@@ -40,4 +40,16 @@
             </div>
         </field>
     </record>
+    <!-- Need to get related field invoicing_finished_task when _onchange_stage_id
+         and save invoiceable value in kanban view -->
+    <record id="view_task_kanban" model="ir.ui.view">
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.view_task_kanban" />
+        <field name="arch" type="xml">
+            <field name="stage_id" position="after">
+                <field name="sale_line_id" />
+                <field name="invoiceable" />
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
… properly in kanban view drag and drop.

The field invoicing_finished_task is False If sale_line_id is not defined in kanban view. The field invoiceable is not saved If it is not defined in kanban view.

FW-Port https://github.com/OCA/sale-workflow/pull/1972

@Tecnativa TT51087