### PR TITLE
Revert "[15][PORT] sale_quotation_number: allow customizable quotation sequence"

### DIFF
--- a/sale_quotation_number/models/sale_order.py
+++ b/sale_quotation_number/models/sale_order.py
@@ -49,12 +49,7 @@ class SaleOrder(models.Model):
         return self.env["ir.sequence"].next_by_code("sale.order")
 
     def _action_confirm(self):
-        sequence = self.env["ir.sequence"].search(
-            [("code", "=", "sale.quotation")], limit=1
-        )
         for order in self:
-            if sequence and self.name[: len(sequence.prefix)] != sequence.prefix:
-                continue
             if not (
                 order.state == "sale"
                 and order.quotation_seq_used


### PR DESCRIPTION
This PR reverts commit https://github.com/OCA/sale-workflow/pull/3311/commits/df94b4da5343f044e039d56203c39cff424fba2a, which generates the problems pointed out here: https://github.com/OCA/sale-workflow/pull/3310#issuecomment-2486195170

This revert is only applied to v15, as it is the only version in which module sale_quotation_number already dealt with the issues explained in the PR https://github.com/OCA/sale-workflow/pull/3310.

I-6628