### PR TITLE
[16.0][FIX] sale_blanket_order: SO blanket_order_id computation

### DIFF
--- a/sale_blanket_order/models/sale_orders.py
+++ b/sale_blanket_order/models/sale_orders.py
@@ -13,7 +13,7 @@ class SaleOrder(models.Model):
     blanket_order_id = fields.Many2one(
         "sale.blanket.order",
         string="Origin blanket order",
-        related="order_line.blanket_order_line.order_id",
+        compute="_compute_blanket_order_id",
     )
     disable_adding_lines = fields.Boolean(
         compute="_compute_disable_adding_lines",
@@ -49,6 +49,12 @@ class SaleOrder(models.Model):
                             "blanket order lines customer"
                         )
                     )
+
+    @api.depends("order_line.blanket_order_line.order_id")
+    def _compute_blanket_order_id(self):
+        for order in self:
+            blanket_order = order.order_line.mapped("blanket_order_line.order_id")
+            order.blanket_order_id = blanket_order[:1]
 
     @api.depends("blanket_order_id")
     @api.depends_context("uid")

--- a/sale_blanket_order/tests/test_sale_order.py
+++ b/sale_blanket_order/tests/test_sale_order.py
@@ -194,3 +194,62 @@ class TestSaleOrder(common.TransactionCase):
             ]
         )
         self.assertEqual(so_line.blanket_order_line, bo_line_assigned)
+
+    def test_03_create_sale_order(self):
+        blanket_order = self.create_blanket_order_01()
+        blanket_order.sudo().action_confirm()
+        bo_lines = self.blanket_order_line_obj.search(
+            [("order_id", "=", blanket_order.id)]
+        )
+        self.assertEqual(len(bo_lines), 2)
+
+        so = self.sale_order_obj.create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product_2.name,
+                            "product_id": self.product_2.id,
+                            "product_uom_qty": 5.0,
+                            "product_uom": self.product_2.uom_po_id.id,
+                            "price_unit": 10.0,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product.name,
+                            "product_id": self.product.id,
+                            "product_uom_qty": 5.0,
+                            "product_uom": self.product.uom_po_id.id,
+                            "price_unit": 10.0,
+                        },
+                    ),
+                ],
+            }
+        )
+        so_line_1 = so.order_line[0]
+        so_line_2 = so.order_line[1]
+        so_line_1.with_context(from_sale_order=True).name_get()
+        so_line_1.onchange_product_id()
+        self.assertFalse(so_line_1._get_eligible_bo_lines())
+        so_line_2.with_context(from_sale_order=True).name_get()
+        so_line_2.onchange_product_id()
+        self.assertEqual(
+            so_line_2._get_eligible_bo_lines(),
+            bo_lines.filtered(lambda l: l.product_id == self.product),
+        )
+        bo_line_assigned = self.blanket_order_line_obj.search(
+            [
+                ("order_id", "=", blanket_order.id),
+                ("product_id", "=", self.product.id),
+                ("date_schedule", "=", fields.Date.to_string(self.date_schedule_1)),
+            ]
+        )
+        self.assertFalse(so_line_1.blanket_order_line)
+        self.assertEqual(so_line_2.blanket_order_line, bo_line_assigned)
+        self.assertEqual(so.blanket_order_id, blanket_order)


### PR DESCRIPTION
Before this commit, the `blanket_order_id` was a related field, meaning that if a SO had multiple lines and the first line was not linked to a BO line, this field remained unset, even if other lines were linked to a BO.

With these changes, we assign the first BO that we can find, regardless of its position in the order lines, and avoid this problem. Also added some test cases.