### PR TITLE
[16.0][IMP] sale_order_line_cancel: On sale.order action_cancel do not decrease sale.order.line's product_uom_qty

### DIFF
--- a/sale_order_line_cancel/models/sale_order.py
+++ b/sale_order_line_cancel/models/sale_order.py
@@ -15,6 +15,7 @@ class SaleOrder(models.Model):
         return res
 
     def _action_cancel(self):
-        res = super()._action_cancel()
+        new_self = self.with_context(ignore_sale_order_line_cancel=True)
+        res = super(SaleOrder, new_self)._action_cancel()
         self.order_line._update_qty_canceled()
         return res

--- a/sale_order_line_cancel/models/stock_move.py
+++ b/sale_order_line_cancel/models/stock_move.py
@@ -12,6 +12,8 @@ class StockMove(models.Model):
 
     def _action_cancel(self):
         res = super()._action_cancel()
+        if self.env.context.get("ignore_sale_order_line_cancel", False):
+            return res
         sale_lines = self._get_sale_lines_to_update_qty_canceled()
         sale_lines._update_qty_canceled()
         return res

--- a/sale_order_line_cancel/tests/test_sale_order_line_cancel.py
+++ b/sale_order_line_cancel/tests/test_sale_order_line_cancel.py
@@ -166,3 +166,13 @@ class TestSaleOrderLineCancel(TestSaleOrderLineCancelBase):
         self.assertEqual(line.qty_to_deliver, 0)
         self.assertEqual(line.qty_delivered, 4)
         self.assertEqual(line.product_uom_qty, 4)
+
+    def test_ensure_no_decrease_product_uom_qty_on_so_cancel(self):
+        sale = self.sale
+        sale.with_context(disable_cancel_warning=True).action_cancel()
+        sale.picking_ids.unlink()
+        sale.action_draft()
+        sale.action_confirm()
+        sale.company_id.on_sale_line_cancel_decrease_line_qty = True
+        sale.action_cancel()
+        self.assertEqual(sale.order_line.product_uom_qty, 10)


### PR DESCRIPTION
As a followup to #3757. 
When `action_cancel` on a sale.order is called we should not decrease the product_uom_qty of the order lines. 

cc @jbaudoux @rousseldenis @lmignon @raumschmiede-joshuaL @i-vyshnevska 