### PR TITLE
[17.0][FIX] product_supplierinfo_for_customer_sale: ensure partner context

### DIFF
--- a/product_supplierinfo_for_customer_sale/models/sale_order_line.py
+++ b/product_supplierinfo_for_customer_sale/models/sale_order_line.py
@@ -56,3 +56,12 @@ class SaleOrderLine(models.Model):
                 if customerinfo.min_qty:
                     line.product_uom_qty = customerinfo.min_qty
         return res
+
+    def _get_product_price_context(self):
+        """Extend to make sure the partner context is set for price computation."""
+        self.ensure_one()
+        context = super()._get_product_price_context()
+        # Add partner_id to the context
+        if self.order_id.partner_id:
+            context.update({"partner_id": self.order_id.partner_id.id})
+        return context

--- a/product_supplierinfo_for_customer_sale/tests/test_product_supplierinfo_for_customer_sale.py
+++ b/product_supplierinfo_for_customer_sale/tests/test_product_supplierinfo_for_customer_sale.py
@@ -14,6 +14,8 @@ class TestProductSupplierinfoForCustomerSale(TransactionCase):
         cls.customerinfo_model = cls.env["product.customerinfo"]
         cls.pricelist_item_model = cls.env["product.pricelist.item"]
         cls.pricelist_model = cls.env["product.pricelist"]
+        cls.sale_order_model = cls.env["sale.order"]
+        cls.sale_order_line_model = cls.env["sale.order.line"]
         cls.customer = cls._create_customer("customer1")
         cls.product = cls.env.ref("product.product_product_4")
         cls.product_variant_1 = cls.env.ref("product.product_product_4b")
@@ -41,6 +43,27 @@ class TestProductSupplierinfoForCustomerSale(TransactionCase):
         )
         cls.pricelist_template = cls._create_pricelist(
             "Test Pricelist Template", cls.product_template.product_variant_ids[:1]
+        )
+        cls.pricelist_customer = cls.pricelist_model.create(
+            {
+                "name": "Test Pricelist Customer",
+                "currency_id": cls.env.ref("base.USD").id,
+            }
+        )
+        cls.pricelist_item_customer = cls.pricelist_item_model.create(
+            {
+                "applied_on": "3_global",
+                "base": "partner",
+                "name": "Test Pricelist Item",
+                "pricelist_id": cls.pricelist_customer.id,
+                "compute_price": "formula",
+            }
+        )
+        cls.sale_order_customer = cls.sale_order_model.create(
+            {
+                "partner_id": cls.customer.id,
+                "pricelist_id": cls.pricelist_customer.id,
+            }
         )
         cls.env.user.groups_id |= cls.env.ref("product.group_product_pricelist")
 
@@ -166,3 +189,57 @@ class TestProductSupplierinfoForCustomerSale(TransactionCase):
             customerinfo.product_code,
             "Error: Customer product code was not passed to sale order line",
         )
+
+    def test_product_supplierinfo_sale_price_with_context_passed(self):
+        """Test normal behaviour when context is passed from view."""
+        # GIVEN / WHEN
+        self.sale_order_line_w_ctx = self.sale_order_line_model.with_context(
+            partner_id=self.customer.id
+        ).create(
+            {
+                "order_id": self.sale_order_customer.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 1.0,
+            }
+        )
+        # THEN
+        self.assertEqual(self.sale_order_line_w_ctx.price_unit, 100.0)
+
+    def test_product_supplierinfo_sale_price_without_context_passed(self):
+        """Test case when context is not passed during price computation.
+
+        The context should be created in the method _get_product_price_context.
+        """
+        # GIVEN / WHEN
+        self.sale_order_line_wo_ctx = self.sale_order_line_model.create(
+            {
+                "order_id": self.sale_order_customer.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 1.0,
+            }
+        )
+        # THEN
+        self.assertEqual(
+            self.sale_order_line_wo_ctx.price_unit,
+            100.0,
+        )
+
+    def test_product_supplierinfo_sale_price_after_qty_update(self):
+        """Test the price is kept when the recomputation is triggered.
+
+        Updating the quantity retriggers _compute_price_unit from the backend,
+        where the view context with the partner is no longer available.
+        """
+        # GIVEN
+        line = self.sale_order_line_model.create(
+            {
+                "order_id": self.sale_order_customer.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 1.0,
+            }
+        )
+        self.assertEqual(line.price_unit, 100.0)
+        # WHEN
+        line.product_uom_qty = 5.0
+        # THEN
+        self.assertEqual(line.price_unit, 100.0)

--- a/product_supplierinfo_for_customer_sale/tests/test_product_supplierinfo_for_customer_sale.py
+++ b/product_supplierinfo_for_customer_sale/tests/test_product_supplierinfo_for_customer_sale.py
@@ -14,6 +14,8 @@ class TestProductSupplierinfoForCustomerSale(TransactionCase):
         cls.customerinfo_model = cls.env["product.customerinfo"]
         cls.pricelist_item_model = cls.env["product.pricelist.item"]
         cls.pricelist_model = cls.env["product.pricelist"]
+        cls.sale_order_model = cls.env["sale.order"]
+        cls.sale_order_line_model = cls.env["sale.order.line"]
         cls.customer = cls._create_customer("customer1")
         cls.product = cls.env.ref("product.product_product_4")
         cls.product_variant_1 = cls.env.ref("product.product_product_4b")
@@ -30,6 +32,7 @@ class TestProductSupplierinfoForCustomerSale(TransactionCase):
         cls._create_partnerinfo(
             "customer", cls.customer, cls.product_variant_2, empty_variant=True
         )
+        cls._create_partnerinfo("customer", cls.customer, cls.product)
         cls.product_template = cls.env["product.template"].create(
             {"name": "product wo variants"}
         )
@@ -41,6 +44,27 @@ class TestProductSupplierinfoForCustomerSale(TransactionCase):
         )
         cls.pricelist_template = cls._create_pricelist(
             "Test Pricelist Template", cls.product_template.product_variant_ids[:1]
+        )
+        cls.pricelist_customer = cls.pricelist_model.create(
+            {
+                "name": "Test Pricelist Customer",
+                "currency_id": cls.env.ref("base.USD").id,
+            }
+        )
+        cls.pricelist_item_customer = cls.pricelist_item_model.create(
+            {
+                "applied_on": "3_global",
+                "base": "partner",
+                "name": "Test Pricelist Item",
+                "pricelist_id": cls.pricelist_customer.id,
+                "compute_price": "formula",
+            }
+        )
+        cls.sale_order_customer = cls.sale_order_model.create(
+            {
+                "partner_id": cls.customer.id,
+                "pricelist_id": cls.pricelist_customer.id,
+            }
         )
         cls.env.user.groups_id |= cls.env.ref("product.group_product_pricelist")
 
@@ -165,4 +189,38 @@ class TestProductSupplierinfoForCustomerSale(TransactionCase):
             line.product_customer_code,
             customerinfo.product_code,
             "Error: Customer product code was not passed to sale order line",
+        )
+
+    def test_product_supplierinfo_sale_price_with_context_passed(self):
+        """Test normal behaviour when context is passed from view."""
+        # GIVEN / WHEN
+        self.sale_order_line_w_ctx = self.sale_order_line_model.with_context(
+            partner_id=self.customer.id
+        ).create(
+            {
+                "order_id": self.sale_order_customer.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 1.0,
+            }
+        )
+        # THEN
+        self.assertEqual(self.sale_order_line_w_ctx.price_unit, 100.0)
+
+    def test_product_supplierinfo_sale_price_without_context_passed(self):
+        """Test case when context is not passed during price computation.
+
+        The context should be created in the method _get_product_price_context.
+        """
+        # GIVEN / WHEN
+        self.sale_order_line_wo_ctx = self.sale_order_line_model.create(
+            {
+                "order_id": self.sale_order_customer.id,
+                "product_id": self.product.id,
+                "product_uom_qty": 1.0,
+            }
+        )
+        # THEN
+        self.assertEqual(
+            self.sale_order_line_wo_ctx.price_unit,
+            100.0,
         )


### PR DESCRIPTION
partner context passed from view not always present.


**Description**
If sale order Pricelist type `partner`,  `price_unit` of sale order line is calculated using partner context passed in the view (https://github.com/odoo/odoo/blob/17.0/addons/sale/views/sale_order_views.xml#L520-L526).
However context is lost if price computation is triggered again from backend (e.g. when updating quantities) and it sets `list price`, but not `product.customerinfo` price.

**Current Behaviour**
When pricelist type is "Partner Prices on the product form", unit price in sale order line sometimes is set from list price not from customer info. Example by updating product quantity a few times in sale order line.

**Expected Behavior**
When pricelist type is "Partner Prices on the product form", unit price in sale order line is always set from customer info.

**Proposed implementation**
extend `_get_product_price_context` and update context by adding `partner_id` from sale order.
