### PR TITLE
[15.0][FIX] sale_planner_calendar: All wizard lines are updated even if are not modified

### DIFF
--- a/sale_planner_calendar/migrations/15.0.2.2.1/post-migration.py
+++ b/sale_planner_calendar/migrations/15.0.2.2.1/post-migration.py
@@ -1,0 +1,26 @@
+# Copyright 2024 Tecnativa - Carlos Dauden
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+def _remove_renamed_selection_values(env):
+    """After rename value from upper to lower the values are duplicated.
+    This method removes old upper values"""
+    week_list_field = env.ref(
+        "sale_planner_calendar.field_sale_planner_calendar_wizard__week_list"
+    )
+    value_ids = week_list_field.selection_ids.filtered(lambda x: x.value.isupper()).ids
+    if value_ids:
+        openupgrade.logged_query(
+            env.cr,
+            """
+            DELETE FROM ir_model_fields_selection
+            WHERE id in %(selection_value_ids)s
+            """,
+            {"selection_value_ids": tuple(value_ids)},
+        )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    _remove_renamed_selection_values(env)

--- a/sale_planner_calendar/wizard/sale_planner_calendar_wizard.py
+++ b/sale_planner_calendar/wizard/sale_planner_calendar_wizard.py
@@ -29,7 +29,8 @@ class SalePlannerCalendarWizard(models.TransientModel):
         ],
         string="Weekday",
     )
-    calendar_event_ids = fields.Many2many(
+    # Special hack One2many field to manage and save records directly
+    calendar_event_ids = fields.One2many(
         comodel_name="calendar.event",
         compute="_compute_calendar_event_ids",
         readonly=False,


### PR DESCRIPTION

Add migration script to remove invalid select valued fields which Odoo has not removed by changing only their value from uppercase to lowercase.

@Tecnativa ping @sergio-teruel @CarlosRoca13 