### PR TITLE
[18.0][IMP] sale_product_set: improve product set search behavior

### DIFF
--- a/sale_product_set/README.rst
+++ b/sale_product_set/README.rst
@@ -46,21 +46,20 @@ updated or removed as any other sales order lines.
 Usage
 =====
 
-- Define a *product set* as sales manager:
+-  Define a *product set* as sales manager:
 
-  - choose products
-  - for each product, define a quantity.
-  - for each product (if Discounts setting is active), define a discount
-    or leave default value
-  - Sort *set* lines, this order will be the default when added into the
-    quotation
+   -  choose products
+   -  for each product, define a quantity.
+   -  for each product (if Discounts setting is active), define a
+      discount or leave default value
+   -  Sort *set* lines, this order will be the default when added into
+      the quotation
 
-- Then you can remove or update added lines as any other sales order
-  lines.
+-  Then you can remove or update added lines as any other sales order
+   lines.
 
-|Sale order|
-
-.. |Sale order| image:: https://raw.githubusercontent.com/sale_product_set/static/description/sale_order.png
+.. image:: https://raw.githubusercontent.com/sale_product_set/static/description/sale_order.png
+   :alt: Sale order
 
 Bug Tracker
 ===========
@@ -83,27 +82,27 @@ Authors
 Contributors
 ------------
 
-- Clovis Nzouendjou <clovis@anybox.fr>
-- Pierre Verkest <pverkest@anybox.fr>
-- Denis Leemann <denis.leemann@camptocamp.com>
-- Simone Orsi <simone.orsi@camptocamp.com>
-- Souheil Bejaoui <souheil.bejaoui@acsone.eu>
-- Adria Gil Sorribes <adria.gil@forgeflow.com>
-- Phuc (Tran Thanh) <phuc@trobz.com>
-- Manuel Regidor <manuel.regidor@sygel.es>
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  Clovis Nzouendjou <clovis@anybox.fr>
+-  Pierre Verkest <pverkest@anybox.fr>
+-  Denis Leemann <denis.leemann@camptocamp.com>
+-  Simone Orsi <simone.orsi@camptocamp.com>
+-  Souheil Bejaoui <souheil.bejaoui@acsone.eu>
+-  Adria Gil Sorribes <adria.gil@forgeflow.com>
+-  Phuc (Tran Thanh) <phuc@trobz.com>
+-  Manuel Regidor <manuel.regidor@sygel.es>
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Pilar Vargas
-  - Juan Carlos Oñate
+   -  Pilar Vargas
+   -  Juan Carlos Oñate
 
-- Nils Coenen <nils.coenen@nico-solutions.de>
+-  Nils Coenen <nils.coenen@nico-solutions.de>
 
 Other credits
 -------------
 
 The development of this module has been financially supported by:
 
-- Camptocamp
+-  Camptocamp
 
 Maintainers
 -----------

--- a/sale_product_set/__manifest__.py
+++ b/sale_product_set/__manifest__.py
@@ -6,7 +6,7 @@
     "category": "Sales",
     "license": "AGPL-3",
     "author": "Anybox, Odoo Community Association (OCA)",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "website": "https://github.com/OCA/sale-workflow",
     "depends": ["sale", "sale_management", "product_set"],
     "data": [

--- a/sale_product_set/models/__init__.py
+++ b/sale_product_set/models/__init__.py
@@ -1,3 +1,4 @@
 from . import product_set_line
+from . import product_set
 from . import res_partner
 from . import res_config

--- a/sale_product_set/models/product_set.py
+++ b/sale_product_set/models/product_set.py
@@ -1,0 +1,18 @@
+# Copyright 2015 Anybox S.A.S
+# Copyright 2016-2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import api, models
+from odoo.osv import expression
+
+
+class ProductSet(models.Model):
+    _inherit = "product.set"
+
+    @api.model
+    def name_search(self, name="", args=None, operator="ilike", limit=100):
+        args = args or []
+        domain = expression.AND(
+            [args, ["|", ("name", operator, name), ("id", operator, name)]]
+        )
+        records = self.search(domain, limit=limit)
+        return [(rec.id, rec.display_name or "") for rec in records]

--- a/sale_product_set/static/description/index.html
+++ b/sale_product_set/static/description/index.html
@@ -397,16 +397,16 @@ updated or removed as any other sales order lines.</p>
 <li>Define a <em>product set</em> as sales manager:<ul>
 <li>choose products</li>
 <li>for each product, define a quantity.</li>
-<li>for each product (if Discounts setting is active), define a discount
-or leave default value</li>
-<li>Sort <em>set</em> lines, this order will be the default when added into the
-quotation</li>
+<li>for each product (if Discounts setting is active), define a
+discount or leave default value</li>
+<li>Sort <em>set</em> lines, this order will be the default when added into
+the quotation</li>
 </ul>
 </li>
 <li>Then you can remove or update added lines as any other sales order
 lines.</li>
 </ul>
-<p><img alt="Sale order" src="https://raw.githubusercontent.com/sale_product_set/static/description/sale_order.png" /></p>
+<img alt="Sale order" src="https://raw.githubusercontent.com/sale_product_set/static/description/sale_order.png" />
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>


### PR DESCRIPTION
This PR improves the user experience when selecting product sets in forms by enhancing the name_search behavior. Product sets are now easier to find through the standard search field.

Before:
Searching for a product set by keywords did not always return relevant results unless "Search more..." was used.

After:
The name_search method is now extended to improve matching, making relevant product sets appear directly in the autocomplete suggestions.