### PR TITLE
[17.0][FIX] sale_order_warn_message: display warning message at full width

### DIFF
--- a/sale_order_warn_message/views/sale_order.xml
+++ b/sale_order_warn_message/views/sale_order.xml
@@ -17,7 +17,7 @@
                     <p>
                         <i class="fa fa-info-circle" />
                         <span>&amp;nbsp;</span>
-                        <field name="sale_warn_msg" class="oe_inline" />
+                        <field name="sale_warn_msg" />
                     </p>
                 </div>
             </header>


### PR DESCRIPTION
fwp https://github.com/OCA/sale-workflow/pull/3852

@Tecnativa

@CarlosRoca13 @pedrobaeza please review