### PR TITLE
[17.0][FWP][IMP] sale_order_line_date: commitment_date copy False

### DIFF
--- a/sale_order_line_date/models/sale_order_line.py
+++ b/sale_order_line_date/models/sale_order_line.py
@@ -14,7 +14,7 @@ from odoo import fields, models
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    commitment_date = fields.Datetime("Delivery Date")
+    commitment_date = fields.Datetime("Delivery Date", copy=False)
 
     def _prepare_procurement_values(self, group_id=False):
         vals = super()._prepare_procurement_values(group_id)

--- a/sale_order_line_date/tests/test_sale_order_line_date.py
+++ b/sale_order_line_date/tests/test_sale_order_line_date.py
@@ -177,3 +177,12 @@ class TestSaleOrderLineDates(TransactionCase):
         self._assert_equal_dates(
             self.sale_line1._expected_date(), self.sale_line1.move_ids.date_deadline
         )
+
+    def test_05_commitment_date_duplication(self):
+        """
+        Test if commitment_date field is empty when duplicating a sale order line.
+        """
+        self._assert_equal_dates(self.sale_line1.commitment_date, self.dt1)
+        duplicated_order = self.sale1.copy()
+        for duplicated_line in duplicated_order.order_line:
+            self.assertFalse(duplicated_line.commitment_date)


### PR DESCRIPTION
FWP of https://github.com/OCA/sale-workflow/pull/3377 to v17

Test fails but not related with this module, will be fix when this is merged: https://github.com/OCA/sale-workflow/pull/3913