### PR TITLE
[FIX] sale_discount_display_amount: reset discount_subtotal when discount is removed

### DIFF
--- a/sale_discount_display_amount/models/sale_order_line.py
+++ b/sale_discount_display_amount/models/sale_order_line.py
@@ -38,7 +38,6 @@ class SaleOrderLine(models.Model):
             if not line.discount:
                 line.price_subtotal_no_discount = line.price_subtotal
                 line.price_total_no_discount = line.price_total
-                continue
             price = line.price_unit
             taxes = line.tax_id.compute_all(
                 price,


### PR DESCRIPTION
**Problem**

When a discount is applied on all order lines using the *sale.order.discount* wizard, the `discount_subtotal` field is updated correctly.
However, when the discount is reset to **0**, the field retains its previous value instead of being reset.

This leads to inconsistent information being displayed on the sales order.

**Solution**

Ensure that `discount_subtotal` is recalculated and reset to **0** when no discount is applied.
This aligns the displayed subtotal with the actual discount state.

**Impact**

Restores the expected behavior of discount computation on sales orders, ensuring `discount_subtotal` always reflects the correct discount value.

Fixes issue #3849
