### PR TITLE
[15.0][IMP] sale_order_secondary_unit: context for skipping default sec. unit

### DIFF
--- a/sale_order_secondary_unit/models/sale_order.py
+++ b/sale_order_secondary_unit/models/sale_order.py
@@ -38,6 +38,8 @@ class SaleOrderLine(models.Model):
         purpose.
         """
         res = super().product_id_change()
+        if self.env.context.get("skip_secondary_uom_default"):
+            return res
         line_uom_qty = self.product_uom_qty
         self.secondary_uom_id = self.product_id.sale_secondary_uom_id
         if self.product_id.sale_secondary_uom_id:


### PR DESCRIPTION
In some cases we might want to skip the default secondary unit to be set. This change brings that possibility.

For example when product matrix changes are applied, the onchange is triggered from the code, usually we won't want to change the secondary unit in the lines

https://github.com/OCA/OCB/blob/eab555dc127b3a60a0f2b019c39abfbb3b078ff5/addons/sale_product_matrix/models/sale_order.py#L126

A module resolving the compatibility with secondary units is also in the works:

- https://github.com/OCA/product-attribute/pull/1854

cc @Tecnativa TT52531

please review @sergio-teruel @carlosdauden 