### PR TITLE
[FIX] sale_sourced_by_line: fix conflict with precompute

### DIFF
--- a/sale_sourced_by_line/__manifest__.py
+++ b/sale_sourced_by_line/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Sale Sourced by Line",
     "summary": "Multiple warehouse source locations for Sale order",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "author": "Camptocamp,"
     "Eficent,"
     "SerpentCS,"

--- a/sale_sourced_by_line/model/sale.py
+++ b/sale_sourced_by_line/model/sale.py
@@ -13,7 +13,6 @@ class SaleOrder(models.Model):
     warehouse_id = fields.Many2one(
         "stock.warehouse",
         string="Default Warehouse",
-        readonly=True,
         help="If no source warehouse is selected on line, "
         "this warehouse is used as default. ",
     )
@@ -25,7 +24,6 @@ class SaleOrderLine(models.Model):
     warehouse_id = fields.Many2one(
         "stock.warehouse",
         "Source Warehouse",
-        readonly=True,
         related="",
         help="If a source warehouse is selected, "
         "it will be used to define the route. "


### PR DESCRIPTION
Built-in filed is marked as precompute=True.
When field is marked as precomputed and readonly, Odoo will remove it's value from create values. (See `odoo.models.BaseModel._prepare_create_values`) Therefore, it was not possible to set `warehouse_id` in create as it would reset to default computed warehouse.

Now, it's fixed and readonly enforced on view level.