### PR TITLE
[15.0][FIX] sale_order_warn_message: display warning message at full width

### DIFF
--- a/sale_order_warn_message/static/description/index.html
+++ b/sale_order_warn_message/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -411,7 +411,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_order_warn_message/views/sale_order.xml
+++ b/sale_order_warn_message/views/sale_order.xml
@@ -17,7 +17,7 @@
                     <p>
                         <i class="fa fa-info-circle" />
                         &amp;nbsp;
-                        <field name="sale_warn_msg" class="oe_inline" />
+                        <field name="sale_warn_msg" />
                     </p>
                 </div>
             </header>


### PR DESCRIPTION
Removed the `oe_inline` class from the `sale_warn_msg` field in the sale order form view to prevent width limitation (45%). This allows the warning message to span the full width of its container, improving readability and visual integration in the form layout.

Before:
<img width="1719" height="381" alt="image" src="https://github.com/user-attachments/assets/680aa94c-4f19-4bdc-91aa-07e5ac671376" />

After:
<img width="1718" height="347" alt="image" src="https://github.com/user-attachments/assets/78f231c7-d33d-4f4b-80e6-330fd0f27c31" />

@Tecnativa
@CarlosRoca13 @pedrobaeza please review