### PR TITLE
[16.0][IMP] sale_order_product_recommendation: create sale lines with write

### DIFF
--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -234,7 +234,9 @@ class SaleOrderRecommendation(models.TransientModel):
         to_remove.reverse()
         sale_order_line_obj.browse(to_remove).unlink()
         if new_line_vals:
-            sale_order_line_obj.create(new_line_vals)
+            self.order_id.write(
+                {"order_line": [(0, 0, vals) for vals in new_line_vals]}
+            )
 
 
 class SaleOrderRecommendationLine(models.TransientModel):


### PR DESCRIPTION
This is intended for also triggering inheritances of the sale order's write method, for example: https://github.com/OCA/l10n-spain/blob/c5a84391e3e2ff87cbbc99f606f386798ea4cfad/l10n_es_sigaus_sale/models/sale_order.py#L48-L76