### PR TITLE
[18.0][FIX] sell_only_by_packaging: min_sellable_qty invisible condition to use consu

### DIFF
--- a/sell_only_by_packaging/views/product_product.xml
+++ b/sell_only_by_packaging/views/product_product.xml
@@ -12,7 +12,7 @@
                 <field
                     name="min_sellable_qty"
                     optional="show"
-                    invisible="type != 'product' or not sell_only_by_packaging"
+                    invisible="type != 'consu' or not sell_only_by_packaging"
                 />
             </field>
         </field>


### PR DESCRIPTION
After this change on the commit the `min_sellable_qty` on product variants list view (e.g.) will display values correctly