### PR TITLE
[17.0][IMP] sale_blanket_order: context in readme

### DIFF
--- a/sale_blanket_order/README.rst
+++ b/sale_blanket_order/README.rst
@@ -39,6 +39,23 @@ exhausting all the quantities of products.
 .. contents::
    :local:
 
+Use Cases / Context
+===================
+
+Others modules provide similar features. The module
+(sale_order_blanket_order)[`https://pypi.org/project/odoo-addon-sale-order-blanket-order] <https://pypi.org/project/odoo-addon-sale-order-blanket-order]>`__
+also defines the concept of sale blanket order. The main differences
+are:
+
+-  This module integrates Blanket Orders and Call-Off Orders into the
+   sale.blanket.order object, whereas the other module extends the
+   sale.order object. This means that any extensions made to the sale
+   order model can also apply to blanket orders.
+
+-  In the other module, you can deliver and invoice directly from the
+   blanket order. You can also create a separate call-off order to
+   partially deliver the blanket order.
+
 Usage
 =====
 
@@ -53,21 +70,21 @@ section:
 Hitting the button create will open the form view in which we can
 introduce the following information:
 
-- Vendor
+-  Vendor
 
-- Salesperson
+-  Salesperson
 
-- Payment Terms
+-  Payment Terms
 
-- Validity date
+-  Validity date
 
-- Order lines:
+-  Order lines:
 
-  - Product
-  - Accorded price
-  - Original, Ordered, Invoiced, Received and Remaining quantities
+   -  Product
+   -  Accorded price
+   -  Original, Ordered, Invoiced, Received and Remaining quantities
 
-- Terms and Conditions of the Blanket Order
+-  Terms and Conditions of the Blanket Order
 
 |image2|
 
@@ -97,8 +114,8 @@ PO line is associated. Upon adding a new product in a newly created Sale
 Order a blanket order line will be suggested depending on the following
 factors:
 
-- Closer Validity date
-- Remaining quantity > Quantity introduced in the Sale Order line
+-  Closer Validity date
+-  Remaining quantity > Quantity introduced in the Sale Order line
 
 |image6|
 
@@ -130,22 +147,22 @@ Authors
 Contributors
 ------------
 
-- André Pereira <github@andreparames.com> (https://www.acsone.eu/)
+-  André Pereira <github@andreparames.com> (https://www.acsone.eu/)
 
-- Adrià Gil Sorribes <adria.gil@eficent.com> (https://www.eficent.com/)
+-  Adrià Gil Sorribes <adria.gil@eficent.com> (https://www.eficent.com/)
 
-- Jordi Ballester Alomar <jordi.ballester@eficent.com>
+-  Jordi Ballester Alomar <jordi.ballester@eficent.com>
 
-- Alex Comba <alex.comba@agilebg.com> (https://www.agilebg.com/)
+-  Alex Comba <alex.comba@agilebg.com> (https://www.agilebg.com/)
 
-- Codeforward (https://www.codeforward.nl/):
+-  Codeforward (https://www.codeforward.nl/):
 
-     - Jasper Jumelet <jasper.jumelet@codeforward.nl>
-     - Chris Bergman <chris.bergman@codeforward.nl>
+      -  Jasper Jumelet <jasper.jumelet@codeforward.nl>
+      -  Chris Bergman <chris.bergman@codeforward.nl>
 
-- `Trobz <https://trobz.com>`__:
+-  `Trobz <https://trobz.com>`__:
 
-     - Nguyễn Minh Chiến <chien@trobz.com>
+      -  Nguyễn Minh Chiến <chien@trobz.com>
 
 Other credits
 -------------

--- a/sale_blanket_order/readme/CONTEXT.md
+++ b/sale_blanket_order/readme/CONTEXT.md
@@ -1,0 +1,5 @@
+Others modules provide similar features. The module (sale_order_blanket_order)[https://pypi.org/project/odoo-addon-sale-order-blanket-order] also defines the concept of sale blanket order. The main differences are:
+
+* This module integrates Blanket Orders and Call-Off Orders into the sale.blanket.order object, whereas the other module extends the sale.order object. This means that any extensions made to the sale order model can also apply to blanket orders.
+
+* In the other module, you can deliver and invoice directly from the blanket order. You can also create a separate call-off order to partially deliver the blanket order.

--- a/sale_blanket_order/static/description/index.html
+++ b/sale_blanket_order/static/description/index.html
@@ -378,19 +378,36 @@ exhausting all the quantities of products.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-2">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-3">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-4">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-5">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="toc-entry-6">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#use-cases-context" id="toc-entry-1">Use Cases / Context</a></li>
+<li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="toc-entry-7">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="use-cases-context">
+<h1><a class="toc-backref" href="#toc-entry-1">Use Cases / Context</a></h1>
+<p>Others modules provide similar features. The module
+(sale_order_blanket_order)[<a class="reference external" href="https://pypi.org/project/odoo-addon-sale-order-blanket-order]">https://pypi.org/project/odoo-addon-sale-order-blanket-order]</a>
+also defines the concept of sale blanket order. The main differences
+are:</p>
+<ul class="simple">
+<li>This module integrates Blanket Orders and Call-Off Orders into the
+sale.blanket.order object, whereas the other module extends the
+sale.order object. This means that any extensions made to the sale
+order model can also apply to blanket orders.</li>
+<li>In the other module, you can deliver and invoice directly from the
+blanket order. You can also create a separate call-off order to
+partially deliver the blanket order.</li>
+</ul>
+</div>
 <div class="section" id="usage">
-<h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
 <p>A new menu in the Sales area is created, allowing users to create new
 blanket orders.</p>
 <p>To create a new Sale Blanket Order go to the sale menu in the Sales
@@ -438,7 +455,7 @@ factors:</p>
 <p><img alt="image6" src="https://raw.githubusercontent.com/OCA/sale-workflow/17.0/sale_blanket_order/static/description/PO_BOLine.png" /></p>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/sale-workflow/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -446,15 +463,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-3">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-4">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>Acsone SA/NV</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-5">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul>
 <li><p class="first">André Pereira &lt;<a class="reference external" href="mailto:github&#64;andreparames.com">github&#64;andreparames.com</a>&gt; (<a class="reference external" href="https://www.acsone.eu/">https://www.acsone.eu/</a>)</p>
 </li>
@@ -482,12 +499,12 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h2><a class="toc-backref" href="#toc-entry-6">Other credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Other credits</a></h2>
 <p>The migration of this module from 15.0 to 16.0 was financially supported
 by Camptocamp</p>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />


### PR DESCRIPTION
As discussed here https://github.com/OCA/sale-blanket/issues/6 there is another module that implements sale blanket orders so we must clarify the difference between them.