### PR TITLE
[18.0][FIX] sale_stock_picking_blocking: Fixed issue when duplicating a sales order.

### DIFF
--- a/sale_stock_picking_blocking/models/sale_order.py
+++ b/sale_stock_picking_blocking/models/sale_order.py
@@ -46,7 +46,6 @@ class SaleOrder(models.Model):
         order_to_unblock.order_line._action_launch_stock_rule()
         return True
 
-    @api.returns("self", lambda value: value.id)
     def copy(self, default=None):
         new_so = super().copy(default=default)
         for so in new_so:

--- a/sale_stock_picking_blocking/tests/test_sale_stock_picking_blocking.py
+++ b/sale_stock_picking_blocking/tests/test_sale_stock_picking_blocking.py
@@ -136,3 +136,53 @@ class TestSaleDeliveryBlock(TransactionCase):
         so = so_form.save()
         self.assertEqual(so.delivery_block_id, block_reason)
         self.assertEqual(so.copy().delivery_block_id, block_reason)
+
+    def test_copy_applies_delivery_block_logic(self):
+        """Test if copy() correctly applies delivery block from partner or payment
+        term"""
+        block_reason = self.block_model.with_user(self.user_test).create(
+            {"name": "Test Block Copy"}
+        )
+        # Partner with default block reason
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Copy Partner",
+                "default_delivery_block": block_reason.id,
+            }
+        )
+        # Payment term with default block reason
+        payment_term = self.env["account.payment.term"].create(
+            {
+                "name": "Copy Payment Term",
+                "default_delivery_block_reason_id": block_reason.id,
+            }
+        )
+        # Case 1: partner default_delivery_block applies
+        so = self.so_model.with_user(self.user_test).create(
+            {
+                "partner_id": partner.id,
+                "payment_term_id": payment_term.id,
+            }
+        )
+        copied_so = so.copy()
+        self.assertEqual(
+            copied_so.delivery_block_id,
+            block_reason,
+            "Delivery block should come from partner's default_delivery_block",
+        )
+
+        # Case 2: partner does NOT have block, but payment term does
+        partner.default_delivery_block = False
+        so_no_partner_block = self.so_model.with_user(self.user_test).create(
+            {
+                "partner_id": partner.id,
+                "payment_term_id": payment_term.id,
+            }
+        )
+        copied_so2 = so_no_partner_block.copy()
+        self.assertEqual(
+            copied_so2.delivery_block_id,
+            block_reason,
+            "Delivery block should come from payment term's "
+            "default_delivery_block_reason_id",
+        )


### PR DESCRIPTION
Removed @api.returns("self", lambda value: value.id) from the copy() method because it must return a recordset, not an ID. Returning an ID causes an error when duplicating records like sale.order, since the ORM expects a record, not a primitive value.