### PR TITLE
[17.0][FIX] `sale_fixed_discount`: fix portal template

### DIFF
--- a/sale_fixed_discount/views/sale_portal_templates.xml
+++ b/sale_fixed_discount/views/sale_portal_templates.xml
@@ -35,8 +35,13 @@
                 name="t-att-class"
             >((line.discount or line.discount_fixed) and 'text-danger' or '') + ' text-right'</attribute>
         </xpath>
-        <xpath expr="//div[@t-if='line.discount']/t" position="attributes">
-            <attribute name="t-out">line.price_unit - line.discount_fixed</attribute>
+        <xpath expr="//div[@t-if='line.discount']" position="after">
+            <div t-elif="line.discount_fixed">
+                <t
+                    t-out="line.price_unit - line.discount_fixed"
+                    t-options='{"widget": "float", "decimal_precision": "Product Price"}'
+                />
+            </div>
         </xpath>
         <xpath
             expr="//section[@id='details']//table/tbody//t[@t-foreach='lines_to_report']/tr//t[@t-if='not line.display_type']//td[@t-if='display_discount']"


### PR DESCRIPTION
## Fixes portal template incorrect rendering of discounted unit prices.

### SO lines info
From the SO form view's `order_line` tree view (using quantity as sequence to ease comparison w/ the template reports below):
<img width="342" height="448" alt="Screenshot from 2025-10-15 09-43-08" src="https://github.com/user-attachments/assets/7a16370a-3d31-467d-80a5-ef5bfc49392d" />

NB: the fact that the "Disc. %" on the second line is 0 even though the "Discount (Fixed)" is 0.10 is not an error: since field `discount` is computed but not readonly, there are cases in which field `discount` could be assigned a value which is different than the one assigned by the `compute` method (for example, when importing the SO through the Odoo file importer).

### Portal report before the fix
<img width="257" height="421" alt="Screenshot from 2025-10-15 09-43-17" src="https://github.com/user-attachments/assets/de7c8f5b-52fb-4312-a8a9-ea29c18eda95" />

:red_circle: line 1: the discounted unit price is 1.00 instead of 0.90 (10% applied on 1.00)
:red_circle: line 2: the discounted unit price is not shown at all
:green_circle: line 3: the discounted unit price is shown correctly (3.00 w/ 0.30 or 10% discount = 2.70)
:green_circle: line 4: no discount applied


### Portal report after the fix
<img width="270" height="419" alt="Screenshot from 2025-10-15 09-43-24" src="https://github.com/user-attachments/assets/f513a09e-759e-4910-8d20-bfe020186e88" />

:green_circle: line 1: the discounted unit price is shown correctly (1.00 w/ 10% discount = 0.90)
:green_circle: line 2: the discounted unit price is shown correctly (2.00 w/ 0.10 discount = 1.90)
:green_circle: line 3: the discounted unit price is shown correctly (3.00 w/ 0.30 or 10% discount = 2.70)
:green_circle: line 4: no discount applied
