### PR TITLE
[18.0][FIX] sale_order_line_date: fix setting empty commitment date on stock moves

### DIFF
--- a/sale_order_line_date/tests/test_sale_order_line_date.py
+++ b/sale_order_line_date/tests/test_sale_order_line_date.py
@@ -166,3 +166,14 @@ class TestSaleOrderLineDates(TransactionCase):
         self._assert_equal_dates(
             self.sale_line1.commitment_date, self.sale_line1.move_ids.date_deadline
         )
+
+    def test_04_line_commitment_date_removal(self):
+        self.sale1.commitment_date = False
+        self.sale1.action_confirm()
+        self._assert_equal_dates(
+            self.sale_line1.commitment_date, self.sale_line1.move_ids.date_deadline
+        )
+        self.sale_line1.commitment_date = False
+        self._assert_equal_dates(
+            self.sale_line1._expected_date(), self.sale_line1.move_ids.date_deadline
+        )


### PR DESCRIPTION
Port of https://github.com/OCA/sale-workflow/pull/3364

Fixes #3363:
```
TypeError: unsupported operand type(s) for -: 'datetime.datetime' and 'NoneType'
```
in stock.move's _set_date_deadline