### PR TITLE
[17.0][IMP] sale_partner_address_restrict: mark dropship addresses to hide the main contact name

### DIFF
--- a/sale_partner_address_restrict/README.rst
+++ b/sale_partner_address_restrict/README.rst
@@ -31,6 +31,11 @@ Sale Partner Address Restrict
 This module restricts the addresses to be used in the sales order form
 to only addresses of the selected customer.
 
+When managing dropship delivery addresses, a delivery address needs to
+be created for the buyer main contact. You can then mark the checkbox
+'Dropship Address' on the delivery address to prevent the buyer main
+contact name to be displayed as part of the delivery address name.
+
 **Table of contents**
 
 .. contents::
@@ -39,11 +44,15 @@ to only addresses of the selected customer.
 Configuration
 =============
 
-- Go to Sales > Configuration > Settings > Quotation & Orders > Sale
-  Partner Address Restriction
-- Check the box if you want to restrict available partners for Delivery
-  and Invoicing addresses to partners that belong to the selected
-  Customer.
+-  Go to Sales > Configuration > Settings > Quotation & Orders > Sale
+   Partner Address Restriction
+-  Check the box if you want to restrict available partners for Delivery
+   and Invoicing addresses to partners that belong to the selected
+   Customer.
+
+If you are managing dropship delivery addresses, you can mark the
+checkbox 'Dropship Address' in the addresses to prevent the parent
+contact name to be displayed.
 
 Bug Tracker
 ===========
@@ -66,8 +75,8 @@ Authors
 Contributors
 ------------
 
-- Marina Alapont <marina.alapont@forgeflow.com>
-- Denis Roussel denis.roussel@acsone.eu
+-  Marina Alapont <marina.alapont@forgeflow.com>
+-  Denis Roussel denis.roussel@acsone.eu
 
 Maintainers
 -----------

--- a/sale_partner_address_restrict/__manifest__.py
+++ b/sale_partner_address_restrict/__manifest__.py
@@ -15,5 +15,9 @@
         "base_partition",
         "sale",
     ],
-    "data": ["views/sale_order_view.xml", "views/res_config_settings.xml"],
+    "data": [
+        "views/sale_order_view.xml",
+        "views/res_config_settings.xml",
+        "views/res_partner_views.xml",
+    ],
 }

--- a/sale_partner_address_restrict/models/__init__.py
+++ b/sale_partner_address_restrict/models/__init__.py
@@ -1,3 +1,4 @@
 from . import sale_order
 from . import res_company
+from . import res_partner
 from . import res_config_settings

--- a/sale_partner_address_restrict/models/res_partner.py
+++ b/sale_partner_address_restrict/models/res_partner.py
@@ -1,0 +1,16 @@
+# Copyright 2025 ForgeFlow S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    is_dropship_address = fields.Boolean(string="Dropship Address")
+
+    def _get_complete_name(self):
+        res = super()._get_complete_name()
+        if not self.is_dropship_address or not self.name or not self.type == "delivery":
+            return res
+        return self.name.strip()

--- a/sale_partner_address_restrict/readme/CONFIGURE.md
+++ b/sale_partner_address_restrict/readme/CONFIGURE.md
@@ -1,3 +1,6 @@
 - Go to Sales \> Configuration \> Settings \> Quotation & Orders \> Sale Partner Address Restriction
-- Check the box if you want to restrict available partners for Delivery and Invoicing addresses to 
+- Check the box if you want to restrict available partners for Delivery and Invoicing addresses to
   partners that belong to the selected Customer.
+
+If you are managing dropship delivery addresses, you can mark the checkbox 'Dropship Address'
+in the addresses to prevent the parent contact name to be displayed.

--- a/sale_partner_address_restrict/readme/DESCRIPTION.md
+++ b/sale_partner_address_restrict/readme/DESCRIPTION.md
@@ -1,2 +1,7 @@
 This module restricts the addresses to be used in the sales order form to only
 addresses of the selected customer.
+
+When managing dropship delivery addresses, a delivery address needs to be created
+for the buyer main contact. You can then mark the checkbox 'Dropship Address' on
+the delivery address to prevent the buyer main contact name to be displayed as
+part of the delivery address name.

--- a/sale_partner_address_restrict/static/description/index.html
+++ b/sale_partner_address_restrict/static/description/index.html
@@ -372,6 +372,10 @@ ul.auto-toc {
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/sale-workflow/tree/17.0/sale_partner_address_restrict"><img alt="OCA/sale-workflow" src="https://img.shields.io/badge/github-OCA%2Fsale--workflow-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/sale-workflow-17-0/sale-workflow-17-0-sale_partner_address_restrict"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/sale-workflow&amp;target_branch=17.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module restricts the addresses to be used in the sales order form
 to only addresses of the selected customer.</p>
+<p>When managing dropship delivery addresses, a delivery address needs to
+be created for the buyer main contact. You can then mark the checkbox
+‘Dropship Address’ on the delivery address to prevent the buyer main
+contact name to be displayed as part of the delivery address name.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -394,6 +398,9 @@ Partner Address Restriction</li>
 and Invoicing addresses to partners that belong to the selected
 Customer.</li>
 </ul>
+<p>If you are managing dropship delivery addresses, you can mark the
+checkbox ‘Dropship Address’ in the addresses to prevent the parent
+contact name to be displayed.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>

--- a/sale_partner_address_restrict/tests/test_sale_order.py
+++ b/sale_partner_address_restrict/tests/test_sale_order.py
@@ -10,7 +10,7 @@ class TestSaleOrder(BaseCommon):
         super().setUpClass()
         cls.partner1 = cls.env["res.partner"].create({"name": "Test Partner 1"})
         cls.child_1 = cls.env["res.partner"].create(
-            {"name": "Child 1", "parent_id": cls.partner1.id}
+            {"name": "Child 1", "parent_id": cls.partner1.id, "type": "delivery"}
         )
         cls.child_2 = cls.env["res.partner"].create(
             {"name": "Child 2", "parent_id": cls.partner1.id}
@@ -83,3 +83,9 @@ class TestSaleOrder(BaseCommon):
                 "partner_shipping_id": self.child_2.id,
             }
         )
+
+    def test_dropship_delivery_address(self):
+        self.assertIn(self.partner1.name, self.child_1.display_name)
+        self.child_1.is_dropship_address = True
+        self.child_1._compute_display_name()
+        self.assertNotIn(self.partner1.name, self.child_1.display_name)

--- a/sale_partner_address_restrict/views/res_partner_views.xml
+++ b/sale_partner_address_restrict/views/res_partner_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_partner_form" model="ir.ui.view">
+        <field
+            name="name"
+        >res.partner.form - sale_partner_address_restrict_dropshipping</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group/group[//field[@name='vat']]" position="inside">
+                <field
+                    name="is_dropship_address"
+                    invisible="type != 'delivery' or not parent_id"
+                />
+            </xpath>
+            <xpath
+                expr="//notebook/page[@name='contact_addresses']//form//field[@name='name']"
+                position="after"
+            >
+                <field name="is_dropship_address" invisible="type != 'delivery'" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
When using the Sale Partner Address Restrict module, you are forced to use invoice and delivery addresses related to the main customer.

When selling to a dropshipper, the delivery address represents a final end customer that is not part of the main customer, but it is still useful to have the relation in the system so that you know which dropship addresses have been created for each of your dropshipper customers.

With the new checkbox you can mark dropship delivery addresses to ensure that the dropshipper name is not displayed for them. This will hide it from the PDF reports.