### PR TITLE
[18.0][FIX] sale_order_lot_selection: Move the lot_id field in the form view

### DIFF
--- a/sale_order_lot_selection/views/sale_order_views.xml
+++ b/sale_order_lot_selection/views/sale_order_views.xml
@@ -17,7 +17,7 @@
                 />
             </xpath>
             <xpath
-                expr="//field[@name='order_line']/form/group/group/div/field[@name='product_id']"
+                expr="//field[@name='order_line']/form/group/group/field[@name='product_uom_readonly']"
                 position="after"
             >
                 <field


### PR DESCRIPTION
Move the `lot_id` field in the form view

**Before**
<img width="802" height="228" alt="antes" src="https://github.com/user-attachments/assets/c74ae1f8-e175-4332-bf07-b2ff949dda8b" />

**After**
<img width="808" height="242" alt="despues" src="https://github.com/user-attachments/assets/5ec1332d-0948-4db3-8691-4cbf50e7353a" />

Please @pilarvargas-tecnativa and @pedrobaeza can you review it?

@Tecnativa TT57124