### PR TITLE
[18.0][FIX] sale_procurement_group_by_line: Fix smart button on sale order with link to purchase orders is not shown.

### DIFF
--- a/sale_procurement_group_by_line/model/sale.py
+++ b/sale_procurement_group_by_line/model/sale.py
@@ -67,6 +67,7 @@ class SaleOrderLine(models.Model):
             if not group_id:
                 vals = line._prepare_procurement_group_vals()
                 group_id = self.env["procurement.group"].create(vals)
+                line.order_id.procurement_group_id = group_id
             else:
                 # In case the procurement group is already created and the
                 # order was cancelled, we need to update certain values


### PR DESCRIPTION
**Problem:**

When the module sale_procurement_group_by_line is installed, the procurement group is stored at the sale order line level instead of directly on the sale order.
However, the smart button that shows related purchase orders on the sales order form relies on order_id.procurement_group_id.
As a result, the smart button disappears or shows no purchase orders, even though purchase orders are generated correctly.

**Solution:**

Added the following line in _action_launch_stock_rule:

**line.order_id.procurement_group_id = group_id**


This ensures that the procurement group assigned to the line is also propagated to the parent sale order.
Now, the smart button correctly retrieves and displays purchase orders when sale_procurement_group_by_line is active.

**Impact:**

Restores expected behavior of the Purchase Orders smart button on sales orders.

Fixes issue [#3864](https://github.com/OCA/sale-workflow/issues/3864?utm_source=chatgpt.com).