### PR TITLE
[18.0][FIX] sale_order_carrier_auto_assign: set carrier on create - create empty SO then add product line

### DIFF
--- a/sale_order_carrier_auto_assign/models/__init__.py
+++ b/sale_order_carrier_auto_assign/models/__init__.py
@@ -1,3 +1,4 @@
 from . import sale_order
+from . import sale_order_line
 from . import res_company
 from . import res_config_settings

--- a/sale_order_carrier_auto_assign/models/sale_order.py
+++ b/sale_order_carrier_auto_assign/models/sale_order.py
@@ -28,11 +28,26 @@ class SaleOrder(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        orders = super().create(vals_list)
-        for order in orders:
-            if not order.carrier_id and order._is_auto_set_carrier_on_create():
-                order._set_delivery_carrier()
+        ctx_carrier_on_create = self.env.context.get("carrier_on_create")
+        orders = super(SaleOrder, self.with_context(carrier_on_create=True)).create(
+            vals_list
+        )
+        orders = orders.with_context(carrier_on_create=ctx_carrier_on_create)
+        orders._set_carrier_on_create()
         return orders
+
+    def _set_carrier_on_create(self):
+        if self.env.context.get("carrier_on_create"):
+            return
+        for order in self:
+            if not order.carrier_id and order._is_auto_set_carrier_on_create():
+                order.with_context(carrier_on_create=True)._set_delivery_carrier()
+
+    def write(self, vals):
+        # When product lines are added, set the carrier
+        res = super(SaleOrder, self.with_context(carrier_on_create=True)).write(vals)
+        self._set_carrier_on_create()
+        return res
 
     def _is_auto_set_carrier_on_confirm(self):
         self.ensure_one()

--- a/sale_order_carrier_auto_assign/models/sale_order.py
+++ b/sale_order_carrier_auto_assign/models/sale_order.py
@@ -71,6 +71,8 @@ class SaleOrder(models.Model):
         :param preserve_order_carrier: It will respect the carrier set on the order
         """
         for order in self:
+            if not order.order_line:
+                continue
             if order.delivery_set:
                 continue
             delivery_wiz_action = order.action_open_delivery_wizard()

--- a/sale_order_carrier_auto_assign/models/sale_order_line.py
+++ b/sale_order_carrier_auto_assign/models/sale_order_line.py
@@ -1,0 +1,30 @@
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        # When product lines are added, set the carrier
+        ctx_carrier_on_create = self.env.context.get("carrier_on_create")
+        order_lines = super(
+            SaleOrderLine, self.with_context(carrier_on_create=True)
+        ).create(vals_list)
+        order_lines = order_lines.with_context(carrier_on_create=ctx_carrier_on_create)
+        order_lines.order_id._set_carrier_on_create()
+        return order_lines
+
+    def write(self, vals):
+        # When product is changed, set the carrier
+        res = super(SaleOrderLine, self.with_context(carrier_on_create=True)).write(
+            vals
+        )
+        if vals.get("product_id"):
+            # compute of is_all_service doesn't list order_line.product_id in its
+            # depends, so invalidate recordset
+            self.order_id.invalidate_recordset(["is_all_service"])
+            self.order_id._set_carrier_on_create()
+        return res

--- a/sale_order_carrier_auto_assign/tests/test_sale_order_carrier_auto_assign.py
+++ b/sale_order_carrier_auto_assign/tests/test_sale_order_carrier_auto_assign.py
@@ -189,3 +189,13 @@ class TestSaleOrderCarrierAutoAssignOnConfirm(TestSaleOrderCarrierAutoAssignComm
         self.sale_order.action_confirm()
         self.assertEqual(self.sale_order.state, "sale")
         self.assertFalse(self.sale_order.carrier_id)
+
+    def test_sale_order_carrier_onchange_no_order_line(self):
+        """Ensure no error occurs when changing partner on an empty sale order."""
+        sale_order = self.env["sale.order"].create({"partner_id": self.partner.id})
+        new_partner = self.env["res.partner"].create({"name": "Another Partner"})
+        sale_order.partner_id = new_partner
+        self.assertFalse(
+            sale_order.carrier_id,
+            "Carrier should not be set for sale order without lines",
+        )

--- a/sale_order_carrier_auto_assign/tests/test_sale_order_carrier_auto_assign.py
+++ b/sale_order_carrier_auto_assign/tests/test_sale_order_carrier_auto_assign.py
@@ -71,6 +71,53 @@ class TestSaleOrderCarrierAutoAssignOnCreate(TestSaleOrderCarrierAutoAssignCommo
         )
         self.assertEqual(sale_order.carrier_id, self.delivery_local_delivery)
 
+    def test_sale_order_carrier_auto_assign_create_2steps_from_order(self):
+        """Test carrier is set when a product line is added"""
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+            }
+        )
+        sale_order.write(
+            {
+                "order_line": [
+                    Command.create({"product_id": self.product_storable.id})
+                ],
+            }
+        )
+        self.assertEqual(sale_order.carrier_id, self.delivery_local_delivery)
+
+    def test_sale_order_carrier_auto_assign_create_2steps_from_line(self):
+        """Test carrier is set when a product line is added"""
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+            }
+        )
+        self.env["sale.order.line"].create(
+            {
+                "order_id": sale_order.id,
+                "product_id": self.product_storable.id,
+            }
+        )
+        self.assertEqual(sale_order.carrier_id, self.delivery_local_delivery)
+
+    def test_sale_order_carrier_auto_assign_create_3steps_from_line(self):
+        """Test carrier is set when a product line is added"""
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+            }
+        )
+        sale_order_line = self.env["sale.order.line"].create(
+            {
+                "order_id": sale_order.id,
+                "product_id": self.product_service.id,
+            }
+        )
+        sale_order_line.product_id = self.product_storable
+        self.assertEqual(sale_order.carrier_id, self.delivery_local_delivery)
+
     def test_sale_order_carrier_auto_assign_disabled(self):
         self.settings.carrier_on_create = False
         self.settings.set_values()


### PR DESCRIPTION
When a blank SO is created and then a product line is added, the carrier should also be set when `carrier_on_create` is enabled. This is because the carrier is not set on create when there are no product line. So while there is no carrier on the SO and  `carrier_on_create` is enabled, try to set a carrier on write.

cc @pedrobaeza @victoralmau @grindtildeath @sebalix 