### PR TITLE
[16.0][FIX] sale_expection: don't compute loyalty program if there is…

### DIFF
--- a/sale_exception/models/sale_order.py
+++ b/sale_exception/models/sale_order.py
@@ -48,6 +48,11 @@ class SaleOrder(models.Model):
 
     def action_confirm(self):
         if self.detect_exceptions():
+            exception_map = {sale.id: sale.exception_ids.ids for sale in self}
+            self.env.cr.rollback()
+            for sale in self:
+                exception_ids = exception_map.get(sale.id, [])
+                sale.write({"exception_ids": [(6, 0, exception_ids)]})
             return self._popup_exceptions()
         return super().action_confirm()
 


### PR DESCRIPTION
… any exception

Before this PR, if a sale was not confirmed due to an exception, the loyalty program would still be applied. For example, if a coupon was used, a point would be added, and then upon confirming the sale, it would be added again.
The issue is in the sale_loyalty module, where the loyalty program is computed before the sale is confirmed in this [line](https://github.com/odoo/odoo/blob/736bf47d670acd53736b67782bf64a2b330b0bcb/addons/sale_loyalty/models/sale_order.py#L72)

This video demonstrates the issue: 
https://drive.google.com/file/d/1qeEYlVVqXb8MOJq7BybVe4EaYtiDcIPS/view




