### PR TITLE
[18.0][IMP] sale_order_revision: Change where the mock has to be loaded

### DIFF
--- a/sale_order_revision/tests/test_sale_order_revision.py
+++ b/sale_order_revision/tests/test_sale_order_revision.py
@@ -5,12 +5,15 @@ from odoo.addons.base_revision.tests import test_base_revision
 
 
 class TestSaleOrderRevision(test_base_revision.TestBaseRevision):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.revision_model = cls.env["sale.order"]
-        cls.partner = cls.env["res.partner"].create({"name": "Mr Odoo"})
-        cls.product = cls.env["product.product"].create({"name": "Test product"})
+    def setUp(self):
+        super().setUp()
+        self.revision_model = self.env["sale.order"]
+        self.partner = self.env["res.partner"].create({"name": "Mr Odoo"})
+        self.product = self.env["product.product"].create({"name": "Test product"})
+
+    def tearDown(self):
+        self.loader.restore_registry()
+        return super().tearDown()
 
     def _create_tester(self, vals_list=None):
         if not vals_list:


### PR DESCRIPTION
Change where the mock has to be loaded

With the changes introduced in odoo/odoo@de056cc#diff-b37c7fd5520c97a29ddc59495779e7be61a66e15e85603928e27b3affb9dc31f, an error was occurring because the change validation on the model was being performed before tearDownClass was executed. Therefore, it has been modified so that the mock changes are applied in each test and cleaned up after each test. This way, the error will no longer appear and the test will run normally.

Please @pedrobaeza can you review it?

@Tecnativa