### PR TITLE
[18.0][FIX] sale_order_secondary_unit: quantity resets to 0 with secondary UoM

### DIFF
--- a/sale_order_secondary_unit/models/sale_order.py
+++ b/sale_order_secondary_unit/models/sale_order.py
@@ -19,19 +19,13 @@ class SaleOrderLine(models.Model):
 
     product_uom_qty = fields.Float(copy=True)
 
-    @api.depends(
-        "display_type",
-        "product_id",
-        "product_packaging_qty",
+    @api.onchange(
         "secondary_uom_qty",
         "secondary_uom_id",
-        "product_uom_qty",
     )
-    def _compute_product_uom_qty(self):
-        res = super()._compute_product_uom_qty()
+    def _compute_target_field_qty(self):
         for line in self:
             line._compute_helper_target_field_qty()
-        return res
 
     @api.depends("product_id")
     def _compute_product_uom(self):
@@ -42,12 +36,22 @@ class SaleOrderLine(models.Model):
 
     @api.onchange("product_id")
     def _onchange_product_id_warning(self):
+        """
+        If default sales secondary unit set on product, put on secondary
+        quantity 1 for being the default quantity. We override this method,
+        that is the one that sets by default 1 on the other quantity with that
+        purpose.
+        """
         res = super()._onchange_product_id_warning()
         if self.product_id and not self.env.context.get("skip_secondary_uom_default"):
+            line_uom_qty = self.product_uom_qty
             self.secondary_uom_id = self.product_id.sale_secondary_uom_id
-            if self.product_uom_qty == 1.0:
-                self.secondary_uom_qty = 1.0
-                self._onchange_helper_product_uom_for_secondary()
+            if self.secondary_uom_id:
+                if line_uom_qty == 1.0:
+                    self.secondary_uom_qty = 1.0
+                    self._compute_helper_target_field_qty()
+                else:
+                    self.product_uom_qty = line_uom_qty
         return res
 
     @api.depends("secondary_uom_qty", "product_uom_qty", "price_unit")


### PR DESCRIPTION
This PR fixes a bug where the product_uom_qty on a sale order line would reset to 0 when adding a product that uses a secondary unit of measure.

The logic that prevented this in previous versions was altered during the migration to v17 (https://github.com/OCA/sale-workflow/pull/3385)