### PR TITLE
[17.0][FIX] sale_invoice_policy: invoice policy

### DIFF
--- a/sale_invoice_policy/models/sale_order.py
+++ b/sale_invoice_policy/models/sale_order.py
@@ -9,7 +9,6 @@ class SaleOrder(models.Model):
 
     invoice_policy = fields.Selection(
         [("order", "Ordered quantities"), ("delivery", "Delivered quantities")],
-        readonly=True,
         help="Ordered Quantity: Invoice based on the quantity the customer "
         "ordered.\n"
         "Delivered Quantity: Invoiced based on the quantity the vendor "

--- a/sale_invoice_policy/models/sale_order_line.py
+++ b/sale_invoice_policy/models/sale_order_line.py
@@ -40,6 +40,7 @@ class SaleOrderLine(models.Model):
         other_lines = self.filtered(
             lambda line: line.product_id.type == "service"
             or line.order_id.invoice_policy == "product"
+            or not line.order_id.invoice_policy
         )
         super(SaleOrderLine, other_lines)._compute_qty_to_invoice()
         for line in self - other_lines:

--- a/sale_invoice_policy/models/sale_order_line.py
+++ b/sale_invoice_policy/models/sale_order_line.py
@@ -18,7 +18,6 @@ class SaleOrderLine(models.Model):
         other_lines = self.filtered(
             lambda line: line.product_id.type == "service"
             or not line.order_id.invoice_policy
-            or not line.order_id.invoice_policy_required
         )
         super(SaleOrderLine, other_lines)._compute_qty_to_invoice()
         for line in self - other_lines:
@@ -44,7 +43,6 @@ class SaleOrderLine(models.Model):
             or not line.order_id.invoice_policy
             or line.order_id.invoice_policy == line.product_id.invoice_policy
             or line.state not in ["sale", "done"]
-            or not line.order_id.invoice_policy_required
         )
         super(SaleOrderLine, other_lines)._compute_untaxed_amount_to_invoice()
         for line in self - other_lines:

--- a/sale_invoice_policy/tests/test_sale_invoice_policy.py
+++ b/sale_invoice_policy/tests/test_sale_invoice_policy.py
@@ -166,3 +166,33 @@ class TestSaleOrderInvoicePolicy(common.TransactionCase):
             "the same invoice policy",
             exc.exception.args[0],
         )
+
+    def test_sale_order_invoice_order_when_policy_is_not_required(self):
+        """Test invoicing based on ordered qty when invoice policy is not required."""
+        settings = self.env["res.config.settings"].create({})
+        settings.sale_invoice_policy_required = False
+        settings.execute()
+        so = self.env["sale.order"].create(
+            {
+                "partner_id": self.env.ref("base.res_partner_2").id,
+                "order_line": [
+                    (0, 0, {"product_id": self.product.id, "product_uom_qty": 2.0}),
+                    (0, 0, {"product_id": self.product2.id, "product_uom_qty": 3.0}),
+                ],
+            }
+        )
+        self.assertFalse(so.invoice_policy_required)
+        self.assertTrue(so.invoice_policy == "order")
+        so.action_confirm()
+        self.assertEqual(len(so.picking_ids), 1)
+        picking = so.picking_ids
+        picking.action_assign()
+        self.assertEqual(picking.state, "assigned")
+        so_line = so.order_line[0]
+        self.assertEqual(so_line.qty_to_invoice, 2)
+        self.assertEqual(so_line.invoice_status, "to invoice")
+        self.assertEqual(so_line.product_id.invoice_policy, "order")
+        so_line = so.order_line[1]
+        self.assertEqual(so_line.qty_to_invoice, 3)
+        self.assertEqual(so_line.invoice_status, "to invoice")
+        self.assertEqual(so_line.product_id.invoice_policy, "order")

--- a/sale_invoice_policy/tests/test_sale_invoice_policy.py
+++ b/sale_invoice_policy/tests/test_sale_invoice_policy.py
@@ -168,9 +168,9 @@ class TestSaleOrderInvoicePolicy(common.TransactionCase):
         )
 
     def test_sale_order_invoice_order_when_policy_is_not_required(self):
-        """Test invoicing based on ordered qty when invoice policy is not required."""
+        """Test invoicing based on ordered qty with default order policy."""
         settings = self.env["res.config.settings"].create({})
-        settings.sale_invoice_policy_required = False
+        settings.sale_default_invoice_policy = "order"
         settings.execute()
         so = self.env["sale.order"].create(
             {
@@ -181,7 +181,6 @@ class TestSaleOrderInvoicePolicy(common.TransactionCase):
                 ],
             }
         )
-        self.assertFalse(so.invoice_policy_required)
         self.assertTrue(so.invoice_policy == "order")
         so.action_confirm()
         self.assertEqual(len(so.picking_ids), 1)

--- a/sale_invoice_policy/tests/test_sale_invoice_policy.py
+++ b/sale_invoice_policy/tests/test_sale_invoice_policy.py
@@ -123,3 +123,34 @@ class TestSaleOrderInvoicePolicy(common.TransactionCase):
         )
         self.assertEqual(so.invoice_policy, "order")
         self.assertTrue(so.invoice_policy_required)
+
+    def test_sale_order_invoice_order_when_policy_is_not_required(self):
+        """Test invoicing based on ordered qty when invoice policy is not required."""
+        settings = self.env["res.config.settings"].create({})
+        settings.sale_invoice_policy_required = False
+        settings.execute()
+        so = self.env["sale.order"].create(
+            {
+                "partner_id": self.env.ref("base.res_partner_2").id,
+                "order_line": [
+                    (0, 0, {"product_id": self.product.id, "product_uom_qty": 2.0}),
+                    (0, 0, {"product_id": self.product2.id, "product_uom_qty": 3.0}),
+                ],
+                "invoice_policy": "order",
+            }
+        )
+        self.assertFalse(so.invoice_policy_required)
+        self.assertTrue(so.invoice_policy == "order")
+        so.action_confirm()
+        self.assertEqual(len(so.picking_ids), 1)
+        picking = so.picking_ids
+        picking.action_assign()
+        self.assertEqual(picking.state, "assigned")
+        so_line = so.order_line[0]
+        self.assertEqual(so_line.qty_to_invoice, 2)
+        self.assertEqual(so_line.invoice_status, "to invoice")
+        self.assertEqual(so_line.product_id.invoice_policy, "order")
+        so_line = so.order_line[1]
+        self.assertEqual(so_line.qty_to_invoice, 3)
+        self.assertEqual(so_line.invoice_status, "to invoice")
+        self.assertEqual(so_line.product_id.invoice_policy, "order")


### PR DESCRIPTION
Fix sale order invoice policy to work regardless of required setting.

Before this fix, the sale order invoice_policy field only affected invoicing calculations when invoice_policy_required was set to True. When invoice_policy_required was False, the invoice policy was ignored, and the system fell back to the default product level invoice policies.

This was problematic because users could set an invoice policy on sale orders, but it would not work. Now the sale order invoice policy works correctly even when the field is not marked as required, allowing optional but functional invoice policies.