### PR TITLE
[18.0][FWD][IMP] sale_delivery_state: Skip sale order lines for delivery state + misc fixes

### DIFF
--- a/.oca/oca-port/blacklist/sale_delivery_state.json
+++ b/.oca/oca-port/blacklist/sale_delivery_state.json
@@ -1,5 +1,6 @@
 {
   "pull_requests": {
-    "https://github.com/OCA/sale-workflow/pull/2864": "Nothing to port from PR #https://github.com/OCA/sale-workflow/pull/2864"
+    "https://github.com/OCA/sale-workflow/pull/2864": "Nothing to port from PR https://github.com/OCA/sale-workflow/pull/2864",
+    "https://github.com/OCA/sale-workflow/pull/3285": "Nothing to port from PR https://github.com/OCA/sale-workflow/pull/3285"
   }
 }

--- a/.oca/oca-port/blacklist/sale_delivery_state.json
+++ b/.oca/oca-port/blacklist/sale_delivery_state.json
@@ -1,0 +1,5 @@
+{
+  "pull_requests": {
+    "https://github.com/OCA/sale-workflow/pull/2864": "Nothing to port from PR #https://github.com/OCA/sale-workflow/pull/2864"
+  }
+}

--- a/sale_delivery_state/__init__.py
+++ b/sale_delivery_state/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import pre_init_hook

--- a/sale_delivery_state/__init__.py
+++ b/sale_delivery_state/__init__.py
@@ -1,2 +1,2 @@
 from . import models
-from .hooks import pre_init_hook
+from .hooks import pre_init_hook, post_init_hook

--- a/sale_delivery_state/__manifest__.py
+++ b/sale_delivery_state/__manifest__.py
@@ -14,6 +14,7 @@
     "depends": ["sale"],
     "data": [
         "views/sale_order_views.xml",
+        "views/res_config_settings_views.xml",
     ],
     "demo": [
         "demo/sale_demo.xml",

--- a/sale_delivery_state/__manifest__.py
+++ b/sale_delivery_state/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Sale delivery State",
     "summary": "Show the delivery state on the sale order",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "category": "Product",
     "website": "https://github.com/OCA/sale-workflow",
     "author": "Akretion, Odoo Community Association (OCA)",
@@ -19,4 +19,5 @@
     "demo": [
         "demo/sale_demo.xml",
     ],
+    "pre_init_hook": "pre_init_hook",
 }

--- a/sale_delivery_state/__manifest__.py
+++ b/sale_delivery_state/__manifest__.py
@@ -20,4 +20,5 @@
         "demo/sale_demo.xml",
     ],
     "pre_init_hook": "pre_init_hook",
+    "post_init_hook": "post_init_hook",
 }

--- a/sale_delivery_state/hooks.py
+++ b/sale_delivery_state/hooks.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Manuel Regidor <manuel.regidor@sygel.es>
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
+# Copyright 2025 Camptocamp SA
+# @author: Simone Orsi <simahawk@gmail.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl)
 
 import logging
 
@@ -9,7 +10,14 @@ from odoo.tools.sql import column_exists, create_column
 _logger = logging.getLogger(__name__)
 
 
-def migrate(cr, version):
+def pre_init_hook(env):
+    _setup_new_columns(env.cr)
+
+
+def _setup_new_columns(cr):
+    if not column_exists(cr, "sale_order", "delivery_status"):
+        _logger.info("Create sale_order column delivery_status")
+        create_column(cr, "sale_order", "delivery_status", "varchar")
     if not column_exists(cr, "sale_order_line", "skip_sale_delivery_state"):
         _logger.info("Create sale_order_line column skip_sale_delivery_state")
         create_column(cr, "sale_order_line", "skip_sale_delivery_state", "boolean")

--- a/sale_delivery_state/hooks.py
+++ b/sale_delivery_state/hooks.py
@@ -1,10 +1,15 @@
+# Copyright 2023 Akretion (https://www.akretion.com).
+# @author Sébastien BEAU <sebastien.beau@akretion.com>
 # Copyright 2024 Manuel Regidor <manuel.regidor@sygel.es>
 # Copyright 2025 Camptocamp SA
 # @author: Simone Orsi <simahawk@gmail.com>
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl)
+# @author: Sébastien Alix <sebastien.alix@camptocamp.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 import logging
+import math
 
+from odoo.tools.misc import split_every
 from odoo.tools.sql import column_exists, create_column
 
 _logger = logging.getLogger(__name__)
@@ -22,3 +27,19 @@ def _setup_new_columns(cr):
         _logger.info("Create sale_order_line column skip_sale_delivery_state")
         create_column(cr, "sale_order_line", "skip_sale_delivery_state", "boolean")
         cr.execute("UPDATE sale_order_line SET skip_sale_delivery_state = False")
+
+
+def post_init_hook(env):
+    # Recompute '<sale.order>.delivery_status' by chunk to keep a constant
+    # memory consumption
+    order_model = env["sale.order"].with_context(prefetch_fields=False)
+    rec_ids = order_model.search([]).ids
+    _logger.info("Recompute 'delivery_status' on %s sale orders...", len(rec_ids))
+    chunk_size = 2000
+    nb_chunks = math.ceil(len(rec_ids) / chunk_size)
+    for i, chunk_ids in enumerate(split_every(chunk_size, rec_ids), 1):
+        _logger.info("... %s / %s", i, nb_chunks)
+        records = order_model.browse(chunk_ids)
+        records._compute_oca_delivery_status()
+        env.cr.commit()
+        env.invalidate_all()

--- a/sale_delivery_state/migrations/14.0.2.0.0/pre-migration.py
+++ b/sale_delivery_state/migrations/14.0.2.0.0/pre-migration.py
@@ -1,0 +1,16 @@
+# Copyright 2024 Manuel Regidor <manuel.regidor@sygel.es>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+import logging
+
+from odoo.tools.sql import column_exists, create_column
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not column_exists(cr, "sale_order_line", "skip_sale_delivery_state"):
+        _logger.info("Create sale_order_line column skip_sale_delivery_state")
+        create_column(cr, "sale_order_line", "skip_sale_delivery_state", "boolean")
+        cr.execute("UPDATE sale_order_line SET skip_sale_delivery_state = False")

--- a/sale_delivery_state/migrations/18.0.1.1.0/pre-migration.py
+++ b/sale_delivery_state/migrations/18.0.1.1.0/pre-migration.py
@@ -1,0 +1,9 @@
+# Copyright 2025 Camptocamp SA
+# @author: Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.addons.sale_delivery_state.hooks import _setup_new_columns
+
+
+def migrate(cr, version):
+    _setup_new_columns(cr)

--- a/sale_delivery_state/models/__init__.py
+++ b/sale_delivery_state/models/__init__.py
@@ -1,1 +1,4 @@
 from . import sale_order
+from . import sale_order_line
+from . import res_company
+from . import res_config_settings

--- a/sale_delivery_state/models/res_company.py
+++ b/sale_delivery_state/models/res_company.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Manuel Regidor <manuel.regidor@sygel.es>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    skip_service_sale_delivery_state = fields.Boolean(
+        string="Skip Service products for Sale Delivery State"
+    )

--- a/sale_delivery_state/models/res_config_settings.py
+++ b/sale_delivery_state/models/res_config_settings.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Manuel Regidor <manuel.regidor@sygel.es>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    skip_service_sale_delivery_state = fields.Boolean(
+        string="Skip Service products for Sale Delivery State",
+        related="company_id.skip_service_sale_delivery_state",
+        readonly=False,
+    )

--- a/sale_delivery_state/models/sale_order.py
+++ b/sale_delivery_state/models/sale_order.py
@@ -2,6 +2,8 @@
 # @author Pierrick BRUN <pierrick.brun@akretion.com>
 # Copyright 2018 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# Copyright 2023 Manuel Regidor <manuel.regidor@sygel.es>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
 from odoo.tools import float_compare, float_is_zero
@@ -34,7 +36,9 @@ class SaleOrder(models.Model):
         """
         self.ensure_one()
         # Skip delivery costs lines
-        sale_lines = self.order_line.filtered(lambda rec: not rec._is_delivery())
+        sale_lines = self.order_line.filtered(
+            lambda rec: not rec._is_delivery() and not rec.skip_sale_delivery_state
+        )
         precision = self.env["decimal.precision"].precision_get(
             "Product Unit of Measure"
         )
@@ -54,7 +58,9 @@ class SaleOrder(models.Model):
         """
         self.ensure_one()
         # Skip delivery costs lines
-        sale_lines = self.order_line.filtered(lambda rec: not rec._is_delivery())
+        sale_lines = self.order_line.filtered(
+            lambda rec: not rec._is_delivery() and not rec.skip_sale_delivery_state
+        )
         precision = self.env["decimal.precision"].precision_get(
             "Product Unit of Measure"
         )
@@ -63,7 +69,12 @@ class SaleOrder(models.Model):
             for line in sale_lines
         )
 
-    @api.depends("order_line.qty_delivered", "state", "force_delivery_state")
+    @api.depends(
+        "order_line.qty_delivered",
+        "order_line.skip_sale_delivery_state",
+        "state",
+        "force_delivery_state",
+    )
     def _compute_oca_delivery_status(self):
         for order in self:
             if order.state in ("draft", "cancel"):

--- a/sale_delivery_state/models/sale_order.py
+++ b/sale_delivery_state/models/sale_order.py
@@ -17,6 +17,16 @@ class SaleOrder(models.Model):
         # the method _compute_delivery_status already exist in odoo sale_stock
         compute="_compute_oca_delivery_status",
         store=True,
+        # Respect the same order as in sale_stock
+        # Including the 'started' state
+        # that is not used here but we compute it
+        # if pickings are available, to be compatible.
+        selection=[
+            ("pending", "Not Delivered"),
+            ("started", "Started"),
+            ("partial", "Partially Delivered"),
+            ("full", "Fully Delivered"),
+        ],
     )
 
     force_delivery_state = fields.Boolean(
@@ -83,10 +93,21 @@ class SaleOrder(models.Model):
                 order.delivery_status = "full"
             elif order._partially_delivered():
                 order.delivery_status = "partial"
-            elif any(p.state == "done" for p in order.picking_ids):
+            elif order._is_delivery_status_started():
                 order.delivery_status = "started"
             else:
                 order.delivery_status = "pending"
+
+    def _is_delivery_status_started(self):
+        # Loose dep on sale_stock. Feel free to customize this method
+        # to add your own logic or to create sale_stock glue module.
+        # NOTE: as the delivery_status is stored the update of a picking
+        # won't have any effect here. Hence, if you really want to
+        # fully support the started state, you should trigger the update
+        # of the sale order when a picking is updated.
+        # For now, we don't care that much as this state was not used before.
+        has_pickings = "picking_ids" in self._fields
+        return has_pickings and any(p.state == "done" for p in self.picking_ids)
 
     def action_force_delivery_state(self):
         self.write({"force_delivery_state": True})

--- a/sale_delivery_state/models/sale_order_line.py
+++ b/sale_delivery_state/models/sale_order_line.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Manuel Regidor <manuel.regidor@sygel.es>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    skip_sale_delivery_state = fields.Boolean(
+        string="Skip Delivery State",
+        compute="_compute_skip_sale_delivery_state",
+        store=True,
+        readonly=False,
+    )
+
+    @api.depends("company_id", "product_id")
+    def _compute_skip_sale_delivery_state(self):
+        for line in self:
+            skip_sale_delivery_state = False
+            if (
+                line.product_id
+                and line.product_id.type == "service"
+                and line.company_id.skip_service_sale_delivery_state
+            ):
+                skip_sale_delivery_state = True
+            line.skip_sale_delivery_state = skip_sale_delivery_state

--- a/sale_delivery_state/readme/CONFIGURE.md
+++ b/sale_delivery_state/readme/CONFIGURE.md
@@ -1,0 +1,2 @@
+#. Go to *Sales > Configuration > Quotations & Orders*.
+#. Check the Skip Service products for Sale Delivery State checkbox to automatically set the field Skip Delivery State in sale order lines to True when the line contains a service product.

--- a/sale_delivery_state/readme/CONTRIBUTORS.md
+++ b/sale_delivery_state/readme/CONTRIBUTORS.md
@@ -5,3 +5,4 @@
   Integrators](https://opensourceintegrators.com)
 - Carlos Lopez \<<celm1990@gmail.com>\>
 - Virendrasinh Dabhi \<<veer.190.dabhi@gmail.com>\>
+- Manuel Regidor <manuel.regidor@sygel.es>

--- a/sale_delivery_state/readme/CONTRIBUTORS.md
+++ b/sale_delivery_state/readme/CONTRIBUTORS.md
@@ -6,3 +6,4 @@
 - Carlos Lopez \<<celm1990@gmail.com>\>
 - Virendrasinh Dabhi \<<veer.190.dabhi@gmail.com>\>
 - Manuel Regidor <manuel.regidor@sygel.es>
+- Simone Orsi <simone.orsi@camptocamp.com>

--- a/sale_delivery_state/readme/DESCRIPTION.md
+++ b/sale_delivery_state/readme/DESCRIPTION.md
@@ -11,6 +11,12 @@ nothing more to deliver.
 Sale order lines can have products or services, as long as the field
 qty_delivered is set, it will trigger the computation of delivery state.
 
+Sale order lines with the Skip Delivery State field set to True will be ignored when
+computing the delivery state. This field is automatically set depending on the field
+Sales > Configuration > Quotations & Orders > Skip Service products for Sale Delivery
+State. If set to True, the field Skip Delivery State in sale order lines containing
+service products will be automatically set to True, but it can manually changed.
+
 This module also works with delivery.carrier fees that are added as a
 sale order line. Thoses line are special as they will never be
 considered delivered. Delivery fees lines are ignored in the computation

--- a/sale_delivery_state/tests/test_delivery_state.py
+++ b/sale_delivery_state/tests/test_delivery_state.py
@@ -17,6 +17,9 @@ class TestDeliveryState(TransactionCase):
         cls.delivery_cost = cls.env["product.product"].create(
             {"name": "delivery", "type": "service"}
         )
+        cls.service_product = cls.env["product.product"].create(
+            {"name": "service", "type": "service"}
+        )
 
     def _mock_delivery(self, delivery_prod=None):
         delivery_prod = delivery_prod or self.delivery_cost
@@ -35,6 +38,19 @@ class TestDeliveryState(TransactionCase):
                 "product_uom_qty": 1,
                 "product_uom": self.env.ref("uom.product_uom_unit").id,
                 "price_unit": 10.0,
+            }
+        )
+
+    def _add_service_line(self, skip_sale_delivery_state=False):
+        self.env["sale.order.line"].create(
+            {
+                "order_id": self.order.id,
+                "name": "Service",
+                "product_id": self.service_product.id,
+                "product_uom_qty": 1,
+                "product_uom": self.env.ref("uom.product_uom_unit").id,
+                "price_unit": 10.0,
+                "skip_sale_delivery_state": skip_sale_delivery_state,
             }
         )
 
@@ -91,3 +107,16 @@ class TestDeliveryState(TransactionCase):
                     continue
                 line.qty_delivered = line.product_uom_qty
             self.assertEqual(self.order.delivery_status, "full")
+
+    def test_skip_service_line(self):
+        self._add_service_line()
+        self.order.action_confirm()
+        for line in self.order.order_line:
+            if line.product_id == self.service_product:
+                continue
+            line.qty_delivered = line.product_uom_qty
+        self.assertEqual(self.order.delivery_status, "partial")
+        self.order.order_line.filtered(
+            lambda a: a.product_id and a.product_id == self.service_product
+        ).write({"skip_sale_delivery_state": True})
+        self.assertEqual(self.order.delivery_status, "full")

--- a/sale_delivery_state/views/res_config_settings_views.xml
+++ b/sale_delivery_state/views/res_config_settings_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="sale_delivery_state_res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">sale.delivery.state.res.config.settings.view.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="sale.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <setting id="proforma_configuration" position="after">
+                <setting id="skip_service_sale_delivery_state_configuration">
+                    <field name="skip_service_sale_delivery_state" />
+                    <div class="text-muted">
+                  If active, sale order lines containing Service products will not be evaluated by default when determining the Delivery State.
+              </div>
+                </setting>
+            </setting>
+        </field>
+    </record>
+</odoo>

--- a/sale_delivery_state/views/sale_order_views.xml
+++ b/sale_delivery_state/views/sale_order_views.xml
@@ -23,6 +23,9 @@
                 <field name="delivery_status" invisible="state != 'sale'" />
                 <field name="force_delivery_state" invisible="1" />
             </group>
+            <xpath expr="//field[@name='order_line']//list" position="inside">
+                <field name="skip_sale_delivery_state" optional="hide" />
+            </xpath>
         </field>
     </record>
 

--- a/sale_delivery_state/views/sale_order_views.xml
+++ b/sale_delivery_state/views/sale_order_views.xml
@@ -40,7 +40,7 @@
                     widget="badge"
                     optional="hide"
                     decoration-info="delivery_status == 'pending'"
-                    decoration-warning="delivery_status == 'partial'"
+                    decoration-warning="delivery_status in ('partial', 'started')"
                     decoration-success="delivery_status == 'full'"
                 />
             </field>


### PR DESCRIPTION
FWD port #2864 + #3285.

NOTE: the migrate script has been used also for pre init hook to avoid impacting existing dbs where this module is not installed yet (this was missing in the work done on v14).
I also moved the post init script from https://github.com/OCA/sale-workflow/pull/3448 to here.

Additional fixes:
* compat of the status field w/ sale_stock
* for the sol view, as the 'started' state was not considered
