### PR TITLE
[17.0][FIX] sale_pricelist_global_rule: No bypass + inject context

### DIFF
--- a/sale_pricelist_global_rule/models/product_pricelist.py
+++ b/sale_pricelist_global_rule/models/product_pricelist.py
@@ -155,8 +155,10 @@ class ProductPricelistItem(models.Model):
         :rtype: bool
         """
         self.ensure_one()
-        qty_data = self.env.context.get("pricelist_global_cummulative_quantity", {})
-        if not qty_data or self.applied_on not in [
+        qty_data = self.env.context.get(
+            "pricelist_global_cummulative_quantity", {"by_template": {}, "by_categ": {}}
+        )
+        if self.applied_on not in [
             "3_1_global_product_template",
             "3_2_global_product_category",
         ]:

--- a/sale_pricelist_global_rule/models/sale_order.py
+++ b/sale_pricelist_global_rule/models/sale_order.py
@@ -14,7 +14,6 @@ class SaleOrder(models.Model):
             by_categ: {product.category: qty}}
         }
         """
-        self.ensure_one()
         qty_data = {
             "by_template": {},
             "by_categ": {},

--- a/sale_pricelist_global_rule/models/sale_order_line.py
+++ b/sale_pricelist_global_rule/models/sale_order_line.py
@@ -4,19 +4,49 @@ from odoo import models
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
+    def _prepare_pricelist_global_cumulative_quantity(self):
+        sale_data = {}
+        for line in self:
+            if line.order_id not in sale_data:
+                sale_data[line.order_id] = line.order_id._get_cummulative_quantity()
+        return sale_data
+
     def _compute_pricelist_item_id(self):
         # Compute the cumulative quantity of products in the sale order
         # for each line to ensure quantities are not mixed between different orders.
         # Store the data in a dictionary to avoid redundant computations
         # for the same order multiple times.
-        sale_data = {}
-        res = None
+        sale_data = self._prepare_pricelist_global_cumulative_quantity()
         for line in self:
-            if line.order_id not in sale_data:
-                sale_data[line.order_id] = line.order_id._get_cummulative_quantity()
             qty_data = sale_data[line.order_id]
             res = super(
                 SaleOrderLine,
                 line.with_context(pricelist_global_cummulative_quantity=qty_data),
             )._compute_pricelist_item_id()
+        return res
+
+    def _compute_price_unit(self):
+        # As the price computation is done in 2 steps, first with the pricelist item,
+        # and then this price, if the pricelists are set in several levels, the first
+        # step only computes the direct rule, but if the global rule is at another
+        # pricelist, then here the cumulative quantities are not set in the context, so
+        # we need to perform the same operation
+        sale_data = self._prepare_pricelist_global_cumulative_quantity()
+        for line in self:
+            qty_data = sale_data[line.order_id]
+            res = super(
+                SaleOrderLine,
+                line.with_context(pricelist_global_cummulative_quantity=qty_data),
+            )._compute_price_unit()
+        return res
+
+    def _compute_discount(self):
+        # Same case as _compute_price_unit
+        sale_data = self._prepare_pricelist_global_cumulative_quantity()
+        for line in self:
+            qty_data = sale_data[line.order_id]
+            res = super(
+                SaleOrderLine,
+                line.with_context(pricelist_global_cummulative_quantity=qty_data),
+            )._compute_discount()
         return res


### PR DESCRIPTION
2 fixes:

- Apply the rule even if no context:
    
  Previously, if no context is provided, the code calls to super to continue getting prices, but that's not a proper default behavior, as in that case, the super code never mark the rule as not applicable, as all the comparisons are not met.
    
  We fix that not calling super if the rule type is a global one, but providing a defaul dictionary for not crashing, although the quantity comparisons were not accumulated, and thus, the rule may not match if a minimum comparison is provided.

- Inject context in price unit/discount computation
    
  As the price computation is done in 2 steps, first with the pricelist item, and then the unit price/discount, if the pricelists are set in several levels, the first step only computes the direct rule, but if the global rule is at another pricelist, then on the final unit price computation, the cumulative quantities are not set in the context, so we need to inject the context as well in this compute.

@Tecnativa TT61419