### PR TITLE
[17.0][FIX] sale_product_multi_add: not pull price from pricelists

### DIFF
--- a/sale_product_multi_add/__manifest__.py
+++ b/sale_product_multi_add/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "ACSONE SA/NV, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "category": "Sale Management",
-    "version": "17.0.1.0.1",
+    "version": "17.0.1.0.2",
     "license": "AGPL-3",
     "depends": ["sale"],
     "data": [

--- a/sale_product_multi_add/wizards/sale_import_products.py
+++ b/sale_product_multi_add/wizards/sale_import_products.py
@@ -41,7 +41,6 @@ class SaleImportProducts(models.TransientModel):
                 "product_id": item.product_id.id,
                 "product_uom_qty": item.quantity,
                 "product_uom": item.product_id.uom_id.id,
-                "price_unit": item.product_id.list_price,
             }
         )
         line_values = sale_line._convert_to_write(sale_line._cache)


### PR DESCRIPTION
price_unit field already have auto compute, if we set it with list_price, compute wouldn't be triggered