### PR TITLE
[IMP] sale_advance_payment: residual field should be monetary

### DIFF
--- a/sale_advance_payment/models/sale.py
+++ b/sale_advance_payment/models/sale.py
@@ -13,7 +13,7 @@ class SaleOrder(models.Model):
         inverse_name="sale_id",
         string="Pay sale advanced",
     )
-    amount_residual = fields.Float(
+    amount_residual = fields.Monetary(
         string="Residual amount",
         compute="_compute_advance_payment",
         store=True,


### PR DESCRIPTION
Without it:
![image](https://github.com/user-attachments/assets/d626fb15-bb1c-48ce-8e43-fcf219601c83)



With the change:
![image](https://github.com/user-attachments/assets/92f54360-60e2-4a60-b167-32a9d884a543)
