### PR TITLE
[17.0][FIX] sale_order_invoicing_finished_task: Change methods that do not exist and/or should not be used

### DIFF
--- a/sale_order_invoicing_finished_task/models/sale_order.py
+++ b/sale_order_invoicing_finished_task/models/sale_order.py
@@ -1,26 +1,9 @@
 # Copyright 2017 Tecnativa - Sergio Teruel
 # Copyright 2017 Tecnativa - Carlos Dauden
+# Copyright 2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
-
-
-class SaleOrder(models.Model):
-    _inherit = "sale.order"
-
-    @api.depends(
-        "state", "order_line.invoice_status", "order_line.task_ids.invoiceable"
-    )
-    def _get_invoiced(self):
-        result = super()._get_invoiced()
-        for order in self.filtered(lambda o: o.invoice_status != "no"):
-            if not all(
-                t.invoiceable
-                for t in order.mapped("order_line.task_ids")
-                if t.invoicing_finished_task
-            ):
-                order.update({"invoice_status": "no"})
-        return result
 
 
 class SaleOrderLine(models.Model):
@@ -32,14 +15,18 @@ class SaleOrderLine(models.Model):
         string="Tasks",
     )
 
-    @api.depends(
-        "qty_invoiced",
-        "qty_delivered",
-        "product_uom_qty",
-        "order_id.state",
-        "task_ids.invoiceable",
-    )
-    def _get_to_invoice_qty(self):
+    @api.depends("task_ids.invoiceable")
+    def _compute_invoice_status(self):
+        res = super()._compute_invoice_status()
+        for item in self.filtered(lambda x: x.task_ids and x.invoice_status != "no"):
+            if not all(
+                t.invoiceable for t in item.task_ids if t.invoicing_finished_task
+            ):
+                item.invoice_status = "no"
+        return res
+
+    @api.depends("task_ids.invoiceable")
+    def _compute_qty_to_invoice(self):
         lines = self.filtered(
             lambda x: (
                 x.product_id.type == "service"
@@ -51,7 +38,7 @@ class SaleOrderLine(models.Model):
         )
         if lines:
             lines.update({"qty_to_invoice": 0.0})
-        return super(SaleOrderLine, self - lines)._get_to_invoice_qty()
+        return super(SaleOrderLine, self - lines)._compute_qty_to_invoice()
 
     def _timesheet_compute_delivered_quantity_domain(self):
         vals = super()._timesheet_compute_delivered_quantity_domain()

--- a/sale_order_invoicing_finished_task/tests/test_sale_order_invoicing_finished_task.py
+++ b/sale_order_invoicing_finished_task/tests/test_sale_order_invoicing_finished_task.py
@@ -1,25 +1,25 @@
 # Copyright 2017 Tecnativa - Sergio Teruel
+# Copyright 2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from odoo import Command
 from odoo.exceptions import ValidationError
-from odoo.tests import TransactionCase
+from odoo.tests import Form, new_test_user
+from odoo.tools import mute_logger
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestInvoicefinishedTask(TransactionCase):
+class TestInvoicefinishedTask(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.hour_uom = cls.env.ref("uom.product_uom_hour")
         cls.env.user.company_id.project_time_mode_id = cls.hour_uom.id
-        group_manager = cls.env.ref("sales_team.group_sale_manager")
-        cls.manager = cls.env["res.users"].create(
-            {
-                "name": "Andrew Manager",
-                "login": "manager",
-                "email": "a.m@example.com",
-                "signature": "--\nAndreww",
-                "groups_id": [(6, 0, [group_manager.id])],
-            }
+        cls.manager = new_test_user(
+            cls.env,
+            login="test-manager-user",
+            groups="sales_team.group_sale_manager",
         )
         cls.employee = cls.env["hr.employee"].create(
             {"name": cls.manager.name, "user_id": cls.manager.id}
@@ -39,8 +39,9 @@ class TestInvoicefinishedTask(TransactionCase):
         )
         cls.uom_unit = cls.env.ref("uom.product_uom_unit")
         cls.Product = cls.env["product.product"]
-        cls.product = cls.Product.create(cls._prepare_product_vals())
-        product_delivery_vals = cls._prepare_product_vals()
+        product_vals = cls._prepare_product_vals()
+        cls.product = cls.Product.create(product_vals)
+        product_delivery_vals = product_vals
         product_delivery_vals.update(
             {
                 "name": "Product - Service - Policy delivery - Test",
@@ -60,7 +61,7 @@ class TestInvoicefinishedTask(TransactionCase):
         return {
             "name": "Test Invoiceable",
             "sequence": 5,
-            "project_ids": [(6, 0, cls.project.ids)],
+            "project_ids": [Command.set(cls.project.ids)],
             "invoiceable": invoiceable_stage,
         }
 
@@ -70,9 +71,7 @@ class TestInvoicefinishedTask(TransactionCase):
             "partner_id": cls.partner.id,
             "pricelist_id": cls.partner.property_product_pricelist.id,
             "order_line": [
-                (
-                    0,
-                    0,
+                Command.create(
                     {
                         "name": product.name,
                         "product_id": product.id,
@@ -110,17 +109,21 @@ class TestInvoicefinishedTask(TransactionCase):
             "task_id": task.id,
         }
 
+    @mute_logger("odoo.models.unlink")
     def test_invoice_status(self):
         self.sale_order.action_confirm()
         self.assertEqual(self.sale_order.invoice_status, "no")
         task = self.sale_order.order_line.task_ids
+        self.assertFalse(task.invoiceable)
         # Add a timesheet line
         timesheet = self.env["account.analytic.line"].create(
             self._prepare_timesheet_vals(task, 5.0)
         )
         # Set task in invoiceable stage
-        task.stage_id = self.stage_invoiceable.id
-        task._onchange_stage_id()
+        task_form = Form(task)
+        task_form.stage_id = self.stage_invoiceable
+        task = task_form.save()
+        self.assertTrue(task.invoiceable)
         self.assertEqual(self.sale_order.invoice_status, "to invoice")
         # delete timesheet
         timesheet.unlink()
@@ -129,8 +132,15 @@ class TestInvoicefinishedTask(TransactionCase):
         self.env["account.analytic.line"].create(
             self._prepare_timesheet_vals(task, 10.0)
         )
-        # Click on toggle_invoiceable method
+        self.assertTrue(task.invoiceable)
+        self.assertEqual(self.sale_order.invoice_status, "to invoice")
+        # Click on toggle_invoiceable method (invoiceable=False)
         task.toggle_invoiceable()
+        self.assertFalse(task.invoiceable)
+        self.assertEqual(self.sale_order.invoice_status, "no")
+        # Click on toggle_invoiceable method (invoiceable=True)
+        task.toggle_invoiceable()
+        self.assertTrue(task.invoiceable)
         self.assertEqual(self.sale_order.invoice_status, "to invoice")
         # Make the invoice
         self.sale_order._create_invoices()
@@ -146,7 +156,7 @@ class TestInvoicefinishedTask(TransactionCase):
             self.env["project.task"].create(
                 {
                     "name": "Other Task",
-                    "user_ids": [(4, self.manager.id)],
+                    "user_ids": [Command.link(self.manager.id)],
                     "project_id": self.project.id,
                     "sale_line_id": self.sale_order.order_line.id,
                 }
@@ -160,6 +170,7 @@ class TestInvoicefinishedTask(TransactionCase):
             self._prepare_timesheet_vals(task, 10.5)
         )
         task.toggle_invoiceable()
+        self.assertTrue(task.invoiceable)
         self.assertEqual(self.sale_order.order_line.qty_to_invoice, 5.0)
         self.sale_order_policy_delivery.action_confirm()
         # Add a timesheet line
@@ -167,8 +178,10 @@ class TestInvoicefinishedTask(TransactionCase):
         self.env["account.analytic.line"].create(
             self._prepare_timesheet_vals(task_delivery, 10.0)
         )
-        task_delivery.write({"stage_id": self.stage_invoiceable.id})
-        task_delivery._onchange_stage_id()
+        task_delivery_form = Form(task_delivery)
+        task_delivery_form.stage_id = self.stage_invoiceable
+        task_delivery = task_delivery_form.save()
+        self.assertTrue(task_delivery.invoiceable)
         self.assertEqual(
             self.sale_order_policy_delivery.order_line.qty_to_invoice, 10.0
         )
@@ -179,11 +192,12 @@ class TestInvoicefinishedTask(TransactionCase):
             {
                 "name": "Other Task",
                 "partner_id": self.manager.id,
-                "user_ids": [(4, self.manager.id)],
+                "user_ids": [Command.link(self.manager.id)],
                 "project_id": self.project.id,
                 "sale_line_id": self.sale_order.order_line.id,
             }
         )
-        task.stage_id = self.stage_invoiceable
-        task._onchange_stage_id()
+        task_form = Form(task)
+        task_form.stage_id = self.stage_invoiceable
+        task = task_form.save()
         self.assertTrue(task.invoiceable)


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/sale-workflow/pull/3839

Change methods that do not exist and/or should not be used

Changes done:
- [x] Change the `_get_to_invoice_qty()` method (no longer exists) to `_compute_qty_to_invoice()`
- [x] Do not use the `_get_invoiced()` method; replace it with `_compute_invoice_status()`
- [x] Make tests more readable + use `Form()` to avoid manually calling onchange methods

Although the `_get_invoiced()` method exists, the name is confusing; it is actually a compute. The appropriate and most readable approach is to use the appropriate `invoice_status` value in each line of the order, and the order status will update itself.

Similar to https://github.com/OCA/sale-workflow/pull/3838

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT57321