### PR TITLE
[18.0][IMP] sale_order_line_sequence: change visible_sequence from int to char

### DIFF
--- a/sale_order_line_sequence/__manifest__.py
+++ b/sale_order_line_sequence/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Sale Order Line Sequence",
     "summary": "Propagates SO line sequence to invoices and stock picking.",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.2.0",
     "author": "ForgeFlow, Serpent CS, Odoo Community Association (OCA)",
     "category": "Sales",
     "website": "https://github.com/OCA/sale-workflow",

--- a/sale_order_line_sequence/migrations/18.0.1.2.0/pre-migrate.py
+++ b/sale_order_line_sequence/migrations/18.0.1.2.0/pre-migrate.py
@@ -1,0 +1,9 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        "ALTER TABLE sale_order_line ALTER COLUMN visible_sequence TYPE varchar",
+    )

--- a/sale_order_line_sequence/models/sale_order_line.py
+++ b/sale_order_line_sequence/models/sale_order_line.py
@@ -14,7 +14,7 @@ class SaleOrderLine(models.Model):
         default=9999,
     )
 
-    visible_sequence = fields.Integer(
+    visible_sequence = fields.Char(
         "Line Number",
         help="Displays the sequence of the line in the sale order.",
         compute="_compute_visible_sequence",
@@ -29,5 +29,5 @@ class SaleOrderLine(models.Model):
                 lambda order_line: not order_line.display_type
             )
             for line in sorted(order_lines, key=lambda order_line: order_line.sequence):
-                line.visible_sequence = sequence
+                line.visible_sequence = str(sequence)
                 sequence += 1

--- a/sale_order_line_sequence/tests/test_sale_order_line_sequence.py
+++ b/sale_order_line_sequence/tests/test_sale_order_line_sequence.py
@@ -52,9 +52,9 @@ class TestSaleOrderLineSequence(TransactionCase):
     def test_sale_order_line_sequence(self):
         so1 = self._create_sale_order()
         so1.action_confirm()
-        self.assertEqual(so1.order_line[0].visible_sequence, 1)
+        self.assertEqual(so1.order_line[0].visible_sequence, "1")
         so2 = so1.copy()
-        self.assertEqual(so2.order_line[0].visible_sequence, 1)
+        self.assertEqual(so2.order_line[0].visible_sequence, "1")
 
     def test_sale_order_line_sequence_section(self):
         so1 = self._create_sale_order()
@@ -82,7 +82,7 @@ class TestSaleOrderLineSequence(TransactionCase):
             if line.display_type:
                 self.assertFalse(line.visible_sequence)
                 continue
-            self.assertEqual(line.visible_sequence, sequence)
+            self.assertEqual(line.visible_sequence, str(sequence))
             sequence += 1
 
     def test_invoice_sequence(self):
@@ -95,11 +95,11 @@ class TestSaleOrderLineSequence(TransactionCase):
         so.order_line.qty_delivered = 5
         self.invoice = so._create_invoices()
         self.assertEqual(
-            str(so.order_line[0].visible_sequence),
+            so.order_line[0].visible_sequence,
             self.invoice.line_ids[0].related_so_sequence,
         )
         self.assertEqual(
-            str(so.order_line[1].visible_sequence),
+            so.order_line[1].visible_sequence,
             self.invoice.line_ids[1].related_so_sequence,
         )
 

--- a/sale_order_line_sequence/views/account_move_view.xml
+++ b/sale_order_line_sequence/views/account_move_view.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath
                 expr="//field[@name='invoice_line_ids']/list/field[@name='sequence']"
-                position="before"
+                position="after"
             >
                 <field
                     name="related_so_sequence"


### PR DESCRIPTION
This PR introduces the following changes:

- Field type of `visible_sequence` (sale.order.line) changed from integer to char. This allows for more flexible numbering schemes e.g: 1.1, 1.2, 1.3 ...
- Reordered the `related_so_sequence` in the view, so that the `handle` widget is shown first (as in sale order lines):
  <img width="2044" height="870" alt="before" src="https://github.com/user-attachments/assets/5cd7bc29-06aa-4467-8f0a-b45c092a828a" />
  
  <img width="2052" height="854" alt="after" src="https://github.com/user-attachments/assets/84988e4d-806c-4777-a7ed-80df5b8071d8" />

