### PR TITLE
[19.0][REF] sale_order_type: replace analytic_account_id by analytic distribution

### DIFF
--- a/sale_order_type/__manifest__.py
+++ b/sale_order_type/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     "name": "Sale Order Type",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.3.0",
     "category": "Sales Management",
     "author": "Grupo Vermon,"
     "AvanzOSC,"

--- a/sale_order_type/migrations/19.0.1.3.0/post-migration.py
+++ b/sale_order_type/migrations/19.0.1.3.0/post-migration.py
@@ -1,0 +1,14 @@
+def migrate(cr, version):
+    cr.execute(
+        "SELECT EXISTS (SELECT 1 FROM information_schema.columns "
+        "WHERE table_name = 'sale_order_type' AND column_name = 'analytic_account_id')"
+    )
+    if not cr.fetchone()[0]:
+        return
+    cr.execute(
+        """
+        UPDATE sale_order_type
+        SET analytic_distribution = jsonb_build_object(analytic_account_id::text, 100.0)
+        WHERE analytic_account_id IS NOT NULL
+        """
+    )

--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -205,3 +205,10 @@ class SaleOrderLine(models.Model):
             if order_type.route_ids:
                 line.route_ids = order_type.route_ids
         return res
+
+    @api.depends("order_id.type_id")
+    def _compute_analytic_distribution(self):
+        res = super()._compute_analytic_distribution()
+        for line in self.filtered("order_id.type_id.analytic_distribution"):
+            line.analytic_distribution = line.order_id.type_id.analytic_distribution
+        return res

--- a/sale_order_type/models/sale_order_type.py
+++ b/sale_order_type/models/sale_order_type.py
@@ -7,6 +7,7 @@ class SaleOrderTypology(models.Model):
     _name = "sale.order.type"
     _description = "Type of sale order"
     _check_company_auto = True
+    _inherit = ["analytic.mixin"]
 
     name = fields.Char(required=True, translate=True)
     description = fields.Text(translate=True)
@@ -49,11 +50,6 @@ class SaleOrderTypology(models.Model):
         string="Routes",
         domain=[("sale_selectable", "=", True)],
         ondelete="restrict",
-        check_company=True,
-    )
-    analytic_account_id = fields.Many2one(
-        comodel_name="account.analytic.account",
-        string="Analytic account",
         check_company=True,
     )
     active = fields.Boolean(default=True)

--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -129,6 +129,25 @@ class TestSaleOrderType(BaseCommon):
                 "route_ids": [(6, 0, [cls.sale_route.id])],
             }
         )
+        cls.analytic_plan = cls.env["account.analytic.plan"].create(
+            {"name": "Test Plan"}
+        )
+        cls.analytic_account = cls.env["account.analytic.account"].create(
+            {"name": "Test Analytic", "plan_id": cls.analytic_plan.id}
+        )
+        cls.sale_type_analytic = cls.sale_type_model.create(
+            {
+                "name": "Test Sale Order Type With Analytics",
+                "sequence_id": cls.sequence.id,
+                "journal_id": cls.journal.id,
+                "warehouse_id": cls.warehouse.id,
+                "picking_policy": "one",
+                "payment_term_id": cls.immediate_payment.id,
+                "pricelist_id": cls.sale_pricelist.id,
+                "incoterm_id": cls.free_carrier.id,
+                "analytic_distribution": {str(cls.analytic_account.id): 100.0},
+            }
+        )
 
     def create_sale_order(self, partner=False):
         sale_form = Form(self.env["sale.order"])
@@ -285,3 +304,12 @@ class TestSaleOrderType(BaseCommon):
             order_line.product_uom_qty = 1.0
         sale_form.type_id = self.sale_type.browse()
         sale_form.save()
+
+    def test_analytic_distribution_propagation(self):
+        self.partner.sale_type = self.sale_type_analytic
+        order = self.create_sale_order()
+        self.assertEqual(order.type_id, self.sale_type_analytic)
+        self.assertEqual(
+            order.order_line[0].analytic_distribution,
+            {str(self.analytic_account.id): 100.0},
+        )

--- a/sale_order_type/views/sale_order_type_view.xml
+++ b/sale_order_type/views/sale_order_type_view.xml
@@ -34,7 +34,8 @@
                             <field name="route_ids" groups="stock.group_adv_location" />
                             <field name="sequence_id" />
                             <field
-                                name="analytic_account_id"
+                                name="analytic_distribution"
+                                widget="analytic_distribution"
                                 groups="analytic.group_analytic_accounting"
                             />
                         </group>


### PR DESCRIPTION
The analytic_account_id field was defined in the sale.order.type model but was not being used anywhere in the module's logic. This field has no practical functionality in the current implementation.

Additionally, this field was removed from the standard Odoo sale.order model in version 18.0