### PR TITLE
[17.0][IMP] product_supplierinfo_for_customer_sale: Short label

### DIFF
--- a/product_supplierinfo_for_customer_sale/i18n/ca.po
+++ b/product_supplierinfo_for_customer_sale/i18n/ca.po
@@ -24,8 +24,8 @@ msgstr "Preus de client"
 
 #. module: product_supplierinfo_for_customer_sale
 #: model:ir.model.fields,field_description:product_supplierinfo_for_customer_sale.field_sale_order_line__product_customer_code
-msgid "Product Customer Code"
-msgstr "Codi de producte del client"
+msgid "Cust. Code"
+msgstr "Codi del client"
 
 #. module: product_supplierinfo_for_customer_sale
 #: model:ir.model,name:product_supplierinfo_for_customer_sale.model_sale_order_line

--- a/product_supplierinfo_for_customer_sale/i18n/de.po
+++ b/product_supplierinfo_for_customer_sale/i18n/de.po
@@ -24,8 +24,8 @@ msgstr "Kundenpreise"
 
 #. module: product_supplierinfo_for_customer_sale
 #: model:ir.model.fields,field_description:product_supplierinfo_for_customer_sale.field_sale_order_line__product_customer_code
-msgid "Product Customer Code"
-msgstr "Kundencode des Produkts"
+msgid "Cust. Code"
+msgstr "Kundencode"
 
 #. module: product_supplierinfo_for_customer_sale
 #: model:ir.model,name:product_supplierinfo_for_customer_sale.model_sale_order_line

--- a/product_supplierinfo_for_customer_sale/i18n/es.po
+++ b/product_supplierinfo_for_customer_sale/i18n/es.po
@@ -25,8 +25,8 @@ msgstr "Precios para clientes"
 
 #. module: product_supplierinfo_for_customer_sale
 #: model:ir.model.fields,field_description:product_supplierinfo_for_customer_sale.field_sale_order_line__product_customer_code
-msgid "Product Customer Code"
-msgstr "Código de cliente del producto"
+msgid "Cust. Code"
+msgstr "Cód. cliente"
 
 #. module: product_supplierinfo_for_customer_sale
 #: model:ir.model,name:product_supplierinfo_for_customer_sale.model_sale_order_line

--- a/product_supplierinfo_for_customer_sale/i18n/it.po
+++ b/product_supplierinfo_for_customer_sale/i18n/it.po
@@ -26,8 +26,8 @@ msgstr "Prezzi per i clienti"
 
 #. module: product_supplierinfo_for_customer_sale
 #: model:ir.model.fields,field_description:product_supplierinfo_for_customer_sale.field_sale_order_line__product_customer_code
-msgid "Product Customer Code"
-msgstr "Codice prodotto cliente"
+msgid "Cust. Code"
+msgstr "Cod. cliente"
 
 #. module: product_supplierinfo_for_customer_sale
 #: model:ir.model,name:product_supplierinfo_for_customer_sale.model_sale_order_line

--- a/product_supplierinfo_for_customer_sale/i18n/product_supplierinfo_for_customer_sale.pot
+++ b/product_supplierinfo_for_customer_sale/i18n/product_supplierinfo_for_customer_sale.pot
@@ -21,7 +21,7 @@ msgstr ""
 
 #. module: product_supplierinfo_for_customer_sale
 #: model:ir.model.fields,field_description:product_supplierinfo_for_customer_sale.field_sale_order_line__product_customer_code
-msgid "Product Customer Code"
+msgid "Cust. Code"
 msgstr ""
 
 #. module: product_supplierinfo_for_customer_sale

--- a/product_supplierinfo_for_customer_sale/i18n/pt.po
+++ b/product_supplierinfo_for_customer_sale/i18n/pt.po
@@ -24,8 +24,8 @@ msgstr ""
 
 #. module: product_supplierinfo_for_customer_sale
 #: model:ir.model.fields,field_description:product_supplierinfo_for_customer_sale.field_sale_order_line__product_customer_code
-msgid "Product Customer Code"
-msgstr "Código do Produto no Cliente"
+msgid "Cust. Code"
+msgstr "Cód. no Cliente"
 
 #. module: product_supplierinfo_for_customer_sale
 #: model:ir.model,name:product_supplierinfo_for_customer_sale.model_sale_order_line

--- a/product_supplierinfo_for_customer_sale/models/sale_order_line.py
+++ b/product_supplierinfo_for_customer_sale/models/sale_order_line.py
@@ -12,7 +12,7 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     product_customer_code = fields.Char(
-        compute="_compute_product_customer_code",
+        compute="_compute_product_customer_code", string="Cust. Code"
     )
 
     @api.depends("product_id")


### PR DESCRIPTION
As odoo resizes columns according their content, including the header labels, this column is taking a lot of space without the real need, so let's short it for better sales order display.

@Tecnativa TT61142