### PR TITLE
[15.0][FIX] sale_planner_acalendar: Invalid field when user search events by week day in reassign wizard

### DIFF
--- a/sale_planner_calendar/i18n/es.po
+++ b/sale_planner_calendar/i18n/es.po
@@ -6,16 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-07-11 08:40+0000\n"
-"PO-Revision-Date: 2024-05-24 13:38+0000\n"
-"Last-Translator: Pilar Vargas <pilar.vargas@tecnativa.com>\n"
+"POT-Creation-Date: 2024-10-30 16:12+0000\n"
+"PO-Revision-Date: 2024-10-30 17:12+0100\n"
+"Last-Translator: Sergio Teruel <sergio.teruel@tecnativa.com>\n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: sale_planner_calendar
 #: model_terms:ir.ui.view,arch_db:sale_planner_calendar.view_sale_planner_calendar_summary_kanban
@@ -440,7 +440,7 @@ msgid "Forward months to create calendar events"
 msgstr "Meses posteriores para crear eventos de calendario"
 
 #. module: sale_planner_calendar
-#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__fr
+#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__fri
 #: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_wizard__week_list__fri
 msgid "Friday"
 msgstr "Viernes"
@@ -634,7 +634,7 @@ msgid "Mobile"
 msgstr "Móvil"
 
 #. module: sale_planner_calendar
-#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__mo
+#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__mon
 #: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_wizard__week_list__mon
 msgid "Monday"
 msgstr "Lunes"
@@ -1016,7 +1016,7 @@ msgid "Sanitized Partner Mobile"
 msgstr ""
 
 #. module: sale_planner_calendar
-#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__sa
+#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__sat
 #: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_wizard__week_list__sat
 msgid "Saturday"
 msgstr "Sábado"
@@ -1097,7 +1097,7 @@ msgid "Subject"
 msgstr "Asunto"
 
 #. module: sale_planner_calendar
-#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__su
+#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__sun
 #: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_wizard__week_list__sun
 msgid "Sunday"
 msgstr "Domingo"
@@ -1132,7 +1132,7 @@ msgstr ""
 "Debes de realizar el cambio de comercial desde el asistente de reasignación"
 
 #. module: sale_planner_calendar
-#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__th
+#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__thu
 #: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_wizard__week_list__thu
 msgid "Thursday"
 msgstr "Jueves"
@@ -1174,7 +1174,7 @@ msgid "Totals"
 msgstr "Totales"
 
 #. module: sale_planner_calendar
-#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__tu
+#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__tue
 #: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_wizard__week_list__tue
 msgid "Tuesday"
 msgstr "Martes"
@@ -1232,7 +1232,7 @@ msgid "Website communication history"
 msgstr "Historial de comunicaciones del sitio web"
 
 #. module: sale_planner_calendar
-#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__we
+#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__wed
 #: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_wizard__week_list__wed
 msgid "Wednesday"
 msgstr "Miércoles"
@@ -1252,21 +1252,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:sale_planner_calendar.view_sale_planner_calendar_reassign_wiz
 msgid "or"
 msgstr "o"
-
-#~ msgid "SMS Delivery error"
-#~ msgstr "Error en la entrega de SMS"
-
-#~ msgid "Failed Messages"
-#~ msgstr "Mensajes Fallidos"
-
-#~ msgid "Message Content"
-#~ msgstr "Contenido del mensaje"
-
-#~ msgid "Message content, to be used only in searches"
-#~ msgstr "Contenido del mensaje, para usarse en búsquedas"
-
-#~ msgid "Procurement purchase grouping settings"
-#~ msgstr "Agrupación de la compra abastecida"
-
-#~ msgid "Wizards"
-#~ msgstr "Asistentes"

--- a/sale_planner_calendar/i18n/sale_planner_calendar.pot
+++ b/sale_planner_calendar/i18n/sale_planner_calendar.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-30 16:12+0000\n"
+"PO-Revision-Date: 2024-10-30 16:12+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -428,7 +430,7 @@ msgid "Forward months to create calendar events"
 msgstr ""
 
 #. module: sale_planner_calendar
-#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__fr
+#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__fri
 #: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_wizard__week_list__fri
 msgid "Friday"
 msgstr ""
@@ -616,7 +618,7 @@ msgid "Mobile"
 msgstr ""
 
 #. module: sale_planner_calendar
-#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__mo
+#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__mon
 #: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_wizard__week_list__mon
 msgid "Monday"
 msgstr ""
@@ -998,7 +1000,7 @@ msgid "Sanitized Partner Mobile"
 msgstr ""
 
 #. module: sale_planner_calendar
-#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__sa
+#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__sat
 #: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_wizard__week_list__sat
 msgid "Saturday"
 msgstr ""
@@ -1075,7 +1077,7 @@ msgid "Subject"
 msgstr ""
 
 #. module: sale_planner_calendar
-#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__su
+#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__sun
 #: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_wizard__week_list__sun
 msgid "Sunday"
 msgstr ""
@@ -1107,7 +1109,7 @@ msgid ""
 msgstr ""
 
 #. module: sale_planner_calendar
-#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__th
+#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__thu
 #: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_wizard__week_list__thu
 msgid "Thursday"
 msgstr ""
@@ -1148,7 +1150,7 @@ msgid "Totals"
 msgstr ""
 
 #. module: sale_planner_calendar
-#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__tu
+#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__tue
 #: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_wizard__week_list__tue
 msgid "Tuesday"
 msgstr ""
@@ -1206,7 +1208,7 @@ msgid "Website communication history"
 msgstr ""
 
 #. module: sale_planner_calendar
-#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__we
+#: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_reassign_wiz__week_list__wed
 #: model:ir.model.fields.selection,name:sale_planner_calendar.selection__sale_planner_calendar_wizard__week_list__wed
 msgid "Wednesday"
 msgstr ""

--- a/sale_planner_calendar/wizard/sale_planner_calendar_reassign.py
+++ b/sale_planner_calendar/wizard/sale_planner_calendar_reassign.py
@@ -22,13 +22,13 @@ class SalePlannerCalendarReassignWiz(models.TransientModel):
     )
     week_list = fields.Selection(
         [
-            ("MO", "Monday"),
-            ("TU", "Tuesday"),
-            ("WE", "Wednesday"),
-            ("TH", "Thursday"),
-            ("FR", "Friday"),
-            ("SA", "Saturday"),
-            ("SU", "Sunday"),
+            ("mon", "Monday"),
+            ("tue", "Tuesday"),
+            ("wed", "Wednesday"),
+            ("thu", "Thursday"),
+            ("fri", "Friday"),
+            ("sat", "Saturday"),
+            ("sun", "Sunday"),
         ],
         string="Weekday",
     )
@@ -72,7 +72,7 @@ class SalePlannerCalendarReassignWiz(models.TransientModel):
         if self.event_type_id:
             domain.append(("categ_ids", "in", self.event_type_id.ids))
         if self.week_list:
-            domain.append((self.week_list.lower(), "=", True))
+            domain.append((self.week_list, "=", True))
         calendar_events = self.env["calendar.event"].search(domain)
         self.line_ids = False
         for calendar_event in calendar_events:

--- a/sale_planner_calendar/wizard/sale_planner_calendar_wizard.py
+++ b/sale_planner_calendar/wizard/sale_planner_calendar_wizard.py
@@ -19,13 +19,13 @@ class SalePlannerCalendarWizard(models.TransientModel):
     )
     week_list = fields.Selection(
         [
-            ("MON", "Monday"),
-            ("TUE", "Tuesday"),
-            ("WED", "Wednesday"),
-            ("THU", "Thursday"),
-            ("FRI", "Friday"),
-            ("SAT", "Saturday"),
-            ("SUN", "Sunday"),
+            ("mon", "Monday"),
+            ("tue", "Tuesday"),
+            ("wed", "Wednesday"),
+            ("thu", "Thursday"),
+            ("fri", "Friday"),
+            ("sat", "Saturday"),
+            ("sun", "Sunday"),
         ],
         string="Weekday",
     )
@@ -48,7 +48,7 @@ class SalePlannerCalendarWizard(models.TransientModel):
             if rec.event_type_id:
                 domain.append(("categ_ids", "in", rec.event_type_id.ids))
             if rec.week_list:
-                domain.append(("recurrence_id." + rec.week_list.lower(), "=", True))
+                domain.append(("recurrence_id." + rec.week_list, "=", True))
             rec.calendar_event_ids = (
                 self.env["calendar.event"].search(domain).sorted("hour")
             )


### PR DESCRIPTION
cc @Tecnativa TT51485

ping @carlosdauden @pilarvargas-tecnativa 