### PR TITLE
[FIX] sale_exception: add a register_hook to prevent other action_con…

### DIFF
--- a/sale_exception/models/sale_order.py
+++ b/sale_exception/models/sale_order.py
@@ -54,6 +54,25 @@ class SaleOrder(models.Model):
             return self._popup_exceptions()
         return super().action_confirm()
 
+    def _register_hook(self):
+        ModelClass = self.env.registry["sale.order"]
+
+        original_action_confirm = ModelClass.action_confirm
+
+        def patched_action_confirm(self):
+            if self.detect_exceptions():
+                if not self.env.company.sale_exception_show_popup:
+                    return
+                return self._popup_exceptions()
+            original_func = patched_action_confirm.origin
+            return original_func(self)
+
+        patched_action_confirm.origin = original_action_confirm
+
+        ModelClass.action_confirm = patched_action_confirm
+
+        return super()._register_hook()
+
     def action_draft(self):
         res = super().action_draft()
         orders = self.filtered("ignore_exception")

--- a/sale_exception/models/sale_order.py
+++ b/sale_exception/models/sale_order.py
@@ -54,6 +54,34 @@ class SaleOrder(models.Model):
         self.detect_exceptions()
         return super().action_confirm()
 
+    def _register_hook(self):
+        # Exceptions must be detected before any other module runs its own
+        # `action_confirm` logic. Standard inheritance cannot grant that:
+        # modules with no dependency between them are ordered by installation
+        # order, so an override that acts before calling `super()` may run
+        # first. `sale_loyalty` is one case: it adds the loyalty points before
+        # the order is confirmed, so the points were granted even when an
+        # exception blocked the confirmation. The same happens with
+        # `sale_order_lot_generator`, and it may happen with payment or
+        # e-invoicing integrations, whose side effects live outside the
+        # transaction and are not undone by a rollback.
+        # Patching the resolved `action_confirm` on the registry class puts the
+        # detection outermost, whatever the MRO is.
+        ModelClass = self.env.registry["sale.order"]
+
+        original_action_confirm = ModelClass.action_confirm
+
+        def patched_action_confirm(self):
+            self.detect_exceptions()
+            original_func = patched_action_confirm.origin
+            return original_func(self)
+
+        patched_action_confirm.origin = original_action_confirm
+
+        ModelClass.action_confirm = patched_action_confirm
+
+        return super()._register_hook()
+
     def action_draft(self):
         res = super().action_draft()
         orders = self.filtered("ignore_exception")

--- a/sale_exception/tests/test_sale_exception.py
+++ b/sale_exception/tests/test_sale_exception.py
@@ -13,6 +13,8 @@ class TestSaleException(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env["sale.order"]._register_hook()
+        cls.env["exception.rule"].search([]).write({"active": False})
         cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.default_pl = cls.env["product.pricelist"].create(
             {

--- a/sale_exception/tests/test_sale_exception.py
+++ b/sale_exception/tests/test_sale_exception.py
@@ -29,6 +29,8 @@ class TestSaleException(TransactionCase):
                 cls.env.context, test_base_exception=True, tracking_disable=True
             )
         )
+        cls.env["sale.order"]._register_hook()
+        cls.env["exception.rule"].search([]).write({"active": False})
         cls.default_pl = cls.env["product.pricelist"].create(
             {
                 "name": "Public Pricelist",


### PR DESCRIPTION
…firm being executed if there is an exception rule.

For example, if a coupon was used, a point would be added, and then upon confirming the sale, it would be added again.
The issue is in the sale_loyalty module, where the loyalty program is computed before the sale is confirmed in this [line](https://github.com/odoo/odoo/blob/812d8a5c0117346b7fa40689213a0b0fda61f9ad/addons/sale_loyalty/models/sale_order.py#L136)

This video demonstrates the issue (version 16), because in the version 16 there is the same problem. We decided to apply the fix in version 18, since version 16 is a stable.
https://drive.google.com/file/d/1qeEYlVVqXb8MOJq7BybVe4EaYtiDcIPS/view

Before this PR, if a sale was not confirmed due to an exception, the loyalty program would still be applied.

Although the problem occurs with coupons, it's possible that new problems might also arise with payment integrations or electronic invoicing.