### PR TITLE
[18.0][FIX] product_customerinfo_sale: pass partner context from sale to get correct price

### DIFF
--- a/product_customerinfo_sale/models/sale_order_line.py
+++ b/product_customerinfo_sale/models/sale_order_line.py
@@ -56,3 +56,14 @@ class SaleOrderLine(models.Model):
                 if customerinfo.min_qty:
                     line.product_uom_qty = customerinfo.min_qty
         return res
+
+    def _get_product_price_context(self):
+        # Include partner in the context to ensure correct computation
+        # of the price based on product customerinfo.
+        res = super()._get_product_price_context()
+        if not self.order_id.partner_id:
+            return res
+        return dict(
+            res,
+            partner_id=self.order_id.partner_id.id,
+        )

--- a/product_customerinfo_sale/tests/test_product_customerinfo_sale.py
+++ b/product_customerinfo_sale/tests/test_product_customerinfo_sale.py
@@ -106,6 +106,11 @@ class TestProductCustomerInfoSale(BaseCommon):
             self.customerinfo.min_qty,
             "Error: Min qty was not passed to the sale order line",
         )
+        self.assertEqual(
+            line.price_unit,
+            100.0,
+            "Error: Unit price was not passed to the sale order line",
+        )
 
     def test_product_customerinfo_variant(self):
         order_form = Form(self.env["sale.order"])


### PR DESCRIPTION
Partner context was otherwise not passed when prices are calculated in the SO. The module was not even testing that the prices were passed correctly.