### PR TITLE
[18.0][FIX] sale_order_type: Don't hide route_id field if no warehouse

### DIFF
--- a/sale_order_type/views/sale_order_type_view.xml
+++ b/sale_order_type/views/sale_order_type_view.xml
@@ -32,11 +32,7 @@
                                 name="company_id"
                                 groups="base.group_multi_company"
                             />
-                            <field
-                                name="route_id"
-                                invisible="not warehouse_id"
-                                groups="stock.group_adv_location"
-                            />
+                            <field name="route_id" groups="stock.group_adv_location" />
                             <field name="sequence_id" />
                             <field
                                 name="analytic_account_id"


### PR DESCRIPTION
As there is no default value for warehouse_id field and if you don't have multi warehouse functionality, you should be able to select a route

@ivantodorovich 