### PR TITLE
[17.0][FIX] sale_force_whole_invoiceability: button visibility

### DIFF
--- a/sale_force_whole_invoiceability/views/sale_order_views.xml
+++ b/sale_force_whole_invoiceability/views/sale_order_views.xml
@@ -11,7 +11,7 @@
                     name="force_lines_to_invoice_policy_order"
                     string="Force Invoice Policy"
                     type="object"
-                    invisible="state not in ['sale'] and invoice_count > 0"
+                    invisible="state not in ['sale'] or invoice_count > 0"
                     groups="sales_team.group_sale_manager"
                 />
             </button>


### PR DESCRIPTION
Since the code will throw an error if the button is used when it is not a confirmed sale order or if we already have an invoice, we should hide the button in those cases.