### PR TITLE
[16.0][FIX]sale_delivery_state: add state to silence warning

### DIFF
--- a/sale_delivery_state/models/sale_order.py
+++ b/sale_delivery_state/models/sale_order.py
@@ -13,6 +13,7 @@ class SaleOrder(models.Model):
     delivery_status = fields.Selection(
         [
             ("pending", "Not Delivered"),
+            ("started", "Started"),  # Odoo delivery_status compat, unused
             ("partial", "Partially Delivered"),
             ("full", "Fully Delivered"),
         ],

--- a/sale_delivery_state/models/sale_order.py
+++ b/sale_delivery_state/models/sale_order.py
@@ -14,6 +14,7 @@ class SaleOrder(models.Model):
     delivery_status = fields.Selection(
         [
             ("pending", "Not Delivered"),
+            ("started", "Started"),  # Odoo delivery_status compat, unused
             ("partial", "Partially Delivered"),
             ("full", "Fully Delivered"),
         ],


### PR DESCRIPTION
Both `sale_delivery_state` and `sale_stock` add a `delivery_status` field. The two modules add the same selection options except for one, missing in `sale_delivery_state`. This is the "started" option.

With both modules installed we are witnessing a lot of warnings like the following

```
sale.order.delivery_status: selection=[('pending', 'Not Delivered'), ('started', 'Started'), ('partial', 'Partially Delivered'), ('full', 'Fully Delivered')] overrides existing selection; use selection_add instead 
```

With this PR we add the same option as `sale_stock` but we ignore it during the computation. 
