### PR TITLE
[FIX] sale_order_type: Smart Button click on existing SOs

### DIFF
--- a/sale_order_type/views/sale_order_view.xml
+++ b/sale_order_type/views/sale_order_view.xml
@@ -7,7 +7,7 @@
             <field name="currency_id" position="after">
                 <field
                     name="type_id"
-                    required="1"
+                    required="state in ['draft', 'sent']"
                     readonly="state in ['sale', 'cancel'] or locked"
                 />
             </field>


### PR DESCRIPTION
After installing sale_order_type, on existing confirmed orders
it is not possible to use the smart buttons to navigate to the
related deliveries and invoices.
