### PR TITLE
[FIX] sale_exception: 'ignore_exception' field visibility by group

### DIFF
--- a/sale_exception/views/sale_view.xml
+++ b/sale_exception/views/sale_view.xml
@@ -48,7 +48,11 @@
                 </div>
             </sheet>
             <xpath expr="//field[@name='date_order']/.." position="inside">
-                <field name="ignore_exception" invisible="state != 'sale'" />
+                <field
+                    name="ignore_exception"
+                    invisible="state != 'sale'"
+                    groups="base_exception.group_exception_rule_manager"
+                />
             </xpath>
             <xpath expr="//field[@name='order_line']/form/group[1]" position="before">
                 <div


### PR DESCRIPTION
The ignore_exception field is now only visible to users belonging to the base_exception.group_exception_rule_manager group, ensuring consistent access control with the related action button.