### PR TITLE
[16.0][IMP] sale_order_line_sequence: Reduce column size through label + optional

### DIFF
--- a/sale_order_line_sequence/views/sale_view.xml
+++ b/sale_order_line_sequence/views/sale_view.xml
@@ -17,7 +17,7 @@
                 expr="//field[@name='order_line']/tree/field[@name='product_id']"
                 position="before"
             >
-                <field name="visible_sequence" />
+                <field name="visible_sequence" string="#" optional="show" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Odoo, when auto-sizing the columns of a list view, takes the column label for distributing the widths. Having a label "Line number" (or longer in other languages), makes the column to take by default a lot of space, while its contents will always be 1, 2, 3..., aka very sort contents.

Let's change specifically in the view the label to "#" to have the minimum size for the initial width distribution.

We take the occasion to make it optional (but shown by default) as well.

@Tecnativa TT57583