### PR TITLE
[15.0][FIX] sale_order_product_assortment: Add compute_sudo in has_allowed_products

### DIFF
--- a/sale_order_product_assortment/models/sale_order.py
+++ b/sale_order_product_assortment/models/sale_order.py
@@ -16,7 +16,10 @@ class SaleOrder(models.Model):
         compute="_compute_product_assortment_ids",
         compute_sudo=True,
     )
-    has_allowed_products = fields.Boolean(compute="_compute_product_assortment_ids")
+    has_allowed_products = fields.Boolean(
+        compute="_compute_product_assortment_ids",
+        compute_sudo=True,
+    )
 
     @api.depends("partner_id", "partner_shipping_id", "partner_invoice_id")
     def _compute_product_assortment_ids(self):


### PR DESCRIPTION
We detect problem creating sales with non manager users. In this moment, allowed assortments are not being calculated correctly.

So, we've added compute_sudo in has_allowed_products too like in allowed_product_ids and tested again.

@sergio-teruel how do you see this fix? I'm not sure if this field has not compute_sudo for any reason or not.

Thanks!