### PR TITLE
[17.0][FIX] sale_substate: fix inheritance order to restore tracking

### DIFF
--- a/sale_substate/models/sale_order.py
+++ b/sale_substate/models/sale_order.py
@@ -13,5 +13,5 @@ class BaseSubstateType(models.Model):
 
 
 class SaleOrder(models.Model):
-    _inherit = ["sale.order", "base.substate.mixin"]
+    _inherit = ["base.substate.mixin", "sale.order"]  # order matters
     _name = "sale.order"

--- a/sale_substate/tests/test_sale_substate.py
+++ b/sale_substate/tests/test_sale_substate.py
@@ -61,6 +61,15 @@ class TestBaseSubstate(TransactionCase):
         self.assertTrue(so_test1.state == "sale")
         self.assertTrue(so_test1.substate_id == self.substate_valid_docs)
 
+        # manually change the substate; this one has a mail template
+        self.env.cr.flush()  # this is to post the messages (it's in after commit hook)
+        messages = so_test1.message_ids
+        so_test1.write({"substate_id": self.substate_in_delivery.id})
+        self.env.cr.flush()  # this is to post the messages (again)
+        new_messages = so_test1.message_ids - messages
+        expected_msg = "You order is being prepared for delivery."
+        self.assertTrue(expected_msg in "".join(new_messages.mapped("body")))
+
         # Test that substate_id is set to false if
         # there is not substate corresponding to state
         so_test1._action_cancel()


### PR DESCRIPTION
With the current order, the super to _track_template from the mixin was never called. Which was a good thing since it was also buggy;
however the override in this model was removed on the assumption that it was.

Depends on https://github.com/OCA/server-ux/pull/982 since the super function is actually borked.

(it's therefore expected tests crash before the dependencies are updated)

Also, the problem is present in other substate modules like `purchase_substate` but their migration is in limbo so it's all good.