### PR TITLE
[17.0][FIX] sale_discount_display_amount: Fix discount_total field label

### DIFF
--- a/sale_discount_display_amount/models/sale_order_line.py
+++ b/sale_discount_display_amount/models/sale_order_line.py
@@ -9,7 +9,6 @@ class SaleOrderLine(models.Model):
 
     discount_total = fields.Monetary(
         compute="_compute_amount",
-        string="Discount Subtotal",
         store=True,
         precompute=True,
     )


### PR DESCRIPTION
in v17 we define field `discount_subtotal` but not change label of field `discount_total`