### PR TITLE
[15.0][FIX] sale_planner_calendar: Go back on history when deleted from form view

### DIFF
--- a/sale_planner_calendar/static/src/js/basic_controller.js
+++ b/sale_planner_calendar/static/src/js/basic_controller.js
@@ -57,6 +57,9 @@ odoo.define("sale_planner_calendar.basic_controller", function (require) {
                 const recurrenceUpdate = await this._askRecurrenceUpdatePolicy();
                 if (recurrenceUpdate !== "self_only") {
                     await this._launchMassDeletion(records, recurrenceUpdate);
+                    if (this.controlPanelProps.view.arch.tag === "form") {
+                        return this.trigger_up("history_back");
+                    }
                     return this.reload();
                 }
                 this.confirmOnDelete = false;


### PR DESCRIPTION
Steps to reproduce the problem:

1. Go to Calendar planner > Calendar events > Recurrent calendar events
2. Create or select a recurrent event
3. Go to the form view of the event
4. Delete the event from the form view
5. Select "This and following events" or "All events"

Current behavior: The event is deleted from the database and data displayed on screen reloaded. An error will be throwed because the event is not in the database anymore.

Expected behavior: The event is deleted from the database and going back on history to avoid the error.

cc @Tecnativa TT51142

ping @sergio-teruel @chienandalu 