### PR TITLE
[16.0][IMP] sale_order_safe_commitment_date: delivery date helper

### DIFF
--- a/sale_order_safe_commitment_date/models/sale_order.py
+++ b/sale_order_safe_commitment_date/models/sale_order.py
@@ -1,26 +1,61 @@
 # Copyright 2025 Moduon Team S.L.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+from datetime import datetime, time
+
+import pytz
+
 from odoo import api, fields, models
 
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
 
-    commitment_date = fields.Datetime(
-        compute="_compute_commitment_date",
-        store=True,
+    date_for_commitment = fields.Date(
+        string="Delivery date",
+        compute="_compute_date_for_commitment",
+        inverse="_inverse_date_for_commitment",
         readonly=False,
+        help="This is the delivery date promised to the customer. "
+        "If set, the delivery order will be scheduled based on "
+        "this date rather than product lead times.",
     )
     is_commitment_date_unsafe = fields.Boolean(
-        compute="_compute_is_commitment_date_unsafe",
+        compute="_compute_is_commitment_date_unsafe", store=True
     )
 
-    @api.depends("expected_date")
-    def _compute_commitment_date(self):
-        for sale in self.filtered(
-            lambda x: x.expected_date and x.state in ["draft", "sent"]
-        ):
-            sale.commitment_date = sale.expected_date
+    # We need to avoid this trigger as the UI will do a circular change when we try
+    # to set the hour manually -> it would trigger the compute -> and the compute would
+    # trigger the onchange. Maybe this could be solved more properly adding a compute
+    # to commitment_date, but currently the side effect is minimal so we keep it simple.
+    # @api.depends("commitment_date")
+    def _compute_date_for_commitment(self):
+        """By default we simply get the commitment date attending to the proper tz"""
+        tz = pytz.timezone(self.env.user.tz or "UTC")
+        self.date_for_commitment = False
+        for order in self.filtered("commitment_date"):
+            commitment_utc = order.commitment_date.replace(tzinfo=pytz.utc)
+            order.date_for_commitment = commitment_utc.astimezone(tz).date()
+
+    def _inverse_date_for_commitment(self):
+        """Always set the last possible minute of that date so users don't have to
+        worry about non integer lead times"""
+        tz = pytz.timezone(self.env.user.tz or "UTC")
+        for order in self:
+            if order.date_for_commitment:
+                # Compose a datetime at 23:59:59 in user's local time
+                local_dt = tz.localize(
+                    datetime.combine(order.date_for_commitment, time(23, 59, 59))
+                )
+                dt_utc = local_dt.astimezone(pytz.utc)
+                # Store as naive UTC datetime in Odoo
+                order.commitment_date = dt_utc.replace(tzinfo=None)
+            else:
+                order.commitment_date = False
+
+    @api.onchange("date_for_commitment")
+    def _onchange_date_for_commitment(self):
+        """React on the UI"""
+        self._inverse_date_for_commitment()
 
     @api.depends("commitment_date", "expected_date", "state")
     def _compute_is_commitment_date_unsafe(self):

--- a/sale_order_safe_commitment_date/views/sale_order_views.xml
+++ b/sale_order_safe_commitment_date/views/sale_order_views.xml
@@ -19,47 +19,12 @@
                     />, but it's not possible based on current lead times. Odoo will adjust the date automatically. Contact your sales manager if it’s urgent.
                 </div>
             </sheet>
-        </field>
-    </record>
-    <record id="view_order_form_commitment_date_ux" model="ir.ui.view">
-        <field name="model">sale.order</field>
-        <field
-            name="inherit_id"
-            ref="sale_order_safe_commitment_date.view_order_form"
-        />
-        <field name="arch" type="xml">
             <field name="show_update_pricelist" position="before">
-                <label
-                    for="commitment_date"
-                    string="Delivery Date"
-                    attrs="{'invisible': [('expected_date', '=', False)]}"
+                 <field
+                    name="date_for_commitment"
+                    attrs="{'readonly': [('state', 'in', ['cancel', 'done'])]}"
                 />
-                <div
-                    name="commitment_date_div"
-                    class="o_row"
-                    attrs="{'invisible': [('expected_date', '=', False)]}"
-                >
-                    <field
-                        name="commitment_date"
-                        attrs="{'invisible': [('commitment_date', '=', False), ('state', 'not in', ('draft', 'sent'))]}"
-                    />
-                    <span name="expected_date_span" class="text-muted"><i
-                            class="fa fa-warning text-warning"
-                            attrs="{'invisible': [('is_commitment_date_unsafe', '=', False)]}"
-                            alt="The delivery date is sooner than the expected date. You may be unable to honor the delivery date."
-                        /> Expected: <field
-                            name="expected_date"
-                            class="oe_inline"
-                            widget="date"
-                        /></span>
-                </div>
             </field>
         </field>
     </record>
-    <data noupdate="1">
-        <!-- TODO: Enable via res.config.settings -->
-        <record id="view_order_form_commitment_date_ux" model="ir.ui.view">
-            <field name="active" eval="False" />
-        </record>
-    </data>
 </odoo>


### PR DESCRIPTION
When the lead time has decimals (for example, 1.5 = 36 hours) a lot of false positives are raised for the delivery exceptions. as the default hour for the delivery date is the current one. For example: in that case if the current hour is 01:00, the expected date will be 13:00 for the next day, but when we set the delivery date for tomorrow, the default hour will be tomorrow at 1:00, which is before that expected day. The users tend to ignore the warnings after stumbling upon these cases over and over.

So now:

- There's a new delivery date helper field to simply set the date (no time) that sets the hour to 23.59.59 for the delivery date (commitment_date)
- The delivery date can be still changed manually whenever that info is important as usal in the standard.

<img width="1073" height="641" alt="2025-08-06_09-01" src="https://github.com/user-attachments/assets/19042d64-f24d-4ac6-9235-9e1ec69d4feb" />


cc @moduon MT-9790

please review @rafaelbn @EmilioPascual 