### PR TITLE
[17.0][FIX ]sale_order_secondary_unit: fix test conflicts when used with product_matrix

### DIFF
--- a/sale_order_secondary_unit/tests/test_product_template.py
+++ b/sale_order_secondary_unit/tests/test_product_template.py
@@ -1,10 +1,12 @@
 # Copyright 2018-2020 Tecnativa - Carlos Dauden
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo.tests import TransactionCase, tagged
+from odoo.tests import tagged
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
 @tagged("post_install", "-at_install")
-class TestProductTemplate(TransactionCase):
+class TestProductTemplate(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -26,7 +28,10 @@ class TestProductTemplate(TransactionCase):
             ]
         )
         cls.size_attribute = cls.product_attribute_model.create(
-            {"name": "Size", "create_variant": "always"}
+            {
+                "name": "Test Size (sale_order_secondary_unit)",
+                "create_variant": "always",
+            }
         )
         cls.size_values = cls.product_attribute_value_model.create(
             [

--- a/sale_order_secondary_unit/tests/test_sale_order.py
+++ b/sale_order_secondary_unit/tests/test_sale_order.py
@@ -1,23 +1,17 @@
 # Copyright 2018-2020 Tecnativa - Carlos Dauden
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo.tests import Form, TransactionCase, tagged
+from odoo.tests import Form, tagged
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
 @tagged("post_install", "-at_install")
-class TestSaleOrder(TransactionCase):
+class TestSaleOrder(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         # Remove this variable in v16 and put instead:
         # from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
-        DISABLED_MAIL_CONTEXT = {
-            "tracking_disable": True,
-            "mail_create_nolog": True,
-            "mail_create_nosubscribe": True,
-            "mail_notrack": True,
-            "no_reset_password": True,
-        }
-        cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
         cls.product_uom_kg = cls.env.ref("uom.product_uom_kgm")
         cls.product_uom_gram = cls.env.ref("uom.product_uom_gram")
         cls.product_uom_unit = cls.env.ref("uom.product_uom_unit")


### PR DESCRIPTION
Fixes the follwing error when testing alongside product_matrix (and probably some other addon) that define the Size product attribute.
```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "product_attribute_number_uniq"
DETAIL:  Key (name)=({"en_US": "Size"}) already exists.
```
@Tecnativa @victoralmau @pilarvargas-tecnativa 
TT52360