### PR TITLE
[16.0][IMP] sale_order_line_input: add smartbutton to view sol

### DIFF
--- a/sale_order_line_input/README.rst
+++ b/sale_order_line_input/README.rst
@@ -48,6 +48,19 @@ To use this module, you need to:
 #. Create new line related with existing order
 #. If order field is empty, a new order will be created
 
+
+An out-of-the-box Smartbutton to view SO lines directly from SO Form. To enable the button for current user, you need to:
+
+#. Go to Settings > Users > Technical
+#. Check 'Allows to view SO line right on SO Form?'
+
+
+Or you can grant access to all salesman as following
+
+#. Go to Settings > Sales > Quotations & Orders
+#. Check 'Enable Smart Button to view SO line right on SO Form'
+
+
 Bug Tracker
 ===========
 
@@ -73,6 +86,9 @@ Contributors
 
   * Carlos Dauden
   * Carolina Fernandez
+* `Trobz <https://www.trobz.com>`_:
+
+  * Tris Doan <tridm@trobz.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_order_line_input/__manifest__.py
+++ b/sale_order_line_input/__manifest__.py
@@ -10,5 +10,15 @@
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": ["sale_management"],
-    "data": ["views/sale_order_line_view.xml"],
+    "data": [
+        "security/sale_order_line_view_group.xml",
+        "views/sale_order_line_view.xml",
+        "views/sale_order_view.xml",
+        "views/res_config_settings.xml",
+    ],
+    "assets": {
+        "web.assets_backend": [
+            "sale_order_line_input/static/src/**/*",
+        ],
+    },
 }

--- a/sale_order_line_input/models/__init__.py
+++ b/sale_order_line_input/models/__init__.py
@@ -1,1 +1,3 @@
+from . import sale_order_line
 from . import sale_order
+from . import res_config_settings

--- a/sale_order_line_input/models/res_config_settings.py
+++ b/sale_order_line_input/models/res_config_settings.py
@@ -1,0 +1,32 @@
+# Copyright 2025 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    show_view_sale_order_line = fields.Boolean(
+        string="Enable Smart Button to view SO line right on SO Form",
+        config_parameter="sale_order_line_input.show_view_sale_order_line ",
+    )
+
+    def set_values(self):
+        res = super().set_values()
+        group = self.env.ref("sale_order_line_input.sale_orderline_view_group")
+        if self.show_view_sale_order_line:
+            users = self.env["res.users"].search(
+                [
+                    (
+                        "groups_id",
+                        "in",
+                        self.env.ref("sales_team.group_sale_salesman").id,
+                    )
+                ]
+            )
+            users.write({"groups_id": [(4, group.id)]})
+        else:
+            users = self.env["res.users"].search([("groups_id", "in", [group.id])])
+            users.write({"groups_id": [(3, group.id)]})
+        return res

--- a/sale_order_line_input/models/sale_order.py
+++ b/sale_order_line_input/models/sale_order.py
@@ -1,57 +1,33 @@
-# Copyright 2018 Tecnativa - Carlos Dauden
-# Copyright 2023 Tecnativa - Carolina Fernandez
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# Copyright 2025 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
-from odoo import api, fields, models
+from odoo import _, fields, models
 
 
-class SaleOrderLine(models.Model):
-    _inherit = "sale.order.line"
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
 
-    pricelist_id = fields.Many2one(related="order_id.pricelist_id")
-    force_company_id = fields.Many2one(
-        comodel_name="res.company",
-        string="Forced company",
-        compute="_compute_force_company_id",
-        readonly=False,
-        help="Technical field to force company or get it "
-        "from env user if order don't exist.",
-    )
+    sol_count = fields.Integer(compute="_compute_sol_count")
 
-    @api.depends("order_id")
-    def _compute_force_company_id(self):
-        """Related company is not computed already when we click create new line"""
-        for line in self:
-            line.force_company_id = line.order_id.company_id or self.env.company
+    def _compute_sol_count(self):
+        for rec in self:
+            rec.sol_count = len(rec.order_line)
 
-    def _compute_name(self):
-        # A NewId is needed to set the product for the parent method to set
-        # the language correctly. Empty id leads to error in ‘_get_lang’.
-        for line in self:
-            if not line.order_id and line.product_id:
-                SaleOrder = self.env["sale.order"]
-                line.order_id = SaleOrder.new({})
-        return super()._compute_name()
-
-    @api.onchange("force_company_id")
-    def _onchange_force_company_id(self):
-        """Assign company_id because is used in domains as partner,
-        product, taxes..."""
-        for line in self:
-            line.company_id = line.force_company_id
-
-    @api.onchange("order_partner_id")
-    def _onchange_order_partner_id(self):
-        """Create order to correct compute of taxes"""
-        if not self.order_partner_id or self.order_id:
-            return
-        SaleOrder = self.env["sale.order"]
-        new_so = SaleOrder.new({"partner_id": self.order_partner_id})
-        for onchange_method in new_so._onchange_methods["partner_id"]:
-            onchange_method(new_so)
-        order_vals = new_so._convert_to_write(new_so._cache)
-        self.order_id = SaleOrder.create(order_vals)
-
-    def action_sale_order_form(self):
+    def action_view_sale_order_line(self):
         self.ensure_one()
-        return self.order_id.get_formview_action()
+        return {
+            "name": _("SO Lines"),
+            "type": "ir.actions.act_window",
+            "view_mode": "tree",
+            "res_model": "sale.order.line",
+            "domain": [("order_id", "=", self.id)],
+            "context": {"default_order_id": self.id},
+            "views": [
+                [
+                    self.env.ref(
+                        "sale_order_line_input.view_sales_order_line_input_tree_inherit"
+                    ).id,
+                    "tree",
+                ]
+            ],
+        }

--- a/sale_order_line_input/models/sale_order_line.py
+++ b/sale_order_line_input/models/sale_order_line.py
@@ -1,0 +1,57 @@
+# Copyright 2018 Tecnativa - Carlos Dauden
+# Copyright 2023 Tecnativa - Carolina Fernandez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    pricelist_id = fields.Many2one(related="order_id.pricelist_id")
+    force_company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Forced company",
+        compute="_compute_force_company_id",
+        readonly=False,
+        help="Technical field to force company or get it "
+        "from env user if order don't exist.",
+    )
+
+    @api.depends("order_id")
+    def _compute_force_company_id(self):
+        """Related company is not computed already when we click create new line"""
+        for line in self:
+            line.force_company_id = line.order_id.company_id or self.env.company
+
+    def _compute_name(self):
+        # A NewId is needed to set the product for the parent method to set
+        # the language correctly. Empty id leads to error in ‘_get_lang’.
+        for line in self:
+            if not line.order_id and line.product_id:
+                SaleOrder = self.env["sale.order"]
+                line.order_id = SaleOrder.new({})
+        return super()._compute_name()
+
+    @api.onchange("force_company_id")
+    def _onchange_force_company_id(self):
+        """Assign company_id because is used in domains as partner,
+        product, taxes..."""
+        for line in self:
+            line.company_id = line.force_company_id
+
+    @api.onchange("order_partner_id")
+    def _onchange_order_partner_id(self):
+        """Create order to correct compute of taxes"""
+        if not self.order_partner_id or self.order_id:
+            return
+        SaleOrder = self.env["sale.order"]
+        new_so = SaleOrder.new({"partner_id": self.order_partner_id})
+        for onchange_method in new_so._onchange_methods["partner_id"]:
+            onchange_method(new_so)
+        order_vals = new_so._convert_to_write(new_so._cache)
+        self.order_id = SaleOrder.create(order_vals)
+
+    def action_sale_order_form(self):
+        self.ensure_one()
+        return self.order_id.get_formview_action()

--- a/sale_order_line_input/readme/CONTRIBUTORS.rst
+++ b/sale_order_line_input/readme/CONTRIBUTORS.rst
@@ -2,3 +2,6 @@
 
   * Carlos Dauden
   * Carolina Fernandez
+* `Trobz <https://www.trobz.com>`_:
+
+  * Tris Doan <tridm@trobz.com>

--- a/sale_order_line_input/readme/USAGE.rst
+++ b/sale_order_line_input/readme/USAGE.rst
@@ -4,3 +4,16 @@ To use this module, you need to:
 #. You can filter, group and switch view type
 #. Create new line related with existing order
 #. If order field is empty, a new order will be created
+
+
+An out-of-the-box Smartbutton to view SO lines directly from SO Form. To enable the button for current user, you need to:
+
+#. Go to Settings > Users > Technical
+#. Check 'Allows to view SO line right on SO Form?'
+
+
+Or you can grant access to all salesman as following
+
+#. Go to Settings > Sales > Quotations & Orders
+#. Check 'Enable Smart Button to view SO line right on SO Form'
+

--- a/sale_order_line_input/security/sale_order_line_view_group.xml
+++ b/sale_order_line_input/security/sale_order_line_view_group.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="sale_orderline_view_group" model="res.groups">
+        <field name="name">Allows to view SO line right on SO Form</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+    </record>
+</odoo>

--- a/sale_order_line_input/static/description/index.html
+++ b/sale_order_line_input/static/description/index.html
@@ -395,6 +395,16 @@ sale lines directly.</p>
 <li>Create new line related with existing order</li>
 <li>If order field is empty, a new order will be created</li>
 </ol>
+<p>An out-of-the-box Smartbutton to view SO lines directly from SO Form. To enable the button for current user, you need to:</p>
+<ol class="arabic simple">
+<li>Go to Settings &gt; Users &gt; Technical</li>
+<li>Check ‘Allows to view SO line right on SO Form?’</li>
+</ol>
+<p>Or you can grant access to all salesman as following</p>
+<ol class="arabic simple">
+<li>Go to Settings &gt; Sales &gt; Quotations &amp; Orders</li>
+<li>Check ‘Enable Smart Button to view SO line right on SO Form’</li>
+</ol>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
@@ -418,6 +428,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Carlos Dauden</li>
 <li>Carolina Fernandez</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://www.trobz.com">Trobz</a>:<ul>
+<li>Tris Doan &lt;<a class="reference external" href="mailto:tridm&#64;trobz.com">tridm&#64;trobz.com</a>&gt;</li>
 </ul>
 </li>
 </ul>

--- a/sale_order_line_input/static/src/section_and_note_list_view.esm.js
+++ b/sale_order_line_input/static/src/section_and_note_list_view.esm.js
@@ -1,0 +1,76 @@
+/** @odoo-module **/
+
+import {listView} from "@web/views/list/list_view";
+import {registry} from "@web/core/registry";
+import {ListRenderer} from "@web/views/list/list_renderer";
+const {useEffect} = owl;
+
+export class SOLSectionAndNoteListRenderer extends ListRenderer {
+    setup() {
+        super.setup();
+        this.titleField = "name";
+        useEffect(
+            () => this.focusToName(this.props.list.editedRecord),
+            () => [this.props.list.editedRecord]
+        );
+    }
+
+    focusToName(editRec) {
+        if (editRec && editRec.isVirtual && this.isSectionOrNote(editRec)) {
+            const col = this.state.columns.find((c) => c.name === this.titleField);
+            this.focusCell(col, null);
+        }
+    }
+
+    isSectionOrNote(record = null) {
+        record = record || this.record;
+        return ["line_section", "line_note"].includes(record.data.display_type);
+    }
+
+    getRowClass(record) {
+        const existingClasses = super.getRowClass(record);
+        return `${existingClasses} o_is_${record.data.display_type}`;
+    }
+
+    getCellClass(column, record) {
+        const classNames = super.getCellClass(column, record);
+        if (
+            this.isSectionOrNote(record) &&
+            column.widget !== "handle" &&
+            column.name !== this.titleField
+        ) {
+            return `${classNames} o_hidden`;
+        }
+        return classNames;
+    }
+
+    getColumns(record) {
+        const columns = super.getColumns(record);
+        if (this.isSectionOrNote(record)) {
+            return this.getSectionColumns(columns);
+        }
+        return columns;
+    }
+
+    getSectionColumns(columns) {
+        const sectionCols = columns.filter(
+            (col) =>
+                col.widget === "handle" ||
+                (col.type === "field" && col.name === this.titleField)
+        );
+        return sectionCols.map((col) => {
+            if (col.name === this.titleField) {
+                return {...col, colspan: columns.length - sectionCols.length + 1};
+            }
+            return {...col};
+        });
+    }
+}
+SOLSectionAndNoteListRenderer.template =
+    "sale_order_line_input.sectionAndNoteListRenderer";
+
+export const SOLSectionAndNoteView = {
+    ...listView,
+    Renderer: SOLSectionAndNoteListRenderer,
+};
+registry.category("views").add("sol_section_and_note", SOLSectionAndNoteView);

--- a/sale_order_line_input/static/src/section_and_note_list_view.xml
+++ b/sale_order_line_input/static/src/section_and_note_list_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<templates>
+    <t
+        t-name="sale_order_line_input.sectionAndNoteListRenderer"
+        t-inherit="web.ListRenderer"
+        t-inherit-mode="primary"
+        owl="1"
+    >
+        <xpath expr="//table" position="attributes">
+            <attribute
+                name="class"
+                position="add"
+                separator=" "
+            >o_section_and_note_list_view</attribute>
+        </xpath>
+    </t>
+
+
+</templates>

--- a/sale_order_line_input/views/res_config_settings.xml
+++ b/sale_order_line_input/views/res_config_settings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+  <record id="res_config_settings_view_form" model="ir.ui.view">
+    <field name="model">res.config.settings</field>
+    <field name="inherit_id" ref="sale.res_config_settings_view_form" />
+    <field name="arch" type="xml">
+      <xpath expr="//div[@name='quotation_order_setting_container']" position="inside">
+        <div class="col-12 col-lg-6 o_setting_box" id="show_view_sale_order_line">
+          <div class="o_setting_left_pane">
+            <field name="show_view_sale_order_line" />
+          </div>
+          <div class="o_setting_right_pane">
+            <label for="show_view_sale_order_line" />
+            <div class="text-muted">
+                                   This access will be applied to all Salesman
+                                </div>
+          </div>
+        </div>
+      </xpath>
+    </field>
+  </record>
+</odoo>

--- a/sale_order_line_input/views/sale_order_line_view.xml
+++ b/sale_order_line_input/views/sale_order_line_view.xml
@@ -213,6 +213,25 @@
             </tree>
         </field>
     </record>
+
+    <!-- A copied view to hide order_id and partner_id, which is redundant when viewing from a smart button -->
+    <record id="view_sales_order_line_input_tree_inherit" model="ir.ui.view">
+        <field name="model">sale.order.line</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="view_sales_order_line_input_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//tree" position="attributes">
+                <attribute name="js_class">sol_section_and_note</attribute>
+                </xpath>
+            <field name="order_id" position="attributes">
+                <attribute name="optional">hide</attribute>
+                </field>
+            <field name="order_partner_id" position="attributes">
+                <attribute name="optional">hide</attribute>
+                </field>
+
+            </field>
+        </record>
     <record id="view_sales_order_line_filter" model="ir.ui.view">
         <field name="model">sale.order.line</field>
         <field name="inherit_id" ref="sale.view_sales_order_line_filter" />

--- a/sale_order_line_input/views/sale_order_view.xml
+++ b/sale_order_line_input/views/sale_order_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+<odoo>
+  <record id="sale_order_form_inherit" model="ir.ui.view">
+    <field name="model">sale.order</field>
+    <field name="inherit_id" ref="sale.view_order_form" />
+    <field name="arch" type="xml">
+      <div name="button_box" position="inside">
+        <button
+                    type="object"
+                    name="action_view_sale_order_line"
+                    class="oe_stat_button"
+                    icon="fa-bars"
+                    groups="sale_order_line_input.sale_orderline_view_group"
+                >
+          <field string="SO Lines" name="sol_count" widget="statinfo" />
+        </button>
+      </div>
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
### This change
- Add a button to view SO lines
![2025-04-21_18-17](https://github.com/user-attachments/assets/1c4dd5e6-c44f-4ed4-bb39-9e98ce539a65)

- `sol_section_and_note` is to be able to view section and note in list view of SO lines (Before it's only available for embedded o2m field)
![2025-04-21_18-18](https://github.com/user-attachments/assets/bb747509-71c1-464d-b960-08edd958c0ac)
