### PR TITLE
[FIX] [16.0] sale_order_product_recommendation: Update line if quantities had changed

### DIFF
--- a/sale_order_product_recommendation/README.rst
+++ b/sale_order_product_recommendation/README.rst
@@ -91,6 +91,7 @@ To use this module, you need to:
 #. Configure the recommendations parameters.
 #. Press *Get recommendations* button.
 #. Add products into the opened wizard.
+#. If you don't change quantities, the line will not be updated.
 #. Press *Accept*.
 
 Bug Tracker

--- a/sale_order_product_recommendation/readme/USAGE.rst
+++ b/sale_order_product_recommendation/readme/USAGE.rst
@@ -6,4 +6,5 @@ To use this module, you need to:
 #. Configure the recommendations parameters.
 #. Press *Get recommendations* button.
 #. Add products into the opened wizard.
+#. If you don't change quantities, the line will not be updated.
 #. Press *Accept*.

--- a/sale_order_product_recommendation/static/description/index.html
+++ b/sale_order_product_recommendation/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -436,6 +437,7 @@ You can then edit the desired quantities directly in the sale order.</p>
 <li>Configure the recommendations parameters.</li>
 <li>Press <em>Get recommendations</em> button.</li>
 <li>Add products into the opened wizard.</li>
+<li>If you don’t change quantities, the line will not be updated.</li>
 <li>Press <em>Accept</em>.</li>
 </ol>
 </div>
@@ -487,7 +489,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_order_product_recommendation/tests/test_recommendation.py
+++ b/sale_order_product_recommendation/tests/test_recommendation.py
@@ -174,6 +174,10 @@ class RecommendationCaseTests(RecommendationCase):
                 }
             ],
         )
+        # Check line is not updated if no product uom qty is changed
+        # If a line is accepted without quantity modifications, nothing will be updated
+        wizard = self.wizard()
+        self.assertFalse(wizard.line_ids[0]._prepare_update_so_line_vals())
 
     def test_recommendations_archived_product(self):
         self.env["sale.order"].create(


### PR DESCRIPTION
Only update the line if quantities had changed. 

This will help if you has another module that recomputes discounts when quantities are write/updated.

MT-7993 @moduon @rafaelbn @Gelojr @fcvalgar @yajo please review if you want :)