### PR TITLE
[15.0][FIX]sale_advance_payment: Amount residual with signed invoice amount

### DIFF
--- a/sale_advance_payment/models/sale.py
+++ b/sale_advance_payment/models/sale.py
@@ -83,7 +83,9 @@ class SaleOrder(models.Model):
             # Consider payments in related invoices.
             invoice_paid_amount = 0.0
             for inv in order.invoice_ids:
-                invoice_paid_amount += inv.amount_total - inv.amount_residual
+                invoice_paid_amount += (
+                    inv.amount_total_signed - inv.amount_residual_signed
+                )
             amount_residual = order.amount_total - advance_amount - invoice_paid_amount
             payment_state = "not_paid"
             inv_currency = order.currency_id or self.env.company.currency_id


### PR DESCRIPTION
Before this fix, field amount_residual in sale.order was calculated using the unsigned amounts of related invoices. That caused that amount_residual was wrongly calculated when a sale order had related customer credit notes.

T-7394