### PR TITLE
[18.0][FIX] sale_order_general_discount: do not set discount to 0 if general discount is bypassed

### DIFF
--- a/sale_order_general_discount/models/sale_order_line.py
+++ b/sale_order_general_discount/models/sale_order_line.py
@@ -24,6 +24,4 @@ class SaleOrderLine(models.Model):
                 line.order_id.general_discount or line.order_id._origin.general_discount
             ):
                 line.discount = line.order_id.general_discount
-            else:
-                line.discount = 0
         return res

--- a/sale_order_general_discount/tests/test_sale_order_general_discount.py
+++ b/sale_order_general_discount/tests/test_sale_order_general_discount.py
@@ -165,7 +165,7 @@ class TestSaleOrderLineInput(TransactionCase):
         self.order.order_line[1].discount = 2
         self.order.order_line._compute_discount()
         self.assertEqual(self.order.order_line[0].discount, 10)
-        self.assertEqual(self.order.order_line[1].discount, 0)
+        self.assertEqual(self.order.order_line[1].discount, 2)
 
     def test_product_template(self):
         self.assertFalse(self.product.product_tmpl_id.bypass_general_discount)


### PR DESCRIPTION
With the current logic, whenever we are not applying the generic discount we are forcing always a 0 discount.

Bypassing the general discount should not imply having a 0 discount (maybe we want to set the discount manually for a particular line, or maybe the discount is applied via a configured pricelist rule). Therefore, we should rely on what super() has defined on the discount.