### PR TITLE
[16.0][FIX] sale_blanket_order: SO from Blanket Order disable adding lines

### DIFF
--- a/sale_blanket_order/models/sale_orders.py
+++ b/sale_blanket_order/models/sale_orders.py
@@ -15,6 +15,9 @@ class SaleOrder(models.Model):
         string="Origin blanket order",
         related="order_line.blanket_order_line.order_id",
     )
+    disable_adding_lines = fields.Boolean(
+        compute="_compute_disable_adding_lines",
+    )
 
     @api.model
     def _check_exchausted_blanket_order_line(self):
@@ -46,6 +49,16 @@ class SaleOrder(models.Model):
                             "blanket order lines customer"
                         )
                     )
+
+    @api.depends("blanket_order_id")
+    @api.depends_context("uid")
+    def _compute_disable_adding_lines(self):
+        self.disable_adding_lines = False
+        if self.env.user.has_group(
+            "sale_blanket_order.blanket_orders_disable_adding_lines"
+        ):
+            for order in self:
+                order.disable_adding_lines = order.blanket_order_id
 
 
 class SaleOrderLine(models.Model):

--- a/sale_blanket_order/views/sale_order_views.xml
+++ b/sale_blanket_order/views/sale_order_views.xml
@@ -28,10 +28,11 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']" position="before">
+                <field name="disable_adding_lines" invisible="1" />
+            </xpath>
             <xpath expr="//field[@name='order_line']//tree" position="attributes">
-                <t groups="sale_blanket_order.blanket_orders_disable_adding_lines">
-                    <attribute name="create">blanket_order_id==False</attribute>
-                </t>
+                <attribute name="create">not disable_adding_lines</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Before this fix, SO lines could never be added to SOs from Blanket Orders, no matter if the user belonged to the _Disable adding more lines to SOs from Blanket Orders_ or not. It seems like `<t groups...` in an `attributes` `<xpath>` was not working as expected.

With this commit, that problem is solved.