### PR TITLE
[16.0][FIX] sale_tier_validation: Basic compatibility with sale_loyalty

### DIFF
--- a/sale_tier_validation/models/sale_order.py
+++ b/sale_tier_validation/models/sale_order.py
@@ -20,3 +20,18 @@ class SaleOrder(models.Model):
 
     def _get_rejected_notification_subtype(self):
         return "sale_tier_validation.sale_order_tier_validation_rejected"
+
+    def _get_fields_to_write_validation(self, vals, records_exception_function):
+        # Don't block order validation when sale_loyalty is installed and no coupon
+        # is being handled, due to this code assigning always an empty value:
+        # https://github.com/odoo/odoo/blob/2a7876538e9ea630563e39ee8402b27147d1e428/
+        # addons/sale_loyalty/models/sale_order.py#L740
+        # Done here for not creating a glue module as we can detect the situation. The
+        # only drawback is that this doesn't have any regression test
+        (
+            allowed_field_names,
+            not_allowed_field_names,
+        ) = super()._get_fields_to_write_validation(vals, records_exception_function)
+        if "applied_coupon_ids" in vals and not vals.get("applied_coupon_ids"):
+            allowed_field_names += ["applied_coupon_ids"]
+        return allowed_field_names, not_allowed_field_names


### PR DESCRIPTION
If you install `sale_loyalty`, this piece of code:

https://github.com/odoo/odoo/blob/2a7876538e9ea630563e39ee8402b27147d1e428/addons/sale_loyalty/models/sale_order.py#L740

is always executed when confirming a sales order, so it blocks it, no matter if no coupons are being handled.

This little code avoids this blocking without requiring a glue module, although further work would be needed if some coupons are applied.

@Tecnativa TT51484