### PR TITLE
[IMP] sale_advance_payment: Allow edition of the related payments

### DIFF
--- a/sale_advance_payment/__manifest__.py
+++ b/sale_advance_payment/__manifest__.py
@@ -13,6 +13,7 @@
     "data": [
         "wizard/sale_advance_payment_wzd_view.xml",
         "views/sale_view.xml",
+        "views/account_payment.xml",
         "security/ir.model.access.csv",
     ],
     "installable": True,

--- a/sale_advance_payment/views/account_payment.xml
+++ b/sale_advance_payment/views/account_payment.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <record id="view_account_payment_tree" model="ir.ui.view">
+        <field name="name">account.payment.tree</field>
+        <field name="model">account.payment</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="account.view_account_payment_tree" />
+        <field name="arch" type="xml">
+            <tree position="attributes">
+                <attribute name="create">0</attribute>
+                <attribute name="delete">0</attribute>
+            </tree>
+        </field>
+    </record>
+</odoo>

--- a/sale_advance_payment/views/sale_view.xml
+++ b/sale_advance_payment/views/sale_view.xml
@@ -20,8 +20,8 @@
                         name="account_payment_ids"
                         nolabel="1"
                         colspan="4"
-                        readonly="True"
-                        context="{'form_view_ref': 'account.view_account_payment_form','tree_view_ref': 'account.view_account_payment_tree'}"
+                        readonly="False"
+                        context="{'form_view_ref': 'account.view_account_payment_form','tree_view_ref': 'sale_advance_payment.view_account_payment_tree'}"
                     />
                 </page>
             </notebook>


### PR DESCRIPTION
Actually, you can press buttons on the related payment that would make it editable, but you cannot edit it.
