### PR TITLE
[16.0][FIX] sale_loyalty_exclude: Apply a domain to product_ids so tht only non-excluded products are displayed.

### DIFF
--- a/sale_loyalty_exclude/models/__init__.py
+++ b/sale_loyalty_exclude/models/__init__.py
@@ -1,3 +1,4 @@
 from . import loyalty_reward
+from . import loyalty_rule
 from . import product_template
 from . import sale_order

--- a/sale_loyalty_exclude/models/loyalty_rule.py
+++ b/sale_loyalty_exclude/models/loyalty_rule.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class LoyaltyRule(models.Model):
+    _inherit = "loyalty.rule"
+
+    product_ids = fields.Many2many(domain=[("loyalty_exclude", "=", False)])


### PR DESCRIPTION
## Description

It was identified that within discount programs, when selecting products in the reward rules configuration, it was possible to choose products that were marked as excluded from loyalty programs.

This behavior allowed excluded products to be configured in discount rules, leading to inconsistent discount logic.

## Cases Covered with This Improvement

- Prevents excluded products from being selectable within discount rule configurations.
- Ensures that only eligible (non-excluded) products can be added to loyalty reward rules.

## Implemented Solution

A domain filter has been added in the `sale_loyalty_exclude` module to ensure that only products not marked as excluded are displayed when configuring discount program rules.

This guarantees consistency between product configuration and loyalty rule eligibility.

FL-571-7802