### PR TITLE
[FIX] sale_discount_display_amount: remove duplicated naming in fields.

### DIFF
--- a/sale_discount_display_amount/models/sale_order.py
+++ b/sale_discount_display_amount/models/sale_order.py
@@ -21,7 +21,7 @@ class SaleOrder(models.Model):
     )
     price_total_no_discount = fields.Monetary(
         compute='_compute_discount_total',
-        string='Subtotal Without Discount',
+        string='Total Without Discount',
         currency_field='currency_id',
         store=True)
 

--- a/sale_discount_display_amount/models/sale_order_line.py
+++ b/sale_discount_display_amount/models/sale_order_line.py
@@ -19,7 +19,7 @@ class SaleOrderLine(models.Model):
     )
     price_total_no_discount = fields.Monetary(
         compute='_compute_amount',
-        string='Subtotal Without Discount',
+        string='Total Without Discount',
         store=True)
 
     def _compute_discount(self):


### PR DESCRIPTION
The module introduces price_total_no_discount and price_subtotal_no_discount fields in 'sale.order' and 'sale.order.line' models. However, the string is the same, so it generates warning in odoo logs, and impossibility to distinguish the fields for end-users

Fixes: #3000

CC original developper / reviewers :  @sergiocorato, @dreispt,  @rousseldenis
