### PR TITLE
[17.0][FIX] sale_force_invoiced: Don't hide the field

### DIFF
--- a/sale_force_invoiced/view/sale_order.xml
+++ b/sale_force_invoiced/view/sale_order.xml
@@ -10,7 +10,6 @@
                     name="force_invoiced"
                     groups="sale_force_invoiced.group_force_invoiced"
                     widget="boolean_toggle"
-                    invisible="state != 'sale'"
                     readonly="state != 'sale'"
                 />
             </group>


### PR DESCRIPTION
You may want to predefine in draft status to force invoiceable status before confirming the quotation, and in the migration to 17 (#2961), such option was restricted.

@Tecnativa TT57973