### PR TITLE
[16.0][IMP] sale_order_lot_selection: add lot selection wizard

### DIFF
--- a/sale_order_lot_selection/README.rst
+++ b/sale_order_lot_selection/README.rst
@@ -36,16 +36,62 @@ This selected lot number will be the one delivered to the Customer.
 .. contents::
    :local:
 
+Use Cases / Context
+===================
+
+Sometimes companies need to create quotations with precise lot/serial number
+specifications before confirming orders, such as used equipment with unique serial
+numbers or specific inventory lots.
+
+This is particularly important in several business scenarios:
+
+* In industries where product traceability is critical and customers need specific
+  serial numbers (electronics, automotive parts, medical devices)
+* When dealing with batches that vary in quality or characteristics, where
+  customers require products from specific production runs
+* In regulated industries where lot traceability is mandatory for compliance
+  purposes
+
+For example:
+
+* A machinery reseller needs to quote specific used equipment with known serial
+  numbers
+* An electronics distributor must sell particular serial-numbered items for
+  warranty tracking
+* A car parts supplier needs to specify exact serial numbers for rare components
+
+Configuration
+=============
+
+If you want to allow users to generate sales quotas directly from the stock.lots tree view:
+
+* Go to Inventory > Configuration > Settings
+* Under Operations section select the "Allow to generate sales quotations from stock lots" check box
+
 Usage
 =====
 
-- Create/edit a product and set traceability by 'By Lots' option.
-- Create a new lot number and assign product.
-- Update quantity for that product and assign lot number.
-- Go to Sales > Orders > Quotations.
-- Create a new quotation and add recently above configured product.
-- Select lot number and confirm it.
-- Delivery order will reserve the lot when available
+There are two ways to add Lots to a Sale Order:
+
+1. From Sale Order:
+
+   - Create/edit a product and set traceability by 'By Lots' option
+   - Create a new lot number and assign product
+   - Update quantity for that product and assign lot number
+   - Go to Sales > Orders > Quotations
+   - Create a new quotation and add recently above configured product
+   - Select lot number and confirm it
+   - Delivery order will reserve the lot when available
+
+2. From Lots/Serial Numbers:
+
+   - Go to "Sales > Products > Lots/Serial Numbers"
+   - Select Serial Numbers you would like to add to quotation
+   - Click action > Create quotation
+   - In the action wizard:
+
+     * To add to existing order: Select a Quotation/Sales order and click "Add"
+     * To create new order: Click "New" to create quotation with selected lots
 
 Known issues / Roadmap
 ======================
@@ -84,6 +130,10 @@ Contributors
 * Bhavesh Odedra <bodedra@opensourceintegrators.com>
 * François Honoré <francois.honore@acsone.eu>
 * Florian da Costa <florian.dacosta@akretion.com>
+* `Cetmix <https://cetmix.com>`_:
+
+  * George Smirnov
+  * Anatol Mikheev
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_order_lot_selection/__manifest__.py
+++ b/sale_order_lot_selection/__manifest__.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 {
     "name": "Sale Order Lot Selection",
     "version": "16.0.1.0.1",
@@ -6,7 +9,13 @@
     "website": "https://github.com/OCA/sale-workflow",
     "license": "AGPL-3",
     "depends": ["sale_stock", "stock_restrict_lot"],
-    "data": ["view/sale_view.xml"],
+    "data": [
+        "security/ir.model.access.csv",
+        "view/sale_view.xml",
+        "view/lot_view.xml",
+        "view/res_config_settings.xml",
+        "wizards/stock_lot_add_to_sale_order.xml",
+    ],
     "demo": ["demo/sale_demo.xml"],
     "maintainers": ["bodedra"],
     "installable": True,

--- a/sale_order_lot_selection/models/__init__.py
+++ b/sale_order_lot_selection/models/__init__.py
@@ -1,1 +1,6 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from . import sale_order_line
+from . import res_config_settings
+from . import stock_lot

--- a/sale_order_lot_selection/models/res_config_settings.py
+++ b/sale_order_lot_selection/models/res_config_settings.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    allow_generate_so_from_lots = fields.Boolean(
+        string="Allow Generate SO from Lots",
+        config_parameter="sale_order_lot_selection.allow_generate_from_lots",
+        default=False,
+    )

--- a/sale_order_lot_selection/models/stock_lot.py
+++ b/sale_order_lot_selection/models/stock_lot.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, models
+from odoo.exceptions import AccessError
+
+
+class StockLot(models.Model):
+    _inherit = "stock.lot"
+
+    def action_add_to_sale_order(self):
+        """Open the wizard to add lots to a sale order."""
+        self.ensure_one()
+        return self.action_generate_sale_order()
+
+    def action_generate_sale_order(self):
+        """Open wizard to generate sale order from lots."""
+        if (
+            not self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("sale_order_lot_selection.allow_generate_from_lots")
+        ):
+            raise AccessError(_("You are not allowed to generate Sale Order from Lot."))
+
+        wizard = self.env["stock.lot.sale.order.wizard"].create(
+            {
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "lot_id": lot.id,
+                            "quantity": lot.product_qty,
+                        },
+                    )
+                    for lot in self
+                ]
+            }
+        )
+
+        return {
+            "name": _("Add Lot to Sale Order"),
+            "type": "ir.actions.act_window",
+            "res_model": "stock.lot.sale.order.wizard",
+            "view_mode": "form",
+            "res_id": wizard.id,
+            "target": "new",
+        }

--- a/sale_order_lot_selection/pyproject.toml
+++ b/sale_order_lot_selection/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/sale_order_lot_selection/readme/CONFIGURE.rst
+++ b/sale_order_lot_selection/readme/CONFIGURE.rst
@@ -1,0 +1,4 @@
+If you want to allow users to generate sales quotas directly from the stock.lots tree view:
+
+* Go to Inventory > Configuration > Settings
+* Under Operations section select the "Allow to generate sales quotations from stock lots" check box

--- a/sale_order_lot_selection/readme/CONTEXT.rst
+++ b/sale_order_lot_selection/readme/CONTEXT.rst
@@ -1,0 +1,20 @@
+Sometimes companies need to create quotations with precise lot/serial number
+specifications before confirming orders, such as used equipment with unique serial
+numbers or specific inventory lots.
+
+This is particularly important in several business scenarios:
+
+* In industries where product traceability is critical and customers need specific
+  serial numbers (electronics, automotive parts, medical devices)
+* When dealing with batches that vary in quality or characteristics, where
+  customers require products from specific production runs
+* In regulated industries where lot traceability is mandatory for compliance
+  purposes
+
+For example:
+
+* A machinery reseller needs to quote specific used equipment with known serial
+  numbers
+* An electronics distributor must sell particular serial-numbered items for
+  warranty tracking
+* A car parts supplier needs to specify exact serial numbers for rare components

--- a/sale_order_lot_selection/readme/CONTRIBUTORS.rst
+++ b/sale_order_lot_selection/readme/CONTRIBUTORS.rst
@@ -4,3 +4,7 @@
 * Bhavesh Odedra <bodedra@opensourceintegrators.com>
 * François Honoré <francois.honore@acsone.eu>
 * Florian da Costa <florian.dacosta@akretion.com>
+* `Cetmix <https://cetmix.com>`_:
+
+  * George Smirnov
+  * Anatol Mikheev

--- a/sale_order_lot_selection/readme/USAGE.rst
+++ b/sale_order_lot_selection/readme/USAGE.rst
@@ -1,7 +1,21 @@
-- Create/edit a product and set traceability by 'By Lots' option.
-- Create a new lot number and assign product.
-- Update quantity for that product and assign lot number.
-- Go to Sales > Orders > Quotations.
-- Create a new quotation and add recently above configured product.
-- Select lot number and confirm it.
-- Delivery order will reserve the lot when available
+There are two ways to add Lots to a Sale Order:
+
+1. From Sale Order:
+
+   - Create/edit a product and set traceability by 'By Lots' option
+   - Create a new lot number and assign product
+   - Update quantity for that product and assign lot number
+   - Go to Sales > Orders > Quotations
+   - Create a new quotation and add recently above configured product
+   - Select lot number and confirm it
+   - Delivery order will reserve the lot when available
+
+2. From Lots/Serial Numbers:
+
+   - Go to "Sales > Products > Lots/Serial Numbers"
+   - Select Serial Numbers you would like to add to quotation
+   - Click action > Create quotation
+   - In the action wizard:
+
+     * To add to existing order: Select a Quotation/Sales order and click "Add"
+     * To create new order: Click "New" to create quotation with selected lots

--- a/sale_order_lot_selection/security/ir.model.access.csv
+++ b/sale_order_lot_selection/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_stock_lot_sale_order_wizard,stock.lot.sale.order.wizard,model_stock_lot_sale_order_wizard,sales_team.group_sale_salesman,1,1,1,1
+access_stock_lot_sale_order_wizard_line,stock.lot.sale.order.wizard.line,model_stock_lot_sale_order_wizard_line,sales_team.group_sale_salesman,1,1,1,1

--- a/sale_order_lot_selection/static/description/index.html
+++ b/sale_order_lot_selection/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -375,31 +375,79 @@ This selected lot number will be the one delivered to the Customer.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-2">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#use-cases-context" id="toc-entry-1">Use Cases / Context</a></li>
+<li><a class="reference internal" href="#configuration" id="toc-entry-2">Configuration</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-3">Usage</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-4">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-5">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-6">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-7">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-8">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-9">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
-<div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
+<div class="section" id="use-cases-context">
+<h1><a class="toc-backref" href="#toc-entry-1">Use Cases / Context</a></h1>
+<p>Sometimes companies need to create quotations with precise lot/serial number
+specifications before confirming orders, such as used equipment with unique serial
+numbers or specific inventory lots.</p>
+<p>This is particularly important in several business scenarios:</p>
 <ul class="simple">
-<li>Create/edit a product and set traceability by ‘By Lots’ option.</li>
-<li>Create a new lot number and assign product.</li>
-<li>Update quantity for that product and assign lot number.</li>
-<li>Go to Sales &gt; Orders &gt; Quotations.</li>
-<li>Create a new quotation and add recently above configured product.</li>
-<li>Select lot number and confirm it.</li>
-<li>Delivery order will reserve the lot when available</li>
+<li>In industries where product traceability is critical and customers need specific
+serial numbers (electronics, automotive parts, medical devices)</li>
+<li>When dealing with batches that vary in quality or characteristics, where
+customers require products from specific production runs</li>
+<li>In regulated industries where lot traceability is mandatory for compliance
+purposes</li>
+</ul>
+<p>For example:</p>
+<ul class="simple">
+<li>A machinery reseller needs to quote specific used equipment with known serial
+numbers</li>
+<li>An electronics distributor must sell particular serial-numbered items for
+warranty tracking</li>
+<li>A car parts supplier needs to specify exact serial numbers for rare components</li>
 </ul>
 </div>
+<div class="section" id="configuration">
+<h1><a class="toc-backref" href="#toc-entry-2">Configuration</a></h1>
+<p>If you want to allow users to generate sales quotas directly from the stock.lots tree view:</p>
+<ul class="simple">
+<li>Go to Inventory &gt; Configuration &gt; Settings</li>
+<li>Under Operations section select the “Allow to generate sales quotations from stock lots” check box</li>
+</ul>
+</div>
+<div class="section" id="usage">
+<h1><a class="toc-backref" href="#toc-entry-3">Usage</a></h1>
+<p>There are two ways to add Lots to a Sale Order:</p>
+<ol class="arabic simple">
+<li>From Sale Order:<ul>
+<li>Create/edit a product and set traceability by ‘By Lots’ option</li>
+<li>Create a new lot number and assign product</li>
+<li>Update quantity for that product and assign lot number</li>
+<li>Go to Sales &gt; Orders &gt; Quotations</li>
+<li>Create a new quotation and add recently above configured product</li>
+<li>Select lot number and confirm it</li>
+<li>Delivery order will reserve the lot when available</li>
+</ul>
+</li>
+<li>From Lots/Serial Numbers:<ul>
+<li>Go to “Sales &gt; Products &gt; Lots/Serial Numbers”</li>
+<li>Select Serial Numbers you would like to add to quotation</li>
+<li>Click action &gt; Create quotation</li>
+<li>In the action wizard:<ul>
+<li>To add to existing order: Select a Quotation/Sales order and click “Add”</li>
+<li>To create new order: Click “New” to create quotation with selected lots</li>
+</ul>
+</li>
+</ul>
+</li>
+</ol>
+</div>
 <div class="section" id="known-issues-roadmap">
-<h1><a class="toc-backref" href="#toc-entry-2">Known issues / Roadmap</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Known issues / Roadmap</a></h1>
 <p>Block sale order validation on confirmation if the selected lot has been removed of this module
 Indeed nobody seems to know  what it had been implemented on early versions and it is really blocking other generic use case.
 One may want to validate a sale order restricting it to a lot that will be produced for instance and does not exist yet.</p>
@@ -407,7 +455,7 @@ One may want to validate a sale order restricting it to a lot that will be produ
 The removal of this feature was made on this commit : 3234b2ccccf1dffafbe0a8fa8efaaea44f2e47ef.</p>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/sale-workflow/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -415,15 +463,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-6">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Authors</a></h2>
 <ul class="simple">
 <li>Agile Business Group</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Contributors</a></h2>
 <ul class="simple">
 <li>Nicola Malcontenti &lt;<a class="reference external" href="mailto:nicola.malcontenti&#64;agilebg.com">nicola.malcontenti&#64;agilebg.com</a>&gt;</li>
 <li>Lorenzo Battistini &lt;<a class="reference external" href="mailto:lorenzo.battistini&#64;agilebg.com">lorenzo.battistini&#64;agilebg.com</a>&gt;</li>
@@ -431,12 +479,19 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Bhavesh Odedra &lt;<a class="reference external" href="mailto:bodedra&#64;opensourceintegrators.com">bodedra&#64;opensourceintegrators.com</a>&gt;</li>
 <li>François Honoré &lt;<a class="reference external" href="mailto:francois.honore&#64;acsone.eu">francois.honore&#64;acsone.eu</a>&gt;</li>
 <li>Florian da Costa &lt;<a class="reference external" href="mailto:florian.dacosta&#64;akretion.com">florian.dacosta&#64;akretion.com</a>&gt;</li>
+<li><a class="reference external" href="https://cetmix.com">Cetmix</a>:<ul>
+<li>George Smirnov</li>
+<li>Anatol Mikheev</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-9">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_order_lot_selection/tests/__init__.py
+++ b/sale_order_lot_selection/tests/__init__.py
@@ -1,4 +1,6 @@
 # © 2015 Agile Business Group
+# Copyright (C) 2025 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import test_sale_order_lot_selection
+from . import test_stock_lot_add_to_sale_order

--- a/sale_order_lot_selection/tests/test_stock_lot_add_to_sale_order.py
+++ b/sale_order_lot_selection/tests/test_stock_lot_add_to_sale_order.py
@@ -1,0 +1,132 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import AccessError, ValidationError
+from odoo.tests.common import TransactionCase
+
+
+class TestAddLotToSaleOrder(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.sale = cls.env.ref("sale_order_lot_selection.sale1")
+        cls.sale_empty = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.sale.partner_id.id,
+                "user_id": cls.env.ref("base.user_admin").id,
+            }
+        )
+        cls.lot_cable = cls.env.ref("sale_order_lot_selection.lot_cable")
+        cls.env["ir.config_parameter"].sudo().set_param(
+            "sale_order_lot_selection.allow_generate_from_lots", True
+        )
+
+    def test_create_sale_order_with_lots(self):
+        """Test creating a new sale order from selected lot via wizard."""
+        wizard = self.env["stock.lot.sale.order.wizard"].create(
+            {
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "lot_id": self.lot_cable.id,
+                            "quantity": self.lot_cable.product_qty,
+                        },
+                    )
+                ]
+            }
+        )
+        wizard.partner_id = self.sale.partner_id
+
+        wizard.action_create_sale_order()
+
+        sale_order = wizard.sale_order_id
+        self.assertTrue(sale_order, "Sale Order was not created")
+        self.assertEqual(sale_order.partner_id, self.sale.partner_id)
+        self.assertEqual(sale_order.order_line.lot_id, self.lot_cable)
+        self.assertEqual(sale_order.order_line.product_id, self.lot_cable.product_id)
+
+    def test_add_lots_to_existing_sale_order(self):
+        """Test adding selected lots to an existing sale order."""
+        wizard = self.env["stock.lot.sale.order.wizard"].create(
+            {
+                "sale_order_id": self.sale_empty.id,
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "lot_id": self.lot_cable.id,
+                            "quantity": self.lot_cable.product_qty,
+                        },
+                    )
+                ],
+            }
+        )
+
+        wizard.action_add_lots_to_sale_order()
+
+        sale_order = self.sale_empty
+        lines = sale_order.order_line.filtered(lambda l: l.lot_id == self.lot_cable)
+        self.assertTrue(lines, "Lot was not added to Sale Order")
+        self.assertEqual(lines.product_id, self.lot_cable.product_id)
+        self.assertEqual(lines.product_uom_qty, self.lot_cable.product_qty)
+
+    def test_error_if_no_partner_on_create(self):
+        """Test that wizard raises error when trying to create sale order without partner."""
+        wizard = self.env["stock.lot.sale.order.wizard"].create(
+            {
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "lot_id": self.lot_cable.id,
+                            "quantity": self.lot_cable.product_qty,
+                        },
+                    )
+                ]
+            }
+        )
+
+        with self.assertRaises(ValidationError):
+            wizard.action_create_sale_order()
+
+    def test_error_if_no_sale_order_on_add(self):
+        """Test error when adding lots without sale order selection."""
+        wizard = self.env["stock.lot.sale.order.wizard"].create(
+            {
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "lot_id": self.lot_cable.id,
+                            "quantity": self.lot_cable.product_qty,
+                        },
+                    )
+                ]
+            }
+        )
+
+        with self.assertRaises(ValidationError):
+            wizard.action_add_lots_to_sale_order()
+
+    def test_not_allowed_generate_from_lots(self):
+        """Test that wizard raises error when generation from lots is not allowed"""
+        self.env["ir.config_parameter"].sudo().set_param(
+            "sale_order_lot_selection.allow_generate_from_lots", False
+        )
+
+        with self.assertRaises(AccessError):
+            self.lot_cable.action_generate_sale_order()
+
+        self.env["ir.config_parameter"].sudo().set_param(
+            "sale_order_lot_selection.allow_generate_from_lots", True
+        )
+
+        result = self.lot_cable.action_generate_sale_order()
+        self.assertTrue(
+            result, "Wizard should open when generation from lots is allowed"
+        )

--- a/sale_order_lot_selection/view/lot_view.xml
+++ b/sale_order_lot_selection/view/lot_view.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <menuitem
+        id="menu_lots"
+        name="Lots/Serial Numbers"
+        action="stock.action_production_lot_form"
+        parent="sale.product_menu_catalog"
+        sequence="30"
+    />
+</odoo>

--- a/sale_order_lot_selection/view/res_config_settings.xml
+++ b/sale_order_lot_selection/view/res_config_settings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form_stock" model="ir.ui.view">
+        <field
+            name="name"
+        >res.config.settings.view.form.inherit.sale_order_lot_selection</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='warning_info']" position="after">
+                <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    groups="stock.group_production_lot"
+                >
+                    <div class="o_setting_left_pane">
+                        <field name="allow_generate_so_from_lots" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="allow_generate_so_from_lots" />
+                        <div class="text-muted">
+                            Allow to generate Sale Quotations from stock lots
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_order_lot_selection/wizards/__init__.py
+++ b/sale_order_lot_selection/wizards/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2025 Cetmix OÜ
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from . import models
-from . import wizards
+from . import stock_lot_add_to_sale_order
+from . import stock_lot_sale_order_wizard_line

--- a/sale_order_lot_selection/wizards/stock_lot_add_to_sale_order.py
+++ b/sale_order_lot_selection/wizards/stock_lot_add_to_sale_order.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class StockLotSaleOrderWizard(models.TransientModel):
+    _name = "stock.lot.sale.order.wizard"
+    _description = "Add Lot to Sale Order Wizard"
+
+    line_ids = fields.One2many(
+        "stock.lot.sale.order.wizard.line",
+        "wizard_id",
+        string="Lot Lines",
+        ondelete="cascade",
+    )
+
+    sale_order_id = fields.Many2one(
+        "sale.order",
+        string="Sale Order",
+        domain="[('state', 'not in', ['done', 'cancel'])]",
+    )
+
+    partner_id = fields.Many2one(
+        "res.partner",
+        string="Customer",
+        store=True,
+        compute="_compute_partner_id",
+    )
+
+    @api.depends("sale_order_id")
+    def _compute_partner_id(self):
+        for record in self:
+            record.partner_id = record.sale_order_id.partner_id.id
+
+    def action_add_lots_to_sale_order(self):
+        """Add selected lots to the existing sale order."""
+        self.ensure_one()
+        if not self.sale_order_id:
+            raise ValidationError(
+                _("Please select an existing Sale Order to add lots to.")
+            )
+        self.sale_order_id.write(
+            {
+                "order_line": self._prepare_sale_order_line_vals(),
+            }
+        )
+        return self._action_open_sale_order()
+
+    def action_create_sale_order(self):
+        """Create a sale order from the selected lots."""
+        self.ensure_one()
+        if not self.partner_id:
+            raise ValidationError(
+                _("Please select a customer to create a new Sale Order.")
+            )
+        self.sale_order_id = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_id.id,
+                "order_line": self._prepare_sale_order_line_vals(),
+            }
+        )
+        return self._action_open_sale_order()
+
+    def _prepare_sale_order_line_vals(self):
+        """Get values for adding lot in sale order line."""
+        if not self.line_ids:
+            raise ValidationError(_("Please select at least one lot."))
+        return [
+            (
+                0,
+                0,
+                {
+                    "lot_id": line.lot_id.id,
+                    "product_id": line.lot_id.product_id.id,
+                    "product_uom_qty": line.quantity,
+                },
+            )
+            for line in self.line_ids
+        ]
+
+    def _action_open_sale_order(self):
+        """Open the sale order form view."""
+        return {
+            "type": "ir.actions.act_window",
+            "name": "Sale Order",
+            "res_model": "sale.order",
+            "view_mode": "form",
+            "res_id": self.sale_order_id.id,
+            "target": "current",
+        }

--- a/sale_order_lot_selection/wizards/stock_lot_add_to_sale_order.xml
+++ b/sale_order_lot_selection/wizards/stock_lot_add_to_sale_order.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright (C) 2025 Cetmix OÜ
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+    <record id="view_stock_lot_add_to_sale_order_wizard" model="ir.ui.view">
+        <field name="name">stock.lot.sale.order.wizard.form</field>
+        <field name="model">stock.lot.sale.order.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Add Lot to Sale Order" create="false">
+                <group>
+                    <field
+                        name="sale_order_id"
+                        placeholder="Select an existing sale order or leave empty to create a new one"
+                        options="{'no_create': True, 'no_create_edit': True}"
+                    />
+                    <field
+                        name="partner_id"
+                        attrs="{'readonly': [('sale_order_id', '!=', False)]}"
+                    />
+                </group>
+                <field name="line_ids">
+                    <tree editable="bottom" create="false">
+                        <field
+                            name="lot_id"
+                            options="{'no_create': True, 'no_create_edit': True}"
+                        />
+                        <field name="product_id" optional="hide" />
+                        <field name="quantity" />
+                        <field name="max_qty" optional="hide" />
+                    </tree>
+                </field>
+                <footer>
+                    <button
+                        name="action_add_lots_to_sale_order"
+                        type="object"
+                        string="Add"
+                        class="btn-primary"
+                    />
+                    <button
+                        name="action_create_sale_order"
+                        type="object"
+                        string="New"
+                        class="btn-secondary"
+                        attrs="{'invisible': [('sale_order_id', '!=', False)]}"
+                    />
+                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_stock_lot_add_to_sale_order" model="ir.actions.server">
+        <field name="name">Create Quotation</field>
+        <field name="model_id" ref="stock.model_stock_lot" />
+        <field name="binding_model_id" ref="stock.model_stock_lot" />
+        <field name="binding_view_types">tree</field>
+        <field name="state">code</field>
+        <field name="code">
+if records:
+    action = records.action_generate_sale_order()
+        </field>
+    </record>
+</odoo>

--- a/sale_order_lot_selection/wizards/stock_lot_sale_order_wizard_line.py
+++ b/sale_order_lot_selection/wizards/stock_lot_sale_order_wizard_line.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2025 Cetmix OÜ
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class StockLotSaleOrderWizardLine(models.TransientModel):
+    _name = "stock.lot.sale.order.wizard.line"
+    _description = "Add Lot to Sale Order Wizard Line"
+
+    wizard_id = fields.Many2one(
+        "stock.lot.sale.order.wizard",
+        string="Wizard",
+        required=True,
+    )
+    lot_id = fields.Many2one(
+        "stock.lot",
+        string="Lot",
+        required=True,
+    )
+    product_id = fields.Many2one(related="lot_id.product_id")
+    quantity = fields.Float(string="Quantity")  # pylint: disable=W8113
+    max_qty = fields.Float(string="Max Quantity", related="lot_id.product_qty")
+
+    @api.constrains("quantity")
+    def _check_quantity(self):
+        """Check that the quantity is not greater than the max quantity."""
+        for record in self:
+            if record.quantity > record.max_qty:
+                raise ValidationError(
+                    _(
+                        "The quantity of lot %(lot_name)s cannot be greater than "
+                        "the available quantity %(max_qty)s.",
+                        lot_name=record.lot_id.name,
+                        max_qty=record.max_qty,
+                    )
+                )


### PR DESCRIPTION
Implement lot selection wizard for sales quotations to enable creating quotations with specific lot/serial numbers directly from stock lots. This improves traceability and allows precise lot selection for industries requiring specific serial number tracking.

Task: 4470