### PR TITLE
[14.0][IMP] sale_exception: SO line inherit change to base.exception

### DIFF
--- a/sale_exception/__manifest__.py
+++ b/sale_exception/__manifest__.py
@@ -1,11 +1,12 @@
 # Copyright 2011 Akretion, Sodexis
 # Copyright 2018 Akretion
 # Copyright 2019 Camptocamp SA
+# Copyright 2025 Raumschmiede GmbH
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Sale Exception",
     "summary": "Custom exceptions on sale order",
-    "version": "14.0.1.1.1",
+    "version": "14.0.1.2.0",
     "category": "Generic Modules/Sale",
     "author": "Akretion, "
     "Sodexis, "

--- a/sale_exception/migrations/14.0.1.2.0/pre-migration.py
+++ b/sale_exception/migrations/14.0.1.2.0/pre-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2025 Raumschmiede GmbH
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tools.sql import column_exists, create_column
+
+
+def migrate(cr, version):
+    if column_exists(cr, "sale_order_line", "main_exception_id"):
+        return
+
+    create_column(cr, "sale_order_line", "main_exception_id", "int4")

--- a/sale_exception/models/sale.py
+++ b/sale_exception/models/sale.py
@@ -27,11 +27,9 @@ class SaleOrder(models.Model):
     _name = "sale.order"
     _order = "main_exception_id asc, date_order desc, name desc"
 
-    def detect_exceptions(self):
-        all_exceptions = super().detect_exceptions()
-        lines = self.mapped("order_line")
-        all_exceptions += lines.detect_exceptions()
-        return all_exceptions
+    @api.model
+    def _get_sub_exception_field_names(self):
+        return ["order_line"]
 
     @api.model
     def test_all_draft_orders(self):

--- a/sale_exception/models/sale.py
+++ b/sale_exception/models/sale.py
@@ -1,6 +1,7 @@
 # Copyright 2011 Akretion, Sodexis
 # Copyright 2018 Akretion
 # Copyright 2019 Camptocamp SA
+# Copyright 2025 Raumschmiede GmbH
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
@@ -19,17 +20,12 @@ class ExceptionRule(models.Model):
             "sale.order.line": "cascade",
         },
     )
-    sale_ids = fields.Many2many("sale.order", string="Sales")
 
 
 class SaleOrder(models.Model):
     _inherit = ["sale.order", "base.exception"]
     _name = "sale.order"
     _order = "main_exception_id asc, date_order desc, name desc"
-
-    @api.model
-    def _reverse_field(self):
-        return "sale_ids"
 
     def detect_exceptions(self):
         all_exceptions = super().detect_exceptions()
@@ -79,10 +75,6 @@ class SaleOrder(models.Model):
         orders = self.filtered("ignore_exception")
         orders.write({"ignore_exception": False})
         return res
-
-    def _sale_get_lines(self):
-        self.ensure_one()
-        return self.order_line
 
     @api.model
     def _get_popup_action(self):

--- a/sale_exception/models/sale_order_line.py
+++ b/sale_exception/models/sale_order_line.py
@@ -1,50 +1,16 @@
 # © 2019 Akretion
+# Copyright 2025 Raumschmiede GmbH
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import html
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class SaleOrderLine(models.Model):
-    _inherit = ["sale.order.line", "base.exception.method"]
+    _inherit = ["sale.order.line", "base.exception"]
     _name = "sale.order.line"
 
-    exception_ids = fields.Many2many(
-        "exception.rule", string="Exceptions", copy=False, readonly=True
-    )
-    exceptions_summary = fields.Html(
-        readonly=True, compute="_compute_exceptions_summary"
-    )
-    ignore_exception = fields.Boolean(
-        related="order_id.ignore_exception", store=True, string="Ignore Exceptions"
-    )
-
-    @api.depends("exception_ids", "ignore_exception")
-    def _compute_exceptions_summary(self):
-        for rec in self:
-            if rec.exception_ids and not rec.ignore_exception:
-                rec.exceptions_summary = rec._get_exception_summary()
-            else:
-                rec.exceptions_summary = False
-
-    def _get_exception_summary(self):
-        return "<ul>%s</ul>" % "".join(
-            [
-                "<li>%s: <i>%s</i></li>"
-                % tuple(map(html.escape, (e.name, e.description)))
-                for e in self.exception_ids
-            ]
-        )
+    ignore_exception = fields.Boolean(related="order_id.ignore_exception")
 
     def _get_main_records(self):
         return self.mapped("order_id")
-
-    def _detect_exceptions(self, rule):
-        records = super()._detect_exceptions(rule)
-        # Thanks to the new flush of odoo 13.0, queries will be optimized
-        # together at the end even if we update the exception_ids many times.
-        # On previous versions, this could be unoptimized.
-        (self - records).exception_ids = [(3, rule.id)]
-        records.exception_ids = [(4, rule.id)]
-        return records.mapped("order_id")

--- a/sale_exception/models/sale_order_line.py
+++ b/sale_exception/models/sale_order_line.py
@@ -40,10 +40,6 @@ class SaleOrderLine(models.Model):
     def _get_main_records(self):
         return self.mapped("order_id")
 
-    @api.model
-    def _reverse_field(self):
-        return "sale_ids"
-
     def _detect_exceptions(self, rule):
         records = super()._detect_exceptions(rule)
         # Thanks to the new flush of odoo 13.0, queries will be optimized

--- a/sale_exception/tests/test_multi_records.py
+++ b/sale_exception/tests/test_multi_records.py
@@ -100,6 +100,17 @@ class TestSaleExceptionMultiRecord(SavepointCase):
                 "</ul>"
             ),
         )
+        exception_no_dumping.is_blocking = True
+        so3.order_line[0].flush()
+        self.assertEqual(
+            so3.order_line[0].exceptions_summary,
+            (
+                "<ul>"
+                "<li>No dumping: <i>A product is sold cheaper than his cost.</i> "
+                "<b>(Blocking exception)</b></li>"
+                "</ul>"
+            ),
+        )
 
         # test return value of detect_exception()
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,3 @@
 odoo_test_helper
+
+odoo14-addon-base_exception @ git+https://github.com/OCA/server-tools.git@refs/pull/3346/head#subdirectory=setup/base_exception


### PR DESCRIPTION
Hi.

Because of my other PR https://github.com/OCA/server-tools/pull/3346 I changed `sale_exception` to use more of `base_exception`. Some fields are added again to `sale.order.line` eventhough they already exist on `base.exception`.

With these changes the note "(Is blocking)" now also appears in the exceptions summary on the SO line. Previously not as `sale.order.line` defined its own computation for this field.
And with the new inherit it has now the field `main_exception_id`.

Here I did more changes than in other modules that depend on `base_exception` to remove the duplicated stuff