### PR TITLE
[16.0][FIX] sale_order_lot_selection: Added a check, if the lot id has actually changed, before propagating it to stock moves. This prevents unwanted propagation of lot_id from sale order line to stock move.

### DIFF
--- a/sale_order_lot_selection/models/sale_order_line.py
+++ b/sale_order_lot_selection/models/sale_order_line.py
@@ -39,12 +39,41 @@ class SaleOrderLine(models.Model):
             )
 
     def write(self, vals):
+        """
+        Override of write to manage propagation of lot changes to stock moves.
+
+        Behavior
+        - If vals does not include lot_id, this method behaves exactly as the
+          standard write and returns.
+        - If lot_id is present, we compare the original lot per line with the
+          new lot after super().write(vals):
+          - If the lot did not actually change, the call is a no-op regarding
+            stock moves (nothing is propagated and no error is raised).
+          - If the order is in draft/quotation (not in sale/done), we propagate
+            the change to related stock moves by writing move.restrict_lot_id
+            to the new value (which can be a lot id or False).
+          - If the order is in sale/done:
+            - When the company setting allow_to_change_lot_on_confirmed_so is
+              True, we propagate the change to the related stock moves.
+            - When the company setting is False, we prevent changing the lot
+              and raise a UserError.
+        """
+        # Capture original lot ids to detect actual changes per record
+        original_lots = {rec.id: rec.lot_id.id for rec in self}
         res = super().write(vals)
+        if "lot_id" not in vals:
+            return res
         allow_to_change_lot = self.env.company.allow_to_change_lot_on_confirmed_so
-        if "lot_id" in vals and (
-            allow_to_change_lot or self.order_id.state not in ["sale", "done"]
-        ):
-            self.move_ids.write({"restrict_lot_id": vals.get("lot_id")})
-        elif "lot_id" in vals and not allow_to_change_lot:
-            raise UserError(_("You can't change the lot on confirmed sale order."))
+        for line in self:
+            old_lot = original_lots.get(line.id)
+            new_lot = line.lot_id.id
+            # Only act if there is an actual change
+            if new_lot == old_lot:
+                continue
+            if allow_to_change_lot or line.order_id.state not in ["sale", "done"]:
+                # Propagate the new lot restriction to related stock moves
+                line.move_ids.write({"restrict_lot_id": new_lot})
+            else:
+                # Disallow changing the lot on confirmed SO if company setting forbids it
+                raise UserError(_("You can't change the lot on confirmed sale order."))
         return res

--- a/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
+++ b/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
@@ -358,3 +358,65 @@ class TestSaleOrderLotSelection(test_common.SingleTransactionCase):
         self.assertEqual(
             m.exception.args[0], "You can't change the lot on confirmed sale order."
         )
+
+    def test_write_same_lot_on_confirmed_so_does_not_raise(self):
+        """Rewriting the very same lot_id on a confirmed order line must not
+        raise, since nothing actually changes. Only genuine changes should
+        be blocked when allow_to_change_lot_on_confirmed_so is False.
+        """
+        company = self.env.ref("base.main_company")
+        company.allow_to_change_lot_on_confirmed_so = False
+        self.sale.action_confirm()
+        line = self.sale.order_line[0]
+        current_lot = line.lot_id
+        self.assertTrue(current_lot)
+        # No exception expected: the lot value does not actually change,
+        # even though "lot_id" is present in the write values.
+        line.write({"lot_id": current_lot.id})
+        self.assertEqual(line.lot_id, current_lot)
+
+    def test_write_lot_id_false_no_change_does_not_propagate_to_done_move(self):
+        """Regression test for the fix that avoids propagating lot_id to
+        stock moves when it did not actually change.
+
+        Scenario: a sale order line without an initial lot_id, whose related
+        move ends up done and later carries a restrict_lot_id set
+        independently from the sale order line (e.g. by another process).
+        Saving the line again without changing the lot (still False, but
+        present in the write values) must not attempt to propagate
+        lot_id=False to the done move, which previously raised a
+        ValidationError from stock_restrict_lot.
+        """
+        self._inventory_products(self.prd_cable, self.lot_cable, 1)
+        order = self.env["sale.order"].create(
+            {"partner_id": self.env.ref("base.res_partner_1").id}
+        )
+        line = self.env["sale.order.line"].create(
+            {
+                "name": "sol_no_lot",
+                "order_id": order.id,
+                "product_id": self.prd_cable.id,
+                "product_uom_qty": 1,
+            }
+        )
+        self.assertFalse(line.lot_id)
+        order.action_confirm()
+        picking = order.picking_ids
+        picking.action_assign()
+        move = picking.move_ids
+        move.move_line_ids.write({"lot_id": self.lot_cable.id, "qty_done": 1})
+        picking.button_validate()
+        self.assertEqual(move.state, "done")
+        self.assertEqual(move.move_line_ids.lot_id, self.lot_cable)
+
+        # The move ends up with a restrict_lot_id, set independently from
+        # the sale order line lot_id (still False).
+        move.write({"restrict_lot_id": self.lot_cable.id})
+        self.assertEqual(move.restrict_lot_id, self.lot_cable)
+
+        # Saving the line again without actually changing lot_id (still
+        # False, but present in vals) must be a no-op regarding the move.
+        line.write({"lot_id": False})
+
+        self.assertFalse(line.lot_id)
+        self.assertEqual(move.restrict_lot_id, self.lot_cable)


### PR DESCRIPTION
This pull request is a follow up to https://github.com/OCA/sale-workflow/pull/3934. 

I have discovered some issues with this module after this pull request https://github.com/OCA/sale-workflow/pull/3057 was integrated.

My scenario is:

Sale order line doesn't have a lot id
Related stock moves get a restrict_lot_id independently from the sale order line
Sale order is changed and saved, lot_id was not changed but is in the vals for write function (it's still false)
Since the sale order line propagates the lot_id, no matter if it is filled or not, we try to set restrict_lot_id = False on stock moves which have a restrict_lot_id and are may already done. This is the moment, where the validation in stock_restrict_lot kicks in.

https://github.com/OCA/stock-logistics-workflow/blob/16.0/stock_restrict_lot/models/stock_move.py#L147

I am not exactly sure if my fix is what we want and if it is complete.

I think in general we should question:

Should we propagate empty lot_id to move ids
Should we propagate lot_id to move ids, regardless of the move ids state

We run the proposed fix productive in our products without issues.

FYI @rousseldenis @pedrobaeza