### PR TITLE
[15.0][FIX] sale_pricelist_global_rule: Prevent test errors due to unique constraint conflicts

### DIFF
--- a/sale_pricelist_global_rule/tests/test_pricelist_global.py
+++ b/sale_pricelist_global_rule/tests/test_pricelist_global.py
@@ -16,8 +16,12 @@ class TestPricelistGlobal(TransactionCase):
         cls.Partner = cls.env["res.partner"]
         cls.SaleOrder = cls.env["sale.order"]
         cls.SaleOrderLine = cls.env["sale.order.line"]
-        cls.attr_size = cls.ProductAttribute.create({"name": "Size", "sequence": 1})
-        cls.attr_color = cls.ProductAttribute.create({"name": "Color", "sequence": 2})
+        cls.attr_size = cls.ProductAttribute.create(
+            {"name": "sale_pricelist_global_rule Size", "sequence": 1}
+        )
+        cls.attr_color = cls.ProductAttribute.create(
+            {"name": "sale_pricelist_global_rule Color", "sequence": 2}
+        )
         cls.size_m = cls.ProductAttributeValue.create(
             {
                 "name": "M",


### PR DESCRIPTION

The `product_variant_default_code` module adds a unique constraint, which causes test failures when installed alongside `sale_pricelist_global_rule`. This fix adjusts the tests in to avoid conflicts with this unique constraint, ensuring compatibility when both modules are installed.

https://github.com/OCA/product-variant/blob/e58e66d3f278664116b245cdb04b811f4d7ef00b/product_variant_default_code/models/product.py#L256

TT51247
@Tecnativa @pedrobaeza @victoralmau could you please review this