### PR TITLE
[18.0][IMP] sale_exception: avoid useless writes

### DIFF
--- a/sale_exception/models/sale_order_line.py
+++ b/sale_exception/models/sale_order_line.py
@@ -56,6 +56,12 @@ class SaleOrderLine(models.Model):
         # Thanks to the new flush of odoo 13.0, queries will be optimized
         # together at the end even if we update the exception_ids many times.
         # On previous versions, this could be unoptimized.
-        (self - records).exception_ids = [Command.unlink(rule.id)]
-        records.exception_ids = [Command.link(rule.id)]
+        lines_to_remove_exception = (self - records).filtered(
+            lambda line: rule.id in line.exception_ids.ids
+        )
+        lines_to_remove_exception.exception_ids = [Command.unlink(rule.id)]
+        lines_to_add_exception = records.filtered(
+            lambda line: rule.id not in line.exception_ids.ids
+        )
+        lines_to_add_exception.exception_ids = [Command.link(rule.id)]
         return records.mapped("order_id")


### PR DESCRIPTION
Although the ORM will properly handle multiple write (as mentioned in the comment)
Without the filtering the write method will still be called many time without need.