### PR TITLE
[16.0] [FIX] sale_order_line_date: remove TypeError

### DIFF
--- a/sale_order_line_date/models/sale_order_line.py
+++ b/sale_order_line_date/models/sale_order_line.py
@@ -32,12 +32,12 @@ class SaleOrderLine(models.Model):
     def write(self, vals):
         res = super().write(vals)
         moves_to_upd = set()
-        if "commitment_date" in vals:
+        if vals.get("commitment_date"):
             for move in self.move_ids:
                 if move.state not in ["cancel", "done"]:
                     moves_to_upd.add(move.id)
-        if moves_to_upd:
-            self.env["stock.move"].browse(moves_to_upd).write(
-                {"date_deadline": vals.get("commitment_date")}
-            )
+            if moves_to_upd:
+                self.env["stock.move"].browse(moves_to_upd).write(
+                    {"date_deadline": vals.get("commitment_date")}
+                )
         return res


### PR DESCRIPTION
FL-556-5216

There is no checking that commitment_date has a correct value, only that it is set.
`File "sale-workflow/sale_order_line_date/models/sale_order_line.py", line 40, in write`

````python
    def write(self, vals):
        res = super().write(vals)
        moves_to_upd = set()
        if "commitment_date" in vals:
            for move in self.move_ids:
                if move.state not in ["cancel", "done"]:
                    moves_to_upd.add(move.id)
        if moves_to_upd:
            self.env["stock.move"].browse(moves_to_upd).write(
                {"date_deadline": vals.get("commitment_date")} # <-----------------------
            )
        return res
````
Translating an empty value is not done correctly in the stock module
`File "/odoo-base/odoo-server/addons/stock/models/stock_move.py", line 698, in write`
```python
if 'date_deadline' in vals:
    self._set_date_deadline(vals.get('date_deadline')) # <---------------------
```
`File "/odoo-base/odoo-server/addons/stock/models/stock_move.py", line 539, in _set_date_deadline`
```python
if move.date_deadline:
    delta = move.date_deadline - fields.Datetime.to_datetime(new_deadline) # <------------------------
```
