### PR TITLE
[17.0][FIX] sale_order_secondary_unit: fix test

### DIFF
--- a/sale_order_secondary_unit/tests/test_sale_order.py
+++ b/sale_order_secondary_unit/tests/test_sale_order.py
@@ -26,6 +26,7 @@ class TestSaleOrder(TransactionCase):
                 "name": "test",
                 "uom_id": cls.product_uom_kg.id,
                 "uom_po_id": cls.product_uom_kg.id,
+                "list_price": 1000,
             }
         )
         # Set secondary uom on product template
@@ -54,7 +55,6 @@ class TestSaleOrder(TransactionCase):
             with order_form.order_line.new() as line_form:
                 line_form.product_id = cls.product
                 line_form.product_uom_qty = 1
-                line_form.price_unit = 1000.00
         cls.order = order_form.save()
 
     def test_onchange_secondary_uom(self):


### PR DESCRIPTION
The behaviour of odoo in v17 when modifying an existing order line is to recalculate the price based on the price set on the product and not on the line. This module itself had an error in its tests as it was checking a price based on the modified price of the line (1000) which was not correct as when modifying any data of the order line the price was recalculated based on the price of the product which by default is 1 if it has not been set.

cc @tecnativa TT54893

@juancarlosonate-tecnativa @pedrobaeza please review