### PR TITLE
[16.0][FIX] sale_order_product_picker: Fix addon installation when this addon is installed

### DIFF
--- a/sale_order_product_picker/models/sale_order.py
+++ b/sale_order_product_picker/models/sale_order.py
@@ -60,12 +60,23 @@ class SaleOrder(models.Model):
     def _get_partner_picker_field(self):
         # HACK: To avoid installation error when get default value to be used in a
         # depends of a computed field
-        if "sale_order_product_picker" in self.env.registry._init_modules and self.env[
-            "ir.default"
-        ].get("sale.order", "use_delivery_address"):
-            return "partner_shipping_id"
-        else:
-            return "partner_id"
+        if "sale_order_product_picker" in self.env.registry._init_modules:
+            use_delivery_address_defined = self.env["ir.default"].get(
+                "sale.order", "use_delivery_address"
+            )
+            # accessing the registry into the initialization phase is a really bad
+            # idea and could lead to a lot of issues. For example, it will load the
+            # cache of the field's id of the model. That means that starting from this
+            # new field added to the model will not be returned by the method
+            # _get_ids of 'ir.model.fields' model and therefore will break the
+            # installation of other modules that extend the model that has been
+            # loaded here.
+            # We must invalidate the cache of this method now to avoid this issue.
+            IMF = self.env["ir.model.fields"]
+            IMF._get_ids.clear_cache(IMF)
+            if use_delivery_address_defined:
+                return "partner_shipping_id"
+        return "partner_id"
 
     def _get_picker_trigger_search_fields(self):
         return [


### PR DESCRIPTION
It's a bad idea to use the registry at initialization phase. When you access the registry some info are set into the cache. For exemple the field's ids list of a given model. That means that new field added to the model later into the installation process will not be returned by a new call to the _get_ids method of the ir.model.fields model. At the end, the installation of new addon adding, for exemple, a selection field to the sale.order model is no more possible.

This fix solve https://github.com/OCA/sale-workflow/actions/runs/12144814546/job/33865050704?pr=3436#step:8:2078