### PR TITLE
[18.0][IMPL] sale_order_line_sequence: Adds a name to the th and td element for easier capture in inheriting module

### DIFF
--- a/sale_order_line_sequence/views/report_invoice.xml
+++ b/sale_order_line_sequence/views/report_invoice.xml
@@ -7,6 +7,7 @@
         <!--complicated expr to be compatible with other modules-->
         <xpath expr="//table/thead/tr/th[1]" position="before">
             <th
+                name="th_linenumber"
                 t-if="(o.move_type == 'out_invoice' or o.move_type == 'out_refund') and any(l.related_so_sequence for l in o.invoice_line_ids)"
             >
                 Line Number
@@ -15,6 +16,7 @@
         <!--complicated expr to be compatible with other modules-->
         <xpath expr="//table/tbody//span[1]/.." position="before">
             <td
+                name="td_linenumber"
                 t-if="(o.move_type == 'out_invoice' or o.move_type == 'out_refund') and line.related_so_sequence"
             >
                 <span t-field="line.related_so_sequence" />


### PR DESCRIPTION
This adds a name attribute to the `<th>` and `<td>` element in `report_invoice.xml` to help with capture in inheriting modules