### PR TITLE
[FIX] [16.0] sale_order_line_price_history: Add button to kanban view

### DIFF
--- a/sale_order_line_price_history/views/sale_views.xml
+++ b/sale_order_line_price_history/views/sale_views.xml
@@ -22,6 +22,21 @@
                     help="Price History"
                 />
             </xpath>
+            <xpath
+                expr="//field[@name='order_line']/kanban//t[@t-out='record.price_unit.value']/.."
+                position="inside"
+            >
+                <field name="order_partner_id" invisible="1" />
+                <field
+                    name="id"
+                    string=" "
+                    context="{'active_id': id, 'active_ids': [id]}"
+                    widget="sale_line_price_history_widget"
+                    help="Price History"
+                    class="float-start"
+                    style="min-width: 1.5rem;"
+                />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Add button also to kanban view (same as tree + class) of sale order lines.

The red squares are from other modules.
![image](https://github.com/user-attachments/assets/3f7b7d7b-0c0d-423b-b5f0-2ea243cd8b88)



MT-8825 @moduon @rafaelbn @yajo @ernestotejeda @CarlosRoca13 please review if you want! 😄 