### PR TITLE
[16.0][IMP] sale_pricelist_from_commitment_date force date on compute price rule

### DIFF
--- a/sale_pricelist_from_commitment_date/models/product_pricelist.py
+++ b/sale_pricelist_from_commitment_date/models/product_pricelist.py
@@ -13,3 +13,11 @@ class ProductPricelist(models.Model):
         if force_pricelist_date:
             date = force_pricelist_date
         return super()._get_product_rule(product, quantity, uom, date, **kwargs)
+
+    def _compute_price_rule(self, products, quantity, uom=None, date=False, **kwargs):
+        force_pricelist_date = self.env.context.get("force_pricelist_date")
+        if force_pricelist_date:
+            date = force_pricelist_date
+        return super()._compute_price_rule(
+            products, quantity, uom=uom, date=date, **kwargs
+        )

--- a/sale_pricelist_from_commitment_date/tests/test_pricelist_from_commitment_date.py
+++ b/sale_pricelist_from_commitment_date/tests/test_pricelist_from_commitment_date.py
@@ -100,6 +100,16 @@ class PricelistFromCommitmentDate(TransactionCase):
         self.assertEqual(order_line.price_unit, product.list_price)
         # Test with commitment date
         sale.commitment_date = "2020-03-08"
+        self.assertEqual(
+            sale.pricelist_id.with_context(
+                force_pricelist_date=sale.commitment_date
+            )._compute_price_rule(product, 1.0, date=order_line.order_id.date_order)[
+                product.id
+            ][
+                0
+            ],
+            10,
+        )
         self.assertEqual(order_line.price_unit, 10)
         sale.commitment_date = "2020-03-12"
         self.assertEqual(order_line.price_unit, 20)


### PR DESCRIPTION
…
This improvement allows `_compute_price_rule` to obtain the price and rule on a specific date passed by context