### PR TITLE
[18.0][IMP] sale_order_split_strategy: Allow not posting messages

### DIFF
--- a/sale_order_split_strategy/__manifest__.py
+++ b/sale_order_split_strategy/__manifest__.py
@@ -16,6 +16,7 @@
     "data": [
         "security/ir.model.access.csv",
         "views/mail_message_template.xml",
+        "views/res_config.xml",
         "views/sale_order_split_strategy.xml",
         "views/sale_order.xml",
     ],

--- a/sale_order_split_strategy/models/__init__.py
+++ b/sale_order_split_strategy/models/__init__.py
@@ -1,2 +1,4 @@
+from . import res_company
+from . import res_config
 from . import sale_order_split_strategy
 from . import sale_order

--- a/sale_order_split_strategy/models/res_company.py
+++ b/sale_order_split_strategy/models/res_company.py
@@ -1,0 +1,17 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    sale_order_split_strategy_errors = fields.Selection(
+        [
+            ("raise_errors", "Raise errors"),
+            ("post_message", "Post message"),
+            ("do_nothing", "Do nothing"),
+        ],
+        required=True,
+        default="raise_errors",
+    )

--- a/sale_order_split_strategy/models/res_config.py
+++ b/sale_order_split_strategy/models/res_config.py
@@ -1,0 +1,12 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    sale_order_split_strategy_errors = fields.Selection(
+        related="company_id.sale_order_split_strategy_errors",
+        readonly=False,
+    )

--- a/sale_order_split_strategy/models/sale_order.py
+++ b/sale_order_split_strategy/models/sale_order.py
@@ -1,9 +1,12 @@
 # Copyright 2024 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+import logging
 from collections import defaultdict
 
 from odoo import fields, models
 from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
 
 
 class SaleOrder(models.Model):
@@ -15,6 +18,16 @@ class SaleOrder(models.Model):
     )
 
     def action_split(self, silent_errors=False):
+        # TODO: Remove silent_errors arg on next major migration and rely on company
+        #  field
+        if silent_errors:
+            _logger.warning(
+                "sale.order.action_split argument silent_errors is deprecated."
+                " Please set error handling in split strategy at company level."
+            )
+        silent_errors = (
+            self.company_id.sale_order_split_strategy_errors != "raise_errors"
+        )
         orders_without_split = self.filtered(lambda o: not o.split_strategy_id)
         if not silent_errors and orders_without_split:
             raise UserError(
@@ -52,18 +65,21 @@ class SaleOrder(models.Model):
         )
         if not silent_errors:
             raise UserError(msg)
-        else:
+        elif self.company_id.sale_order_split_strategy_errors == "post_message":
             self.message_post(body=msg)
 
     def _handle_only_lines_to_split(self):
         self.ensure_one()
-        self.message_post(
-            body=self.env._(
-                "This sale order was not split using strategy %(strategy)s"
-                " because there would not be any lines left on this order.",
-                strategy=self.split_strategy_id.name,
-            )
+        msg = self.env._(
+            "This sale order was not split using strategy %(strategy)s"
+            " because there would not be any lines left on this order.",
+            strategy=self.split_strategy_id.name,
         )
+        strategy_errors = self.company_id.sale_order_split_strategy_errors
+        if strategy_errors == "raise_errors":
+            raise UserError(msg)
+        elif strategy_errors == "post_message":
+            self.message_post(body=msg)
 
     def _has_only_lines_to_split(self, lines_to_split):
         self.ensure_one()

--- a/sale_order_split_strategy/tests/test_split_strategy.py
+++ b/sale_order_split_strategy/tests/test_split_strategy.py
@@ -1,6 +1,8 @@
 # Copyright 2024 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.exceptions import UserError
 from odoo.tests import Form
+from odoo.tests.common import RecordCapturer
 
 from odoo.addons.base.tests.common import BaseCommon
 
@@ -166,3 +168,58 @@ class TestSplitStrategy(BaseCommon):
         self.assertIn("Middle lines", order.order_line.mapped("name"))
         self.assertIn("Last line", order.order_line.mapped("name"))
         self.assertNotIn("Empty section", order.order_line.mapped("name"))
+
+    def test_error_no_strategy_on_split(self):
+        order = self._create_order()
+        with self.assertRaisesRegex(UserError, "without any split strategy defined"):
+            order.action_split()
+
+    def test_error_no_lines_to_split(self):
+        order = self._create_order()
+        order.split_strategy_id = self.product_type_not_service_strategy
+        order.company_id.sale_order_split_strategy_errors = "do_nothing"
+        order.order_line.filtered(
+            lambda li: li.product_id in (self.product_consu_1, self.product_consu_2)
+        ).unlink()
+        with RecordCapturer(self.env["mail.message"].sudo(), []) as message_capture:
+            new_orders = order.action_split()
+            self.assertFalse(message_capture.records)
+            self.assertFalse(new_orders)
+        order.company_id.sale_order_split_strategy_errors = "post_message"
+        with RecordCapturer(self.env["mail.message"].sudo(), []) as message_capture:
+            new_orders = order.action_split()
+            self.assertTrue(message_capture.records)
+            self.assertFalse(new_orders)
+        order.company_id.sale_order_split_strategy_errors = "raise_errors"
+        with (
+            RecordCapturer(self.env["mail.message"].sudo(), []) as message_capture,
+            self.assertRaisesRegex(UserError, "there are no matching lines"),
+        ):
+            new_orders = order.action_split()
+            self.assertFalse(message_capture.records)
+
+    def test_error_only_lines_to_split(self):
+        order = self._create_order()
+        order.split_strategy_id = self.product_type_not_service_strategy
+        order.company_id.sale_order_split_strategy_errors = "do_nothing"
+        order.order_line.filtered(
+            lambda li: li.product_id not in (self.product_consu_1, self.product_consu_2)
+        ).unlink()
+        with RecordCapturer(self.env["mail.message"].sudo(), []) as message_capture:
+            new_orders = order.action_split()
+            self.assertFalse(message_capture.records)
+            self.assertFalse(new_orders)
+        order.company_id.sale_order_split_strategy_errors = "post_message"
+        with RecordCapturer(self.env["mail.message"].sudo(), []) as message_capture:
+            new_orders = order.action_split()
+            self.assertTrue(message_capture.records)
+            self.assertFalse(new_orders)
+        order.company_id.sale_order_split_strategy_errors = "raise_errors"
+        with (
+            RecordCapturer(self.env["mail.message"].sudo(), []) as message_capture,
+            self.assertRaisesRegex(
+                UserError, "there would not be any lines left on this order"
+            ),
+        ):
+            new_orders = order.action_split()
+            self.assertFalse(message_capture.records)

--- a/sale_order_split_strategy/views/res_config.xml
+++ b/sale_order_split_strategy/views/res_config.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form_sale_exception" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="sale.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <block name="quotation_order_setting_container" position="inside">
+                <setting
+                    id="split_strategy_config"
+                    help="How split errors are to be reported"
+                >
+                    <field
+                        name="sale_order_split_strategy_errors"
+                        class="o_light_label"
+                        widget="radio"
+                        options="{'horizontal': true}"
+                        required="True"
+                    />
+                </setting>
+            </block>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
In case there are no lines to split through the strategy, we can now avoid posting the message that the order cannot be split according to its strategy.