### PR TITLE
[16.0][FIX] sale_order_type: assign base company in non-multicompany environments

### DIFF
--- a/sale_order_type/data/default_type.xml
+++ b/sale_order_type/data/default_type.xml
@@ -1,7 +1,7 @@
 <odoo noupdate="1">
     <record id="normal_sale_type" model="sale.order.type">
         <field name="name">Normal Order</field>
-        <field name="company_id" eval="False" />
+        <field name="company_id" ref="base.main_company" />
         <field name="sequence_id" ref="sale.seq_sale_order" />
     </record>
 </odoo>


### PR DESCRIPTION
We have modified the following company field in data/default_type.xml from:

        <field name="company_id" eval="False" />
To:


        <field name="company_id" ref="base.main_company" />


This change is due to the fact that in an environment without the multi-company parameter, the warehouse field cannot be filled because it is not assigned to a company. 