### PR TITLE
[18.0][FIX] sale_advance_payment: Wrong residual amount calculation on multi-currency Sale Orders after invoicing

### DIFF
--- a/sale_advance_payment/models/sale.py
+++ b/sale_advance_payment/models/sale.py
@@ -80,10 +80,19 @@ class SaleOrder(models.Model):
                     advance_amount += line_amount
             # Consider payments in related invoices.
             invoice_paid_amount = 0.0
-            for inv in order.invoice_ids:
-                invoice_paid_amount += (
-                    inv.amount_total_signed - inv.amount_residual_signed
-                )
+            for inv in order.invoice_ids.filtered(lambda m: m.state == "posted"):
+                paid = inv.amount_total - inv.amount_residual
+                if inv.move_type == "out_refund":
+                    paid = -paid
+                if inv.currency_id != order.currency_id:
+                    paid = inv.currency_id._convert(
+                        paid,
+                        order.currency_id,
+                        order.company_id,
+                        inv.invoice_date or inv.date or fields.Date.today(),
+                    )
+                invoice_paid_amount += paid
+
             amount_residual = order.amount_total - advance_amount - invoice_paid_amount
             payment_state = "not_paid"
             if mls:

--- a/sale_advance_payment/tests/test_sale_advance_payment.py
+++ b/sale_advance_payment/tests/test_sale_advance_payment.py
@@ -454,3 +454,83 @@ class TestSaleAdvancePayment(BaseCommon):
             }
         )._create_payments()
         self.assertEqual(self.sale_order_1.amount_residual, 3600)
+
+    def test_06_multicurrency_residual_amount(self):
+        sale_order_usd = self.env["sale.order"].create(
+            {
+                "partner_id": self.res_partner_1.id,
+                "currency_id": self.currency_usd.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_1.id,
+                            "product_uom_qty": 1.0,
+                            "price_unit": 100.0,
+                        },
+                    )
+                ],
+            }
+        )
+
+        total_amount = sale_order_usd.amount_total
+        self.assertEqual(sale_order_usd.amount_residual, total_amount)
+
+        sale_order_usd.action_confirm()
+
+        context_payment = {
+            "active_ids": [sale_order_usd.id],
+            "active_id": sale_order_usd.id,
+        }
+        advance_payment = (
+            self.env["account.voucher.wizard"]
+            .with_context(**context_payment)
+            .create(
+                {
+                    "journal_id": self.journal_usd_bank.id,
+                    "payment_type": "inbound",
+                    "amount_advance": 40.0,
+                    "order_id": sale_order_usd.id,
+                }
+            )
+        )
+        advance_payment.make_advance_payment()
+
+        self.assertEqual(sale_order_usd.amount_residual, total_amount - 40.0)
+
+        invoice = sale_order_usd._create_invoices()
+        invoice.invoice_date = fields.Date.today()
+        invoice.action_post()
+
+        self.assertEqual(sale_order_usd.amount_residual, total_amount - 40.0)
+
+        credit_note = invoice._reverse_moves()
+        credit_note.invoice_date = fields.Date.today()
+        credit_note.action_post()
+
+        self.assertEqual(sale_order_usd.amount_residual, total_amount - 40.0)
+
+        dummy_invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.res_partner_1.id,
+                "currency_id": self.currency_euro.id,
+                "invoice_date": fields.Date.today(),
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Dummy for coverage",
+                            "price_unit": 0.0,
+                            "quantity": 1.0,
+                            "sale_line_ids": [(6, 0, sale_order_usd.order_line.ids)],
+                        },
+                    )
+                ],
+            }
+        )
+        dummy_invoice.action_post()
+
+        _ = sale_order_usd.amount_residual


### PR DESCRIPTION
**Description of the issue/feature:**

Fixes an issue with the calculation of amount_residual on Sale Orders when using multi-currency.

Currently, when a Sale Order is created in a foreign currency and its corresponding invoice is posted, the _compute_advance_payment method calculates the paid amount using amount_total_signed and amount_residual_signed. Since _signed fields are always in the company currency, subtracting this from the SO's amount_total (which is in the foreign currency) results in a wrong amount_residual.

This PR fixes the issue by:

* Using the document currency fields (amount_total and amount_residual) instead of the _signed fields.
* Converting the invoice paid amount to the Sale Order currency if they differ.
* Filtering related invoices to only consider posted ones.

**Steps to reproduce:**

1. Install sale_advance_payment.
2. Enable multi-currency and activate a currency different from your Company Currency (e.g., USD if the company is in EUR). Set an exchange rate.
3. Create a Sale Order in the foreign currency (e.g., USD).
4. Register an advance payment using the "Pay sale advanced" button.
5. Check the amount_residual on the SO.
6. Confirm the Sale Order, create a regular Invoice for the total amount, and Post it.

**Current behavior:**
Once the invoice is posted, the amount_residual on the Sale Order is recalculated incorrectly because it mixes company currency amounts with foreign currency amounts.

**Expected behavior:**
The amount_residual remains consistent and correct. The paid amount from related invoices is properly converted to the Sale Order currency before subtraction.



Fixes #4160 