### PR TITLE
[17.0][FIX] sale_product_multi_add: avoid description overwrite

### DIFF
--- a/sale_product_multi_add/wizards/sale_import_products.py
+++ b/sale_product_multi_add/wizards/sale_import_products.py
@@ -38,7 +38,6 @@ class SaleImportProducts(models.TransientModel):
         sale_line = self.env["sale.order.line"].new(
             {
                 "order_id": sale.id,
-                "name": item.product_id.name,
                 "product_id": item.product_id.id,
                 "product_uom_qty": item.quantity,
                 "product_uom": item.product_id.uom_id.id,


### PR DESCRIPTION
Current behavior of the wizard overwrites the Description of the sale order line (removing internal reference)

![image](https://github.com/user-attachments/assets/5db5a9ea-cb17-4413-8c8c-8faf47f893ce)

After fix
![image](https://github.com/user-attachments/assets/0da0014a-136b-4075-8741-4dffeb6fc2fb)
