### PR TITLE
[15.0][FIX] sale_pricelist_global_rule: Exclude sections and notes from computes

### DIFF
--- a/sale_pricelist_global_rule/models/product_pricelist.py
+++ b/sale_pricelist_global_rule/models/product_pricelist.py
@@ -82,7 +82,7 @@ class ProductPricelist(models.Model):
             "by_template": {},
             "by_categ": {},
         }
-        for line in sale.order_line:
+        for line in sale.order_line.filtered(lambda x: not x.display_type):
             qty_in_product_uom = line.product_uom_qty
             # Final unit price is computed according to `qty` in the default `uom_id`.
             if line.product_uom != line.product_id.uom_id:
@@ -102,7 +102,7 @@ class ProductPricelist(models.Model):
             date, prod_tmpl_ids, categ_ids
         )
         results = {}
-        for line in sale.order_line:
+        for line in sale.order_line.filtered(lambda x: not x.display_type):
             product = line.product_id
             results[line.id] = 0.0
             suitable_rule = False

--- a/sale_pricelist_global_rule/models/sale_order.py
+++ b/sale_pricelist_global_rule/models/sale_order.py
@@ -35,7 +35,7 @@ class SaleOrder(models.Model):
             self.pricelist_id.discount_policy == "without_discount"
             and self.env.user.has_group("product.group_discount_per_so_line")
         )
-        for line in self.order_line:
+        for line in self.order_line.filtered(lambda x: not x.display_type):
             vals_to_write = {"discount": 0.0}
             product = line.product_id.with_context(
                 lang=self.partner_id.lang,


### PR DESCRIPTION

complementary to commit 637c76649ed93991099347374aaf70d60f6a692e

Clicking the `Recompute Pricelist Global` button on a sales order containing sections or notes would result in a traceback error.
@Tecnativa @victoralmau @chienandalu @pedrobaeza 