### PR TITLE
[19.0][IMP] sale_order_type: Remove redundant company domain from journal_id

### DIFF
--- a/sale_order_type/models/sale_order_type.py
+++ b/sale_order_type/models/sale_order_type.py
@@ -19,8 +19,7 @@ class SaleOrderTypology(models.Model):
     journal_id = fields.Many2one(
         comodel_name="account.journal",
         string="Billing Journal",
-        domain="[('type', '=', 'sale'), '|', ('company_id', '=', False), "
-        "('company_id', '=', company_id)]",
+        domain="[('type', '=', 'sale')]",
         check_company=True,
     )
     warehouse_id = fields.Many2one(


### PR DESCRIPTION
The explicit company domain in journal_id field is redundant because the check_company=True attribute already handles company filtering correctly.

The check_company mechanism automatically filters records based on the appropriate companies, including parent companies when working with child companies (branches). This provides the correct Odoo behavior for multi-company scenarios.

This simplification makes the code cleaner and aligns with standard Odoo patterns for company-dependent fields.
