### PR TITLE
[16.0][FIX] - sale_advance_payment errored residual

### DIFF
--- a/sale_advance_payment/models/sale.py
+++ b/sale_advance_payment/models/sale.py
@@ -82,7 +82,7 @@ class SaleOrder(models.Model):
             # Consider payments in related invoices.
             invoice_paid_amount = 0.0
             for inv in order.invoice_ids:
-                invoice_paid_amount += inv.amount_total - inv.amount_residual
+                invoice_paid_amount += inv.amount_total_signed - inv.amount_residual_signed
             amount_residual = order.amount_total - advance_amount - invoice_paid_amount
             payment_state = "not_paid"
             if mls:


### PR DESCRIPTION
Reproduced on runboat: 

https://github.com/user-attachments/assets/272b184f-1b1e-4f25-b2f7-2763e783aff8

The residual amount on a SO is calculated with the sum of `amount_total` on each invoice.
If we have a credit note, the result isn't good.. Using `amount_total_signed` seems fix.