### PR TITLE
[FIX] sale_stock_delivery_address: prevent overriding procurement group key without dest_address_id

### DIFF
--- a/sale_stock_delivery_address/models/sale_order_line.py
+++ b/sale_stock_delivery_address/models/sale_order_line.py
@@ -22,8 +22,7 @@ class SaleOrderLine(models.Model):
         priority = 15
         key = super(SaleOrderLine, self)._get_procurement_group_key()
         # Check priority
-        if key[0] >= priority:
-            return key
-        if self.dest_address_id:
-            return (priority, self.dest_address_id)
-        return (priority, key)
+        if key[0] < priority:
+            if self.dest_address_id:
+                return (priority, self.dest_address_id)
+        return key


### PR DESCRIPTION
PR created from the discussion at https://github.com/OCA/sale-workflow/pull/3462#discussion_r2140582884.
Avoid overriding procurement group key when `dest_address_id` is not set. This ensures correct priority handling and avoids interfering with other modules' grouping logic.
![image](https://github.com/user-attachments/assets/6f0cb292-e7c2-45c9-9ab3-79a4e4adbe54)
