### PR TITLE
[FIX] sale_exception: Don't order by main exception

### DIFF
--- a/sale_exception/models/sale_order.py
+++ b/sale_exception/models/sale_order.py
@@ -9,7 +9,6 @@ from odoo import api, models
 class SaleOrder(models.Model):
     _inherit = ["sale.order", "base.exception"]
     _name = "sale.order"
-    _order = "main_exception_id asc, date_order desc, name desc"
 
     @api.model
     def _reverse_field(self):


### PR DESCRIPTION
As this is breaking the standard behavior, don't order on model side.

@sebastienbeau 