### PR TITLE
[18.0][FIX] sale_elaboration: route inheritance

### DIFF
--- a/sale_elaboration/models/sale_order.py
+++ b/sale_elaboration/models/sale_order.py
@@ -70,8 +70,17 @@ class SaleOrderLine(models.Model):
 
     @api.depends("elaboration_ids")
     def _compute_route_id(self):
-        for line in self:
+        # Reset routes: elaboration might be unset.
+        self.filtered(
+            lambda x: x.route_id not in x.elaboration_ids.route_ids
+        ).route_id = False
+        # Other modules might use this compute. Let's respect inheritance
+        res = None
+        if hasattr(super(), "_compute_route_id"):
+            res = super()._compute_route_id()
+        for line in self.filtered("elaboration_ids"):
             line.route_id = line.get_elaboration_stock_route()
+        return res
 
     @api.depends("elaboration_ids", "order_id.pricelist_id")
     def _compute_elaboration_price_unit(self):


### PR DESCRIPTION
- Get along with other modules adding automatic route mechanisms, like sale_order_type or stock_customer_deposit
- Now when we unset the elaborations, the elaboration routes are removed.

Pending:

- [ ] Add test cases for routes

cc @moduon MT-11838