### PR TITLE
[18.0][FIX] sale_order_lot_selection/sale_order_product_availability_inline: Don't use demo data for tests / fix display

### DIFF
--- a/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
+++ b/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
@@ -1,6 +1,6 @@
 # © 2015 Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-
+from odoo.fields import Command
 from odoo.tests import TransactionCase
 
 
@@ -18,17 +18,62 @@ class TestSaleOrderLotSelection(TransactionCase):
 
         """
         super().setUpClass()
-        cls.prd_cable = cls.env.ref("stock.product_cable_management_box")
-        cls.prd_cable.tracking = "lot"
-        cls.product_46 = cls.env.ref("product.product_product_13")
-        cls.product_12 = cls.env.ref("product.product_product_12")
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Partner Test",
+            }
+        )
+        cls.prd_cable = cls.env["product.product"].create(
+            {
+                "name": "Cable Test",
+                "tracking": "lot",
+                "is_storable": True,
+            }
+        )
+        cls.product_46 = cls.env["product.product"].create(
+            {
+                "name": "Product 46",
+                "is_storable": True,
+            }
+        )
+        cls.product_12 = cls.env["product.product"].create(
+            {
+                "name": "Product 12",
+                "is_storable": True,
+            }
+        )
         cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
         cls.customer_location = cls.env.ref("stock.stock_location_customers")
         cls.stock_location = cls.env.ref("stock.stock_location_stock")
         cls.product_model = cls.env["product.product"]
         cls.lot_model = cls.env["stock.lot"]
-        cls.lot_cable = cls.env.ref("sale_order_lot_selection.lot_cable_demo")
-        cls.sale = cls.env.ref("sale_order_lot_selection.sale_order_demo")
+        cls.lot_cable = cls.env["stock.lot"].create(
+            {
+                "name": "cable test lot",
+                "product_id": cls.prd_cable.id,
+            }
+        )
+        cls.sale = cls.env["sale.order"].create(
+            {
+                "partner_id": cls.partner.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": cls.prd_cable.id,
+                            "product_uom_qty": 1.0,
+                            "lot_id": cls.lot_cable.id,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "product_id": cls.prd_cable.id,
+                            "product_uom_qty": 1.0,
+                            "lot_id": cls.lot_cable.id,
+                        }
+                    ),
+                ],
+            }
+        )
 
     def _retrieve_stock_quantity(self, product, lot, location):
         return product.with_context(lot_id=lot.id, location=location.id).qty_available

--- a/sale_order_product_availability_inline/models/__init__.py
+++ b/sale_order_product_availability_inline/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import product_product
+from . import product_template
 from . import sale

--- a/sale_order_product_availability_inline/models/product_template.py
+++ b/sale_order_product_availability_inline/models/product_template.py
@@ -1,0 +1,32 @@
+# Copyright 2020 Tecnativa - Ernesto Tejeda
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    def _compute_display_name(self):
+        res = super()._compute_display_name()
+        if self.env.context.get("so_product_stock_inline"):
+            self = self.with_context(warehouse=self.env.context.get("warehouse"))
+            availability = {
+                r.id: [
+                    sum(p.free_qty for p in r.product_variant_ids),
+                    r.uom_id.display_name,
+                ]
+                for r in self
+            }
+            precision = self.env["decimal.precision"].precision_get(
+                "Product Unit of Measure"
+            )
+            for record in self:
+                name = "{} ({:.{}f} {})".format(
+                    record.display_name,
+                    availability[record.id][0],
+                    precision,
+                    availability[record.id][1],
+                )
+                record.display_name = name
+        return res

--- a/sale_order_product_availability_inline/models/sale.py
+++ b/sale_order_product_availability_inline/models/sale.py
@@ -12,3 +12,8 @@ class SaleOrderLine(models.Model):
         if self.env.context.get("so_product_stock_inline"):
             self = self.with_context(so_product_stock_inline=False)
         return super()._compute_name()
+
+    def _compute_translated_product_name(self):
+        if self.env.context.get("so_product_stock_inline"):
+            self = self.with_context(so_product_stock_inline=False)
+        return super()._compute_translated_product_name()

--- a/sale_order_product_availability_inline/views/sale_views.xml
+++ b/sale_order_product_availability_inline/views/sale_views.xml
@@ -15,6 +15,16 @@
                     "warehouse": parent.warehouse_id}
                 </attribute>
             </xpath>
+
+            <xpath
+                expr="//field[@name='order_line']/list//field[@name='product_template_id']"
+                position="attributes"
+            >
+                <attribute name="context" operation="update">
+                    {"so_product_stock_inline": True,
+                    "warehouse": parent.warehouse_id}
+                </attribute>
+            </xpath>
             <xpath
                 expr="//field[@name='order_line']/form//field[@name='product_id']"
                 position="attributes"


### PR DESCRIPTION
Fixes:

- [x] sale_order_lot_selection: Don't rely on demo data for tests
- [x] sale_order_product_availability_inline: Since Odoo's change here: https://github.com/odoo/odoo/commit/c84b67e5dca1a74e1a5862e754455944015f4105