### PR TITLE
[IMP] sale_invoice_policy: Several improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 # generated from manifests external_dependencies
+openupgradelib

--- a/sale_invoice_policy/README.rst
+++ b/sale_invoice_policy/README.rst
@@ -72,6 +72,7 @@ Contributors
 * Luis J. Salvatierra <luis.salvatierra@factorlibre.com>
 * Alejandro Ji Cheung <alejandro.jicheung@factorlibre.com>
 * Ioan Galan <ioan@studio73.es>
+* Laurent Mignon <laurent.mignon@acsone.eu>
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_invoice_policy/README.rst
+++ b/sale_invoice_policy/README.rst
@@ -28,21 +28,58 @@ Sale invoice Policy
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This modules helps to get Invoicing Policy on Sale Order Level without
-breaking behaviour (as it is defined from >= v10 on product level).
+This module adds an invoicing policy on sale order level in order to
+apply that invoicing policy on the whole sale order.
+
+That invoicing policy can take three values:
+
+- Products Invoicing Policy: The sale order will follow the standard
+  behavior and apply the policy depending on products configurations.
+- Ordered Quantities: The sale order will invoice the ordered quantities.
+- Delivered Quantities: The sale order will invoice the delivered quantities.
+
+Following the chosen policy, the quantity to invoice and the
+amount to invoice on each line will be computed accordingly.
+Note that the sale order policy will affect only storable products.
+
+You will be able also to define a default invoicing policy
+(globally per company)
+that can be different than the default invoicing policy for new products.
 
 **Table of contents**
 
 .. contents::
    :local:
 
+Use Cases / Context
+===================
+
+In Odoo, products have their own invoicing policy that can be:
+
+- Invoicing on ordered quantities
+- Invoicing on ordered quantities
+
+Following that configuration, when trying to create invoices from
+sale orders, each line of product will apply its invoicing policy.
+
+In some cases, user needs to apply an invoicing policy on a whole
+sale order.
+
+The solution proposed here is to add an invoicing policy on
+sale order level.
+
+Configuration
+=============
+
+* Go to Sale > Configuration > Settings > Sale Invoice Policy
+* Choose the one that fits your needs.
+
 Usage
 =====
 
 * Create Sale Order
-* Select Invoicing Policy on Sale Order or let it void
-* Either the policy selected on Sale Order would be used, either if not
-  filled in, the policy would be chosen from product configuration
+* Select Invoicing Policy on Sale Order or let it on Products Invoicing Policy
+* The created invoices will use the configuration on sale order.
 
 Bug Tracker
 ===========

--- a/sale_invoice_policy/__init__.py
+++ b/sale_invoice_policy/__init__.py
@@ -1,1 +1,2 @@
+from .hooks import pre_init_hook
 from . import models

--- a/sale_invoice_policy/__manifest__.py
+++ b/sale_invoice_policy/__manifest__.py
@@ -10,9 +10,11 @@
     "category": "Sales Management",
     "version": "16.0.2.0.0",
     "license": "AGPL-3",
-    "depends": ["sale_stock"],
+    "depends": ["sale_stock", "base_partition"],
+    "external_dependencies": {"python": ["openupgradelib"]},
     "data": [
         "views/res_config_settings_view.xml",
         "views/sale_view.xml",
     ],
+    "pre_init_hook": "pre_init_hook",
 }

--- a/sale_invoice_policy/hooks.py
+++ b/sale_invoice_policy/hooks.py
@@ -1,0 +1,25 @@
+# Copyright 2024 ACSONE SA/NV (<https://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+from odoo.api import SUPERUSER_ID, Environment
+
+
+def pre_init_hook(cr):
+    """
+    Create the sale order invoice policy with the "product" policy (standard)
+    but with a postgres query to avoid an update on all sale order records
+    """
+    env = Environment(cr, SUPERUSER_ID, {})
+    field_spec = [
+        (
+            "invoice_policy",
+            "sale.order",
+            False,
+            "selection",
+            False,
+            "sale_invoice_policy",
+            "product",
+        )
+    ]
+    openupgrade.add_fields(env, field_spec=field_spec)

--- a/sale_invoice_policy/models/__init__.py
+++ b/sale_invoice_policy/models/__init__.py
@@ -1,3 +1,4 @@
 from . import res_config_settings
 from . import sale_order
 from . import sale_order_line
+from . import res_company

--- a/sale_invoice_policy/models/res_company.py
+++ b/sale_invoice_policy/models/res_company.py
@@ -1,0 +1,20 @@
+# Copyright 2024 ACSONE SA/NV (<https://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+
+    _inherit = "res.company"
+
+    sale_default_invoice_policy = fields.Selection(
+        [
+            ("product", "Products Invoice Policy"),
+            ("order", "Ordered quantities"),
+            ("delivery", "Delivered quantities"),
+        ],
+        default="product",
+        required=True,
+        help="This will be the default invoice policy for sale orders.",
+    )

--- a/sale_invoice_policy/models/res_config_settings.py
+++ b/sale_invoice_policy/models/res_config_settings.py
@@ -1,34 +1,13 @@
 # Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
-    sale_invoice_policy_required = fields.Boolean(
-        help="This makes Invoice Policy required on Sale Orders"
+    sale_default_invoice_policy = fields.Selection(
+        related="company_id.sale_default_invoice_policy",
+        readonly=False,
     )
-
-    @api.model
-    def get_values(self):
-        res = super().get_values()
-        res.update(
-            sale_invoice_policy_required=self.env["ir.default"].get(
-                "res.config.settings", "sale_invoice_policy_required"
-            )
-        )
-        return res
-
-    def set_values(self):
-        super().set_values()
-        ir_default_obj = self.env["ir.default"]
-        if self.env["res.users"].has_group("base.group_erp_manager"):
-            ir_default_obj = ir_default_obj.sudo()
-            ir_default_obj.set(
-                "res.config.settings",
-                "sale_invoice_policy_required",
-                self.sale_invoice_policy_required,
-            )
-        return True

--- a/sale_invoice_policy/models/sale_order.py
+++ b/sale_invoice_policy/models/sale_order.py
@@ -9,41 +9,27 @@ class SaleOrder(models.Model):
     _inherit = "sale.order"
 
     invoice_policy = fields.Selection(
-        [("order", "Ordered quantities"), ("delivery", "Delivered quantities")],
-        readonly=True,
+        [
+            ("product", "Products Invoice Policy"),
+            ("order", "Ordered quantities"),
+            ("delivery", "Delivered quantities"),
+        ],
+        compute="_compute_invoice_policy",
+        store=True,
+        readonly=False,
+        required=True,
         states={"draft": [("readonly", False)], "sent": [("readonly", False)]},
+        precompute=True,
         help="Ordered Quantity: Invoice based on the quantity the customer "
         "ordered.\n"
         "Delivered Quantity: Invoiced based on the quantity the vendor "
-        "delivered (time or deliveries).",
-    )
-    invoice_policy_required = fields.Boolean(
-        compute="_compute_invoice_policy_required",
-        default=lambda self: self.env["ir.default"].get(
-            "res.config.settings", "sale_invoice_policy_required"
-        ),
+        "delivered (time or deliveries). This applies for storable products only.",
     )
 
-    @api.model
-    def default_get(self, fields_list):
-        res = super().default_get(fields_list)
-        default_invoice_policy = (
-            self.env["res.config.settings"]
-            .sudo()
-            .default_get(["default_invoice_policy"])
-            .get("default_invoice_policy", False)
-        )
-        if "invoice_policy" not in res:
-            res.update({"invoice_policy": default_invoice_policy})
-        return res
-
-    @api.depends("partner_id")
-    def _compute_invoice_policy_required(self):
-        invoice_policy_required = (
-            self.env["res.config.settings"]
-            .sudo()
-            .default_get(["sale_invoice_policy_required"])
-            .get("sale_invoice_policy_required", False)
-        )
-        for sale in self:
-            sale.invoice_policy_required = invoice_policy_required
+    @api.depends("company_id")
+    def _compute_invoice_policy(self) -> None:
+        """
+        Get default sale order invoice policy
+        """
+        for company, sale_orders in self.partition("company_id").items():
+            sale_orders.invoice_policy = company.sale_default_invoice_policy

--- a/sale_invoice_policy/models/sale_order_line.py
+++ b/sale_invoice_policy/models/sale_order_line.py
@@ -15,10 +15,11 @@ class SaleOrderLine(models.Model):
         "order_id.invoice_policy",
     )
     def _compute_qty_to_invoice(self):
+        """
+        Exclude lines that have their order invoice policy filled in
+        """
         other_lines = self.filtered(
-            lambda l: l.product_id.type == "service"
-            or not l.order_id.invoice_policy
-            or not l.order_id.invoice_policy_required
+            lambda l: l.product_id.type == "service" or not l.order_id.invoice_policy
         )
         super(SaleOrderLine, other_lines)._compute_qty_to_invoice()
         for line in self - other_lines:

--- a/sale_invoice_policy/models/sale_order_line.py
+++ b/sale_invoice_policy/models/sale_order_line.py
@@ -7,13 +7,7 @@ from odoo import api, fields, models
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    @api.depends(
-        "qty_invoiced",
-        "qty_delivered",
-        "product_uom_qty",
-        "state",
-        "order_id.invoice_policy",
-    )
+    @api.depends("order_id.invoice_policy")
     def _compute_qty_to_invoice(self):
         """
         Exclude lines that have their order invoice policy filled in
@@ -30,15 +24,7 @@ class SaleOrderLine(models.Model):
                 line.qty_to_invoice = line.qty_delivered - line.qty_invoiced
         return True
 
-    @api.depends(
-        "state",
-        "price_reduce",
-        "product_id",
-        "untaxed_amount_invoiced",
-        "qty_delivered",
-        "product_uom_qty",
-        "order_id.invoice_policy",
-    )
+    @api.depends("order_id.invoice_policy")
     def _compute_untaxed_amount_to_invoice(self):
         other_lines = self.filtered(
             lambda line: line.product_id.type == "service"

--- a/sale_invoice_policy/models/sale_order_line.py
+++ b/sale_invoice_policy/models/sale_order_line.py
@@ -1,7 +1,7 @@
 # Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import api, models
 
 
 class SaleOrderLine(models.Model):
@@ -34,55 +34,12 @@ class SaleOrderLine(models.Model):
         )
         super(SaleOrderLine, other_lines)._compute_untaxed_amount_to_invoice()
         for line in self - other_lines:
-            invoice_policy = line.order_id.invoice_policy
-            amount_to_invoice = 0.0
-            price_subtotal = 0.0
-            uom_qty_to_consider = (
-                line.qty_delivered
-                if invoice_policy == "delivery"
-                else line.product_uom_qty
-            )
-            price_reduce = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
-            price_subtotal = price_reduce * uom_qty_to_consider
-            if len(line.tax_id.filtered(lambda tax: tax.price_include)) > 0:
-                price_subtotal = line.tax_id.compute_all(
-                    price_reduce,
-                    currency=line.currency_id,
-                    quantity=uom_qty_to_consider,
-                    product=line.product_id,
-                    partner=line.order_id.partner_shipping_id,
-                )["total_excluded"]
-            inv_lines = line._get_invoice_lines()
-            if any(inv_lines.mapped(lambda l: l.discount != line.discount)):
-                amount = 0
-                for inv_line in inv_lines:
-                    if (
-                        len(inv_line.tax_ids.filtered(lambda tax: tax.price_include))
-                        > 0
-                    ):
-                        amount += inv_line.tax_ids.compute_all(
-                            inv_line.currency_id._convert(
-                                inv_line.price_unit,
-                                line.currency_id,
-                                line.company_id,
-                                inv_line.date or fields.Date.today(),
-                                round=False,
-                            )
-                            * inv_line.quantity
-                        )["total_excluded"]
-                    else:
-                        amount += (
-                            inv_line.currency_id._convert(
-                                inv_line.price_unit,
-                                line.currency_id,
-                                line.company_id,
-                                inv_line.date or fields.Date.today(),
-                                round=False,
-                            )
-                            * inv_line.quantity
-                        )
-                amount_to_invoice = max(price_subtotal - amount, 0)
-            else:
-                amount_to_invoice = price_subtotal - line.untaxed_amount_invoiced
-            line.untaxed_amount_to_invoice = amount_to_invoice
-        return True
+            # Save product invoice policy, change it to sale order one, add context manager
+            # to not trigger other computes. Then, restablish former one.
+            with self.env.norecompute():
+                policy = line.product_id.invoice_policy
+                line.product_id.invoice_policy = line.order_id.invoice_policy
+            super(SaleOrderLine, line)._compute_untaxed_amount_to_invoice()
+            with self.env.norecompute():
+                line.product_id.invoice_policy = policy
+        return

--- a/sale_invoice_policy/models/sale_order_line.py
+++ b/sale_invoice_policy/models/sale_order_line.py
@@ -31,7 +31,6 @@ class SaleOrderLine(models.Model):
             or not line.order_id.invoice_policy
             or line.order_id.invoice_policy == line.product_id.invoice_policy
             or line.state not in ["sale", "done"]
-            or not line.order_id.invoice_policy_required
         )
         super(SaleOrderLine, other_lines)._compute_untaxed_amount_to_invoice()
         for line in self - other_lines:

--- a/sale_invoice_policy/models/sale_order_line.py
+++ b/sale_invoice_policy/models/sale_order_line.py
@@ -13,7 +13,8 @@ class SaleOrderLine(models.Model):
         Exclude lines that have their order invoice policy filled in
         """
         other_lines = self.filtered(
-            lambda l: l.product_id.type == "service" or not l.order_id.invoice_policy
+            lambda l: l.product_id.type == "service"
+            or l.order_id.invoice_policy == "product"
         )
         super(SaleOrderLine, other_lines)._compute_qty_to_invoice()
         for line in self - other_lines:
@@ -28,7 +29,7 @@ class SaleOrderLine(models.Model):
     def _compute_untaxed_amount_to_invoice(self) -> None:
         other_lines = self.filtered(
             lambda line: line.product_id.type == "service"
-            or not line.order_id.invoice_policy
+            or line.order_id.invoice_policy == "product"
             or line.order_id.invoice_policy == line.product_id.invoice_policy
             or line.state not in ["sale", "done"]
         )

--- a/sale_invoice_policy/models/sale_order_line.py
+++ b/sale_invoice_policy/models/sale_order_line.py
@@ -1,11 +1,36 @@
 # Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from contextlib import contextmanager
 
 from odoo import api, models
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
+
+    @contextmanager
+    def _sale_invoice_policy(self, lines):
+        """Apply the sale invoice policy to the products
+
+        This method must be called with lines sharing the same invoice policy
+        """
+        invoice_policy = set(lines.mapped("order_id.invoice_policy"))
+        if len(invoice_policy) > 1:
+            raise Exception(
+                "The method _sale_invoice_policy() must be called with lines "
+                "sharing the same invoice policy"
+            )
+        invoice_policy = next(iter(invoice_policy))
+        invoice_policy_field = self.env["product.product"]._fields["invoice_policy"]
+        products = lines.product_id
+        with self.env.protecting([invoice_policy_field], products):
+            old_values = {}
+            for product in products:
+                old_values[product] = product.invoice_policy
+                product.invoice_policy = invoice_policy
+            yield
+            for product, invoice_policy in old_values.items():
+                product.invoice_policy = invoice_policy
 
     @api.depends("order_id.invoice_policy")
     def _compute_qty_to_invoice(self):
@@ -34,18 +59,7 @@ class SaleOrderLine(models.Model):
             or line.state not in ["sale", "done"]
         )
         super(SaleOrderLine, other_lines)._compute_untaxed_amount_to_invoice()
-        saved_product_values = dict()
-        lines = self - other_lines
-        for line in lines:
-            # Save product invoice policy, change it to sale order one, add context manager
-            # to not trigger other computes. Then, restablish former one.
-            with self.env.norecompute():
-                saved_product_values[line.product_id] = line.product_id.invoice_policy
-                line.product_id.invoice_policy = line.order_id.invoice_policy
-            # We should call the super() per line as each sale order can have different policy
-            super(SaleOrderLine, line)._compute_untaxed_amount_to_invoice()
-        with self.env.norecompute():
-            # Restore saved values
-            for product, value in saved_product_values.items():
-                product.invoice_policy = value
+        for lines in (self - other_lines).partition("order_id.invoice_policy").values():
+            with self._sale_invoice_policy(lines):
+                super(SaleOrderLine, lines)._compute_untaxed_amount_to_invoice()
         return

--- a/sale_invoice_policy/readme/CONFIGURE.rst
+++ b/sale_invoice_policy/readme/CONFIGURE.rst
@@ -1,0 +1,2 @@
+* Go to Sale > Configuration > Settings > Sale Invoice Policy
+* Choose the one that fits your needs.

--- a/sale_invoice_policy/readme/CONTEXT.rst
+++ b/sale_invoice_policy/readme/CONTEXT.rst
@@ -1,0 +1,13 @@
+In Odoo, products have their own invoicing policy that can be:
+
+- Invoicing on ordered quantities
+- Invoicing on ordered quantities
+
+Following that configuration, when trying to create invoices from
+sale orders, each line of product will apply its invoicing policy.
+
+In some cases, user needs to apply an invoicing policy on a whole
+sale order.
+
+The solution proposed here is to add an invoicing policy on
+sale order level.

--- a/sale_invoice_policy/readme/CONTRIBUTORS.rst
+++ b/sale_invoice_policy/readme/CONTRIBUTORS.rst
@@ -5,3 +5,4 @@
 * Luis J. Salvatierra <luis.salvatierra@factorlibre.com>
 * Alejandro Ji Cheung <alejandro.jicheung@factorlibre.com>
 * Ioan Galan <ioan@studio73.es>
+* Laurent Mignon <laurent.mignon@acsone.eu>

--- a/sale_invoice_policy/readme/DESCRIPTION.rst
+++ b/sale_invoice_policy/readme/DESCRIPTION.rst
@@ -1,2 +1,17 @@
-This modules helps to get Invoicing Policy on Sale Order Level without
-breaking behaviour (as it is defined from >= v10 on product level).
+This module adds an invoicing policy on sale order level in order to
+apply that invoicing policy on the whole sale order.
+
+That invoicing policy can take three values:
+
+- Products Invoicing Policy: The sale order will follow the standard
+  behavior and apply the policy depending on products configurations.
+- Ordered Quantities: The sale order will invoice the ordered quantities.
+- Delivered Quantities: The sale order will invoice the delivered quantities.
+
+Following the chosen policy, the quantity to invoice and the
+amount to invoice on each line will be computed accordingly.
+Note that the sale order policy will affect only storable products.
+
+You will be able also to define a default invoicing policy
+(globally per company)
+that can be different than the default invoicing policy for new products.

--- a/sale_invoice_policy/readme/USAGE.rst
+++ b/sale_invoice_policy/readme/USAGE.rst
@@ -1,4 +1,3 @@
 * Create Sale Order
-* Select Invoicing Policy on Sale Order or let it void
-* Either the policy selected on Sale Order would be used, either if not
-  filled in, the policy would be chosen from product configuration
+* Select Invoicing Policy on Sale Order or let it on Products Invoicing Policy
+* The created invoices will use the configuration on sale order.

--- a/sale_invoice_policy/static/description/index.html
+++ b/sale_invoice_policy/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -424,7 +425,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_invoice_policy/static/description/index.html
+++ b/sale_invoice_policy/static/description/index.html
@@ -420,6 +420,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Luis J. Salvatierra &lt;<a class="reference external" href="mailto:luis.salvatierra&#64;factorlibre.com">luis.salvatierra&#64;factorlibre.com</a>&gt;</li>
 <li>Alejandro Ji Cheung &lt;<a class="reference external" href="mailto:alejandro.jicheung&#64;factorlibre.com">alejandro.jicheung&#64;factorlibre.com</a>&gt;</li>
 <li>Ioan Galan &lt;<a class="reference external" href="mailto:ioan&#64;studio73.es">ioan&#64;studio73.es</a>&gt;</li>
+<li>Laurent Mignon &lt;<a class="reference external" href="mailto:laurent.mignon&#64;acsone.eu">laurent.mignon&#64;acsone.eu</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/sale_invoice_policy/static/description/index.html
+++ b/sale_invoice_policy/static/description/index.html
@@ -370,32 +370,67 @@ ul.auto-toc {
 !! source digest: sha256:c97ec053f6a06fcb824861d16be9e31cc8a53549f47a0f38b6f54f534d09138b
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/sale-workflow/tree/16.0/sale_invoice_policy"><img alt="OCA/sale-workflow" src="https://img.shields.io/badge/github-OCA%2Fsale--workflow-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/sale-workflow-16-0/sale-workflow-16-0-sale_invoice_policy"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/sale-workflow&amp;target_branch=16.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This modules helps to get Invoicing Policy on Sale Order Level without
-breaking behaviour (as it is defined from &gt;= v10 on product level).</p>
+<p>This module adds an invoicing policy on sale order level in order to
+apply that invoicing policy on the whole sale order.</p>
+<p>That invoicing policy can take three values:</p>
+<ul class="simple">
+<li>Products Invoicing Policy: The sale order will follow the standard
+behavior and apply the policy depending on products configurations.</li>
+<li>Ordered Quantities: The sale order will invoice the ordered quantities.</li>
+<li>Delivered Quantities: The sale order will invoice the delivered quantities.</li>
+</ul>
+<p>Following the chosen policy, the quantity to invoice and the
+amount to invoice on each line will be computed accordingly.
+Note that the sale order policy will affect only storable products.</p>
+<p>You will be able also to define a default invoicing policy
+(globally per company)
+that can be different than the default invoicing policy for new products.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
+<li><a class="reference internal" href="#use-cases-context" id="toc-entry-1">Use Cases / Context</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-2">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-3">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="use-cases-context">
+<h1><a class="toc-backref" href="#toc-entry-1">Use Cases / Context</a></h1>
+<p>In Odoo, products have their own invoicing policy that can be:</p>
+<ul class="simple">
+<li>Invoicing on ordered quantities</li>
+<li>Invoicing on ordered quantities</li>
+</ul>
+<p>Following that configuration, when trying to create invoices from
+sale orders, each line of product will apply its invoicing policy.</p>
+<p>In some cases, user needs to apply an invoicing policy on a whole
+sale order.</p>
+<p>The solution proposed here is to add an invoicing policy on
+sale order level.</p>
+</div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#toc-entry-2">Configuration</a></h1>
+<ul class="simple">
+<li>Go to Sale &gt; Configuration &gt; Settings &gt; Sale Invoice Policy</li>
+<li>Choose the one that fits your needs.</li>
+</ul>
+</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Usage</a></h1>
 <ul class="simple">
 <li>Create Sale Order</li>
-<li>Select Invoicing Policy on Sale Order or let it void</li>
-<li>Either the policy selected on Sale Order would be used, either if not
-filled in, the policy would be chosen from product configuration</li>
+<li>Select Invoicing Policy on Sale Order or let it on Products Invoicing Policy</li>
+<li>The created invoices will use the configuration on sale order.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/sale-workflow/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -403,15 +438,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Authors</a></h2>
 <ul class="simple">
 <li>ACSONE SA/NV</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Contributors</a></h2>
 <ul class="simple">
 <li>Cédric Pigeon &lt;<a class="reference external" href="mailto:cedric.pigeon&#64;acsone.eu">cedric.pigeon&#64;acsone.eu</a>&gt;</li>
 <li>François Honoré &lt;<a class="reference external" href="mailto:francois.honore&#64;acsone.eu">francois.honore&#64;acsone.eu</a>&gt;</li>
@@ -424,7 +459,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/sale_invoice_policy/tests/test_sale_invoice_policy.py
+++ b/sale_invoice_policy/tests/test_sale_invoice_policy.py
@@ -26,9 +26,6 @@ class TestSaleOrderInvoicePolicy(common.TransactionCase):
 
     def test_sale_order_invoice_order(self):
         """Test invoicing based on ordered quantities"""
-        settings = self.env["res.config.settings"].create({})
-        settings.sale_invoice_policy_required = True
-        settings.execute()
         so = self.env["sale.order"].create(
             {
                 "partner_id": self.env.ref("base.res_partner_2").id,
@@ -39,8 +36,7 @@ class TestSaleOrderInvoicePolicy(common.TransactionCase):
                 "invoice_policy": "order",
             }
         )
-        self.assertTrue(so.invoice_policy_required)
-        self.assertTrue(so.invoice_policy == "order")
+        self.assertEqual(so.invoice_policy, "order")
 
         # SO is not confirmed yet
         self.assertEqual([0.0, 0.0], so.order_line.mapped("untaxed_amount_to_invoice"))
@@ -64,9 +60,6 @@ class TestSaleOrderInvoicePolicy(common.TransactionCase):
 
     def test_sale_order_invoice_deliver(self):
         """Test invoicing based on delivered quantities"""
-        settings = self.env["res.config.settings"].create({})
-        settings.sale_invoice_policy_required = True
-        settings.execute()
         self.assertEqual("order", self.product.invoice_policy)
         so = self.env["sale.order"].create(
             {
@@ -78,8 +71,7 @@ class TestSaleOrderInvoicePolicy(common.TransactionCase):
                 ],
             }
         )
-        self.assertTrue(so.invoice_policy_required)
-        self.assertTrue(so.invoice_policy == "delivery")
+        self.assertEqual(so.invoice_policy, "delivery")
 
         # SO is not confirmed yet
         self.assertEqual([0.0, 0.0], so.order_line.mapped("untaxed_amount_to_invoice"))
@@ -125,19 +117,16 @@ class TestSaleOrderInvoicePolicy(common.TransactionCase):
     def test_settings(self):
         # delivery policy is the default
         settings = self.env["res.config.settings"].create({})
-        settings.default_invoice_policy = "delivery"
-        settings.sale_invoice_policy_required = True
+        settings.sale_default_invoice_policy = "delivery"
         settings.execute()
         so = self.env["sale.order"].create(
             {"partner_id": self.env.ref("base.res_partner_2").id}
         )
         self.assertEqual(so.invoice_policy, "delivery")
-        self.assertTrue(so.invoice_policy_required)
         # order policy is the default
-        settings.default_invoice_policy = "order"
+        settings.sale_default_invoice_policy = "order"
         settings.execute()
         so = self.env["sale.order"].create(
             {"partner_id": self.env.ref("base.res_partner_2").id}
         )
         self.assertEqual(so.invoice_policy, "order")
-        self.assertTrue(so.invoice_policy_required)

--- a/sale_invoice_policy/tests/test_sale_invoice_policy.py
+++ b/sale_invoice_policy/tests/test_sale_invoice_policy.py
@@ -42,6 +42,9 @@ class TestSaleOrderInvoicePolicy(common.TransactionCase):
         self.assertTrue(so.invoice_policy_required)
         self.assertTrue(so.invoice_policy == "order")
 
+        # SO is not confirmed yet
+        self.assertEqual([0.0, 0.0], so.order_line.mapped("untaxed_amount_to_invoice"))
+
         so.action_confirm()
 
         self.assertEqual(len(so.picking_ids), 1)
@@ -64,6 +67,7 @@ class TestSaleOrderInvoicePolicy(common.TransactionCase):
         settings = self.env["res.config.settings"].create({})
         settings.sale_invoice_policy_required = True
         settings.execute()
+        self.assertEqual("order", self.product.invoice_policy)
         so = self.env["sale.order"].create(
             {
                 "partner_id": self.env.ref("base.res_partner_2").id,
@@ -77,7 +81,13 @@ class TestSaleOrderInvoicePolicy(common.TransactionCase):
         self.assertTrue(so.invoice_policy_required)
         self.assertTrue(so.invoice_policy == "delivery")
 
+        # SO is not confirmed yet
+        self.assertEqual([0.0, 0.0], so.order_line.mapped("untaxed_amount_to_invoice"))
+
         so.action_confirm()
+
+        # SO is not delivered
+        self.assertEqual([0.0, 0.0], so.order_line.mapped("untaxed_amount_to_invoice"))
 
         self.assertEqual(len(so.picking_ids), 1)
 
@@ -102,9 +112,15 @@ class TestSaleOrderInvoicePolicy(common.TransactionCase):
         self.assertEqual(so_line.qty_to_invoice, 2)
         self.assertEqual(so_line.invoice_status, "to invoice")
 
+        self.assertEqual(40.0, so_line.untaxed_amount_to_invoice)
+        # Check that product has still its original invoice policy
+        self.assertEqual("order", self.product.invoice_policy)
+
         so_line = so.order_line[1]
         self.assertEqual(so_line.qty_to_invoice, 3)
         self.assertEqual(so_line.invoice_status, "to invoice")
+
+        self.assertEqual(135.0, so_line.untaxed_amount_to_invoice)
 
     def test_settings(self):
         # delivery policy is the default

--- a/sale_invoice_policy/tests/test_sale_invoice_policy.py
+++ b/sale_invoice_policy/tests/test_sale_invoice_policy.py
@@ -130,3 +130,39 @@ class TestSaleOrderInvoicePolicy(common.TransactionCase):
             {"partner_id": self.env.ref("base.res_partner_2").id}
         )
         self.assertEqual(so.invoice_policy, "order")
+
+    def test_context_manager_exception(self):
+        """Check the exception is well managed when called with several invoice policies"""
+        self.assertEqual("order", self.product.invoice_policy)
+        so = self.env["sale.order"].create(
+            {
+                "partner_id": self.env.ref("base.res_partner_2").id,
+                "invoice_policy": "delivery",
+                "order_line": [
+                    (0, 0, {"product_id": self.product.id, "product_uom_qty": 2.0}),
+                    (0, 0, {"product_id": self.product2.id, "product_uom_qty": 3.0}),
+                ],
+            }
+        )
+
+        so2 = self.env["sale.order"].create(
+            {
+                "partner_id": self.env.ref("base.res_partner_2").id,
+                "invoice_policy": "order",
+                "order_line": [
+                    (0, 0, {"product_id": self.product.id, "product_uom_qty": 2.0}),
+                    (0, 0, {"product_id": self.product2.id, "product_uom_qty": 3.0}),
+                ],
+            }
+        )
+        lines = (so | so2).order_line
+        with self.assertRaises(Exception) as exc:
+            with self.env["sale.order.line"]._sale_invoice_policy(
+                lines
+            ):  # pragma: no cover
+                pass
+        self.assertEqual(
+            "The method _sale_invoice_policy() must be called with lines sharing "
+            "the same invoice policy",
+            exc.exception.args[0],
+        )

--- a/sale_invoice_policy/views/res_config_settings_view.xml
+++ b/sale_invoice_policy/views/res_config_settings_view.xml
@@ -11,15 +11,15 @@
                     id="sale_invoice_policy_setting"
                 >
                     <div class="o_setting_left_pane">
-                        <field name="sale_invoice_policy_required" />
+                        <field name="sale_default_invoice_policy" />
                     </div>
                     <div class="o_setting_right_pane">
                         <label
                             string="Sale Invoice Policy"
-                            for="sale_invoice_policy_required"
+                            for="sale_default_invoice_policy"
                         />
-                        <div class="text-muted" id="sale_invoice_policy_required">
-                            Invoice Policy required in Sale Orders
+                        <div class="text-muted" id="sale_default_invoice_policy">
+                            Default Invoice Policy in Sale Orders
                         </div>
                     </div>
                 </div>

--- a/sale_invoice_policy/views/res_config_settings_view.xml
+++ b/sale_invoice_policy/views/res_config_settings_view.xml
@@ -10,16 +10,18 @@
                     class="col-12 col-lg-6 o_setting_box"
                     id="sale_invoice_policy_setting"
                 >
-                    <div class="o_setting_left_pane">
-                        <field name="sale_default_invoice_policy" />
-                    </div>
+                    <div class="o_setting_left_pane" />
                     <div class="o_setting_right_pane">
                         <label
                             string="Sale Invoice Policy"
                             for="sale_default_invoice_policy"
                         />
                         <div class="text-muted" id="sale_default_invoice_policy">
-                            Default Invoice Policy in Sale Orders
+                            <div class="text-muted">
+                                <field name="sale_default_invoice_policy" />
+                                <p><span
+                                    >Choose the default policy that will be applied for new sale orders (the 'Invoicing Policy' configuration is the policy for new products).</span></p>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/sale_invoice_policy/views/sale_view.xml
+++ b/sale_invoice_policy/views/sale_view.xml
@@ -7,11 +7,7 @@
         <field name="priority">50</field>
         <field name="arch" type="xml">
             <field name="payment_term_id" position="after">
-                <field name="invoice_policy_required" invisible="1" />
-                <field
-                    name="invoice_policy"
-                    attrs="{'required': [('invoice_policy_required', '=', True)]}"
-                />
+                <field name="invoice_policy" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
- [x] Don't use the required parameter to compute the quantity to invoice
- [x] Simplify `depends()`
- [x] Don't use the required parameter to compute the untaxed amount to invoice
- [x] Don't rewrite the Odoo core compute method
- [x] Improve README

Refactor:

I think the default policy that was applied on sale orders from the default product configuration (defined in sale module) was the wrong approach as it is not contextually correct (products are not sale orders).

That said, I introduced an invoice policy on sale order level more explicitly than before (void) which is 'Products Invoicing Policy'. That let the user free to choose between standard behavior or sale order level configuration.

The question is:

- As the required attribute was used before means that the sale order invoicing policy should not use the product configurations. Should we reintroduce that behavior (to constrain sale orders to NOT use product configuration at all ?) ? @ioans73 @fuentes73 @sergio-teruel @ACheung-FactorLibre @Cedric-Pigeon @acsonefho 