### PR TITLE
[18.0][IMP] sale_order_lot_selection: Hide the lot_id field if the product does not have tracking defined

### DIFF
--- a/sale_order_lot_selection/models/sale_order_line.py
+++ b/sale_order_lot_selection/models/sale_order_line.py
@@ -4,6 +4,15 @@ from odoo import api, fields, models
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
+    def _selection_product_tracking(self):
+        return self.env["product.product"].fields_get(
+            allfields=["tracking"],
+        )["tracking"]["selection"]
+
+    product_tracking = fields.Selection(
+        selection=_selection_product_tracking,
+        compute="_compute_product_tracking",
+    )
     lot_id = fields.Many2one(
         "stock.lot",
         "Lot",
@@ -19,6 +28,11 @@ class SaleOrderLine(models.Model):
         if self.lot_id:
             vals["restrict_lot_id"] = self.lot_id.id
         return vals
+
+    @api.depends("product_id")
+    def _compute_product_tracking(self):
+        for sol in self:
+            sol.product_tracking = sol.product_id.tracking or sol.product_tracking
 
     @api.depends("product_id")
     def _compute_lot_id(self):

--- a/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
+++ b/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
@@ -1,10 +1,11 @@
 # © 2015 Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo.fields import Command
-from odoo.tests import TransactionCase
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestSaleOrderLotSelection(TransactionCase):
+class TestSaleOrderLotSelection(BaseCommon):
     @classmethod
     def setUpClass(cls):
         """

--- a/sale_order_lot_selection/views/sale_order_views.xml
+++ b/sale_order_lot_selection/views/sale_order_views.xml
@@ -14,6 +14,7 @@
                     invisible="not product_id or product_tracking=='none'"
                     context="{'default_product_id': product_id}"
                     groups="stock.group_production_lot"
+                    optional="show"
                 />
             </xpath>
             <xpath

--- a/sale_order_lot_selection/views/sale_order_views.xml
+++ b/sale_order_lot_selection/views/sale_order_views.xml
@@ -11,6 +11,7 @@
                 <field
                     name="lot_id"
                     domain="[('product_id','=', product_id)]"
+                    invisible="not product_id or product_tracking=='none'"
                     context="{'default_product_id': product_id}"
                     groups="stock.group_production_lot"
                 />
@@ -22,6 +23,7 @@
                 <field
                     name="lot_id"
                     domain="[('product_id','=', product_id)]"
+                    invisible="not product_id or product_tracking=='none'"
                     context="{'default_product_id': product_id}"
                     groups="stock.group_production_lot"
                 />


### PR DESCRIPTION
Changes done:
- [x] Hide the `lot_id` field if the product does not have tracking defined
- [x] Add optional=show to the `lot_id` field
- [x] Change TransactionCase to BaseCommon

Please @juancarlosonate-tecnativa and @pilarvargas-tecnativa can you review it?

@Tecnativa