### PR TITLE
[18.0][IMP] sale_invoice_policy: automatic invoice

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# generated from manifests external_dependencies
+openupgradelib

--- a/sale_invoice_policy/__manifest__.py
+++ b/sale_invoice_policy/__manifest__.py
@@ -11,6 +11,7 @@
     "version": "18.0.1.0.0",
     "license": "AGPL-3",
     "depends": ["sale_stock", "base_partition"],
+    "external_dependencies": {"python": ["openupgradelib"]},
     "data": [
         "views/res_config_settings_view.xml",
         "views/sale_view.xml",

--- a/sale_invoice_policy/models/sale_order.py
+++ b/sale_invoice_policy/models/sale_order.py
@@ -1,4 +1,5 @@
 # Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
@@ -31,3 +32,10 @@ class SaleOrder(models.Model):
         """
         for company, sale_orders in self.partition("company_id").items():
             sale_orders.invoice_policy = company.sale_default_invoice_policy
+
+    def _force_lines_to_invoice_policy_order(self):
+        # When a SO is fully paid by a payment transaction and the automatic
+        # invoicing is enabled, the lines are forced to policy on order.
+        # Reflect this on the SO policy.
+        self.invoice_policy = "order"
+        return super()._force_lines_to_invoice_policy_order()

--- a/sale_invoice_policy/readme/CONTRIBUTORS.md
+++ b/sale_invoice_policy/readme/CONTRIBUTORS.md
@@ -7,3 +7,4 @@
 - Ioan Galan \<<ioan@studio73.es>\>
 - Laurent Mignon \<<laurent.mignon@acsone.eu>\>
 - Marie Lejeune \<<marie.lejeune@acsone.eu>\>
+- Jacques-Etienne Baudoux (BCIM) \<<je.bcim.be>\>

--- a/sale_invoice_policy/tests/test_sale_invoice_policy.py
+++ b/sale_invoice_policy/tests/test_sale_invoice_policy.py
@@ -1,4 +1,5 @@
-# © 2017 Acsone SA/NV (http://www.acsone.eu)
+# Copyright 2017 Acsone SA/NV (http://www.acsone.eu)
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import odoo.tests.common as common
 
@@ -167,3 +168,21 @@ class TestSaleOrderInvoicePolicy(common.TransactionCase):
             "the same invoice policy",
             exc.exception.args[0],
         )
+
+    def test_force_lines_to_invoice_policy_order(self):
+        """Check when a SO is fully paid by a payment transaction and the automatic
+        invoicing is enabled, that the policy is changed on order."""
+        so = self.env["sale.order"].create(
+            {
+                "partner_id": self.env.ref("base.res_partner_2").id,
+                "order_line": [
+                    (0, 0, {"product_id": self.product.id, "product_uom_qty": 2.0}),
+                    (0, 0, {"product_id": self.product2.id, "product_uom_qty": 3.0}),
+                ],
+                "invoice_policy": "delivery",
+            }
+        )
+        so.action_confirm()
+        self.assertEqual(so.invoice_policy, "delivery")
+        so._force_lines_to_invoice_policy_order()
+        self.assertEqual(so.invoice_policy, "order")


### PR DESCRIPTION
Mark the SO invoicing policy on order when the SO lines are forced to order by the automatic invoicing.

To better support this odoo feature:
* https://github.com/odoo/odoo/blob/57b4056798b9a380027fd3da1c4f3965249a4509/addons/sale/models/sale_order.py#L1806

Also added openupgradelib in external dependencies as it is called by pre-init-hook

cc @marielejeune @rousseldenis 