### PR TITLE
[17.0][IMP] sale_tier_validation: Change the use of the validated field to validation_status

### DIFF
--- a/sale_tier_validation/reports/sale_report.py
+++ b/sale_tier_validation/reports/sale_report.py
@@ -15,7 +15,9 @@ class ReportSaleOrder(models.AbstractModel):
         for order in docs:
             if not order.company_id.sale_report_print_block:
                 continue
-            if order.need_validation or (order.review_ids and not order.validated):
+            if order.need_validation or (
+                order.review_ids and order.validation_status != "validated"
+            ):
                 raise UserError(
                     _("Quotation printing is blocked until the order is approved.")
                 )

--- a/sale_tier_validation/views/sale_order_view.xml
+++ b/sale_tier_validation/views/sale_order_view.xml
@@ -17,7 +17,7 @@
                 <filter
                     name="tier_validated"
                     string="Validated"
-                    domain="[('validated', '=', True)]"
+                    domain="[('validation_status', '=', 'validated')]"
                     help="SOs validated and ready to be confirmed"
                 />
             </filter>


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/sale-workflow/pull/3842

Change the use of the `validated` field to `validation_status`

Related to https://github.com/OCA/server-ux/pull/1136

Locked by:
- [ ] `base_tier_validation`: https://github.com/OCA/server-ux/pull/1136

Please @pedrobaeza can you review it?

@Tecnativa