### PR TITLE
[18.0][IMP] sale_exception: sale_exception_show_popup configurable

### DIFF
--- a/sale_exception/__manifest__.py
+++ b/sale_exception/__manifest__.py
@@ -19,6 +19,7 @@
         "data/sale_exception_data.xml",
         "wizard/sale_exception_confirm_view.xml",
         "views/sale_view.xml",
+        "views/res_config_settings.xml",
     ],
     "demo": ["demo/sale_exception_demo.xml"],
 }

--- a/sale_exception/models/__init__.py
+++ b/sale_exception/models/__init__.py
@@ -2,3 +2,5 @@
 from . import exception_rule
 from . import sale_order
 from . import sale_order_line
+from . import res_company
+from . import res_config_settings

--- a/sale_exception/models/res_company.py
+++ b/sale_exception/models/res_company.py
@@ -1,0 +1,12 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    sale_exception_show_popup = fields.Boolean(
+        string="Sale Exception Popup",
+        default=True,
+    )

--- a/sale_exception/models/res_config_settings.py
+++ b/sale_exception/models/res_config_settings.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    sale_exception_show_popup = fields.Boolean(
+        related="company_id.sale_exception_show_popup",
+        readonly=False,
+    )

--- a/sale_exception/models/sale_order.py
+++ b/sale_exception/models/sale_order.py
@@ -49,6 +49,8 @@ class SaleOrder(models.Model):
 
     def action_confirm(self):
         if self.detect_exceptions():
+            if not self.env.company.sale_exception_show_popup:
+                return
             return self._popup_exceptions()
         return super().action_confirm()
 

--- a/sale_exception/tests/test_sale_exception.py
+++ b/sale_exception/tests/test_sale_exception.py
@@ -155,7 +155,28 @@ class TestSaleException(TransactionCase):
         sale_order.action_confirm()
         partner.sale_warn = "warning"
         sale_order2 = sale_order.copy()
-        sale_order2.detect_exceptions()
+        self.env.company.sale_exception_show_popup = True
+        result = sale_order2.action_confirm()
+        self.assertEqual(
+            result.get("xml_id"), "sale_exception.action_sale_exception_confirm"
+        )
+        self.assertEqual(sale_order2.state, "draft")
+        self.assertTrue(sale_order2.exception_ids.filtered(lambda x: x == exception))
+
+    def test_exception_partner_sale_warning_no_popup(self):
+        exception = self.env.ref("sale_exception.exception_partner_sale_warning")
+        exception.active = True
+        partner = self.env.ref("base.res_partner_1")
+        sale_order = self._create_sale_order(
+            partner=partner, product=self.env.ref("product.product_product_6")
+        )
+        sale_order.action_confirm()
+        partner.sale_warn = "warning"
+        sale_order2 = sale_order.copy()
+        self.env.company.sale_exception_show_popup = False
+        result = sale_order2.action_confirm()
+        self.assertIsNone(result)
+        self.assertEqual(sale_order2.state, "draft")
         self.assertTrue(sale_order2.exception_ids.filtered(lambda x: x == exception))
 
     def test_exception_product_sale_warning(self):

--- a/sale_exception/views/res_config_settings.xml
+++ b/sale_exception/views/res_config_settings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="res_config_settings_view_form_sale_exception" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="sale.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <setting id="order_warnings" position="after">
+                <setting
+                    id="sale_exception_show_popup"
+                    help="Display popup at confirm or simply rely on the red alert already visible on top of the order."
+                    company_dependent="1"
+                    invisible="not group_warning_sale"
+                >
+                    <field name="sale_exception_show_popup" />
+                </setting>
+            </setting>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR includes changes to the company sale configuration, allowing the exception wizard to be optionally shown to the user. This way, the user doesn't have to confirm multiple times and can rely on the warning blocking message displayed on the sale order form.