### PR TITLE
[16.0][FIX] sale_stock_picking_blocking: Do not compute blocking_id on create()

### DIFF
--- a/sale_stock_picking_blocking/models/sale_order.py
+++ b/sale_stock_picking_blocking/models/sale_order.py
@@ -14,6 +14,7 @@ class SaleOrder(models.Model):
         string="Delivery Block Reason",
         compute="_compute_delivery_block_id",
         store=True,
+        precompute=True,
         states={"draft": [("readonly", False)], "sent": [("readonly", False)]},
     )
 


### PR DESCRIPTION
This tackles this bug:

https://github.com/OCA/sale-workflow/issues/3815

for version 16.0