### PR TITLE
[18.0][FIX] sale_order_type: preserve sale_type_id from sale order in invoices

### DIFF
--- a/sale_order_type/models/account_move.py
+++ b/sale_order_type/models/account_move.py
@@ -25,8 +25,11 @@ class AccountMove(models.Model):
             if record.move_type not in ["out_invoice", "out_refund"]:
                 record.sale_type_id = sale_type
                 continue
-            else:
+            # Preserve existing sale_type_id (e.g., from sale order or manual entry)
+            # instead of overwriting with partner's default
+            if record._origin.sale_type_id:
                 record.sale_type_id = record._origin.sale_type_id
+                continue
             if not record.partner_id:
                 record.sale_type_id = self.env["sale.order.type"].search(
                     [("company_id", "in", [self.env.company.id, False])], limit=1

--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -287,3 +287,52 @@ class TestSaleOrderType(BaseCommon):
             order_line.product_uom_qty = 1.0
         sale_form.type_id = self.sale_type.browse()
         sale_form.save()
+
+    def test_credit_note_preserves_sale_type_from_sale_order(self):
+        """Test credit notes preserve sale order type.
+
+        When creating a credit note (refund) from an invoice that originated
+        from a sale order, the sale_type_id from the sale order should be
+        maintained and not overridden by the partner's default sale type.
+        """
+        # Create a test partner with a specific default sale type
+        test_partner = self.env["res.partner"].create(
+            {
+                "name": "Test Partner",
+                "sale_type": self.sale_type_quot.id,
+            }
+        )
+        # Create and confirm a sale order with a DIFFERENT sale type
+        # than partner's default
+        sale_form = Form(self.env["sale.order"])
+        sale_form.partner_id = test_partner
+        sale_form.type_id = self.sale_type
+        with sale_form.order_line.new() as order_line:
+            order_line.product_id = self.product
+        sale_order = sale_form.save()
+        sale_order.action_confirm()
+        invoice = sale_order._create_invoices()
+        invoice.action_post()
+        # Create a credit note (refund) from the invoice
+        refund_wizard = (
+            self.env["account.move.reversal"]
+            .with_context(active_model="account.move", active_ids=invoice.ids)
+            .create(
+                {
+                    "reason": "Test refund",
+                    "journal_id": invoice.journal_id.id,
+                }
+            )
+        )
+        refund_action = refund_wizard.refund_moves()
+        credit_note = self.env["account.move"].browse(refund_action["res_id"])
+        # CRITICAL ASSERTION: Credit note should preserve the sale order's type,
+        # NOT default to the partner's sale type
+        self.assertEqual(
+            credit_note._origin.sale_type_id,
+            sale_order.type_id,
+            "Credit note should preserve sale type from sale order "
+            f"(expected: {sale_order.type_id.name}), "
+            "not use partner's default sale type "
+            f"(partner has: {sale_order.partner_id.sale_type.name})",
+        )


### PR DESCRIPTION
When creating credit note from a sale orders, the sale_type_id from the sale order was being overridden by the _compute_sale_type_id method in account.move.

This commit modifies the compute method to:
- Preserve existing sale_type_id when it comes from a sale order

This ensures that the sale type configured in the sale order is properly transferred and maintained in the generated invoices.

 **Description of the Issue/Feature this PR Addresses**
The issue is that when a Credit Note is created from a confirmed Sales Order, the resulting Credit Note defaults to an incorrect Sale Type, instead of inheriting the specific Sale Order Type used on the original Sales Order.


**Steps to Reproduce the Error**
1) Ensure there are at least two different Sale Order Types configured (e.g., "Normal Order General" and "Normal Order Partner").

2) Configure a customer (e.g., "Azure Interior") to use the secondary/non-default Sale Order Type ("Normal Order Partner").

3) Create and confirm a Sales Order (S00054) for that customer, verifying it correctly uses the "Normal Order Partner" type.

4) Process the delivery and create the final Customer Invoice (INV/2025/00005) from the Sales Order.

Observation step: Note the Sale Type on the Invoice is consistent with the sale's order type. In the video, it correctly shows "Normal Order General."

5) Return all the products.

6) On the confirmed sale, click "Create invoice ".

7)Observe that the Sale Type field on the Credit Note is defaulted to "Normal Order Partner", instead of inheriting the desired "Normal Order General" type from the sale order.

**Video**

https://drive.google.com/file/d/1QUMPRC0xY3eemc7B1XFJ9Rw3we19xV8O/view