### PR TITLE
[FIX] sell_only_by_packaging crash

### DIFF
--- a/sell_only_by_packaging/models/product_template.py
+++ b/sell_only_by_packaging/models/product_template.py
@@ -76,6 +76,6 @@ class ProductTemplate(models.Model):
     @api.depends("sale_ok")
     def _compute_expense_policy(self):
         self.filtered(
-            lambda t: not t.sale_ok and self.sell_only_by_packaging
+            lambda t: not t.sale_ok and t.sell_only_by_packaging
         ).sell_only_by_packaging = False
         return super()._compute_expense_policy()


### PR DESCRIPTION
The code would crash when setting sale_ok on more than 1 product.

I'm really unsure about that method, though: sell_only_by_packaging is company dependent, and sale_or and expense_policy are not