### PR TITLE
[17.0][IMP] sale_delivery_state: add delivery status field to search views

### DIFF
--- a/sale_delivery_state/views/sale_order_views.xml
+++ b/sale_delivery_state/views/sale_order_views.xml
@@ -44,4 +44,29 @@
         </field>
     </record>
 
+    <record
+        id="sale_order_view_search_inherit_sale_inherit_delivery_status"
+        model="ir.ui.view"
+    >
+        <field name="name">sale.order.search</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.sale_order_view_search_inherit_sale" />
+        <field name="arch" type="xml">
+            <filter name="order_date" position="after">
+                <separator />
+                <filter
+                    string="Pending Deliveries"
+                    name="filter_delivery_status_pending"
+                    domain="[('delivery_status','in',['pending', 'partial'])]"
+                />
+            </filter>
+            <filter name="order_month" position="after">
+                <filter
+                    string="Delivery Status"
+                    name="delivery_status"
+                    context="{'group_by': 'delivery_status'}"
+                />
+            </filter>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
With this improvement a filter for pending deliveries is added. A group by this field is added as well.