### PR TITLE
[18.0][FIX] sale_automatic_workflow: Fix SO domains

### DIFF
--- a/sale_automatic_workflow/data/automatic_workflow_data.xml
+++ b/sale_automatic_workflow/data/automatic_workflow_data.xml
@@ -15,7 +15,7 @@
         <field name="model_id">sale.order</field>
         <field
             name="domain"
-        >[('state','=','sale'),('invoice_status','=','to invoice')]</field>
+        >[('state','=','sale'), ('locked', '=', False), ('invoice_status','=','to invoice')]</field>
         <field name="user_id" ref="base.user_root" />
     </record>
     <record id="automatic_workflow_validate_invoice_filter" model="ir.filters">
@@ -31,7 +31,7 @@
         <field name="model_id">sale.order</field>
         <field
             name="domain"
-        >[('state', '=', 'sale'),('invoice_status','=','invoiced')]</field>
+        >[('state', '=', 'sale'), ('locked', '=', False), ('invoice_status','=','invoiced')]</field>
         <field name="user_id" ref="base.user_root" />
     </record>
     <record id="automatic_workflow_payment_filter" model="ir.filters">

--- a/sale_automatic_workflow_job/tests/test_auto_workflow_job.py
+++ b/sale_automatic_workflow_job/tests/test_auto_workflow_job.py
@@ -84,6 +84,7 @@ class TestAutoWorkflowJob(TestCommon, TestAutomaticWorkflowMixin):
                 self.sale,
                 [
                     ("state", "=", "sale"),
+                    ("locked", "=", False),
                     ("invoice_status", "=", "to invoice"),
                     ("workflow_process_id", "=", self.sale.workflow_process_id.id),
                 ],
@@ -153,6 +154,7 @@ class TestAutoWorkflowJob(TestCommon, TestAutomaticWorkflowMixin):
                 self.sale,
                 [
                     ("state", "=", "sale"),
+                    ("locked", "=", False),
                     ("invoice_status", "=", "invoiced"),
                     ("workflow_process_id", "=", self.sale.workflow_process_id.id),
                 ],


### PR DESCRIPTION
Since 18.0, there's no `done` state anymore on sale orders.
Both former `done` and `sale` states are now `sale`.
Whethere a SO is done or not is represented by the `locked` boolean state.
Applied this on the `sale_automatic_workflow` domains.