### PR TITLE
[17.0][FIX] sale_procurement_group_by_line: update to odoo

### DIFF
--- a/sale_procurement_group_by_line/model/sale.py
+++ b/sale_procurement_group_by_line/model/sale.py
@@ -46,7 +46,7 @@ class SaleOrderLine(models.Model):
                 or line.product_id.type not in ("consu", "product")
             ):
                 continue
-            qty = line._get_qty_procurement(previous_product_uom_qty)
+            qty = line._get_qty_procurement(previous_product_uom_qty) or 0.0
             if (
                 float_compare(qty, line.product_uom_qty, precision_digits=precision)
                 == 0


### PR DESCRIPTION
Adapt to:

 - https://github.com/odoo/odoo/commit/29f03ebe70738000fd259dee4b7f9ada6eb503be
 
 
 Explanation:
 
 See this recent change in Odoo:
 https://github.com/odoo/odoo/blob/17.0/addons/sale_mrp/models/sale_order_line.py#L141
 
 The `_get_qty_procurement` method can return `None`, which would cause a TypeError in `float_compare` and doesn't allow any future supers to work.
 
 
 