### PR TITLE
[FIX]sale_order_secondary_unit: secondary uom qty assignation

### DIFF
--- a/sale_order_secondary_unit/models/sale_order.py
+++ b/sale_order_secondary_unit/models/sale_order.py
@@ -43,9 +43,10 @@ class SaleOrderLine(models.Model):
     @api.onchange("product_id")
     def _onchange_product_id_warning(self):
         res = super()._onchange_product_id_warning()
+        qty = self.product_uom_qty
         if self.product_id and not self.env.context.get("skip_secondary_uom_default"):
             self.secondary_uom_id = self.product_id.sale_secondary_uom_id
-            if self.product_uom_qty == 1.0:
+            if qty == 1.0:
                 self.secondary_uom_qty = 1.0
                 self._onchange_helper_product_uom_for_secondary()
         return res


### PR DESCRIPTION
I create this fix because i noticed the method '_onchange_product_id_warning' is not assigning the secondary uom qty the value of 1 when product uom qty was 1. In this video i explain in detail the fix: https://drive.google.com/file/d/1C7oSN5TlzEseknyCETu-BkBPtuvIM_ib/view