### PR TITLE
[16.0] sell_only_by_packaging: fix sell_only_by_packaging copy

### DIFF
--- a/sell_only_by_packaging/models/product_template.py
+++ b/sell_only_by_packaging/models/product_template.py
@@ -14,6 +14,7 @@ class ProductTemplate(models.Model):
         default=False,
         help="Restrict the usage of this product on sale order lines without "
         "packaging defined",
+        copy=False,
     )
 
     min_sellable_qty = fields.Float(


### PR DESCRIPTION
This flag should not be copied as the rest of the configuration won't be copied (eg: packaging) leading to useless user errors when duplicating products.

Backport of #3694 