### PR TITLE
[17.0][IMP] sale_elaboration: elaboration profile from product category

### DIFF
--- a/sale_elaboration/README.rst
+++ b/sale_elaboration/README.rst
@@ -50,7 +50,30 @@ To configure this module you need to:
 1. Go to *Sale > Configuration > Products > Sale Elaboration*.
 2. Create a new record.
 3. Set a product linked to the elaboration.
-4. Also you can select a route to procure this elaboration.
+4. If you use Multi-Step Routes, you can also select a route to procure
+   this elaboration.
+5. Go to *Settings > Inventory > Traceability* and select *Display
+   Elaboration notes on Delivery Slips* if you want to show elaborations
+   on Delivery Slips or *Display Elaboration notes on Picking
+   Operations* if you want to show elaborations on Picking Operations.
+
+You can define elaboration profiles to limit the elaborations that can
+be selected for each product.
+
+To set the profile globally for a product category:
+
+1. Go to *Inventory > Configuration > Product Categories* and choose
+   one.
+2. In the **Logistics** sections, you can set the desired **Elaboration
+   profile**.
+
+If you want to set an specific elaboration profile for a product:
+
+1. Go to *Sale > Configuration > Elaborations > Sale Elaboration
+   Profile*.
+2. Create a new record.
+3. Select the elaborations included to the profile.
+4. Set the elaboration to the related products.
 
 Usage
 =====

--- a/sale_elaboration/__manifest__.py
+++ b/sale_elaboration/__manifest__.py
@@ -27,6 +27,7 @@
         "reports/report_base.xml",
         "reports/report_deliveryslip.xml",
         "reports/report_picking_operations.xml",
+        "views/product_category_views.xml",
     ],
     "pre_init_hook": "pre_init_hook",
     "maintainers": ["CarlosRoca13", "rafaelbn", "sergio-teruel", "yajo"],

--- a/sale_elaboration/models/__init__.py
+++ b/sale_elaboration/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from . import product
+from . import product_category
 from . import product_elaboration
 from . import product_elaboration_mixin
 from . import product_elaboration_profile

--- a/sale_elaboration/models/product.py
+++ b/sale_elaboration/models/product.py
@@ -7,5 +7,8 @@ class ProductProduct(models.Model):
     _inherit = "product.product"
 
     elaboration_profile_id = fields.Many2one(
-        comodel_name="product.elaboration.profile", ondelete="restrict"
+        comodel_name="product.elaboration.profile",
+        ondelete="restrict",
+        help="Keep this field empty to use the default value from the product "
+        "category.",
     )

--- a/sale_elaboration/models/product_category.py
+++ b/sale_elaboration/models/product_category.py
@@ -1,0 +1,11 @@
+# Copyright 2025 Moduon Team S.L. <info@moduon.team>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ProductCategory(models.Model):
+    _inherit = "product.category"
+
+    elaboration_profile_id = fields.Many2one(
+        comodel_name="product.elaboration.profile", string="Elaboration Profile"
+    )

--- a/sale_elaboration/models/product_template.py
+++ b/sale_elaboration/models/product_template.py
@@ -12,6 +12,8 @@ class ProductTemplate(models.Model):
         compute="_compute_elaboration_profile_id",
         inverse="_inverse_elaboration_profile_id",
         store=True,
+        help="Keep this field empty to use the default value from the product "
+        "category.",
     )
 
     @api.depends("product_variant_ids", "product_variant_ids.elaboration_profile_id")

--- a/sale_elaboration/models/sale_order.py
+++ b/sale_elaboration/models/sale_order.py
@@ -48,7 +48,8 @@ class SaleOrderLine(models.Model):
     date_order = fields.Datetime(related="order_id.date_order", string="Date")
     route_id = fields.Many2one(compute="_compute_route_id", store=True, readonly=False)
     elaboration_profile_id = fields.Many2one(
-        related="product_id.elaboration_profile_id"
+        comodel_name="product.elaboration.profile",
+        compute="_compute_elaboration_profile_id",
     )
     elaboration_price_unit = fields.Float(
         "Elab. Price", compute="_compute_elaboration_price_unit", store=True
@@ -58,6 +59,16 @@ class SaleOrderLine(models.Model):
         search="_search_is_prepared",
         help=("Dummy field to be able to find prepared lines"),
     )
+
+    @api.depends("product_id")
+    def _compute_elaboration_profile_id(self):
+        """Order of applicability: product profile > category profile > no profile"""
+        self.elaboration_profile_id = False
+        for line in self.filtered("product_id"):
+            line.elaboration_profile_id = (
+                line.product_id.elaboration_profile_id
+                or line.product_id.categ_id.elaboration_profile_id
+            )
 
     def get_elaboration_stock_route(self):
         self.ensure_one()

--- a/sale_elaboration/readme/CONFIGURE.md
+++ b/sale_elaboration/readme/CONFIGURE.md
@@ -3,4 +3,25 @@ To configure this module you need to:
 1.  Go to *Sale \> Configuration \> Products \> Sale Elaboration*.
 2.  Create a new record.
 3.  Set a product linked to the elaboration.
-4.  Also you can select a route to procure this elaboration.
+4.  If you use Multi-Step Routes, you can also select a route to procure
+    this elaboration.
+5.  Go to *Settings \> Inventory \> Traceability* and select *Display
+    Elaboration notes on Delivery Slips* if you want to show
+    elaborations on Delivery Slips or *Display Elaboration notes on
+    Picking Operations* if you want to show elaborations on Picking
+    Operations.
+
+You can define elaboration profiles to limit the elaborations that can be
+selected for each product.
+
+To set the profile globally for a product category:
+
+1. Go to *Inventory > Configuration > Product Categories* and choose one.
+2. In the **Logistics** sections, you can set the desired **Elaboration profile**.
+
+If you want to set an specific elaboration profile for a product:
+
+1.  Go to *Sale \> Configuration \> Elaborations \> Sale Elaboration Profile*.
+2.  Create a new record.
+3.  Select the elaborations included to the profile.
+4.  Set the elaboration to the related products.

--- a/sale_elaboration/static/description/index.html
+++ b/sale_elaboration/static/description/index.html
@@ -398,7 +398,29 @@ final price.</p>
 <li>Go to <em>Sale &gt; Configuration &gt; Products &gt; Sale Elaboration</em>.</li>
 <li>Create a new record.</li>
 <li>Set a product linked to the elaboration.</li>
-<li>Also you can select a route to procure this elaboration.</li>
+<li>If you use Multi-Step Routes, you can also select a route to procure
+this elaboration.</li>
+<li>Go to <em>Settings &gt; Inventory &gt; Traceability</em> and select <em>Display
+Elaboration notes on Delivery Slips</em> if you want to show elaborations
+on Delivery Slips or <em>Display Elaboration notes on Picking
+Operations</em> if you want to show elaborations on Picking Operations.</li>
+</ol>
+<p>You can define elaboration profiles to limit the elaborations that can
+be selected for each product.</p>
+<p>To set the profile globally for a product category:</p>
+<ol class="arabic simple">
+<li>Go to <em>Inventory &gt; Configuration &gt; Product Categories</em> and choose
+one.</li>
+<li>In the <strong>Logistics</strong> sections, you can set the desired <strong>Elaboration
+profile</strong>.</li>
+</ol>
+<p>If you want to set an specific elaboration profile for a product:</p>
+<ol class="arabic simple">
+<li>Go to <em>Sale &gt; Configuration &gt; Elaborations &gt; Sale Elaboration
+Profile</em>.</li>
+<li>Create a new record.</li>
+<li>Select the elaborations included to the profile.</li>
+<li>Set the elaboration to the related products.</li>
 </ol>
 </div>
 <div class="section" id="usage">

--- a/sale_elaboration/tests/test_sale_elaboration.py
+++ b/sale_elaboration/tests/test_sale_elaboration.py
@@ -1,5 +1,6 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import Command
 from odoo.tests import Form, tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -11,9 +12,21 @@ class TestSaleElaboration(AccountTestInvoicingCommon):
     def setUpClass(cls):
         super().setUpClass()
         cls.Elaboration = cls.env["product.elaboration"]
+        cls.ElaborationProfile = cls.env["product.elaboration.profile"]
+        cls.category_1 = cls.env["product.category"].create({"name": "Meat"})
+        cls.category_2 = cls.env["product.category"].create({"name": "Fish"})
         cls.product = cls.env["product.product"].create(
             {"name": "test", "tracking": "none", "list_price": 1000}
         )
+        cls.product_2 = cls.env["product.product"].create(
+            {"name": "test 2", "tracking": "none", "list_price": 1000}
+        )
+        cls.product_3 = cls.env["product.product"].create(
+            {"name": "test 2", "tracking": "none", "list_price": 1000}
+        )
+        cls.product.categ_id = cls.category_1
+        cls.product_2.categ_id = cls.category_2
+        cls.product_3.categ_id = cls.category_1
         cls.product_elaboration_A = cls.env["product.product"].create(
             {
                 "name": "Product Elaboration A",
@@ -65,9 +78,25 @@ class TestSaleElaboration(AccountTestInvoicingCommon):
                 "product_id": cls.product_elaboration_B.id,
             }
         )
+        cls.elaboration_profile_a = cls.ElaborationProfile.create(
+            {
+                "name": "Elaboration Profile A",
+                "elaboration_ids": [
+                    Command.set([cls.elaboration_a.id, cls.elaboration_b.id])
+                ],
+            }
+        )
+        cls.elaboration_profile_b = cls.ElaborationProfile.create(
+            {
+                "name": "Elaboration Profile B",
+                "elaboration_ids": [Command.set(cls.elaboration_a.ids)],
+            }
+        )
+        cls.product.elaboration_profile_id = cls.elaboration_profile_a
         cls.order = cls._create_sale_order(
             cls, [(cls.product, 10, [cls.elaboration_a])]
         )
+        cls.category_1.elaboration_profile_id = cls.elaboration_profile_b
 
     def _create_sale_order(self, products_info):
         order_form = Form(self.env["sale.order"])

--- a/sale_elaboration/views/product_category_views.xml
+++ b/sale_elaboration/views/product_category_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record
+        model="ir.ui.view"
+        id="sale_elaboration_product_category_view_form_inherit_elaboration_id"
+    >
+        <field name="name">product.category.view.form.sale.elaboration</field>
+        <field name="model">product.category</field>
+        <field name="inherit_id" ref="product.product_category_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='logistics']" position="inside">
+                <field name="elaboration_profile_id" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
fw of

- #3809 

Elaboration profiles can now be set from the category so if no profile is set in the product it defaults to that one.

TODO:

- `test.Form` doesn't constrain the view domain for profiles... so the only way to test the flow would be either to use a helper domain field or a tour... Some tooling left in the test case anyway.

cc @moduon MT-10786

please review if you feel like it :slightly_smiling_face:  @rafaelbn @sergio-teruel @Andrii9090 