### PR TITLE
[18.0][FIX] sale_order_product_recommendation: improve the tests to be compatible with other modules tests

### DIFF
--- a/sale_order_product_recommendation/tests/test_recommendation_common.py
+++ b/sale_order_product_recommendation/tests/test_recommendation_common.py
@@ -73,7 +73,6 @@ class RecommendationCase(BaseCommon):
         cls.order1 = cls.env["sale.order"].create(
             {
                 "partner_id": cls.partner.id,
-                "locked": "True",
                 "date_order": "2021-05-05",
                 "order_line": [
                     Command.create(
@@ -83,7 +82,6 @@ class RecommendationCase(BaseCommon):
                             "product_uom_qty": 25,
                             "qty_delivered_method": "manual",
                             "qty_delivered": 25,
-                            "price_unit": 24.50,
                         },
                     ),
                     Command.create(
@@ -93,7 +91,6 @@ class RecommendationCase(BaseCommon):
                             "product_uom_qty": 50,
                             "qty_delivered_method": "manual",
                             "qty_delivered": 50,
-                            "price_unit": 49.50,
                         },
                     ),
                     Command.create(
@@ -103,19 +100,21 @@ class RecommendationCase(BaseCommon):
                             "product_uom_qty": 100,
                             "qty_delivered_method": "manual",
                             "qty_delivered": 100,
-                            "price_unit": 74.50,
                         },
                     ),
                 ],
             }
         )
+        cls.order1.order_line[0].write({"price_unit": 24.50})
+        cls.order1.order_line[1].write({"price_unit": 49.50})
+        cls.order1.order_line[2].write({"price_unit": 74.50})
+        cls.order1.write({"locked": True})
         with freeze_time("2021-05-05"):
             cls.order1.action_confirm()
         cls.order2 = cls.env["sale.order"].create(
             {
                 "partner_id": cls.partner.id,
                 "partner_shipping_id": cls.partner_delivery.id,
-                "locked": "True",
                 "date_order": "2021-05-03",
                 "order_line": [
                     (
@@ -127,12 +126,13 @@ class RecommendationCase(BaseCommon):
                             "product_uom_qty": 50,
                             "qty_delivered_method": "manual",
                             "qty_delivered": 50,
-                            "price_unit": 89.00,
                         },
                     ),
                 ],
             }
         )
+        cls.order2.order_line.write({"price_unit": 89.00})
+        cls.order2.write({"locked": True})
         with freeze_time("2021-05-03"):
             cls.order2.action_confirm()
         # Create a new sale order for the same customer


### PR DESCRIPTION
Before this PR, if there is an implementation that updates the `price_unit` of a `sale.order.line` after the line is created, the test cases in `sale_order_product_recommendation` fail. The reason is that the recomputation of `price_unit` is not skipped for a manually set `price_unit `(it should be skipped), so the price is recalculated.

With the current creation flow, creating an order line with a manual `price_unit` triggers the method at
https://github.com/odoo/odoo/blob/ec212f38e50520edf612522717952855c8c09a80/addons/sale/models/sale_order_line.py#L1274-L1278

which makes `technical_price_unit` and `price_unit` identical. As a result, the condition that should ignore recomputation for manual prices (see
https://github.com/odoo/odoo/blob/ec212f38e50520edf612522717952855c8c09a80/addons/sale/models/sale_order_line.py#L563-L570
)
is not met, and the recomputation is incorrectly applied.

This PR fixes that behavior.

Reference for incompatible module - https://github.com/OCA/sale-workflow/pull/4002

@qrtl QT5924