### PR TITLE
[FIX] sale_order_type: Fix item search in account move view

### DIFF
--- a/sale_order_type/views/account_move_views.xml
+++ b/sale_order_type/views/account_move_views.xml
@@ -11,7 +11,10 @@
                     readonly="state != 'draft'"
                 />
             </label>
-            <xpath expr="//notebook//list//field[@name='sequence']" position="before">
+            <xpath
+                expr="//notebook//page[@id='invoice_tab']//list//field[@name='sequence']"
+                position="before"
+            >
                 <field name="account_id" column_invisible="True" />
             </xpath>
         </field>


### PR DESCRIPTION
- In case there is a modification of the view, with studio or a custom development by adding a new tab before the main invoice lines tab, an error occurs with this search because it doesn't find the item in the xpath expression. With this modification, we ensure that the item to search for is in the main invoice lines tab.