### PR TITLE
[FIX] sale_fixed_discount, sale_triple_discount: modules are incompatibles and can not work together by design.

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -18,6 +18,8 @@ org_name: Odoo Community Association (OCA)
 org_slug: OCA
 rebel_module_groups:
 - sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration
+- sale_triple_discount
+- sale_fixed_discount
 repo_description: 'TODO: add repo description.'
 repo_name: sale-workflow
 repo_slug: sale-workflow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,10 +43,24 @@ jobs:
             name: test with OCB
             makepot: "true"
           - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
-            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration"
+            include: "sale_triple_discount"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
-            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration"
+            include: "sale_triple_discount"
+            name: test with OCB
+            makepot: "true"
+          - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
+            include: "sale_fixed_discount"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
+            include: "sale_fixed_discount"
+            name: test with OCB
+            makepot: "true"
+          - container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
+            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_triple_discount,sale_fixed_discount"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.10-ocb16.0:latest
+            exclude: "sale_packaging_default,sale_order_product_recommendation,sale_order_product_recommendation_packaging_default,sale_order_product_recommendation_elaboration,sale_triple_discount,sale_fixed_discount"
             name: test with OCB
             makepot: "true"
     services:

--- a/sale_fixed_discount/__manifest__.py
+++ b/sale_fixed_discount/__manifest__.py
@@ -11,6 +11,7 @@
     "application": False,
     "installable": True,
     "depends": ["sale", "account_invoice_fixed_discount"],
+    "excludes": ["sale_triple_discount"],
     "data": [
         "security/res_groups.xml",
         "reports/report_sale_order.xml",

--- a/sale_fixed_discount/static/description/index.html
+++ b/sale_fixed_discount/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -436,7 +437,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_triple_discount/__manifest__.py
+++ b/sale_triple_discount/__manifest__.py
@@ -14,6 +14,7 @@
     "license": "AGPL-3",
     "summary": "Manage triple discount on sale order lines",
     "depends": ["sale_management", "account_invoice_triple_discount"],
+    "excludes": ["sale_fixed_discount"],
     "data": ["views/sale_order_report.xml", "views/sale_order_view.xml"],
     "installable": True,
 }


### PR DESCRIPTION
similar to account_invoice_fixed_discount and account_invoice_triple_discount

**Rational:** 

- account_invoice_fixed_discount and account_invoice_triple_discount have been incompatible since their creation. (by design) 
- sale_fixed_discount and sale_triple_discount have exactly the same incompatibility.
- However, modules has never been marked as incompatible. (not in the copier answer / CI and neither in the manifest).
- during @grindtildeath refactoring in https://github.com/OCA/account-invoicing/pull/1638 and https://github.com/OCA/account-invoicing/pull/1840, it was mandatory to mark the two account modules as rebel.
- so in the same way, it is now mandatory to mark the two sale modules as rebel.

Fixes problem in 
- https://github.com/OCA/sale-workflow/pull/3595#issuecomment-2681996180 (CC : @victoralmau)
- https://github.com/OCA/sale-workflow/pull/3592#issue-2877691549 CC : (@manuelregidor)

