### PR TITLE
[17.0][IMP] sale_order_secondary_unit: context for skipping default sec. unit

### DIFF
--- a/sale_order_secondary_unit/models/sale_order.py
+++ b/sale_order_secondary_unit/models/sale_order.py
@@ -43,7 +43,7 @@ class SaleOrderLine(models.Model):
     @api.onchange("product_id")
     def _onchange_product_id_warning(self):
         res = super()._onchange_product_id_warning()
-        if self.product_id:
+        if self.product_id and not self.env.context.get("skip_secondary_uom_default"):
             self.secondary_uom_id = self.product_id.sale_secondary_uom_id
             if self.product_uom_qty == 1.0:
                 self.secondary_uom_qty = 1.0


### PR DESCRIPTION
FWP of https://github.com/OCA/sale-workflow/pull/3588
In some cases we might want to skip the default secondary unit to be set. This change brings that possibility.

TT55850
@Tecnativa @pedrobaeza @pilarvargas-tecnativa could you please review this?