### PR TITLE
[18.0][IMP] sale_order_lot_selection: Define the appropriate lot data in stock moves

### DIFF
--- a/sale_order_lot_selection/models/__init__.py
+++ b/sale_order_lot_selection/models/__init__.py
@@ -1,1 +1,2 @@
 from . import sale_order_line
+from . import stock_move

--- a/sale_order_lot_selection/models/sale_order_line.py
+++ b/sale_order_lot_selection/models/sale_order_line.py
@@ -1,4 +1,5 @@
 from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 from odoo.tools import float_compare
 
 
@@ -21,6 +22,7 @@ class SaleOrderLine(models.Model):
         domain="domain_lot_id",
         copy=False,
         compute="_compute_lot_id",
+        inverse="_inverse_lot_id",
         store=True,
         readonly=False,
         precompute=True,
@@ -71,3 +73,19 @@ class SaleOrderLine(models.Model):
         for sol in self:
             if sol.product_id != sol.lot_id.product_id:
                 sol.lot_id = False
+
+    def _inverse_lot_id(self):
+        for item in self.filtered(
+            lambda x: x.product_id and x.product_tracking != "none" and x.move_ids
+        ):
+            moves = item.move_ids.filtered(lambda x: x.restrict_lot_id)
+            if any(move.state == "done" for move in moves):
+                raise ValidationError(
+                    self.env._(
+                        "You can't modify the Lot/Serial number "
+                        "because some stock move has already been done."
+                    )
+                )
+            pending_moves = moves.filtered(lambda x: x.state != "cancel")
+            if pending_moves:
+                pending_moves._set_restrict_lot_id_from_sol(item.lot_id)

--- a/sale_order_lot_selection/models/stock_move.py
+++ b/sale_order_lot_selection/models/stock_move.py
@@ -1,0 +1,17 @@
+# Copyright 2026 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _set_restrict_lot_id_from_sol(self, lot):
+        """This method can be extended and/or used by other modules to intercept
+        the change from the sales order line.
+        """
+        self.restrict_lot_id = lot
+        self._do_unreserve()
+        self.filtered(
+            lambda move: move.state in ("confirmed', 'partially_available")
+        )._action_assign()

--- a/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
+++ b/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
@@ -1,6 +1,9 @@
 # © 2015 Agile Business Group
+# Copyright 2026 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.exceptions import ValidationError
 from odoo.fields import Command
+from odoo.tools import mute_logger
 
 from odoo.addons.base.tests.common import BaseCommon
 
@@ -365,3 +368,39 @@ class TestSaleOrderLotSelection(BaseCommon):
         self.assertEqual(self.order4.state, "sale")
         # products are reserved
         self.assertEqual(self.order4.picking_ids[0].state, "assigned")
+
+    @mute_logger("odoo.models.unlink")
+    def test_03_sale_order_lot_selection_exception(self):
+        self._update_stock_quantity(self.prd_cable, self.lot_cable, 2)
+        lot_extra_1 = self.env["stock.lot"].create(
+            {
+                "name": "test lot extra 1",
+                "product_id": self.prd_cable.id,
+            }
+        )
+        self._update_stock_quantity(self.prd_cable, lot_extra_1, 1)
+        lot_extra_2 = self.env["stock.lot"].create(
+            {
+                "name": "test lot extra 2",
+                "product_id": self.prd_cable.id,
+            }
+        )
+        self.sale.action_confirm()
+        line_0 = self.sale.order_line[0]
+        line_1 = self.sale.order_line[1]
+        self.assertEqual(line_0.move_ids.state, "assigned")
+        self.assertEqual(line_0.move_ids.restrict_lot_id, self.lot_cable)
+        self.assertEqual(line_1.move_ids.restrict_lot_id, self.lot_cable)
+        line_0.lot_id = lot_extra_1
+        self.assertEqual(line_0.move_ids.state, "assigned")
+        self.assertEqual(line_0.move_ids.restrict_lot_id, lot_extra_1)
+        picking = self.sale.picking_ids
+        picking.move_ids_without_package.mapped("move_line_ids").write({"quantity": 1})
+        picking.button_validate()
+        self.assertEqual(picking.state, "done")
+        msg = (
+            "You can't modify the Lot/Serial number "
+            "because some stock move has already been done."
+        )
+        with self.assertRaisesRegex(ValidationError, msg):
+            line_0.lot_id = lot_extra_2

--- a/sale_order_lot_selection/views/sale_order_views.xml
+++ b/sale_order_lot_selection/views/sale_order_views.xml
@@ -11,6 +11,7 @@
                 <field
                     name="lot_id"
                     invisible="not product_id or product_tracking=='none'"
+                    readonly="qty_delivered>0"
                     context="{'default_product_id': product_id}"
                     groups="stock.group_production_lot"
                     optional="show"
@@ -23,6 +24,7 @@
                 <field
                     name="lot_id"
                     invisible="not product_id or product_tracking=='none'"
+                    readonly="qty_delivered>0"
                     context="{'default_product_id': product_id}"
                     groups="stock.group_production_lot"
                 />


### PR DESCRIPTION
Define the appropriate lot data in stock moves

Example use case:
- Product with Lot A and Lot B.
- SO with Lot A linked.
- The SO is confirmed and the OUT is generated with Lot A linked in the stock move
- The SO is modified to define Lot B.
- The OUT stock move is changed to Lot B.

Please @pedrobaeza and @christian-ramos-tecnativa can you review it?

@Tecnativa TT57112