### PR TITLE
[17.0] FIX sale_order_invoice_amount upgrade script for _ir_translation

### DIFF
--- a/sale_order_invoice_amount/migrations/17.0.1.0.0/post-migration.py
+++ b/sale_order_invoice_amount/migrations/17.0.1.0.0/post-migration.py
@@ -49,16 +49,6 @@ def migrate(cr, version):
                 AND name ~ '{".*" + old_field + ".*"}'
                 """,
             )
-            # Update translations
-            openupgrade.logged_query(
-                cr,
-                f"""
-                UPDATE _ir_translation
-                SET name = '{model},{new_field}'
-                WHERE name = '{model},{old_field}' AND type = 'model'
-                """,
-            )
-
             # Update filters
             openupgrade.logged_query(
                 cr,


### PR DESCRIPTION
Otherwise:
```
psycopg2.errors.UndefinedTable: relation "_ir_translation" does not exist
```

Starting from Odoo 16, translations are stored as JSONB columns directly in each model's table instead of in a separate _ir_translation table.

Since translations are now stored as JSONB in the model's own table columns, and these fields (amount_invoiced, amount_to_invoice) are Float fields (not translatable), the translation update is simply unnecessary.