### PR TITLE
[FIX][18.0] sale_order_carrier_auto_assign: Changing partner changes carrier

### DIFF
--- a/sale_order_carrier_auto_assign/__manifest__.py
+++ b/sale_order_carrier_auto_assign/__manifest__.py
@@ -10,7 +10,10 @@
     "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
     "maintainers": ["jbaudoux"],
     "license": "AGPL-3",
-    "data": ["views/res_config_settings_views.xml"],
+    "data": [
+        "views/res_config_settings_views.xml",
+        "views/sale_order_views.xml",
+    ],
     "application": False,
     "installable": True,
     "depends": ["delivery"],

--- a/sale_order_carrier_auto_assign/models/sale_order.py
+++ b/sale_order_carrier_auto_assign/models/sale_order.py
@@ -73,16 +73,20 @@ class SaleOrder(models.Model):
         for order in self:
             if not order.order_line:
                 continue
-            if order.delivery_set:
+            # Preserve the carrier only if explicitly set on the attribute
+            if preserve_order_carrier and order.delivery_set:
                 continue
             delivery_wiz_action = order.action_open_delivery_wizard()
             delivery_wiz_context = delivery_wiz_action.get("context", {})
             if not delivery_wiz_context.get("default_carrier_id"):
                 continue
+            # Use the real order because can be an onchange
+            if isinstance(delivery_wiz_context.get("default_order_id"), models.NewId):
+                delivery_wiz_context["default_order_id"] = order._origin.id or order.id
             delivery_wiz_model = self.env[
                 delivery_wiz_action.get("res_model")
             ].with_context(**delivery_wiz_context)
-            if self._origin:
+            if order._origin:
                 delivery_wiz = delivery_wiz_model.create({})
             else:
                 delivery_wiz = delivery_wiz_model.new({})

--- a/sale_order_carrier_auto_assign/readme/CONFIGURE.md
+++ b/sale_order_carrier_auto_assign/readme/CONFIGURE.md
@@ -1,4 +1,4 @@
 #. Go to *Settings > Sales > Shipping*.
 
-* Enable on creation: only the carrier will be set.
+* Enable on creation: only the carrier will be set when changing partner.
 * Enable on confirmation: the carrier and delivery line will be set.

--- a/sale_order_carrier_auto_assign/readme/CONTRIBUTORS.md
+++ b/sale_order_carrier_auto_assign/readme/CONTRIBUTORS.md
@@ -4,3 +4,4 @@
 - Phuc (Tran Thanh) \<<phuc@trobz.com>\>
 - Telmo Santos \<<telmo.santos@camptocamp.com>\>
 - Tris Doan \<<tridm@trobz.com>\>
+- Eduardo de Miguel ([Moduon](https://www.moduon.team/))

--- a/sale_order_carrier_auto_assign/tests/test_sale_order_carrier_auto_assign.py
+++ b/sale_order_carrier_auto_assign/tests/test_sale_order_carrier_auto_assign.py
@@ -49,6 +49,7 @@ class TestSaleOrderCarrierAutoAssignOnCreate(TestSaleOrderCarrierAutoAssignCommo
     def setUpClass(cls):
         super().setUpClass()
         cls.settings.carrier_on_create = True
+        cls.settings.carrier_auto_assign = False
         cls.settings.set_values()
 
     def test_sale_order_carrier_auto_assign_no_carrier(self):
@@ -59,6 +60,17 @@ class TestSaleOrderCarrierAutoAssignOnCreate(TestSaleOrderCarrierAutoAssignCommo
     def test_sale_order_carrier_auto_assign_onchange(self):
         sale_order = self._create_sale_order()
         self.assertEqual(sale_order.carrier_id, self.delivery_local_delivery)
+        # Change partner and check carrier change
+        new_carrier = self.delivery_local_delivery.copy()
+        new_partner = self.env["res.partner"].create(
+            {
+                "name": "Test partner 2",
+                "property_delivery_carrier_id": new_carrier.id,
+            }
+        )
+        sale = Form(sale_order)
+        sale.partner_id = new_partner
+        self.assertEqual(sale.carrier_id, new_carrier)
 
     def test_sale_order_carrier_auto_assign_create(self):
         sale_order = self.env["sale.order"].create(
@@ -133,9 +145,10 @@ class TestSaleOrderCarrierAutoAssignOnConfirm(TestSaleOrderCarrierAutoAssignComm
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.settings.carrier_on_create = False
         cls.settings.carrier_auto_assign = True
-        cls._create_sale_order()
         cls.settings.set_values()
+        cls._create_sale_order()
         cls.sale_order_form = Form(cls.env["sale.order"])
         cls.sale_order_form.partner_id = cls.partner
         with cls.sale_order_form.order_line.new() as line_form:

--- a/sale_order_carrier_auto_assign/views/sale_order_views.xml
+++ b/sale_order_carrier_auto_assign/views/sale_order_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_order_form_with_carrier" model="ir.ui.view">
+        <field name="name">delivery.sale.order.form.view.with_carrier</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="delivery.view_order_form_with_carrier" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='delivery_set']" position="after">
+                <!-- carrier_id must exist in view to be able to be wrote it in onchange -->
+                <field name="carrier_id" invisible="1" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Prior to this fix, when changing the partner on a **saved** sale order doesn't change the carrier. You must change manually even if you set `carrier_auto_assign` setting. Clicking on Update Shipping Cost doesn't shows the correct carrier.

Now, if you have activated `carrier_on_create` setting, when changing the partner on a saved sale, also changes the carrier.

Works well with [delivery_auto_refresh](https://github.com/OCA/delivery-carrier/tree/18.0/delivery_auto_refresh) module

https://www.loom.com/share/1828d8b94de045388ea3a60f9080b3b6

MT-13352 @moduon @chienandalu @Gelojr @fcvalgar @jbaudoux @yajo please review if you want 😄 

