### PR TITLE
[sale_company_currency] FIX: Use currency._convert for proper currenc…

### DIFF
--- a/sale_company_currency/models/sale_order.py
+++ b/sale_company_currency/models/sale_order.py
@@ -23,11 +23,21 @@ class SaleOrder(models.Model):
         store=True,
     )
 
-    @api.depends("amount_total", "currency_rate")
+    @api.depends("amount_total", "currency_id", "company_id", "date_order")
     def _compute_amount_company(self):
         for order in self:
-            if order.currency_id.id == order.company_id.currency_id.id:
-                to_amount = order.amount_total
+            # order.currency_id == order.company_id.currency_id: 
+            if order.currency_id == order.company_id.currency_id:
+                order.amount_total_curr = order.amount_total
             else:
-                to_amount = order.amount_total * order.currency_rate
-            order.amount_total_curr = to_amount
+                # Convert order amount to company currency
+                conversion_date = (
+                    order.date_order and order.date_order.date()
+                    or fields.Date.context_today(self)
+                )
+                order.amount_total_curr = order.currency_id._convert(
+                    order.amount_total,
+                    order.company_id.currency_id,
+                    order.company_id,
+                    conversion_date,
+                )

--- a/sale_company_currency/tests/test_sale_company_currency.py
+++ b/sale_company_currency/tests/test_sale_company_currency.py
@@ -1,4 +1,5 @@
 from odoo.tests.common import TransactionCase
+from odoo import fields
 
 
 class TestSaleOrder(TransactionCase):
@@ -60,15 +61,56 @@ class TestSaleOrder(TransactionCase):
         currency."""
         self.sale_order.currency_id = self.currency_eur
         self.sale_order._compute_amount_company()
-        amount_total_curr_rounded = round(self.sale_order.amount_total_curr, 2)
-        amount_total_converted_rounded = round(
-            self.sale_order.amount_total * self.sale_order.currency_rate, 2
+        # Use currency._convert for expected result
+        conversion_date = (
+            self.sale_order.date_order and self.sale_order.date_order.date()
+            or fields.Date.context_today(self.sale_order)
         )
+        expected = self.sale_order.currency_id._convert(
+            self.sale_order.amount_total,
+            self.sale_order.company_id.currency_id,
+            self.sale_order.company_id,
+            conversion_date,
+        )
+        self.assertAlmostEqual(
+            self.sale_order.amount_total_curr,
+            expected,
+            places=2,
+            msg="Amount in company currency should be converted using _convert method.",
+        )
+
+    def test_03_amount_total_curr_reversed_currency(self):
+        """Test conversion when company currency is EUR and sale order is USD."""
+        # Create a new company with EUR currency to avoid UserError
+        new_company = self.env['res.company'].create({
+            'name': 'TestCo EUR',
+            'currency_id': self.currency_eur.id,
+        })
+        # Reassign order to new company
+        self.sale_order.company_id = new_company
+        # Ensure company_currency_id is updated
         self.assertEqual(
-            amount_total_curr_rounded,
-            amount_total_converted_rounded,
-            msg=(
-                "Amount in company currency should be converted "
-                "using the currency rate."
-            ),
+            self.sale_order.company_currency_id,
+            self.currency_eur,
+            msg="Company currency should be EUR."
+        )
+        # Sale currency USD
+        self.sale_order.currency_id = self.currency_usd
+        self.sale_order._compute_amount_company()
+        # Expected USD->EUR conversion
+        conversion_date = (
+            self.sale_order.date_order and self.sale_order.date_order.date()
+            or fields.Date.context_today(self.sale_order)
+        )
+        expected = self.sale_order.currency_id._convert(
+            self.sale_order.amount_total,
+            self.sale_order.company_id.currency_id,
+            self.sale_order.company_id,
+            conversion_date,
+        )
+        self.assertAlmostEqual(
+            self.sale_order.amount_total_curr,
+            expected,
+            places=2,
+            msg="Reversed conversion using _convert should match expected."
         )


### PR DESCRIPTION
…y conversion

Replace manual currency_rate multiplication with standard Odoo currency._convert method for accurate currency conversion:

- Fixed _compute_amount_company to use currency_id._convert()
- Added proper conversion date handling (date_order or today)
- Updated dependencies to include currency_id, company_id, date_order
- Enhanced tests to validate conversion using _convert method
- Added test for reversed currency conversion (USD to EUR)

This ensures proper handling of currency rates, rounding rules, and date-specific exchange rates as per Odoo standards.