### PR TITLE
[IMP][16.0] sale_order_invoicing_picking_filter: inheritance for included stock moves in invoice

### DIFF
--- a/sale_order_invoicing_picking_filter/models/sale_order.py
+++ b/sale_order_invoicing_picking_filter/models/sale_order.py
@@ -77,13 +77,7 @@ class SaleOrder(models.Model):
         incoming_invoice_vals_list = []
         for order in self:
             for code in ["outgoing", "incoming"]:
-                move_ids = (
-                    pickings.filtered(
-                        lambda a: a.sale_id == order and a.picking_type_code == code
-                    )
-                    .mapped("move_ids")
-                    .filtered("sale_line_id")
-                )
+                move_ids = pickings._get_moves_order_picking_invoicing(order, code)
                 if move_ids:
                     invoice_vals = order._prepare_invoice()
                     invoice_line_vals = []

--- a/sale_order_invoicing_picking_filter/models/stock_picking.py
+++ b/sale_order_invoicing_picking_filter/models/stock_picking.py
@@ -21,3 +21,10 @@ class StockPicking(models.Model):
         )
         invoiced_pickings.write({"invoiced": True})
         (self - invoiced_pickings).write({"invoiced": False})
+
+    def _get_moves_order_picking_invoicing(self, order, code):
+        return (
+            self.filtered(lambda a: a.sale_id == order and a.picking_type_code == code)
+            .mapped("move_ids")
+            .filtered("sale_line_id")
+        )


### PR DESCRIPTION
Before this IMP, the way stock moves to be included in an invoice was part of the _create_invoices_from_pickings method in sale.order. That makes it difficult to modify the stock moves that are considered, in case some moves need to be added or removed.

It might happend, for example, if sale order lines have specific routes whose stock moves need a different processing when added to an invoice.

T-8291