### PR TITLE
[16.0] [FIX] sale_order_line_price_history: Add discount field only if discount group is enabled

### DIFF
--- a/sale_order_line_price_history/README.rst
+++ b/sale_order_line_price_history/README.rst
@@ -59,6 +59,9 @@ Known issues / Roadmap
 ======================
 
 * A backend tour would be nice to have.
+* When you are in Kanban View, you can set an historic price from the wizard,
+  but you need to click on the line and save it from form view instead of
+  using sale order save button.
 
 Bug Tracker
 ===========

--- a/sale_order_line_price_history/readme/ROADMAP.rst
+++ b/sale_order_line_price_history/readme/ROADMAP.rst
@@ -1,1 +1,4 @@
 * A backend tour would be nice to have.
+* When you are in Kanban View, you can set an historic price from the wizard,
+  but you need to click on the line and save it from form view instead of
+  using sale order save button.

--- a/sale_order_line_price_history/static/description/index.html
+++ b/sale_order_line_price_history/static/description/index.html
@@ -409,6 +409,9 @@ click the smart button named <em>Set price</em>.</li>
 <h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
 <ul class="simple">
 <li>A backend tour would be nice to have.</li>
+<li>When you are in Kanban View, you can set an historic price from the wizard,
+but you need to click on the line and save it from form view instead of
+using sale order save button.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">

--- a/sale_order_line_price_history/static/src/js/set_price_to_line_widget.js
+++ b/sale_order_line_price_history/static/src/js/set_price_to_line_widget.js
@@ -15,7 +15,9 @@ export class SetPriceToLineWidget extends Component {
             type: "ir.actions.act_window_close",
             infos: {
                 price_unit: this.props.record.data.price_unit,
-                discount: this.props.record.data.discount,
+                ...(this.props.record.fields.discount !== undefined && {
+                    discount: this.props.record.data.discount,
+                }),
             },
         });
     }

--- a/sale_order_line_price_history/views/sale_views.xml
+++ b/sale_order_line_price_history/views/sale_views.xml
@@ -23,6 +23,12 @@
                 />
             </xpath>
             <xpath
+                expr="//field[@name='order_line']/kanban/field[@name='price_unit']"
+                position="after"
+            >
+                <field name="discount" groups="product.group_discount_per_so_line" />
+            </xpath>
+            <xpath
                 expr="//field[@name='order_line']/kanban//t[@t-out='record.price_unit.value']/.."
                 position="inside"
             >


### PR DESCRIPTION
If you try to add historic prices with discounts group deactivated, an error raises because discount field is not present on the view (kanban and tree)
This adds a check to see if discount is present on the record fields and add the key-value of discount if exists.

Added discount with the group to the kanban view (when defining fields)

Also added a known issue:
If you add the historic price from the kanban view, the sale order save button doesn't work. You need to go into the line and click save.

MT-8826 @moduon @CarlosRoca13 @yajo please review if you want :)