### PR TITLE
[16.0][FIX] sale_discount_display_amount: Dedicated compute method for discounts

### DIFF
--- a/sale_discount_display_amount/hooks.py
+++ b/sale_discount_display_amount/hooks.py
@@ -48,4 +48,4 @@ def post_init_hook(cr, registry):
     order_ids = cr.fetchall()
 
     orders = env["sale.order"].search([("id", "in", order_ids)])
-    orders.mapped("order_line")._update_discount_display_fields()
+    orders.mapped("order_line")._compute_discount_amount()

--- a/sale_discount_display_amount/models/sale_order_line.py
+++ b/sale_discount_display_amount/models/sale_order_line.py
@@ -9,19 +9,20 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     discount_total = fields.Monetary(
-        compute="_compute_amount",
+        compute="_compute_discount_amount",
         string="Discount Subtotal",
         store=True,
         precompute=True,
     )
     price_total_no_discount = fields.Monetary(
-        compute="_compute_amount",
+        compute="_compute_discount_amount",
         string="Subtotal Without Discount",
         store=True,
         precompute=True,
     )
 
-    def _update_discount_display_fields(self):
+    @api.depends("product_uom_qty", "discount", "price_unit", "tax_id")
+    def _compute_discount_amount(self):
         for line in self:
             line.price_total_no_discount = 0
             line.discount_total = 0
@@ -46,9 +47,3 @@ class SaleOrderLine(models.Model):
                     "price_total_no_discount": price_total_no_discount,
                 }
             )
-
-    @api.depends("product_uom_qty", "discount", "price_unit", "tax_id")
-    def _compute_amount(self):
-        res = super(SaleOrderLine, self)._compute_amount()
-        self._update_discount_display_fields()
-        return res


### PR DESCRIPTION
Because when the discount total is changed on a SOL, the discount total of every lines of the SO is recomputed.
If we use the same method as the one that computes the price total (`_compute_amount()`), it triggers the re-computation of fields such as 'discount' and 'price_unit', which is unexpected.

See in this video how price and discount of other lines are recomputed when we edit a line (before this patch):

[Capture vidéo du 07-01-26 14:50:06.webm](https://github.com/user-attachments/assets/1c1f93ae-a2c7-4b86-ba88-0d9fb8cc5bbd)
