### PR TITLE
[16.0][PERF] sale_order_line_cancel: Speed up installtion

### DIFF
--- a/sale_order_line_cancel/__init__.py
+++ b/sale_order_line_cancel/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import wizards
+from .hooks import pre_init_hook

--- a/sale_order_line_cancel/__manifest__.py
+++ b/sale_order_line_cancel/__manifest__.py
@@ -1,6 +1,7 @@
 # Copyright 2018 Sylvain Van Hoof (Okia SPRL)
 # Copyright 2018 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # Copyright 2023 ACSONE SA/NV
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 {
@@ -18,4 +19,5 @@
         "views/sale_order_line.xml",
     ],
     "website": "https://github.com/OCA/sale-workflow",
+    "pre_init_hook": "pre_init_hook",
 }

--- a/sale_order_line_cancel/hooks.py
+++ b/sale_order_line_cancel/hooks.py
@@ -1,0 +1,18 @@
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo.tools.sql import column_exists
+
+
+def pre_init_hook(cr):
+    if not column_exists(cr, "sale_order_line", "product_qty_remains_to_deliver"):
+        cr.execute(
+            "ALTER TABLE sale_order_line ADD COLUMN product_qty_remains_to_deliver NUMERIC"
+        )
+        cr.execute(
+            """
+            UPDATE
+                sale_order_line
+            SET
+                product_qty_remains_to_deliver = product_uom_qty - qty_delivered
+        """
+        )

--- a/sale_order_line_cancel/readme/CONTRIBUTORS.rst
+++ b/sale_order_line_cancel/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Sylvain Van Hoof <sylvain@okia.be>
 * Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 * Souheil Bejaoui <souheil.bejaoui@acsone.eu.com>
+* Michael Tietz (MT Software) <mtietz@mt-software.de>


### PR DESCRIPTION
Add and set field product_qty_remains_to_deliver by sql.

On a big database with already a lot sale.order.lines
the computation of `product_qty_remains_to_deliver` takes too long.
therefore it would now be done via sql.

cc @jbaudoux @lmignon @rousseldenis 