### PR TITLE
[IMP] sale_validity_auto_cancel: add warnings for sale orders to be auto cancelled

### DIFF
--- a/sale_validity_auto_cancel/__manifest__.py
+++ b/sale_validity_auto_cancel/__manifest__.py
@@ -10,7 +10,11 @@
     "depends": ["sale_management"],
     "author": "ForgeFlow, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
-    "data": ["data/ir_cron.xml", "views/res_config_settings.xml"],
+    "data": [
+        "data/ir_cron.xml",
+        "views/res_config_settings.xml",
+        "views/sale_order.xml",
+    ],
     "installable": True,
     "maintainers": ["JordiMForgeFlow"],
 }

--- a/sale_validity_auto_cancel/models/res_company.py
+++ b/sale_validity_auto_cancel/models/res_company.py
@@ -1,7 +1,8 @@
 # Copyright 2023 ForgeFlow S.L.
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ResCompany(models.Model):
@@ -13,6 +14,16 @@ class ResCompany(models.Model):
         help="Quotations will be cancelled after the specified number of"
         " days since the expiration date.",
     )
+    sale_validity_warning_days = fields.Integer(
+        string="Default Validity Warning of Sale Orders",
+        default=0,
+        help="By default, the validity date warning of sale orders will be "
+        "the number of days defined on this field before the date of the "
+        "validity sale order. If the value of this field is 0, the sale orders "
+        "will not have a validity warning by default.",
+    )
+
+    sale_validity_warning_enabled = fields.Boolean(default=False)
 
     _sql_constraints = [
         (
@@ -21,4 +32,25 @@ class ResCompany(models.Model):
             "The value of the field 'Auto-cancel expired quotations after' "
             "must be positive or 0.",
         ),
+        (
+            "sale_order_validity_warning_days_positive",
+            "CHECK (sale_validity_warning_days >= 0)",
+            "The value of the field 'Default Validity Warning of Sale Orders' "
+            "must be positive or 0.",
+        ),
     ]
+
+    @api.constrains("sale_validity_warning_days", "sale_validity_auto_cancel_days")
+    def _check_warning_vs_auto_cancel(self):
+        for rec in self:
+            if (
+                rec.sale_validity_warning_days
+                and rec.sale_validity_auto_cancel_days
+                and rec.sale_validity_warning_days >= rec.sale_validity_auto_cancel_days
+            ):
+                raise ValidationError(
+                    _(
+                        "The 'Default Validity Warning of Sale Orders' must be less than "
+                        "'Auto-cancel expired quotations after (days)'."
+                    )
+                )

--- a/sale_validity_auto_cancel/models/res_config_settings.py
+++ b/sale_validity_auto_cancel/models/res_config_settings.py
@@ -10,3 +10,11 @@ class ResConfigSettings(models.TransientModel):
     sale_validity_auto_cancel_days = fields.Integer(
         related="company_id.sale_validity_auto_cancel_days", readonly=False,
     )
+
+    sale_validity_warning_days = fields.Integer(
+        related="company_id.sale_validity_warning_days", readonly=False,
+    )
+
+    sale_validity_warning_enabled = fields.Boolean(
+        related="company_id.sale_validity_warning_enabled", readonly=False,
+    )

--- a/sale_validity_auto_cancel/models/sale_order.py
+++ b/sale_validity_auto_cancel/models/sale_order.py
@@ -4,13 +4,21 @@ import logging
 
 from dateutil.relativedelta import relativedelta
 
-from odoo import fields, models
+from odoo import _, api, fields, models
 
 _logger = logging.getLogger(__name__)
 
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
+
+    validity_date_warning_message = fields.Text(
+        compute="_compute_validity_date_warning_message",
+    )
+
+    sale_validity_warning_enabled = fields.Boolean(
+        related="company_id.sale_validity_warning_enabled", readonly=False,
+    )
 
     def _get_expired_order_states(self):
         # Can be inherited to exclude/include order states
@@ -31,3 +39,33 @@ class SaleOrder(models.Model):
                     order.with_context(company_id=company.id).action_cancel()
                 except Exception as e:
                     _logger.error("Failed to auto-cancel %s: %s" % (order.name, str(e)))
+
+    @api.depends("validity_date", "company_id")
+    def _compute_validity_date_warning_message(self):
+        for order in self:
+            order.validity_date_warning_message = False
+            company = order.company_id or self.env["res.company"]._company_default_get(
+                "sale.order"
+            )
+            if company.sale_validity_warning_days:
+                today = fields.Date.today()
+                expired_states = order._get_expired_order_states()
+                auto_cancel_date = order.validity_date + relativedelta(
+                    days=company.sale_validity_auto_cancel_days
+                )
+                warning_date = auto_cancel_date - relativedelta(
+                    days=company.sale_validity_warning_days
+                )
+                if (
+                    order.state in expired_states
+                    and auto_cancel_date > today > warning_date
+                ):
+                    days = int((auto_cancel_date - today).days)
+                    order.validity_date_warning_message = (
+                        _(
+                            "This Quotation will be automatically cancelled in %s days.\n"
+                            "If needed, the expiration date (found on the 'Other info' tab) "
+                            "can be updated to a future date."
+                        )
+                        % days
+                    )

--- a/sale_validity_auto_cancel/readme/CONFIGURE.rst
+++ b/sale_validity_auto_cancel/readme/CONFIGURE.rst
@@ -1,1 +1,5 @@
 Go to the menu *Sale > Configuration > Settings*, in the section *Quotations & Sales*, set the *Auto-cancel expired quotations after* in days.
+
+To enable warnings:
+
+- Go to the menu *Sale > Configuration > Settings*, in the section *Quotations & Sales*, enable the *Sale Validity Warning Enabled* and set the *Default Validity Warning of Sale Orders* in days.

--- a/sale_validity_auto_cancel/readme/CONTRIBUTORS.rst
+++ b/sale_validity_auto_cancel/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Jordi Masvidal <jordi.masvidal@forgeflow.com>
+* Àlex París <alex.paris@forgeflow.com>

--- a/sale_validity_auto_cancel/readme/DESCRIPTION.rst
+++ b/sale_validity_auto_cancel/readme/DESCRIPTION.rst
@@ -1,3 +1,5 @@
 This module adds a scheduled action that automatically cancels quotations after their expiration date.
+Also adds the possibility to diplay a warning before quotation will be automatically canceled.
 
 A company setting can be modified to decide how many days after the expiration date the quotations are automatically cancelled.
+There is also one company setting to enable the warnings, and define how many days before automatic cancellation the warning will be shown.

--- a/sale_validity_auto_cancel/tests/test_sale_validity_auto_cancel.py
+++ b/sale_validity_auto_cancel/tests/test_sale_validity_auto_cancel.py
@@ -33,3 +33,16 @@ class TestSaleValidityAutoCancel(TransactionCase):
         }
         so = self.env["sale.order"].create(vals)
         return so
+
+    def test_sale_validity_auto_cancel_warning(self):
+        company = self.env.ref("base.main_company")
+        company.sale_validity_auto_cancel_days = 10
+        company.sale_validity_warning_days = 5
+        so = self.create_so()
+        so.validity_date = fields.Date.today() - relativedelta(days=6)
+        self.assertEqual(
+            so.validity_date_warning_message,
+            "This Quotation will be automatically cancelled in 4 days.\n"
+            "If needed, the expiration date (found on the 'Other info' tab) "
+            "can be updated to a future date.",
+        )

--- a/sale_validity_auto_cancel/views/res_config_settings.xml
+++ b/sale_validity_auto_cancel/views/res_config_settings.xml
@@ -25,6 +25,44 @@
                         </div>
                     </div>
                 </div>
+                <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="sale_config_online_confirmation_sign"
+                >
+                    <div class="o_setting_left_pane">
+                        <field name="sale_validity_warning_enabled" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="sale_validity_warning_enabled" />
+                        <span
+                            class="fa fa-lg fa-building-o"
+                            title="Values set here are company-specific."
+                            groups="base.group_multi_company"
+                        />
+                        <div class="text-muted">
+                            Enable warning for sale automatic cancellation.
+                        </div>
+                        <div
+                            class="content-group"
+                            attrs="{'invisible': [('sale_validity_warning_enabled', '=', False)]}"
+                        >
+                            <div class="mt16">
+                                <label for="sale_validity_warning_days" />
+                                <div class="text-muted mt4 mb4">
+                                    Number of days before automatic cancellation to display a warning on quotations.
+                                </div>
+                                <div class="text-muted mt4 mb4">
+                                    <field name="sale_validity_warning_days" />
+                                    <label
+                                        for=""
+                                        string="Days"
+                                        style="margin-left: 5px;"
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>

--- a/sale_validity_auto_cancel/views/sale_order.xml
+++ b/sale_validity_auto_cancel/views/sale_order.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 ForgeFlow S.L.
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record model="ir.ui.view" id="view_order_form_warning">
+        <field name="name">sale.order.form (validity_warn)</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <header position="after">
+                <field name="sale_validity_warning_enabled" invisible="1" />
+                <div
+                    class="alert alert-warning"
+                    role="alert"
+                    attrs="{'invisible': ['|', ('sale_validity_warning_enabled', '=', False), ('validity_date_warning_message', '=', False)]}"
+                    style="margin-bottom:0px;"
+                >
+                    <p>
+                        <i class="fa fa-info-circle" />
+                        &amp;nbsp;
+                        <field name="validity_date_warning_message" class="oe_inline" />
+                    </p>
+                </div>
+            </header>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Adds possibility to define a default validity warning of sale orders.
A warning will be displied if sale order is modified and was going to be auto cancelled in X days.
It is introduced a setting called 'Default Validity Warning of Sale Orders' to define the threshold of number of days for the warning.