### PR TITLE
[16.0][IMP] sale_order_line_cancel: Do not update canceled qty in state draft

### DIFF
--- a/sale_order_line_cancel/models/stock_move.py
+++ b/sale_order_line_cancel/models/stock_move.py
@@ -1,5 +1,6 @@
 # Copyright 2023 ACSONE SA/NV
 # Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import models
@@ -38,5 +39,6 @@ class StockMove(models.Model):
         return (
             self.state == "cancel"
             and self.sale_line_id
+            and self.sale_line_id.state != "draft"
             and self.picking_type_id.code == "outgoing"
         )

--- a/sale_order_line_cancel/tests/test_sale_order_line_cancel.py
+++ b/sale_order_line_cancel/tests/test_sale_order_line_cancel.py
@@ -111,3 +111,17 @@ class TestSaleOrderLineCancel(TestSaleOrderLineCancelBase):
         self.sale.action_draft()
         self.assertEqual(self.sale.order_line.product_qty_canceled, 0)
         self.assertEqual(self.sale.order_line.product_qty_remains_to_deliver, 5)
+
+    def test_draft_sale_order_with_picking_cancel(self):
+        sale = self.sale
+        sale.action_cancel()
+        sale.action_draft()
+        picking = sale.picking_ids.copy()
+        picking.action_assign()
+        self.assertEqual(sale.order_line.product_qty_canceled, 0)
+        self.assertEqual(sale.order_line.qty_to_deliver, 10)
+        self.assertEqual(sale.order_line.product_qty_remains_to_deliver, 10)
+        picking.action_cancel()
+        self.assertEqual(sale.order_line.product_qty_canceled, 0)
+        self.assertEqual(sale.order_line.qty_to_deliver, 10)
+        self.assertEqual(sale.order_line.product_qty_remains_to_deliver, 10)


### PR DESCRIPTION
To make this addon compatible with sale_stock_prebook,
the product_qty_canceled should only be updated in a not draft status.
@i-vyshnevska @raumschmiede-joshuaL @jbaudoux @mmequignon @rousseldenis 