### PR TITLE
[16.0][FIX] sale_order_line_date: fix setting empty commitment date on stock moves

### DIFF
--- a/sale_order_line_date/models/sale_order_line.py
+++ b/sale_order_line_date/models/sale_order_line.py
@@ -31,13 +31,17 @@ class SaleOrderLine(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        moves_to_upd = set()
         if "commitment_date" in vals:
-            for move in self.move_ids:
-                if move.state not in ["cancel", "done"]:
-                    moves_to_upd.add(move.id)
-        if moves_to_upd:
-            self.env["stock.move"].browse(moves_to_upd).write(
-                {"date_deadline": vals.get("commitment_date")}
-            )
+            if vals.get("commitment_date"):
+                self.move_ids.filtered(
+                    lambda sm: sm.state not in ["cancel", "done"]
+                ).write({"date_deadline": vals.get("commitment_date")})
+            else:
+                for line in self:
+                    date_deadline = (
+                        line.order_id.commitment_date or line._expected_date()
+                    )
+                    line.move_ids.filtered(
+                        lambda sm: sm.state not in ["cancel", "done"]
+                    ).write({"date_deadline": date_deadline})
         return res

--- a/sale_order_line_date/tests/test_sale_order_line_date.py
+++ b/sale_order_line_date/tests/test_sale_order_line_date.py
@@ -166,3 +166,14 @@ class TestSaleOrderLineDates(TransactionCase):
         self._assert_equal_dates(
             self.sale_line1.commitment_date, self.sale_line1.move_ids.date_deadline
         )
+
+    def test_04_line_commitment_date_removal(self):
+        self.sale1.commitment_date = False
+        self.sale1.action_confirm()
+        self._assert_equal_dates(
+            self.sale_line1.commitment_date, self.sale_line1.move_ids.date_deadline
+        )
+        self.sale_line1.commitment_date = False
+        self._assert_equal_dates(
+            self.sale_line1._expected_date(), self.sale_line1.move_ids.date_deadline
+        )


### PR DESCRIPTION
…sale order line

Closes #3363 