### PR TITLE
[15.0] Forward-port of [FIX] sale_order_line_chained_move: Fix infinite recursion

### DIFF
--- a/sale_order_line_chained_move/hooks.py
+++ b/sale_order_line_chained_move/hooks.py
@@ -3,11 +3,13 @@
 from odoo import SUPERUSER_ID, api
 
 
-def __find_origin_moves(moves):
+def __find_origin_moves(moves, visited=None):
     all_moves = moves
-    for move in moves:
+    unvisited_moves = (moves - visited) if visited else moves
+    for move in unvisited_moves:
+        visited = visited + move if visited else move
         if move.move_orig_ids:
-            all_moves |= __find_origin_moves(move.move_orig_ids)
+            all_moves |= __find_origin_moves(move.move_orig_ids, visited)
     return all_moves
 
 


### PR DESCRIPTION
Forward-port of the original fix in v13. See PRs https://github.com/OCA/sale-workflow/pull/2638 (v13) and https://github.com/OCA/sale-workflow/pull/2650 (v14). 