### PR TITLE
[16.0][IMP] sale_order_line_cancel: Do not update canceled qty in state sent

### DIFF
--- a/sale_order_line_cancel/models/stock_move.py
+++ b/sale_order_line_cancel/models/stock_move.py
@@ -39,6 +39,6 @@ class StockMove(models.Model):
         return (
             self.state == "cancel"
             and self.sale_line_id
-            and self.sale_line_id.state != "draft"
+            and self.sale_line_id.state not in ["draft", "sent"]
             and self.picking_type_id.code == "outgoing"
         )

--- a/sale_order_line_cancel/tests/test_sale_order_line_cancel.py
+++ b/sale_order_line_cancel/tests/test_sale_order_line_cancel.py
@@ -125,3 +125,18 @@ class TestSaleOrderLineCancel(TestSaleOrderLineCancelBase):
         self.assertEqual(sale.order_line.product_qty_canceled, 0)
         self.assertEqual(sale.order_line.qty_to_deliver, 10)
         self.assertEqual(sale.order_line.product_qty_remains_to_deliver, 10)
+
+    def test_sent_sale_order_with_picking_cancel(self):
+        sale = self.sale
+        sale.action_cancel()
+        sale.action_draft()
+        sale.state = "sent"
+        picking = sale.picking_ids.copy()
+        picking.action_assign()
+        self.assertEqual(sale.order_line.product_qty_canceled, 0)
+        self.assertEqual(sale.order_line.qty_to_deliver, 10)
+        self.assertEqual(sale.order_line.product_qty_remains_to_deliver, 10)
+        picking.action_cancel()
+        self.assertEqual(sale.order_line.product_qty_canceled, 0)
+        self.assertEqual(sale.order_line.qty_to_deliver, 10)
+        self.assertEqual(sale.order_line.product_qty_remains_to_deliver, 10)


### PR DESCRIPTION
In order to make #3724 complete we should also check for state `sent`
@i-vyshnevska @raumschmiede-joshuaL @jbaudoux @mmequignon @rousseldenis