### PR TITLE
[16.0][IMP] sale_blanket_order: lines with price 0

### DIFF
--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -660,9 +660,6 @@ class BlanketOrderLine(models.Model):
         try:
             for line in self:
                 assert (
-                    not line.display_type and line.price_unit > 0.0
-                ) or line.display_type, _("Price must be greater than zero")
-                assert (
                     not line.display_type and line.original_uom_qty > 0.0
                 ) or line.display_type, _("Quantity must be greater than zero")
         except AssertionError as e:


### PR DESCRIPTION
In some business cases, it makes sense to have some blanket order lines with price 0 (maybe they are gifted articles, provided as part of a service package...). We remove the restriction to be able to do so.