### PR TITLE
[FIX] sale_invoice_blocking: return text in _nothing_to_invoice_error_message

### DIFF
--- a/sale_invoice_blocking/models/sale_order.py
+++ b/sale_invoice_blocking/models/sale_order.py
@@ -1,7 +1,6 @@
 # Copyright 2021 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError
 
 
 class SaleOrder(models.Model):
@@ -33,4 +32,4 @@ class SaleOrder(models.Model):
         error = super()._nothing_to_invoice_error_message()
         error += _("\n- You may have an invoice blocking reason on the sale order")
 
-        return UserError(error)
+        return error


### PR DESCRIPTION
Return error message directly instead of a UserError to prevent an error when this module is used together with the enterprise subscription module which tries to append its own message:

result = _call_kw_multi(method, model, args, kwargs)
File "/opt/odoo/src/odoo/odoo/api.py", line 469, in _call_kw_multi
result = method(recs, *args, **kwargs)
File "/opt/odoo/src/enterprise/sale_subscription/models/sale_order.py", line 731, in action_invoice_subscription
raise UserError(self._nothing_to_invoice_error_message())
File "/opt/odoo/src/enterprise/sale_subscription/models/sale_order.py", line 1534, in _nothing_to_invoice_error_message
error_message += _(
TypeError: unsupported operand type(s) for +=: 'UserError' and 'str'