### PR TITLE
[18.0][FIX] sale_order_lot_selection: Add precompute=True to avoid side effects

### DIFF
--- a/sale_order_lot_selection/models/sale_order_line.py
+++ b/sale_order_lot_selection/models/sale_order_line.py
@@ -11,6 +11,7 @@ class SaleOrderLine(models.Model):
         compute="_compute_lot_id",
         store=True,
         readonly=False,
+        precompute=True,
     )
 
     def _prepare_procurement_values(self, group_id=False):


### PR DESCRIPTION
Add precompute=True to avoid side effects

If we use the lot_id field to add it as a dependency of the `_compute_price_unit` method, we may encounter side effects, and indirectly we will need the field to be defined as precompute=True to avoid them.

@Tecnativa TT57110