### PR TITLE
[18.0][IMP] sale_stock_delivery_address: remove address extension from procurement group name

### DIFF
--- a/sale_stock_delivery_address/models/sale_order_line.py
+++ b/sale_stock_delivery_address/models/sale_order_line.py
@@ -26,12 +26,3 @@ class SaleOrderLine(models.Model):
             if self.dest_address_id:
                 return (priority, self.dest_address_id)
         return key
-
-    def _prepare_procurement_group_vals(self):
-        vals = super()._prepare_procurement_group_vals()
-        if self._get_procurement_group_key()[0] == 16 and self.dest_address_id:
-            name_extension = (
-                self.dest_address_id.name or self.dest_address_id.contact_address
-            )
-            vals["name"] = "/".join([vals["name"], name_extension])
-        return vals


### PR DESCRIPTION
As discussed here: https://github.com/OCA/sale-workflow/pull/3737#discussion_r2140334226

We don't want to differentiate the name of the procurement groups
<img width="581" height="105" alt="image" src="https://github.com/user-attachments/assets/07e4a3ff-b1d8-4110-a84a-945baf61373f" />
We want:
<img width="597" height="108" alt="image" src="https://github.com/user-attachments/assets/7c124f49-0fb7-49d3-9905-aef02986131d" />
