### PR TITLE
[18.0] [IMP] sale_exception: Confirm directly the sale order when ignoring exceptions

### DIFF
--- a/sale_exception/tests/test_sale_exception.py
+++ b/sale_exception/tests/test_sale_exception.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import Command
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests import Form, TransactionCase
 
 
@@ -126,7 +126,7 @@ class TestSaleException(TransactionCase):
             }
         )
         exception.active = False
-        so1.action_cancel()
+        so1.with_context(disable_cancel_warning=True).action_cancel()
         so1.action_draft()
         self.assertTrue(not so1.ignore_exception)
 
@@ -137,6 +137,7 @@ class TestSaleException(TransactionCase):
         ).create({"ignore": True})
         so_except_confirm.action_confirm()
         self.assertTrue(so1.ignore_exception)
+        self.assertEqual(so1.state, "sale")
 
     def _create_sale_order(self, partner, product):
         order_form = Form(self.env["sale.order"])
@@ -206,6 +207,10 @@ class TestSaleException(TransactionCase):
                 "active_model": sale_order._name,
             }
         ).create({"ignore": True})
-        so_except_confirm.action_confirm()
+        with self.assertRaisesRegex(
+            UserError,
+            "The exceptions can not be ignored, because some of them are blocking.",
+        ):
+            so_except_confirm.action_confirm()
         self.assertFalse(sale_order.ignore_exception)
         self.assertTrue(sale_order.state == "draft")

--- a/sale_exception/wizard/sale_exception_confirm.py
+++ b/sale_exception/wizard/sale_exception_confirm.py
@@ -14,7 +14,7 @@ class SaleExceptionConfirm(models.TransientModel):
 
     def action_confirm(self):
         self.ensure_one()
-        exceptions_blocking = self.exception_ids.filtered("is_blocking")
-        if self.ignore and not exceptions_blocking:
-            self.related_model_id.ignore_exception = True
+        if self.ignore:
+            self.related_model_id.action_ignore_exceptions()
+            self.related_model_id.action_confirm()
         return super().action_confirm()

--- a/sale_exception/wizard/sale_exception_confirm_view.xml
+++ b/sale_exception/wizard/sale_exception_confirm_view.xml
@@ -13,15 +13,19 @@
                             <field name="description" />
                         </list>
                     </field>
-                    <newline />
-                    <field name="ignore" groups='sales_team.group_sale_manager' />
+                    <field
+                        name="ignore"
+                        widget="boolean_toggle"
+                        groups="sales_team.group_sale_manager"
+                    />
                 </group>
                 <footer>
                     <button
                         name="action_confirm"
                         string="Confirm"
-                        colspan="1"
                         type="object"
+                        class="btn-primary"
+                        invisible="not ignore"
                     />
                     <button class="oe_link" special="cancel" string="Cancel" />
                 </footer>


### PR DESCRIPTION
When there are exceptions blocking the confirmation of an order, the user normally finds out when clicking on the "Confirm" button.

At that time, the wizard is popup and the user -if he has enough permissions- can ignore the exceptions and click confirm.

Before this commit, the wizard would only flag the order to ignore the exceptions, but the order would not be confirmed. The user would have to click again on the "Confirm" button to do so.

This is counter-intuitive since the user intention was clearly to confirm the order in the first place, and it just forces the user to click again.

After this commit, the order is confirmed directly.

Additionally, the wizard will now hide the "Confirm" button if the exceptions haven't been ignored.