### PR TITLE
[FIX] [16.0] sale_order_product_recommendation_packaging_default: Do not update packaging if quantities has not changed

### DIFF
--- a/sale_order_product_recommendation_packaging_default/tests/test_recommendation.py
+++ b/sale_order_product_recommendation_packaging_default/tests/test_recommendation.py
@@ -188,6 +188,35 @@ class PackagingRecommendationCase(test_recommendation_common.RecommendationCase)
             ],
         )
 
+    def test_preexisting_product_without_modification(self):
+        self.new_so.order_line = [
+            Command.create(
+                {
+                    "product_id": self.prod_1.id,
+                    "product_uom_qty": 12,
+                    "qty_delivered_method": "manual",
+                    "discount": 12.0,
+                }
+            )
+        ]
+        # Ensure pricelist wants to recompute discounts
+        self.new_so.sudo().pricelist_id.discount_policy = "without_discount"
+        # Do not modify anything
+        wiz = self.wizard()
+        wiz.action_accept()
+        self.assertRecordValues(
+            self.new_so.order_line,
+            [
+                {
+                    "product_id": self.prod_1.id,
+                    "product_packaging_id": self.prod_1_dozen.id,
+                    "product_packaging_qty": 1,
+                    "product_uom_qty": 12,
+                    "discount": 12.0,  # Discount is preserved
+                },
+            ],
+        )
+
     def test_no_packaging_user(self):
         self.env.user.groups_id -= self.env.ref("product.group_stock_packaging")
         wiz_f = Form(self.wizard())

--- a/sale_order_product_recommendation_packaging_default/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation_packaging_default/wizards/sale_order_recommendation.py
@@ -97,11 +97,15 @@ class SaleOrderRecommendationLine(models.TransientModel):
     def _prepare_update_so_line_vals(self):
         """Update a sale order line with packaging info."""
         result = super()._prepare_update_so_line_vals()
-        vals = self._prepare_packaging_line_vals(result)
-        return vals
+        if not result:
+            # Nothing to update
+            return result
+        return self._prepare_packaging_line_vals(result)
 
     def _prepare_new_so_line_vals(self, sequence):
         """Prepare product packaging info for new sale order line."""
         result = super()._prepare_new_so_line_vals(sequence)
-        vals = self._prepare_packaging_line_vals(result)
-        return vals
+        if not result:
+            # Nothing to create
+            return result
+        return self._prepare_packaging_line_vals(result)


### PR DESCRIPTION
Do not update packaging quantities if quantities has not changed.

This [line](https://github.com/OCA/sale-workflow/blob/16.0/sale_order_product_recommendation_packaging_default/wizards/sale_order_recommendation.py#L84) triggers recomputation and clear `discount`, so avoid calling unncessary function.

The `if` when creating is used for maintain consistency in case we modify something in the future.

MT-7993 @moduon @rafaelbn @Gelojr @yajo @fcvalgar please review if you want :)