### PR TITLE
[18.0][IMP] sale_order_lot_selection: Add lot_id field to kanban view

### DIFF
--- a/sale_order_lot_selection/views/sale_order_views.xml
+++ b/sale_order_lot_selection/views/sale_order_views.xml
@@ -27,6 +27,23 @@
                     groups="stock.group_production_lot"
                 />
             </xpath>
+            <xpath
+                expr="//field[@name='order_line']/kanban//div[hasclass('row')]"
+                position="after"
+            >
+                <div
+                    class="text-muted"
+                    t-if="record.lot_id.value"
+                    groups="stock.group_production_lot"
+                >
+                    Lot:
+                    <field
+                    name="lot_id"
+                    invisible="not product_id or product_tracking=='none'"
+                    context="{'default_product_id': product_id}"
+                />
+                </div>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Add `lot_id` field to kanban view

**Before**
<img width="919" height="424" alt="antes" src="https://github.com/user-attachments/assets/8c3e633a-e388-403e-96d2-7aa5da2beb9e" />

**After**
<img width="917" height="440" alt="despues" src="https://github.com/user-attachments/assets/efa799f8-bd9a-4c5e-a345-c21b836104d2" />

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT57124