### PR TITLE
[FIX] sale_partner_selectable_option: Don't allow to create or edit orders when a partner not selectable is added.

### DIFF
--- a/sale_partner_selectable_option/README.rst
+++ b/sale_partner_selectable_option/README.rst
@@ -70,7 +70,8 @@ Contributors
 
   * Víctor Martínez
   * Pedro M. Baeza
-  * César A. Sánchez <cesar.sanchez@tecnativa.com>
+  * César A. Sánchez
+  * Carlos Roca
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_partner_selectable_option/i18n/es.po
+++ b/sale_partner_selectable_option/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-02 15:52+0000\n"
-"PO-Revision-Date: 2023-07-24 18:09+0000\n"
+"POT-Creation-Date: 2025-07-23 13:02+0000\n"
+"PO-Revision-Date: 2025-07-23 15:03+0200\n"
 "Last-Translator: Ivorra78 <informatica@totmaterial.es>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.17\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. module: sale_partner_selectable_option
 #: model:ir.model,name:sale_partner_selectable_option.model_res_partner
@@ -37,3 +37,9 @@ msgstr "Seleccionable en pedidos"
 #: model:ir.model.fields,field_description:sale_partner_selectable_option.field_res_users__sale_selectable
 msgid "Selectable in sale orders"
 msgstr "Seleccionable en pedidos de venta"
+
+#. module: sale_partner_selectable_option
+#: code:addons/sale_partner_selectable_option/models/sale_order.py:0
+#, python-format
+msgid "The selected customer cannot be used in sales orders"
+msgstr "El cliente que se ha seleccionado no se puede usar en las órdenes de venta"

--- a/sale_partner_selectable_option/i18n/sale_partner_selectable_option.pot
+++ b/sale_partner_selectable_option/i18n/sale_partner_selectable_option.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-23 13:02+0000\n"
+"PO-Revision-Date: 2025-07-23 13:02+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -32,4 +34,10 @@ msgstr ""
 #: model:ir.model.fields,field_description:sale_partner_selectable_option.field_res_partner__sale_selectable
 #: model:ir.model.fields,field_description:sale_partner_selectable_option.field_res_users__sale_selectable
 msgid "Selectable in sale orders"
+msgstr ""
+
+#. module: sale_partner_selectable_option
+#: code:addons/sale_partner_selectable_option/models/sale_order.py:0
+#, python-format
+msgid "The selected customer cannot be used in sales orders"
 msgstr ""

--- a/sale_partner_selectable_option/models/sale_order.py
+++ b/sale_partner_selectable_option/models/sale_order.py
@@ -3,11 +3,22 @@
 
 from lxml import etree
 
-from odoo import api, models
+from odoo import _, api, models
+from odoo.exceptions import UserError
 
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
+
+    @api.constrains("partner_id")
+    def _check_partner_id(self):
+        for order in self:
+            if not order.partner_id.sale_selectable and not self.env.context.get(
+                "skip_sale_partner_selectable_restriction", False
+            ):
+                raise UserError(
+                    _("The selected customer cannot be used in sales orders")
+                )
 
     @api.model
     def fields_view_get(

--- a/sale_partner_selectable_option/readme/CONTRIBUTORS.rst
+++ b/sale_partner_selectable_option/readme/CONTRIBUTORS.rst
@@ -2,4 +2,5 @@
 
   * Víctor Martínez
   * Pedro M. Baeza
-  * César A. Sánchez <cesar.sanchez@tecnativa.com>
+  * César A. Sánchez
+  * Carlos Roca

--- a/sale_partner_selectable_option/static/description/index.html
+++ b/sale_partner_selectable_option/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -416,7 +416,8 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Víctor Martínez</li>
 <li>Pedro M. Baeza</li>
-<li>César A. Sánchez &lt;<a class="reference external" href="mailto:cesar.sanchez&#64;tecnativa.com">cesar.sanchez&#64;tecnativa.com</a>&gt;</li>
+<li>César A. Sánchez</li>
+<li>Carlos Roca</li>
 </ul>
 </li>
 </ul>
@@ -424,7 +425,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
With this change we avoid creating orders with partners that are not selectable. Example: default_partner_id is set on context

cc @Tecnativa TT56709

ping @victoralmau @sergio-teruel 