### PR TITLE
[18.0][IMP] sale_require_po_doc: use xpath to point the exact field position

### DIFF
--- a/sale_require_po_doc/views/sale_order_view.xml
+++ b/sale_require_po_doc/views/sale_order_view.xml
@@ -4,7 +4,10 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
-            <field name="client_order_ref" position="after">
+            <xpath
+                expr="//group[@name='sales_person']/field[@name='client_order_ref']"
+                position="after"
+            >
                 <field name="customer_need_po" readonly="1" />
                 <field name="sale_doc" readonly="1" />
                 <field
@@ -15,7 +18,7 @@
                     invisible="not sale_doc and not sale_document_option"
                     name="sale_document_note"
                 />
-            </field>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
This PR makes an improvement to avoid the view issue if there is same field name (`client_order_ref`) in sale order line.

@qrtl QT6179