### PR TITLE
[16.0][FIX] sale_order_product_recommendation: recommendations on sales with section or notes

### DIFF
--- a/sale_order_product_recommendation/tests/test_recommendation.py
+++ b/sale_order_product_recommendation/tests/test_recommendation.py
@@ -127,6 +127,27 @@ class RecommendationCaseTests(RecommendationCase):
             ],
         )
 
+    def test_recommendations_with_note(self):
+        self.new_so.write(
+            {
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {"display_type": "line_note", "name": "Test Note"},
+                    ),
+                ]
+            }
+        )
+        try:
+            wiz = self.wizard()
+            wiz.line_ids._compute_price_unit()
+        except KeyError:
+            self.fail(
+                "Calling the wizard on a sales order with notes "
+                "raised an exception unexpectedly"
+            )
+
     def test_change_uom(self):
         """Change UoM and units included."""
         unit, dozen = map(

--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -160,7 +160,9 @@ class SaleOrderRecommendation(models.TransientModel):
         existing_product_ids = set()
         # Always recommend all products already present in the linked SO except delivery
         # carrier products
-        for line in self.order_id.order_line.filtered(lambda ln: not ln._is_delivery()):
+        for line in self.order_id.order_line.filtered(
+            lambda ln: not (ln._is_delivery() or ln.display_type)
+        ):
             found_line = found_dict.get(
                 line.product_id.id,
                 {


### PR DESCRIPTION
If you try to use the recommendation wizard in a sales order with section or notes, an error will be displayed when trying to get the recommendations. 

The reason is because it tries to read the section's product, and it does not exist.

This PR fixes it

I-7204