### PR TITLE
[17.0][FIX] sale_order_secondary_unit: fix tests when run alongside sale_stock

### DIFF
--- a/sale_order_secondary_unit/tests/test_sale_order.py
+++ b/sale_order_secondary_unit/tests/test_sale_order.py
@@ -80,8 +80,8 @@ class TestSaleOrder(BaseCommon):
 
     def test_independent_type(self):
         # dependent type is already tested as dependency_type by default
+        self.secondary_unit.write({"dependency_type": "independent"})
         self.order.order_line.secondary_uom_id = self.secondary_unit.id
-        self.order.order_line.secondary_uom_id.write({"dependency_type": "independent"})
 
         # Remember previous UoM quantity for avoiding interactions with other modules
         previous_uom_qty = self.order.order_line.product_uom_qty


### PR DESCRIPTION
When tests ran in a database with sale_stock installed, tests were failing.
I still have no clue of the root cause that makes tests pass when standalone, but fail when sale_stock is installed, but this fixes the issue.

@tecnativa @pedrobaeza @carlos-lopez-tecnativa 
TT52379