### PR TITLE
[16.0][WIP] sale_payment_sheet: Define @freeze_time decorator in tests and not in TestSaleInvoicePayment to avoid side effects

### DIFF
--- a/sale_payment_sheet/tests/test_sale_payment_sheet.py
+++ b/sale_payment_sheet/tests/test_sale_payment_sheet.py
@@ -9,7 +9,6 @@ from odoo.exceptions import UserError, ValidationError
 from odoo.tests import Form, TransactionCase
 
 
-@freeze_time("2021-01-01 09:30:00")
 class TestSaleInvoicePayment(TransactionCase):
     @classmethod
     def setUpClass(cls):
@@ -113,6 +112,7 @@ class TestSaleInvoicePayment(TransactionCase):
                         line_sheet.amount = 50.0
         return sheet_form.save()
 
+    @freeze_time("2021-01-01 09:30:00")
     def test_manual_payment_sheet(self):
         sheet = self._create_payment_sheet()
         self.assertEqual(len(sheet.line_ids), 2)


### PR DESCRIPTION
Define @freeze_time decorator in tests and not in TestSaleInvoicePayment to avoid side effects

If a module (sale_payment_sheet_financial_risk for example) has a test https://github.com/OCA/credit-control/blob/120b39c8d92e856159d79ca084e69dd0d9c6badd/sale_payment_sheet_financial_risk/tests/test_sale_payment_sheet_financial_risk.py#L9 that extends it, a crash occurs in post tests

@Tecnativa