### PR TITLE
[15.0][FIX] sale_pricelist_global_rule: Take into account sections and notes

### DIFF
--- a/sale_pricelist_global_rule/models/product_pricelist.py
+++ b/sale_pricelist_global_rule/models/product_pricelist.py
@@ -61,17 +61,15 @@ class ProductPricelist(models.Model):
         :param sale: browse_record(sale.order)
         :returns: tuple(product_template_ids , product_category_ids)
         """
-        categ_ids = {}
-        prod_tmpl_ids = {}
-        for line in sale.order_line:
-            prod_tmpl_ids[line.product_id.product_tmpl_id.id] = True
+        categ_ids = set()
+        prod_tmpl_ids = set()
+        for line in sale.order_line.filtered(lambda x: not x.display_type):
+            prod_tmpl_ids.add(line.product_id.product_tmpl_id.id)
             categ = line.product_id.categ_id
             while categ:
-                categ_ids[categ.id] = True
+                categ_ids.add(categ.id)
                 categ = categ.parent_id
-        categ_ids = list(categ_ids)
-        prod_tmpl_ids = list(prod_tmpl_ids)
-        return prod_tmpl_ids, categ_ids
+        return list(prod_tmpl_ids), list(categ_ids)
 
     def _compute_price_rule_global(self, sale):
         """Compute the price for the given sale order


### PR DESCRIPTION
If not, we get:

```
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 658, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 301, in _handle_exception
    raise exception.with_traceback(None) from new_cause

psycopg2.errors.DatatypeMismatch: ARRAY types integer and boolean cannot be matched

LINE 9: ...L OR item.global_product_tmpl_id = any(ARRAY[false,...
```

A little refactor for better code in the method is also done.

@Tecnativa TT51677