### PR TITLE
[FIX] sale_company_currency: Fix currency conversion logic (division instead of multiplication)

### DIFF
--- a/sale_company_currency/models/sale_order.py
+++ b/sale_company_currency/models/sale_order.py
@@ -29,5 +29,5 @@ class SaleOrder(models.Model):
             if order.currency_id.id == order.company_id.currency_id.id:
                 to_amount = order.amount_total
             else:
-                to_amount = order.amount_total * order.currency_rate
+                to_amount = order.amount_total / order.currency_rate
             order.amount_total_curr = to_amount

--- a/sale_company_currency/tests/test_sale_company_currency.py
+++ b/sale_company_currency/tests/test_sale_company_currency.py
@@ -168,8 +168,17 @@ class TestSaleOrder(TransactionCase):
         )
 
         # Set different currency rates for both orders
-        # First, change the currency of the original order to force conversion
-        self.sale_order.currency_id = self.currency_eur
+        # First, change the currency of both orders to force conversion
+        # Check what currency the company uses
+        if self.company.currency_id == self.currency_usd:
+            # Company uses USD, so use EUR for both orders
+            self.sale_order.currency_id = self.currency_eur
+            sale_order_2.currency_id = self.currency_eur
+        else:
+            # Company uses something else, use USD for both orders
+            self.sale_order.currency_id = self.currency_usd
+            sale_order_2.currency_id = self.currency_usd
+
         self.sale_order.currency_rate = 0.85
         sale_order_2.currency_rate = 1.20
 

--- a/sale_company_currency/tests/test_sale_company_currency.py
+++ b/sale_company_currency/tests/test_sale_company_currency.py
@@ -168,6 +168,8 @@ class TestSaleOrder(TransactionCase):
         )
 
         # Set different currency rates for both orders
+        # First, change the currency of the original order to force conversion
+        self.sale_order.currency_id = self.currency_eur
         self.sale_order.currency_rate = 0.85
         sale_order_2.currency_rate = 1.20
 

--- a/sale_company_currency/tests/test_sale_company_currency.py
+++ b/sale_company_currency/tests/test_sale_company_currency.py
@@ -101,3 +101,110 @@ class TestSaleOrder(TransactionCase):
             places=2,
             msg="Multiplication should give different result than correct division.",
         )
+
+    def test_04_amount_total_curr_rate_one(self):
+        """Test conversion when currency_rate = 1 (should behave like same currency)."""
+        self.sale_order.currency_id = self.currency_eur
+        self.sale_order.currency_rate = 1.0
+
+        self.sale_order._compute_amount_company()
+
+        self.assertEqual(
+            self.sale_order.amount_total_curr,
+            self.sale_order.amount_total,
+            "When currency_rate = 1, amount_total_curr should equal amount_total",
+        )
+
+    def test_05_amount_total_curr_extreme_rates(self):
+        """Test conversion with very small and very large currency rates."""
+        self.sale_order.currency_id = self.currency_eur
+
+        # Test with very small rate (strong target currency)
+        self.sale_order.currency_rate = 0.01  # 1 EUR = 0.01 USD
+        self.sale_order._compute_amount_company()
+        expected_small = self.sale_order.amount_total / 0.01
+        self.assertAlmostEqual(
+            self.sale_order.amount_total_curr,
+            expected_small,
+            places=2,
+            msg="Conversion with very small rate should work correctly",
+        )
+
+        # Test with very large rate (weak target currency)
+        self.sale_order.currency_rate = 1000.0  # 1 EUR = 1000 USD
+        self.sale_order._compute_amount_company()
+        expected_large = self.sale_order.amount_total / 1000.0
+        self.assertAlmostEqual(
+            self.sale_order.amount_total_curr,
+            expected_large,
+            places=2,
+            msg="Conversion with very large rate should work correctly",
+        )
+
+    def test_06_amount_total_curr_multiple_orders(self):
+        """Test computation with multiple sale orders in one batch."""
+        # Create a second sale order
+        sale_order_2 = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+                "currency_id": self.currency_eur.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product1.id,
+                            "product_uom_qty": 3,
+                            "price_unit": 75.0,
+                        },
+                    )
+                ],
+            }
+        )
+
+        # Set different currency rates for both orders
+        self.sale_order.currency_rate = 0.85
+        sale_order_2.currency_rate = 1.20
+
+        # Compute for both orders in batch
+        orders = self.sale_order + sale_order_2
+        orders._compute_amount_company()
+
+        # Verify both orders computed correctly
+        expected_1 = self.sale_order.amount_total / 0.85
+        expected_2 = sale_order_2.amount_total / 1.20
+
+        self.assertAlmostEqual(
+            self.sale_order.amount_total_curr,
+            expected_1,
+            places=2,
+            msg="First order should compute correctly in batch",
+        )
+        self.assertAlmostEqual(
+            sale_order_2.amount_total_curr,
+            expected_2,
+            places=2,
+            msg="Second order should compute correctly in batch",
+        )
+
+    def test_07_amount_total_curr_edge_cases(self):
+        """Test edge cases like zero amount_total and extreme values."""
+        self.sale_order.currency_id = self.currency_eur
+
+        # Test with zero amount_total
+        self.sale_order.order_line[0].price_unit = 0.0
+        self.sale_order.order_line[1].price_unit = 0.0
+        self.sale_order.currency_rate = 0.85
+
+        self.sale_order._compute_amount_company()
+
+        self.assertEqual(
+            self.sale_order.amount_total_curr,
+            0.0,
+            "Zero amount_total should result in zero amount_total_curr",
+        )
+
+        # Reset to normal values
+        self.sale_order.order_line[0].price_unit = 50.0
+        self.sale_order.order_line[1].price_unit = 100.0

--- a/sale_company_currency/tests/test_sale_company_currency.py
+++ b/sale_company_currency/tests/test_sale_company_currency.py
@@ -62,13 +62,42 @@ class TestSaleOrder(TransactionCase):
         self.sale_order._compute_amount_company()
         amount_total_curr_rounded = round(self.sale_order.amount_total_curr, 2)
         amount_total_converted_rounded = round(
-            self.sale_order.amount_total * self.sale_order.currency_rate, 2
+            self.sale_order.amount_total / self.sale_order.currency_rate, 2
         )
         self.assertEqual(
             amount_total_curr_rounded,
             amount_total_converted_rounded,
             msg=(
                 "Amount in company currency should be converted "
-                "using the currency rate."
+                "using the currency rate (division, not multiplication)."
             ),
+        )
+
+    def test_03_amount_total_curr_conversion_logic(self):
+        """Test specific conversion logic to ensure division is used, not multiplication."""
+        # Set up a specific scenario to test the conversion logic
+        self.sale_order.currency_id = self.currency_eur
+        # Set a specific currency rate for testing
+        self.sale_order.currency_rate = 0.85  # 1 EUR = 0.85 USD
+        
+        # Calculate expected result: amount_total / currency_rate
+        expected_amount = self.sale_order.amount_total / 0.85
+        
+        self.sale_order._compute_amount_company()
+        
+        # Verify the conversion uses division, not multiplication
+        self.assertAlmostEqual(
+            self.sale_order.amount_total_curr,
+            expected_amount,
+            places=2,
+            msg="Conversion should use division (amount_total / rate), not multiplication."
+        )
+        
+        # Verify that multiplication would give a different (wrong) result
+        wrong_amount = self.sale_order.amount_total * 0.85
+        self.assertNotAlmostEqual(
+            self.sale_order.amount_total_curr,
+            wrong_amount,
+            places=2,
+            msg="Multiplication should give a different result than the correct division."
         )

--- a/sale_company_currency/tests/test_sale_company_currency.py
+++ b/sale_company_currency/tests/test_sale_company_currency.py
@@ -34,12 +34,16 @@ class TestSaleOrder(TransactionCase):
                             "product_uom_qty": 2,
                             "price_unit": 50.0,
                         },
+                    ),
+                    (
+                        0,
+                        0,
                         {
                             "product_id": cls.product2.id,
                             "product_uom_qty": 1,
                             "price_unit": 100.0,
                         },
-                    )
+                    ),
                 ],
             }
         )
@@ -172,10 +176,9 @@ class TestSaleOrder(TransactionCase):
         orders._compute_amount_company()
 
         # Verify both orders computed correctly
-        # Order 1: 2×50 + 1×100 = 200.0 total, rate 0.85 → 200.0 / 0.85 = 235.29
-        expected_1 = 200.0 / 0.85
-        # Order 2: 3×75 = 225.0 total, rate 1.20 → 225.0 / 1.20 = 187.50
-        expected_2 = 225.0 / 1.20
+        # Use the actual amount_total values from the orders
+        expected_1 = self.sale_order.amount_total / 0.85
+        expected_2 = sale_order_2.amount_total / 1.20
 
         self.assertAlmostEqual(
             self.sale_order.amount_total_curr,

--- a/sale_company_currency/tests/test_sale_company_currency.py
+++ b/sale_company_currency/tests/test_sale_company_currency.py
@@ -74,30 +74,30 @@ class TestSaleOrder(TransactionCase):
         )
 
     def test_03_amount_total_curr_conversion_logic(self):
-        """Test specific conversion logic to ensure division is used, not multiplication."""
+        """Test specific conversion logic to ensure division is used."""
         # Set up a specific scenario to test the conversion logic
         self.sale_order.currency_id = self.currency_eur
         # Set a specific currency rate for testing
         self.sale_order.currency_rate = 0.85  # 1 EUR = 0.85 USD
-        
+
         # Calculate expected result: amount_total / currency_rate
         expected_amount = self.sale_order.amount_total / 0.85
-        
+
         self.sale_order._compute_amount_company()
-        
+
         # Verify the conversion uses division, not multiplication
         self.assertAlmostEqual(
             self.sale_order.amount_total_curr,
             expected_amount,
             places=2,
-            msg="Conversion should use division (amount_total / rate), not multiplication."
+            msg="Conversion should use division, not multiplication.",
         )
-        
+
         # Verify that multiplication would give a different (wrong) result
         wrong_amount = self.sale_order.amount_total * 0.85
         self.assertNotAlmostEqual(
             self.sale_order.amount_total_curr,
             wrong_amount,
             places=2,
-            msg="Multiplication should give a different result than the correct division."
+            msg="Multiplication should give different result than correct division.",
         )

--- a/sale_company_currency/tests/test_sale_company_currency.py
+++ b/sale_company_currency/tests/test_sale_company_currency.py
@@ -172,8 +172,10 @@ class TestSaleOrder(TransactionCase):
         orders._compute_amount_company()
 
         # Verify both orders computed correctly
-        expected_1 = self.sale_order.amount_total / 0.85
-        expected_2 = sale_order_2.amount_total / 1.20
+        # Order 1: 2×50 + 1×100 = 200.0 total, rate 0.85 → 200.0 / 0.85 = 235.29
+        expected_1 = 200.0 / 0.85
+        # Order 2: 3×75 = 225.0 total, rate 1.20 → 225.0 / 1.20 = 187.50
+        expected_2 = 225.0 / 1.20
 
         self.assertAlmostEqual(
             self.sale_order.amount_total_curr,
@@ -192,9 +194,9 @@ class TestSaleOrder(TransactionCase):
         """Test edge cases like zero amount_total and extreme values."""
         self.sale_order.currency_id = self.currency_eur
 
-        # Test with zero amount_total
-        self.sale_order.order_line[0].price_unit = 0.0
-        self.sale_order.order_line[1].price_unit = 0.0
+        # Test with zero amount_total - set all line prices to zero
+        for line in self.sale_order.order_line:
+            line.price_unit = 0.0
         self.sale_order.currency_rate = 0.85
 
         self.sale_order._compute_amount_company()
@@ -207,4 +209,5 @@ class TestSaleOrder(TransactionCase):
 
         # Reset to normal values
         self.sale_order.order_line[0].price_unit = 50.0
-        self.sale_order.order_line[1].price_unit = 100.0
+        if len(self.sale_order.order_line) > 1:
+            self.sale_order.order_line[1].price_unit = 100.0


### PR DESCRIPTION
## Summary
- Fix critical financial bug #4026 where foreign currency amounts were incorrectly multiplied instead of divided
- Update test to validate correct division logic  
- Add specific test case to ensure multiplication vs division logic is correct

## Bug Description
The bug caused incorrect currency conversion in the `sale_company_currency` module. When converting from foreign currency to company currency, the calculation was using multiplication instead of division, leading to values that were orders of magnitude incorrect.

**Example of the bug:**
- Order amount: 100,000 Bs (foreign currency)
- Exchange rate: 250 Bs / 1 USD
- **Expected result**: 100,000 ÷ 250 = 400 USD
- **Bug result**: 100,000 × 250 = 25,000,000 USD

## Changes Made
1. **Fixed conversion logic** in `sale_order.py:32`: Changed `*` to `/`
2. **Updated existing test** to use correct division logic
3. **Added new test** to specifically validate division vs multiplication logic

## Testing
- All syntax checks pass
- Code follows OCA conventions
- Tests validate the correct mathematical operation

Closes #4026