### PR TITLE
[17.0][FIX] sale_advance_payment: posting many invoices did not reconcile advance payments

### DIFF
--- a/sale_advance_payment/models/account_move.py
+++ b/sale_advance_payment/models/account_move.py
@@ -7,15 +7,19 @@ from odoo import models
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    def action_post(self):
+    def _post(self, soft=True):
         # Automatic reconciliation of payment when invoice confirmed.
-        res = super().action_post()
-        sale_order = self.mapped("line_ids.sale_line_ids.order_id")
-        if sale_order and self.invoice_outstanding_credits_debits_widget is not False:
-            json_invoice_outstanding_data = (
-                self.invoice_outstanding_credits_debits_widget.get("content", [])
+        res = super()._post(soft=soft)
+        for invoice in self:
+            # Get Advance Payment Account Moves
+            sale_orders = invoice.mapped("line_ids.sale_line_ids.order_id")
+            advance_payment_moves = sale_orders.account_payment_ids.move_id
+            # Get reconcilable payments JSON data
+            widget_json = invoice.invoice_outstanding_credits_debits_widget or {}
+            can_reconcile_lines = filter(
+                lambda x: x.get("move_id") in advance_payment_moves.ids,
+                widget_json.get("content", []),
             )
-            for data in json_invoice_outstanding_data:
-                if data.get("move_id") in sale_order.account_payment_ids.move_id.ids:
-                    self.js_assign_outstanding_line(line_id=data.get("id"))
+            for line in can_reconcile_lines:
+                invoice.js_assign_outstanding_line(line_id=line.get("id"))
         return res


### PR DESCRIPTION
Previous logic only supported a one by one invoice posting.
With this change a set of invoices can be posted at the same time, and
the advance payments will be appplied properly.
