### PR TITLE
[FIX] [16.0] sale_elaboration: Apply groups to views correctly

### DIFF
--- a/sale_elaboration/README.rst
+++ b/sale_elaboration/README.rst
@@ -50,6 +50,10 @@ To configure this module you need to:
 #. Create a new record.
 #. Set a product linked to the elaboration.
 #. Also you can select a route to procure this elaboration.
+#. Go to *Settings > Inventory > Traceability* and select *Display Elaboration
+   notes on Delivery Slips* if you want to show elaborations on Delivery Slips
+   or *Display Elaboration notes on Picking Operations* if you want to show
+   elaborations on Picking Operations.
 
 Usage
 =====
@@ -60,6 +64,7 @@ Usage
 #. Select an elaboration in the line.
 #. Confirm the sales order.
 #. Go to the picking created by this sales order and validate it.
+#. Print Delivery Slip and Picking Operations.
 #. Go back to the sales order. A new line is created with the product linked to
    the elaboration.
 

--- a/sale_elaboration/readme/CONFIGURE.rst
+++ b/sale_elaboration/readme/CONFIGURE.rst
@@ -4,3 +4,7 @@ To configure this module you need to:
 #. Create a new record.
 #. Set a product linked to the elaboration.
 #. Also you can select a route to procure this elaboration.
+#. Go to *Settings > Inventory > Traceability* and select *Display Elaboration
+   notes on Delivery Slips* if you want to show elaborations on Delivery Slips
+   or *Display Elaboration notes on Picking Operations* if you want to show
+   elaborations on Picking Operations.

--- a/sale_elaboration/readme/USAGE.rst
+++ b/sale_elaboration/readme/USAGE.rst
@@ -4,5 +4,6 @@
 #. Select an elaboration in the line.
 #. Confirm the sales order.
 #. Go to the picking created by this sales order and validate it.
+#. Print Delivery Slip and Picking Operations.
 #. Go back to the sales order. A new line is created with the product linked to
    the elaboration.

--- a/sale_elaboration/reports/report_base.xml
+++ b/sale_elaboration/reports/report_base.xml
@@ -4,15 +4,14 @@
 <data>
     <!-- Reusable template for printing elaborations and notes -->
     <template id="elaboration_notes">
+        <!-- `record` can be stock.move or stock.move.line -->
         <div
             class="fst-italic"
-            groups="sale_elaboration.group_elaboration_note_on_delivery_slip"
             t-if="record.elaboration_ids or record.elaboration_note"
         >
             <i class="fa fa-comment-o " />
-            <span t-field="record.elaboration_ids" /><t
-                t-if="record.elaboration_ids and record.elaboration_note"
-            >.</t>
+            <span t-field="record.elaboration_ids" />
+            <t t-if="record.elaboration_ids and record.elaboration_note">.</t>
             <span t-field="record.elaboration_note" />
         </div>
     </template>

--- a/sale_elaboration/reports/report_deliveryslip.xml
+++ b/sale_elaboration/reports/report_deliveryslip.xml
@@ -33,6 +33,7 @@
             <t
                 t-if="move.picking_code != 'incoming'"
                 t-call="sale_elaboration.elaboration_notes"
+                groups="sale_elaboration.group_elaboration_note_on_delivery_slip"
             >
                 <t t-set="record" t-value="move" />
             </t>
@@ -47,8 +48,9 @@
             <t
                 t-if="move_line.picking_code != 'incoming'"
                 t-call="sale_elaboration.elaboration_notes"
+                groups="sale_elaboration.group_elaboration_note_on_delivery_slip"
             >
-                <t t-set="record" t-value="move_line.move_id" />
+                <t t-set="record" t-value="move_line" />
             </t>
         </xpath>
     </template>

--- a/sale_elaboration/reports/report_picking_operations.xml
+++ b/sale_elaboration/reports/report_picking_operations.xml
@@ -3,15 +3,17 @@
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0) -->
 <data>
     <template id="report_picking" inherit_id="stock.report_picking">
-        <xpath expr="//td[span[@t-field='ml.product_id.display_name']]">
-            <div
-                class="fst-italic"
+        <xpath
+            expr="//td[span[@t-field='ml.product_id.display_name']]"
+            position="inside"
+        >
+            <t
+                t-if="ml.picking_code != 'incoming'"
+                t-call="sale_elaboration.elaboration_notes"
                 groups="sale_elaboration.group_elaboration_note_on_picking_operations"
-                t-if="ml.picking_code != 'incoming' and ml.elaboration_note"
             >
-                <i class="fa fa-comment-o" />
-                <span t-field="ml.elaboration_note" />
-            </div>
+                <t t-set="record" t-value="ml" />
+            </t>
         </xpath>
     </template>
 </data>

--- a/sale_elaboration/static/description/index.html
+++ b/sale_elaboration/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -397,6 +398,10 @@ an specific product, but it adds a surcharge on the final price.</p>
 <li>Create a new record.</li>
 <li>Set a product linked to the elaboration.</li>
 <li>Also you can select a route to procure this elaboration.</li>
+<li>Go to <em>Settings &gt; Inventory &gt; Traceability</em> and select <em>Display Elaboration
+notes on Delivery Slips</em> if you want to show elaborations on Delivery Slips
+or <em>Display Elaboration notes on Picking Operations</em> if you want to show
+elaborations on Picking Operations.</li>
 </ol>
 </div>
 <div class="section" id="usage">
@@ -408,6 +413,7 @@ an specific product, but it adds a surcharge on the final price.</p>
 <li>Select an elaboration in the line.</li>
 <li>Confirm the sales order.</li>
 <li>Go to the picking created by this sales order and validate it.</li>
+<li>Print Delivery Slip and Picking Operations.</li>
 <li>Go back to the sales order. A new line is created with the product linked to
 the elaboration.</li>
 </ol>
@@ -445,7 +451,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Groups are not being applied correctly because the template of elaboration has a check for the group.

Now you can select Groups independently and shows elaborations correctly depending on what group you choose.

MT-8419 @moduon @rafaelbn @yajo @fcvalgar please reivew if you want 😄 