### PR TITLE
[16.0] [FIX] fix invoiced_amount when invoice currency == sale curren…

### DIFF
--- a/sale_order_invoice_amount/models/sale_order.py
+++ b/sale_order_invoice_amount/models/sale_order.py
@@ -42,6 +42,13 @@ class SaleOrder(models.Model):
                                 invoice.company_id,
                                 invoice.invoice_date or fields.Date.today(),
                             )
+                        elif (
+                            invoice.currency_id == rec.currency_id
+                            and invoice.currency_id != invoice.company_currency_id
+                        ):
+                            rec.invoiced_amount += (
+                                invoice.amount_total_in_currency_signed
+                            )
                         else:
                             rec.invoiced_amount += invoice.amount_total_signed
                 # Uninvoiced amount could not be equal to total - invoiced amount.


### PR DESCRIPTION
We have a bug when:
invoice.currency_id == rec.currency_id  and invoice.currency_id != invoice.company_currency_id
-> This may append in an inter-company scénario

In that case the invoiced amount in the sale order is not correct:
<img width="1055" alt="invoice" src="https://github.com/user-attachments/assets/7f309354-c313-4298-b915-7bd75f4551e1">
<img width="993" alt="Saleorder" src="https://github.com/user-attachments/assets/4e984d7f-00a8-44b8-9565-1f2209b65044">
