### PR TITLE
[IMP] sale_order_line_product_attribute_values: Change filter string

### DIFF
--- a/sale_order_line_product_attribute_values/views/sale_order_line_view.xml
+++ b/sale_order_line_product_attribute_values/views/sale_order_line_view.xml
@@ -58,7 +58,10 @@
         <field name="inherit_id" ref="sale.view_sales_order_line_filter" />
         <field name="arch" type="xml">
             <xpath expr="//search/field[@name='product_id']" position="after">
-                <field name="all_product_attribute_value_ids" />
+                <field
+                    string="Attribute Values"
+                    name="all_product_attribute_value_ids"
+                />
             </xpath>
             <xpath expr="//search/group" position="inside">
                 <filter


### PR DESCRIPTION
With this change, the filter is less confusing for non-technical users, and maintaining consistency with the group_by.

<img width="614" height="363" alt="image" src="https://github.com/user-attachments/assets/c2551e4b-3b2c-4a89-8f58-750d12159719" />


MT-12788 @moduon @Shide @Gelojr 