### PR TITLE
[17.0][IMP] sale_order_product_recommendation: use Product Price decimal precision for price_unit

### DIFF
--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -263,7 +263,7 @@ class SaleOrderRecommendationLine(models.TransientModel):
     product_uom_category_id = fields.Many2one(
         related="product_id.uom_id.category_id", depends=["product_id"]
     )
-    price_unit = fields.Monetary(compute="_compute_price_unit")
+    price_unit = fields.Float(compute="_compute_price_unit", digits="Product Price")
     pricelist_id = fields.Many2one(related="wizard_id.order_id.pricelist_id")
     times_delivered = fields.Integer(readonly=True)
     units_delivered = fields.Float(readonly=True)


### PR DESCRIPTION
Before this change, the wizard field `price_unit` was defined as a Monetary field, which always respects the currency's decimal places (typically 2).  
This caused inconsistencies when the database has a higher decimal precision defined for product prices.

With this change, `price_unit` is now a Float field using `digits="Product Price"`.  
This makes the wizard consistent with other places in Odoo (e.g. `sale.order.line.price_unit`) that already rely on the Product Price decimal precision.