### PR TITLE
[16.0][IMP] sale_tier_validation: Hide Confirm button if the validation is pending or rejected

### DIFF
--- a/sale_tier_validation/README.rst
+++ b/sale_tier_validation/README.rst
@@ -79,6 +79,8 @@ Known issues / Roadmap
 -  The sales order, when moved to the state sent, will still send the
    email even if the validation is not approved by the corresponding
    tier. Code to consider this particular case is not developed.
+-  If any module modifies the attrs of the confirm sales order button,
+   it will invalidate the expected behavior.
 
 Bug Tracker
 ===========

--- a/sale_tier_validation/readme/ROADMAP.md
+++ b/sale_tier_validation/readme/ROADMAP.md
@@ -1,3 +1,5 @@
 - The sales order, when moved to the state sent, will still send the
   email even if the validation is not approved by the corresponding
   tier. Code to consider this particular case is not developed.
+- If any module modifies the attrs of the confirm sales order button,
+  it will invalidate the expected behavior.

--- a/sale_tier_validation/static/description/index.html
+++ b/sale_tier_validation/static/description/index.html
@@ -429,6 +429,8 @@ for her/him to request a validation.</li>
 <li>The sales order, when moved to the state sent, will still send the
 email even if the validation is not approved by the corresponding
 tier. Code to consider this particular case is not developed.</li>
+<li>If any module modifies the attrs of the confirm sales order button,
+it will invalidate the expected behavior.</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">

--- a/sale_tier_validation/views/sale_order_view.xml
+++ b/sale_tier_validation/views/sale_order_view.xml
@@ -2,6 +2,25 @@
 <!-- Copyright 2019 Open Source Integrators
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//button[@name='action_confirm'][1]" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible':['|', ('validation_status', 'in', ('pending', 'rejected')),('state', '!=', 'sent')]}</attribute>
+            </xpath>
+            <xpath expr="//button[@name='action_confirm'][2]" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible':['|', ('validation_status', 'in', ('pending', 'rejected')),('state', '!=', 'draft')]}</attribute>
+            </xpath>
+             <field name="state" position="after">
+                <field name="validation_status" invisible="1" />
+            </field>
+        </field>
+    </record>
     <record id="view_sale_order_filter" model="ir.ui.view">
         <field name="name">sale.order.select - sale_tier_validation</field>
         <field name="model">sale.order</field>


### PR DESCRIPTION
Related to https://github.com/OCA/purchase-workflow/pull/2605#pullrequestreview-2673636854

Hide Confirm button if the validation is pending or rejected.

**Before**
![antes](https://github.com/user-attachments/assets/847b16c1-1f2b-40d2-9c89-5e5f1a7dcd27)

**After**
![despues](https://github.com/user-attachments/assets/c4733364-d487-4fcd-ba10-258ad977badb)

Please @sergio-teruel can you review it?

@Tecnativa 