### PR TITLE
[19.0][FW][IMP] sale_automatic_workflow: add option for default payment journal

### DIFF
--- a/sale_automatic_workflow/README.rst
+++ b/sale_automatic_workflow/README.rst
@@ -106,6 +106,7 @@ Contributors
 - Sander Lienaerts <sander.lienaerts@codeforward.nl>
 - Tri Doan <tridm@trobz.com>
 - Chau Le <chaulb@trobz.com>
+- Kevin Khao <kevinkhao@gmail.com>
 
 Other credits
 -------------

--- a/sale_automatic_workflow/data/automatic_workflow_data.xml
+++ b/sale_automatic_workflow/data/automatic_workflow_data.xml
@@ -40,7 +40,7 @@
         <field name="model_id">account.move</field>
         <field
             name="domain"
-        >[('state', '=', 'posted'), ('move_type', '=', 'out_invoice'), ('payment_state','!=','paid')]</field>
+        >[('state', '=', 'posted'), ('move_type', '=', 'out_invoice'), ('payment_state','=','not_paid')]</field>
         <field name="user_ids" eval="[(4, ref('base.user_root'))]" />
     </record>
     <record id="automatic_validation" model="sale.workflow.process">

--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -166,7 +166,11 @@ class AutomaticWorkflowJob(models.Model):
         payment.action_post()
 
         domain = [
-            ("account_type", "in", ("asset_receivable", "liability_payable")),
+            (
+                "account_type",
+                "in",
+                self.env["account.payment"]._get_valid_payment_account_types(),
+            ),
             ("reconciled", "=", False),
         ]
         payment_lines = payment.move_id.line_ids.filtered_domain(domain)
@@ -175,6 +179,7 @@ class AutomaticWorkflowJob(models.Model):
             (payment_lines + lines).filtered_domain(
                 [("account_id", "=", account.id), ("reconciled", "=", False)]
             ).reconcile()
+        lines.move_id.matched_payment_ids += payment
         return payment
 
     @api.model

--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -134,7 +134,7 @@ class AutomaticWorkflowJob(models.Model):
             and "customer"
             or "supplier"
         )
-        return {
+        res = {
             "reconciled_invoice_ids": [(6, 0, invoice.ids)],
             "amount": invoice.amount_residual,
             "partner_id": invoice.partner_id.id,
@@ -142,6 +142,12 @@ class AutomaticWorkflowJob(models.Model):
             "date": fields.Date.context_today(self),
             "currency_id": invoice.currency_id.id,
         }
+        property_payment_journal_id = (
+            invoice.workflow_process_id.property_payment_journal_id
+        )
+        if property_payment_journal_id:
+            res["journal_id"] = property_payment_journal_id.id
+        return res
 
     @api.model
     def _register_payments(self, payment_filter):

--- a/sale_automatic_workflow/models/sale_workflow_process.py
+++ b/sale_automatic_workflow/models/sale_workflow_process.py
@@ -71,7 +71,15 @@ class SaleWorkflowProcess(models.Model):
         comodel_name="account.journal",
         company_dependent=True,
         string="Sales Journal",
+        domain="[('type', '=', 'sale')]",
         help="Set default journal to use on invoice",
+    )
+    property_payment_journal_id = fields.Many2one(
+        comodel_name="account.journal",
+        company_dependent=True,
+        string="Payment Journal",
+        domain="[('type', 'in', ('bank', 'cash'))]",
+        help="Set default journal to use on payment",
     )
     order_filter_id = fields.Many2one(
         "ir.filters",

--- a/sale_automatic_workflow/readme/CONTRIBUTORS.md
+++ b/sale_automatic_workflow/readme/CONTRIBUTORS.md
@@ -12,3 +12,4 @@
 - Sander Lienaerts \<<sander.lienaerts@codeforward.nl>\>
 - Tri Doan \<<tridm@trobz.com>\>
 - Chau Le \<<chaulb@trobz.com>\>
+- Kevin Khao \<<kevinkhao@gmail.com>\>

--- a/sale_automatic_workflow/static/description/index.html
+++ b/sale_automatic_workflow/static/description/index.html
@@ -455,6 +455,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Sander Lienaerts &lt;<a class="reference external" href="mailto:sander.lienaerts&#64;codeforward.nl">sander.lienaerts&#64;codeforward.nl</a>&gt;</li>
 <li>Tri Doan &lt;<a class="reference external" href="mailto:tridm&#64;trobz.com">tridm&#64;trobz.com</a>&gt;</li>
 <li>Chau Le &lt;<a class="reference external" href="mailto:chaulb&#64;trobz.com">chaulb&#64;trobz.com</a>&gt;</li>
+<li>Kevin Khao &lt;<a class="reference external" href="mailto:kevinkhao&#64;gmail.com">kevinkhao&#64;gmail.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="other-credits">

--- a/sale_automatic_workflow/tests/test_automatic_workflow.py
+++ b/sale_automatic_workflow/tests/test_automatic_workflow.py
@@ -214,6 +214,7 @@ class TestAutomaticWorkflow(TestCommon, TestAutomaticWorkflowMixin):
         )
         self.assertTrue(payment_id)
         self.assertEqual(invoice.currency_id.id, payment_id.currency_id.id)
+        self.assertEqual(invoice.payment_state, invoice._get_invoice_in_payment_state())
 
     def test_create_payment_with_specified_payment_journal(self):
         workflow = self.create_full_automatic()

--- a/sale_automatic_workflow/tests/test_automatic_workflow.py
+++ b/sale_automatic_workflow/tests/test_automatic_workflow.py
@@ -214,3 +214,15 @@ class TestAutomaticWorkflow(TestCommon, TestAutomaticWorkflowMixin):
         )
         self.assertTrue(payment_id)
         self.assertEqual(invoice.currency_id.id, payment_id.currency_id.id)
+
+    def test_create_payment_with_specified_payment_journal(self):
+        workflow = self.create_full_automatic()
+        workflow.register_payment = True
+        payment_journal = self.env["account.journal"].create(
+            {"name": "Payment Journal Test", "code": "TESTJOURNAL", "type": "bank"}
+        )
+        workflow.property_payment_journal_id = payment_journal
+        self.create_sale_order(workflow)
+        self.run_job()
+        payment = self.env["account.payment"].search([], limit=1, order="id desc")
+        self.assertEqual(payment.journal_id, payment_journal)

--- a/sale_automatic_workflow/views/sale_workflow_process_views.xml
+++ b/sale_automatic_workflow/views/sale_workflow_process_views.xml
@@ -264,17 +264,30 @@
                                 </span>
                             </div>
                         </div>
-                        <div
-                            class="row"
-                            groups="account.group_account_invoice"
-                            domain="[('type', '=', 'sale')]"
-                        >
+                        <div class="row" groups="account.group_account_invoice">
                             <div class="col-sm-12">
                                 <label
                                     for="property_journal_id"
                                     class="col-lg-4 o_light_label"
                                 />
-                                <field name="property_journal_id" nolabel="1" />
+                                <field
+                                    name="property_journal_id"
+                                    nolabel="1"
+                                    domain="[('type', '=', 'sale')]"
+                                />
+                            </div>
+                        </div>
+                        <div class="row" groups="account.group_account_invoice">
+                            <div class="col-sm-12">
+                                <label
+                                    for="property_payment_journal_id"
+                                    class="col-lg-4 o_light_label"
+                                />
+                                <field
+                                    name="property_payment_journal_id"
+                                    nolabel="1"
+                                    domain="[('type', 'in', ('bank', 'cash', 'credit'))]"
+                                />
                             </div>
                         </div>
                         <br />


### PR DESCRIPTION
FW of https://github.com/OCA/sale-workflow/pull/4137 and also ensure module works properly when payments don't generate journal entries and using enterprise.

CC @kevinkhao 