### PR TITLE
[FIX] [16.0] sale_elaboration: Ensure elaboration line is created always in the Sale directly related to the move

### DIFF
--- a/sale_elaboration/models/stock_picking.py
+++ b/sale_elaboration/models/stock_picking.py
@@ -14,5 +14,7 @@ class StockPicking(models.Model):
             )
             for line in elaboration_lines:
                 for product in line.sale_line_id.elaboration_ids.product_id:
-                    pick.sale_id._create_elaboration_line(product, line.quantity_done)
+                    line.sale_line_id.order_id._create_elaboration_line(
+                        product, line.quantity_done
+                    )
         return res


### PR DESCRIPTION
We are having strange errors because some elaboration lines on the sale order (created when the move is validated) are linked to stock moves that belongs to another sales...

Picking field [sale_id](https://github.com/odoo/odoo/blob/16.0/addons/sale_stock/models/stock.py#L71) is related to the sale_id field of the Picking Procurement Group and [group_id](https://github.com/odoo/odoo/blob/16.0/addons/stock/models/stock_picking.py#L334-L336) field (procurement group on picking) has an strange relation to the `move_ids.group_id` (this is weird because the field is a m2o and the relation is a o2m.m2o)

So, I think is better to follow the `move.sale_line_id.order_id` to reach the correct sale order in which sale elaboration line should be created instead of choose the sale_id on the picking (that may change if the procurement changes it's sale_id). For example, when doing Waves, another picking is created and maybe the procurement group choose another sale to be it's reference.

I cannot explain the real reason of the elaboration lines being created on another sales, but with this patch, I think we are close to find the real bug (maybe it's more than one bug).

MT-9033 @moduon @rafaelbn @yajo @EmilioPascual @rousseldenis @sergio-teruel please reivew if you want. 😄 