### PR TITLE
[16.0][FIX] sale_advance_payment: Reconcile when posting multiple invoices

### DIFF
--- a/sale_advance_payment/models/account_move.py
+++ b/sale_advance_payment/models/account_move.py
@@ -7,15 +7,22 @@ from odoo import models
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    def action_post(self):
+    def _post(self, soft=True):
         # Automatic reconciliation of payment when invoice confirmed.
-        res = super(AccountMove, self).action_post()
-        sale_order = self.mapped("line_ids.sale_line_ids.order_id")
-        if sale_order and self.invoice_outstanding_credits_debits_widget is not False:
-            json_invoice_outstanding_data = (
-                self.invoice_outstanding_credits_debits_widget.get("content", [])
-            )
-            for data in json_invoice_outstanding_data:
-                if data.get("move_id") in sale_order.account_payment_ids.move_id.ids:
-                    self.js_assign_outstanding_line(line_id=data.get("id"))
+        res = super(AccountMove, self)._post(soft=soft)
+        for move in self:
+            sale_order = move.mapped("line_ids.sale_line_ids.order_id")
+            if (
+                sale_order
+                and move.invoice_outstanding_credits_debits_widget is not False
+            ):
+                json_invoice_outstanding_data = (
+                    move.invoice_outstanding_credits_debits_widget.get("content", [])
+                )
+                for data in json_invoice_outstanding_data:
+                    if (
+                        data.get("move_id")
+                        in sale_order.account_payment_ids.move_id.ids
+                    ):
+                        move.js_assign_outstanding_line(line_id=data.get("id"))
         return res

--- a/sale_advance_payment/models/account_move.py
+++ b/sale_advance_payment/models/account_move.py
@@ -13,16 +13,14 @@ class AccountMove(models.Model):
         for move in self:
             sale_order = move.mapped("line_ids.sale_line_ids.order_id")
             if (
-                sale_order
-                and move.invoice_outstanding_credits_debits_widget is not False
+                not sale_order
+                or move.invoice_outstanding_credits_debits_widget is False
             ):
-                json_invoice_outstanding_data = (
-                    move.invoice_outstanding_credits_debits_widget.get("content", [])
-                )
-                for data in json_invoice_outstanding_data:
-                    if (
-                        data.get("move_id")
-                        in sale_order.account_payment_ids.move_id.ids
-                    ):
-                        move.js_assign_outstanding_line(line_id=data.get("id"))
+                continue
+            json_invoice_outstanding_data = (
+                move.invoice_outstanding_credits_debits_widget.get("content", [])
+            )
+            for data in json_invoice_outstanding_data:
+                if data.get("move_id") in sale_order.account_payment_ids.move_id.ids:
+                    move.js_assign_outstanding_line(line_id=data.get("id"))
         return res


### PR DESCRIPTION
Continues https://github.com/OCA/sale-workflow/pull/2945

Advance payments where not being reconciled when multiple invoices were being posted at once using Post entries (`action_validate_account_move`) action window 

Refactored a bit original code and added test