### PR TITLE
[18.0][FIX] sale_exception: handle exception rollback in action_confirm method

### DIFF
--- a/sale_exception/models/sale_order.py
+++ b/sale_exception/models/sale_order.py
@@ -49,6 +49,11 @@ class SaleOrder(models.Model):
 
     def action_confirm(self):
         if self.detect_exceptions():
+            exception_map = {sale.id: sale.exception_ids.ids for sale in self}
+            self.env.cr.rollback()
+            for sale in self:
+                exception_ids = exception_map.get(sale.id, [])
+                sale.write({"exception_ids": [(6, 0, exception_ids)]})
             if not self.env.company.sale_exception_show_popup:
                 return
             return self._popup_exceptions()


### PR DESCRIPTION
It's the same problem as #3672  https://github.com/OCA/sale-workflow/pull/3767 https://github.com/OCA/sale-workflow/pull/3885