### PR TITLE
mig: set start_date and end_date to datetime to better integrate with…

### DIFF
--- a/sale_start_end_dates/__manifest__.py
+++ b/sale_start_end_dates/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Sale Start End Dates",
-    "version": "16.0.1.0.1",
+    "version": "16.0.1.0.2",
     "category": "Sales",
     "license": "AGPL-3",
     "summary": "Adds start date and end date on sale order lines",

--- a/sale_start_end_dates/models/sale_order.py
+++ b/sale_start_end_dates/models/sale_order.py
@@ -13,10 +13,10 @@ from odoo.tools.misc import format_date
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    default_start_date = fields.Date(
+    default_start_date = fields.Datetime(
         compute="_compute_default_start_date", readonly=False, store=True
     )
-    default_end_date = fields.Date(
+    default_end_date = fields.Datetime(
         compute="_compute_default_end_date", readonly=False, store=True
     )
 
@@ -64,12 +64,12 @@ class SaleOrder(models.Model):
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    start_date = fields.Date(
+    start_date = fields.Datetime(
         compute="_compute_start_date",
         store=True,
         states={"draft": [("readonly", False)], "sent": [("readonly", False)]},
     )
-    end_date = fields.Date(
+    end_date = fields.Datetime(
         compute="_compute_end_date",
         store=True,
         states={"draft": [("readonly", False)], "sent": [("readonly", False)]},


### PR DESCRIPTION
Standard sale_start_end_dates is incompatible with enterprise due to conflicting  field names and incompatible field types:

In sale-workflow->sale_start_end_dates: start_date is a Date
In enterprise->sale_renting: start_date is a Datetime

This causes errors in computed fields due to the mismatching type. 
Testing setting date field to Datetime, but can see that changing the field name to avoid the name conflict with a separate module might be better to keep the calculations separate. 