### PR TITLE
[17.0][FIX] sale_blanket_order: sale.blanket.order note field should be Html

### DIFF
--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -90,7 +90,7 @@ class BlanketOrder(models.Model):
         string="Customer Reference",
         copy=False,
     )
-    note = fields.Text(default=_default_note)
+    note = fields.Html(default=_default_note)
     user_id = fields.Many2one(
         "res.users",
         string="Salesperson",


### PR DESCRIPTION
The `sale.blanket.order` field (type) should be Html, as the default (copied) `res.company` `invoice_terms` field is also Html.