### PR TITLE
[16.0][IMP] sale_order_type: Add post_install tag in tests to prevent test errors

### DIFF
--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -140,7 +140,8 @@ class TestSaleOrderType(common.TransactionCase):
         )
 
     def create_sale_order(self, partner=False):
-        sale_form = Form(self.env["sale.order"])
+        # Set a custom context to "disable" the behavior of sale_isolated_quotation
+        sale_form = Form(self.env["sale.order"].with_context(order_sequence="test"))
         sale_form.partner_id = partner or self.partner
         with sale_form.order_line.new() as order_line:
             order_line.product_id = self.product


### PR DESCRIPTION
FW of #2293 

This is required to fix tests from other addons that also make changes in the SO sequence, mainly: sale_isolated_quotation in #3679 

### Next steps
- Perhaps it would be nice to combine THIS and #3679 in a single PR to see the tests passing 🚀 