### PR TITLE
[16.0][FIX] sale_order_note_template: Fixed the error and improved the view.

### DIFF
--- a/sale_order_note_template/views/sale_terms_template.xml
+++ b/sale_order_note_template/views/sale_terms_template.xml
@@ -17,11 +17,12 @@
         <field name="arch" type="xml">
             <form string="Terms and conditions Templates">
                 <sheet>
+                    <field name="active" invisible="1" />
                     <widget
                         name="web_ribbon"
                         text="Archived"
                         bg_color="bg-danger"
-                        invisible="active"
+                        attrs="{'invisible': [('active','=',True)]}"
                     />
                     <div class="oe_title">
                         <h1>

--- a/sale_order_note_template/views/sale_views.xml
+++ b/sale_order_note_template/views/sale_views.xml
@@ -13,7 +13,7 @@
                     name="terms_template_id"
                     placeholder="Terms and conditions template"
                     nolabel="1"
-                    colspan="4"
+                    colspan="2"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
1) Solved traceback error occurs when clicking on the Terms & Conditions menu (Sales → Configuration → Terms & Conditions).
2) Changed `terms_template_id` colspan from 4 to 2 to make the sale order view more compact and aligned.