### PR TITLE
[18.0][FIX] sale_advance_payment: handle account_finantial_risk wizard on action_post

### DIFF
--- a/sale_advance_payment/models/account_move.py
+++ b/sale_advance_payment/models/account_move.py
@@ -10,6 +10,8 @@ class AccountMove(models.Model):
     def action_post(self):
         # Automatic reconciliation of payment when invoice confirmed.
         res = super().action_post()
+        if isinstance(res, dict):
+            return res
         sale_orders = self.mapped("line_ids.sale_line_ids.order_id")
         all_payment_move_ids = sale_orders.mapped("account_payment_ids.move_id").ids
         all_payment_lines = self.env["account.move.line"].search(

--- a/sale_advance_payment/tests/test_sale_advance_payment.py
+++ b/sale_advance_payment/tests/test_sale_advance_payment.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2021 ForgeFlow S.L.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
 
+from unittest.mock import patch
+
 from odoo import fields
 from odoo.exceptions import ValidationError
 
@@ -534,3 +536,20 @@ class TestSaleAdvancePayment(BaseCommon):
         dummy_invoice.action_post()
 
         _ = sale_order_usd.amount_residual
+
+    def test_07_action_post_interrupted_by_wizard(self):
+        self.sale_order_1.action_confirm()
+        invoice = self.sale_order_1._create_invoices()
+        fake_wizard_action = {
+            "type": "ir.actions.act_window",
+            "name": "Simulated Wizard",
+            "res_model": "test.wizard",
+            "view_mode": "form",
+        }
+        with patch(
+            "odoo.addons.account.models.account_move.AccountMove.action_post",
+            return_value=fake_wizard_action,
+        ):
+            res = invoice.action_post()
+            self.assertEqual(res, fake_wizard_action)
+            self.assertNotEqual(invoice.state, "posted")


### PR DESCRIPTION
**Current behavior**: When using this module alongside others that interrupt the invoice validation process to show a wizard (e.g., account_financial_risk from OCA/credit-control), the action_post method crashes.

<img width="758" height="330" alt="imagen" src="https://github.com/user-attachments/assets/97f104d7-cbc7-4e5c-9265-8f4d6c1c39e3" />

This happens because super().action_post() may return a dictionary (an `ir.actions.act_window`). The current code ignores this return value and proceeds immediately to the automatic reconciliation logic (`js_assign_outstanding_line`).

Since the validation process was halted by the wizard, the invoice remains in `draft` state. Attempting to reconcile a draft invoice raises a UserError.

Traceback / Error:

UserError: You can only reconcile posted entries. (`_check_amls_exigibility_for_reconciliation` from `account`)

<img width="727" height="331" alt="imagen" src="https://github.com/user-attachments/assets/9feecba2-e5ef-412d-9006-3a1b4e5671aa" />


**Fix**: Added a check after super().action_post(). If the return value is a dictionary (indicating a window action/wizard), the method immediately returns that action and stops the reconciliation attempt. This allows the user to interact with the wizard. Once the wizard is accepted, action_post will be called again, and reconciliation will proceed normally.