### PR TITLE
[16.0] [IMP] Make packaging required on orders for configured products.

### DIFF
--- a/sale_order_product_recommendation_packaging_default/wizards/sale_order_recommendation_view.xml
+++ b/sale_order_product_recommendation_packaging_default/wizards/sale_order_recommendation_view.xml
@@ -10,6 +10,14 @@
             ref="sale_order_product_recommendation.sale_order_recommendation_view_form"
         />
         <field name="arch" type="xml">
+
+            <xpath
+                expr="//field[@name='line_ids']/form//field[@name='units_included']"
+                position="before"
+            >
+                <field name="require_packaging" invisible="1" />
+            </xpath>
+
             <xpath
                 expr="//field[@name='line_ids']/tree/field[@name='units_included']"
                 position="before"
@@ -36,12 +44,13 @@
                     name="product_packaging_id"
                     groups="product.group_stock_packaging"
                     context="{'default_product_id': product_id}"
+                    attrs="{'required': [('require_packaging', '=', True)]}"
                 />
                 <field
                     name="product_packaging_qty"
                     groups="product.group_stock_packaging"
                     widget="numeric_step"
-                    attrs="{'readonly': [('product_packaging_id', '=', False)]}"
+                    attrs="{'readonly': ['|', ('product_packaging_id', '=', False), ('require_packaging', '=', True)]}"
                 />
             </xpath>
         </field>

--- a/sale_packaging_default/README.rst
+++ b/sale_packaging_default/README.rst
@@ -71,6 +71,11 @@ To configure this module, you need to:
 1. Go to *Sales > Configuration > Settings*.
 2. Under *Product Catalog*, enable *Product Packagings*.
 
+To configure products for mandatory packaging:
+
+1. Go to \*Inventory > Product and select a product.
+2. Under the ‘Inventory’ tab check the box for ‘Require Packaging'.
+
 Usage
 =====
 

--- a/sale_packaging_default/__manifest__.py
+++ b/sale_packaging_default/__manifest__.py
@@ -15,6 +15,7 @@
     "installable": True,
     "depends": ["sale"],
     "data": [
+        "views/product_template_view.xml",
         "views/sale_order_view.xml",
     ],
 }

--- a/sale_packaging_default/models/__init__.py
+++ b/sale_packaging_default/models/__init__.py
@@ -1,2 +1,3 @@
 from . import product_packaging
+from . import product_template
 from . import sale_order_line

--- a/sale_packaging_default/models/product_template.py
+++ b/sale_packaging_default/models/product_template.py
@@ -1,0 +1,9 @@
+# Copyright 2024 Moduon Team S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    require_packaging = fields.Boolean(default=False)

--- a/sale_packaging_default/readme/CONFIGURE.md
+++ b/sale_packaging_default/readme/CONFIGURE.md
@@ -2,3 +2,9 @@ To configure this module, you need to:
 
 1.  Go to *Sales \> Configuration \> Settings*.
 2.  Under *Product Catalog*, enable *Product Packagings*.
+
+
+To configure products for mandatory packaging:
+
+1. Go to *Inventory \> Product and select a product.
+2. Under the ‘Inventory’ tab check the box for ‘Require Packaging'.

--- a/sale_packaging_default/static/description/index.html
+++ b/sale_packaging_default/static/description/index.html
@@ -419,6 +419,11 @@ Following the same example, you’ll choose bags, then 3, and then the
 <li>Go to <em>Sales &gt; Configuration &gt; Settings</em>.</li>
 <li>Under <em>Product Catalog</em>, enable <em>Product Packagings</em>.</li>
 </ol>
+<p>To configure products for mandatory packaging:</p>
+<ol class="arabic simple">
+<li>Go to *Inventory &gt; Product and select a product.</li>
+<li>Under the ‘Inventory’ tab check the box for ‘Require Packaging’.</li>
+</ol>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-3">Usage</a></h1>

--- a/sale_packaging_default/views/product_template_view.xml
+++ b/sale_packaging_default/views/product_template_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 Moduon Team S.L. <info@moduon.team>
+     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl). -->
+<data>
+
+    <record id="product_template_form_view_inherit" model="ir.ui.view">
+        <field name="name">Simplify packaging fields</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='inventory']" position="inside">
+                <group string="Packaging Division">
+                    <field
+                        name="require_packaging"
+                        placeholder="Indicates if the product can be sold individually or if it requires keeping the original packaging."
+                    />
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+</data>

--- a/sale_packaging_default/views/sale_order_view.xml
+++ b/sale_packaging_default/views/sale_order_view.xml
@@ -36,6 +36,33 @@
                     position="move"
                 />
             </xpath>
+
+            <xpath
+                expr="//field[@name='order_line']/tree/field[@name='product_packaging_id']"
+                position="before"
+            >
+                <field name="require_packaging" invisible="1" />
+            </xpath>
+
+            <!-- Make packaging mandatory when the product is not allow to divide the packaging -->
+            <xpath
+                expr="//field[@name='order_line']/tree/field[@name='product_packaging_id']"
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'required': [('require_packaging', '=', True)]}</attribute>
+            </xpath>
+
+            <!-- Make packaging qty readonly when the product is not allow to divide the packaging -->
+            <xpath
+                expr="//field[@name='order_line']/tree/field[@name='product_packaging_qty']"
+                position="attributes"
+            >
+                <attribute
+                    name="attrs"
+                >{'readonly': [('require_packaging', '=', True)]}</attribute>
+            </xpath>
         </field>
     </record>
 </data>


### PR DESCRIPTION
This PR allows a configured product not to be allowed to be sold without packaging.

This video explains the improvement
https://www.loom.com/share/b4b6a6fc9cdb406086115195a1eeb1c4

@moduon: MT-8489