### PR TITLE
[18.0][IMP] sale_order_lot_selection: Be able to select only available lots

### DIFF
--- a/sale_order_lot_selection/models/sale_order_line.py
+++ b/sale_order_lot_selection/models/sale_order_line.py
@@ -1,4 +1,5 @@
 from odoo import api, fields, models
+from odoo.tools import float_compare
 
 
 class SaleOrderLine(models.Model):
@@ -13,9 +14,11 @@ class SaleOrderLine(models.Model):
         selection=_selection_product_tracking,
         compute="_compute_product_tracking",
     )
+    domain_lot_id = fields.Binary(compute="_compute_domain_lot_id")
     lot_id = fields.Many2one(
         "stock.lot",
         "Lot",
+        domain="domain_lot_id",
         copy=False,
         compute="_compute_lot_id",
         store=True,
@@ -33,6 +36,35 @@ class SaleOrderLine(models.Model):
     def _compute_product_tracking(self):
         for sol in self:
             sol.product_tracking = sol.product_id.tracking or sol.product_tracking
+
+    @api.depends("product_id", "product_uom_qty", "warehouse_id")
+    def _compute_domain_lot_id(self):
+        dp = self.env["decimal.precision"].precision_get("Product Unit of Measure")
+        for sol in self:
+            domain = []
+            if sol.product_id and sol.product_tracking != "none":
+                # Only available lots should be displayed. In pickings, the
+                # corresponding stock.quant record is selected directly, so we
+                # use the same filters that are used.
+                quants = self.env["stock.quant"].search(
+                    [
+                        ("product_id", "=", sol.product_id.id),
+                        ("quantity", ">=", sol.product_uom_qty),
+                        ("lot_id", "!=", False),
+                        ("location_id.usage", "=", "internal"),
+                        ("location_id.warehouse_id", "=", sol.warehouse_id.id),
+                    ]
+                )
+                available_quants = quants.filtered(
+                    lambda x, qty=sol.product_uom_qty: float_compare(
+                        x.available_quantity,
+                        qty,
+                        precision_digits=dp,
+                    )
+                    >= 0
+                )
+                domain = [("id", "in", available_quants.mapped("lot_id").ids)]
+            sol.domain_lot_id = domain
 
     @api.depends("product_id")
     def _compute_lot_id(self):

--- a/sale_order_lot_selection/views/sale_order_views.xml
+++ b/sale_order_lot_selection/views/sale_order_views.xml
@@ -10,7 +10,6 @@
             >
                 <field
                     name="lot_id"
-                    domain="[('product_id','=', product_id)]"
                     invisible="not product_id or product_tracking=='none'"
                     context="{'default_product_id': product_id}"
                     groups="stock.group_production_lot"
@@ -23,7 +22,6 @@
             >
                 <field
                     name="lot_id"
-                    domain="[('product_id','=', product_id)]"
                     invisible="not product_id or product_tracking=='none'"
                     context="{'default_product_id': product_id}"
                     groups="stock.group_production_lot"


### PR DESCRIPTION
Be able to select only available lots

Example use case:
- Create 5 lots (Lot 1, Lot 2, Lot 3, Lot 4, Lot 5) for a product
- Define stock only in lots: Lot 1, Lot 2, and Lot 5
- Only lots with stock should be selectable in the sales order line.

Please @pedrobaeza and @christian-ramos-tecnativa can you review it?

@Tecnativa TT57112