### PR TITLE
[17.0][FIX] sale_fixed_discount: Fixed discount consideration for por…

### DIFF
--- a/sale_fixed_discount/models/sale_order_line.py
+++ b/sale_fixed_discount/models/sale_order_line.py
@@ -83,7 +83,9 @@ class SaleOrderLine(models.Model):
         lines_with_discount_fixed = self.filtered(lambda sol: sol.discount_fixed)
         for line in lines_with_discount_fixed:
             line.discount = line._get_discount_from_fixed_discount()
-        return super(SaleOrderLine, self - lines_with_discount_fixed)
+        return super(
+            SaleOrderLine, self - lines_with_discount_fixed
+        )._compute_discount()
 
     def _get_discount_from_fixed_discount(self):
         """Calculate the discount percentage from the fixed discount amount."""


### PR DESCRIPTION
…tal orders

Issue:
When a pricelist is applied to a specific product with a discount, the discount is visible on the portal product page. However, during checkout, the discount is not reflected in the cart and is not considered in the total.
Attached is a screenshot showing how the discount was not reflected in the portal cart before this fix: 
![image](https://github.com/user-attachments/assets/463ba9e8-7066-49d9-a2f4-8c2dd08f8479)

Fix:
The issue occurred because the module was calling the base method _compute_discount but did not call the super method, which resulted in this behavior. This has now been addressed with the fix in this commit.

Expected Behavior:
Products with discounts applied via pricelists will now correctly show the discount in the cart during checkout.
Attached is a screenshot showing how the discount is now correctly reflected in the cart after applying this fix : 
![image](https://github.com/user-attachments/assets/f391f2ad-50ac-4e26-99fe-9fa3fb5073e7)
