### PR TITLE
[18.0][TEST] sale_order_lot_selection: add "mrp" in dependencies (DO NOT MERGE)

### DIFF
--- a/sale_order_lot_selection/__manifest__.py
+++ b/sale_order_lot_selection/__manifest__.py
@@ -5,7 +5,7 @@
     "author": "Odoo Community Association (OCA), Agile Business Group",
     "website": "https://github.com/OCA/sale-workflow",
     "license": "AGPL-3",
-    "depends": ["sale_stock", "stock_restrict_lot"],
+    "depends": ["sale_stock", "stock_restrict_lot", "mrp"],
     "data": ["views/sale_order_views.xml"],
     "demo": ["demo/sale_demo.xml"],
     "maintainers": ["bodedra"],


### PR DESCRIPTION
This PR is just to proof that tests of module `sale_order_lot_selection` are failing when standard Odoo module `mrp` is installed