### PR TITLE
[18.0][IMP] sell_only_by_packaging: warning when qty not pack multiple

### DIFF
--- a/sell_only_by_packaging/models/sale_order_line.py
+++ b/sell_only_by_packaging/models/sale_order_line.py
@@ -3,7 +3,7 @@
 
 from odoo import api, models
 from odoo.exceptions import ValidationError
-from odoo.tools import float_compare
+from odoo.tools import float_compare, float_round
 
 
 class SaleOrderLine(models.Model):
@@ -16,6 +16,9 @@ class SaleOrderLine(models.Model):
         errors = []
         for line in self:
             if not line.product_uom_qty:
+                continue
+            if error_message_qty_multiple := line._check_pkg_qty_multiple():
+                errors.append(error_message_qty_multiple)
                 continue
             if not line.product_id.sell_only_by_packaging:
                 continue
@@ -44,6 +47,36 @@ class SaleOrderLine(models.Model):
                 "Product %s can only be sold with a packaging and a "
                 "packaging quantity.",
                 self.product_id.name,
+            )
+
+    def _check_pkg_qty_multiple(self):
+        # Ported from sale_stock.models.sale_order_line,_check_package on v14
+        default_uom = self.product_id.uom_id
+        pack = self.product_packaging_id
+        qty = self.product_uom_qty
+        q = default_uom._compute_quantity(pack.qty, self.product_uom)
+        # We do not use the modulo operator to check if qty is a multiple of q.
+        # Indeed the qty per package might be a float, leading to incorrect results.
+        # For example: 8 % 1.6 = 1.5999999999999996
+        #              5.4 % 1.8 = 2.220446049250313e-16
+        if (
+            qty
+            and q
+            and float_compare(
+                qty / q,
+                float_round(qty / q, precision_rounding=1.0),
+                precision_rounding=0.001,
+            )
+            != 0
+        ):
+            next_valid_qty = qty - (qty % q) + q
+            return self.env._(
+                "This product is packaged by %(pack_size).2f %(pack_name)s. "
+                + "You should sell %(quantity).2f %(unit)s.",
+                pack_size=pack.qty,
+                pack_name=default_uom.name,
+                quantity=next_valid_qty,
+                unit=self.product_uom.name,
             )
 
     def _force_qty_with_package(self):

--- a/sell_only_by_packaging/models/sale_order_line.py
+++ b/sell_only_by_packaging/models/sale_order_line.py
@@ -13,26 +13,38 @@ class SaleOrderLine(models.Model):
         "product_id", "product_packaging_id", "product_packaging_qty", "product_uom_qty"
     )
     def _check_product_packaging_sell_only_by_packaging(self):
+        errors = []
         for line in self:
-            if not line.product_id.sell_only_by_packaging or not line.product_uom_qty:
+            if not line.product_uom_qty:
                 continue
+            if not line.product_id.sell_only_by_packaging:
+                continue
+            if error_message_min_qty := line._check_min_qty_packaging():
+                errors.append(error_message_min_qty)
+        if errors:
+            raise ValidationError(
+                self.env._(
+                    "The following lines has some issues with "
+                    + "packaging quantities:\n    - %s",
+                    "\n    - ".join(errors),
+                )
+            )
 
-            if (
-                not line.product_packaging_id
-                or float_compare(
-                    line.product_packaging_qty,
-                    int(line.product_packaging_qty),
-                    precision_digits=2,
-                )
-                != 0
-            ):
-                raise ValidationError(
-                    self.env._(
-                        "Product %s can only be sold with a packaging and a "
-                        "packaging quantity.",
-                        line.product_id.name,
-                    ),
-                )
+    def _check_min_qty_packaging(self):
+        if (
+            not self.product_packaging_id
+            or float_compare(
+                self.product_packaging_qty,
+                int(self.product_packaging_qty),
+                precision_digits=2,
+            )
+            != 0
+        ):
+            return self.env._(
+                "Product %s can only be sold with a packaging and a "
+                "packaging quantity.",
+                self.product_id.name,
+            )
 
     def _force_qty_with_package(self):
         self.ensure_one()

--- a/sell_only_by_packaging/tests/test_sale_only_by_packaging.py
+++ b/sell_only_by_packaging/tests/test_sale_only_by_packaging.py
@@ -98,16 +98,16 @@ class TestSaleProductByPackagingOnly(SellOnlyByPackagingCommon):
                 self.assertEqual(len(logs.records), 1)
                 self.assertEqual(logs.records[0].levelno, logging.WARNING)
 
-    def test_onchange_qty_is_not_pack_multiple(self):
-        """Check package when qantity is not a multiple of package quantity.
+    def test_packaging_validation_with_sell_only_by_packaging(self):
+        """Check quantity validation when product can only be sold by packaging.
 
-        When the uom quantity is changed for a value not a multpile of a
-        possible package an error is raised.
+        When a product is marked as 'sell only by packaging', validate that
+        setting a non-multiple quantity of the packaging raises an error.
         """
         self.product.write({"sell_only_by_packaging": True})
         self.order_line.product_uom_qty = 40  # 2 packs
-        with self.assertRaises(ValidationError):
+        with self.assertRaisesRegex(
+            ValidationError,
+            r"can only be sold with a packaging and a packaging quantity",
+        ):
             self.order_line.product_packaging_qty = 0.9
-            self.assertAlmostEqual(
-                self.order_line.product_uom_qty, 18, places=self.precision
-            )

--- a/sell_only_by_packaging/tests/test_sale_only_by_packaging.py
+++ b/sell_only_by_packaging/tests/test_sale_only_by_packaging.py
@@ -98,6 +98,19 @@ class TestSaleProductByPackagingOnly(SellOnlyByPackagingCommon):
                 self.assertEqual(len(logs.records), 1)
                 self.assertEqual(logs.records[0].levelno, logging.WARNING)
 
+    def test_onchange_qty_is_not_pack_multiple(self):
+        """Check package when quantity is not a multiple of package quantity.
+
+        When the uom quantity is changed for a value not a multiple of a
+        possible package an error is raised.
+        """
+        self.order_line.product_uom_qty = 40
+        # This will only raise from _check_pkg_qty_multiple on order line
+        with self.assertRaisesRegex(
+            ValidationError, r"This product is packaged by.*You should sell"
+        ):
+            self.order_line.product_packaging_qty = 1.7
+
     def test_packaging_validation_with_sell_only_by_packaging(self):
         """Check quantity validation when product can only be sold by packaging.
 


### PR DESCRIPTION
The validation that checks whether the quantity on a sales order line is a multiple of the package quantity was present in v14. This PR restores this functionality to raise a warning on sale order.