### PR TITLE
[18.0][IMP] sale_order_secondary_unit: pass secondary_uom_id to account move line

### DIFF
--- a/sale_order_secondary_unit/models/sale_order.py
+++ b/sale_order_secondary_unit/models/sale_order.py
@@ -62,3 +62,12 @@ class SaleOrderLine(models.Model):
                     line.secondary_uom_unit_price = 0
             else:
                 line.secondary_uom_unit_price = 0
+
+    def _prepare_invoice_line(self, **optional_values):
+        # Set secondary UoM values only when account_move_secondary_unit is installed
+        # (i.e., the fields exist on account.move.line).
+        res = super()._prepare_invoice_line(**optional_values)
+        aml_fields = self.env["account.move.line"]._fields
+        if "secondary_uom_id" in aml_fields and self.secondary_uom_id:
+            res["secondary_uom_id"] = self.secondary_uom_id.id
+        return res


### PR DESCRIPTION
This PR propagates `secondary_uom_id` from sale order lines to account move lines when the field exists on account.move.line. This is useful when `account_move_secondary_unit` is installed, and avoids the need for a glue module.

Related: https://github.com/OCA/account-invoicing/pull/2230

@qrtl QT6210