### PR TITLE
[15.0][IMP] sale_elaboration: Propagate quantities after changes picking unlocked

### DIFF
--- a/sale_elaboration/tests/test_sale_elaboration.py
+++ b/sale_elaboration/tests/test_sale_elaboration.py
@@ -182,3 +182,12 @@ class TestSaleElaboration(TransactionCase):
         elaboration_lines = self.order.order_line.filtered("is_elaboration")
         self.assertEqual(len(elaboration_lines), 2)
         self.assertEqual(sum(elaboration_lines.mapped("product_uom_qty")), 12.0)
+
+    def test_sale_elaboration_done_move_changes(self):
+        self.order.action_confirm()
+        self.order.picking_ids.move_lines.quantity_done = 10.0
+        self.order.picking_ids._action_done()
+        self.order.picking_ids.move_lines.quantity_done = 15.0
+        elaboration_lines = self.order.order_line.filtered("is_elaboration")
+        self.assertEqual(len(elaboration_lines), 1)
+        self.assertEqual(elaboration_lines.product_uom_qty, 15.0)


### PR DESCRIPTION
Update elaboration quantities to sale order when quantity_done changes in done moves (unlock picking)

@Tecnativa TT55334
ping @sergio-teruel @chienandalu 