### PR TITLE
[17.0][FIX] sale_automatic_workflow_stock: skip_sanity_check=True

### DIFF
--- a/sale_automatic_workflow_stock/models/stock_picking.py
+++ b/sale_automatic_workflow_stock/models/stock_picking.py
@@ -32,5 +32,7 @@ class StockPicking(models.Model):
                 ):
                     for move_line in move.move_line_ids:
                         move_line.quantity = move_line.quantity_product_uom
-            picking.with_context(skip_immediate=True, skip_sms=True).button_validate()
+            picking.with_context(
+                skip_immediate=True, skip_sms=True, skip_sanity_check=True
+            ).button_validate()
         return True


### PR DESCRIPTION
The current mechanism of automatic workflow only works if there is stock available.

In case of not any stock available it produces this error:

```
2024-10-28 12:16:25,186 626 ERROR odoo.addons.sale_automatic_workflow.models.automatic_workflow_job: Error during an automatic workflow action.
Traceback (most recent call last):
  File "/home/odoo/src/user/oca/sale_automatic_workflow/models/automatic_workflow_job.py", line 23, in savepoint
    yield
  File "/home/odoo/src/user/oca/sale_automatic_workflow_stock/models/automatic_workflow_job.py", line 37, in _validate_pickings
    self._do_validate_picking(picking, picking_filter)
  File "/home/odoo/src/user/oca/sale_automatic_workflow_stock/models/automatic_workflow_job.py", line 27, in _do_validate_picking
    picking.validate_picking()
  File "/home/odoo/src/user/oca/sale_automatic_workflow_stock/models/stock_picking.py", line 35, in validate_picking
    picking.with_context(skip_immediate=True, skip_sms=True).button_validate()
  File "/home/odoo/src/odoo/addons/stock_picking_batch/models/stock_picking.py", line 118, in button_validate
    res = super().button_validate()
  File "/home/odoo/src/odoo/addons/stock/models/stock_picking.py", line 1137, in button_validate
    self._sanity_check()
  File "/home/odoo/src/odoo/addons/stock/models/stock_picking.py", line 1111, in _sanity_check
    raise UserError(self._get_without_quantities_error_message())
odoo.exceptions.UserError: You cannot validate a transfer if no quantities are reserved. To force the transfer, encode quantities.

```

With this proposed PR we pass `skip_sanity_check=True` on `button_validate()` method so that the automatic workflow mechanism is not broken.
