### PR TITLE
[18.0][IMP] sale_force_invoiced: recompute invoice amounts when changing force boolean

### DIFF
--- a/sale_force_invoiced/model/sale_order.py
+++ b/sale_force_invoiced/model/sale_order.py
@@ -24,6 +24,14 @@ class SaleOrder(models.Model):
         )
         return res
 
+    @api.depends("force_invoiced")
+    def _compute_amount_to_invoice(self):
+        # force_invoiced causes the amount to invoice to be zero
+        res = super()._compute_amount_to_invoice()
+        for so in self.filtered("force_invoiced"):
+            so.amount_to_invoice = 0
+        return res
+
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"

--- a/sale_force_invoiced/tests/test_sale_force_invoiced.py
+++ b/sale_force_invoiced/tests/test_sale_force_invoiced.py
@@ -40,12 +40,21 @@ class TestSaleForceInvoiced(TransactionCase):
     def test_sales_order(self):
         so = self.sale_order_model.create({"partner_id": self.customer.id})
         sol1 = self.sale_order_line_model.create(
-            {"product_id": self.service_1.id, "product_uom_qty": 1, "order_id": so.id}
+            {
+                "product_id": self.service_1.id,
+                "product_uom_qty": 1,
+                "order_id": so.id,
+                "price_unit": 1.0,
+            }
         )
         sol2 = self.sale_order_line_model.create(
-            {"product_id": self.service_2.id, "product_uom_qty": 2, "order_id": so.id}
+            {
+                "product_id": self.service_2.id,
+                "product_uom_qty": 2,
+                "order_id": so.id,
+                "price_unit": 2.0,
+            }
         )
-
         # confirm quotation
         so.action_confirm()
         # update quantities delivered
@@ -80,8 +89,16 @@ class TestSaleForceInvoiced(TransactionCase):
         self.assertEqual(
             sol2.invoice_status, "invoiced", "The SOL invoice status should be Invoiced"
         )
-
+        self.assertFalse(
+            so.amount_to_invoice,
+            "Amount to invoice when invoice is forced should be 0",
+        )
         so.force_invoiced = False
         self.assertEqual(
             so.invoice_status, "to invoice", "The invoice status should be To Invoice"
+        )
+        self.assertEqual(
+            so.amount_to_invoice,
+            sum(so.order_line.mapped("price_total")),
+            "Amount to invoice when invoice is not forced should be original amount",
         )


### PR DESCRIPTION
Port of https://github.com/OCA/sale-workflow/pull/3545 but overriding the relevant compute method instead of `write`, and fixed tests.