### PR TITLE
[16.0][IMP] sale_loyalty_exclude

### DIFF
--- a/sale_loyalty_exclude/i18n/es.po
+++ b/sale_loyalty_exclude/i18n/es.po
@@ -19,7 +19,7 @@ msgstr ""
 #. module: sale_loyalty_exclude
 #: model:ir.model.fields,field_description:sale_loyalty_exclude.field_loyalty_reward__discount_product_ids
 msgid "Discounted Products"
-msgstr ""
+msgstr "Productos con descuento"
 
 #. module: sale_loyalty_exclude
 #: model_terms:ir.ui.view,arch_db:sale_loyalty_exclude.product_template_form_view
@@ -35,7 +35,7 @@ msgstr "Excluir producto en programas de descuento"
 #. module: sale_loyalty_exclude
 #: model:ir.model,name:sale_loyalty_exclude.model_loyalty_reward
 msgid "Loyalty Reward"
-msgstr ""
+msgstr "Recompensa de fidelidad"
 
 #. module: sale_loyalty_exclude
 #: model:ir.model,name:sale_loyalty_exclude.model_product_template
@@ -45,7 +45,14 @@ msgstr "Producto"
 #. module: sale_loyalty_exclude
 #: model:ir.model,name:sale_loyalty_exclude.model_sale_order
 msgid "Sales Order"
-msgstr "Pedidos de venta"
+msgstr "Pedido de venta"
+
+#. module: sale_loyalty_exclude
+#. odoo-python
+#: code:addons/sale_loyalty_exclude/models/sale_order.py:0
+#, python-format
+msgid "This code is invalid."
+msgstr "Este código no es válido."
 
 #. module: sale_loyalty_exclude
 #: model:ir.model.fields,help:sale_loyalty_exclude.field_product_product__loyalty_exclude

--- a/sale_loyalty_exclude/models/sale_order.py
+++ b/sale_loyalty_exclude/models/sale_order.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Camptocamp (<https://www.camptocamp.com>).
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import _, models
 
 
 class SaleOrder(models.Model):
@@ -14,3 +14,22 @@ class SaleOrder(models.Model):
         self.ensure_one()
         lines = self.order_line.filtered(lambda line: line.product_id.loyalty_exclude)
         return lines | super()._get_no_effect_on_threshold_lines()
+
+    def _has_all_products_loyalty_exclude(self):
+        """Check if all order lines have loyalty_exclude set to True."""
+        for line in self.order_line:
+            if not line.product_id.loyalty_exclude:
+                return False
+        return True
+
+    def _get_claimable_rewards(self, forced_coupons=None):
+        if self._has_all_products_loyalty_exclude():
+            return {}
+        else:
+            return super()._get_claimable_rewards(forced_coupons=forced_coupons)
+
+    def _try_apply_program(self, program, coupon=None):
+        if self._has_all_products_loyalty_exclude():
+            return {"error": _("This code is invalid.")}
+        else:
+            return super()._try_apply_program(program, coupon=coupon)


### PR DESCRIPTION
Description: 
The functionality provided by the module allows to set which products are excluded from promotions in a specific field. Currently, if there is a promotion for a product and it has the "Loyalty_exclusion" field as true, the claim reward button is displayed on the e-commerce site, but when clicked, it shows an error preventing the promotion from being added.

With this PR, the goal is to avoid displaying this button altogether in such cases.

Solution: 
To resolve this problem, we have made the following modifications:

- Inherited method that returns the available promotions to filter them based on the products in the cart.
- Inherited method that applies discount codes to control their application based on the products in the cart.


This fix will prevent contradictory information from being displayed on the e-commerce site.
