### PR TITLE
[16.0][FIX] sale_order_line_price_history: fix order_partner_id sync on partner change

### DIFF
--- a/sale_order_line_price_history/models/sale_order_line.py
+++ b/sale_order_line_price_history/models/sale_order_line.py
@@ -8,4 +8,7 @@ class SaleOrderLine(models.Model):
 
     # In core this a related field. We need to trigger its value on view, so we can
     # have it even when we're in a NewId
-    order_partner_id = fields.Many2one(depends=["product_id"])
+    order_partner_id = fields.Many2one(
+        related="order_id.partner_id",
+        depends=["product_id", "order_id.partner_id"],
+    )

--- a/sale_order_line_price_history/tests/test_sale_order_line_price_history.py
+++ b/sale_order_line_price_history/tests/test_sale_order_line_price_history.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Tecnativa - Ernesto Tejeda
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import Form, TransactionCase
 
 
 class TestSaleOrderLinePriceHistory(TransactionCase):
@@ -156,3 +156,30 @@ class TestSaleOrderLinePriceHistory(TransactionCase):
         history_line.action_set_price()
         self.assertEqual(self.sale_order_line_3.price_unit, 10)
         self.assertEqual(self.sale_order_line_3.discount, 5)
+
+    def test_order_partner_id_syncs_on_partner_change(self):
+        """order_partner_id must update when the order's partner changes."""
+        order = self.env["sale.order"].create({"partner_id": self.partner_1.id})
+        self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "name": self.product.name,
+                "product_id": self.product.id,
+                "product_uom_qty": 1,
+                "product_uom": self.product.uom_id.id,
+                "price_unit": 10,
+            }
+        )
+        line = order.order_line[0]
+        self.assertEqual(line.order_partner_id, self.partner_1)
+
+        # Change partner via Form (simulates browser save)
+        form = Form(order)
+        form.partner_id = self.partner_2
+        form.save()
+
+        self.assertEqual(
+            line.order_partner_id,
+            self.partner_2,
+            "order_partner_id should sync when partner_id changes on order",
+        )


### PR DESCRIPTION
## Summary

The `order_partner_id` stored related field on `sale.order.line` stops syncing when the order's partner is changed. This causes stale partner data on order lines, breaking any logic that depends on `order_partner_id` (e.g., price history lookups for the wrong customer).

## Steps to reproduce

1. Create a sale order with Partner A and add a product line
2. Save the order
3. Change the partner to Partner B
4. Save the order
5. Check `order_partner_id` on the line — it still shows Partner A

## Root cause

The module redefines `order_partner_id` with `depends=["product_id"]` to ensure the value is available on NewId records in the view. However, this overrides the implicit depends from the `related` attribute (`order_id.partner_id`), so the ORM no longer triggers a recompute when the partner changes on the parent order.

## Solution

Explicitly declare both `related` and `depends` so the field keeps its related behavior while also triggering on `product_id` changes:

```python
order_partner_id = fields.Many2one(
    related="order_id.partner_id",
    depends=["product_id", "order_id.partner_id"],
)
```

A regression test is included that fails without the fix and passes with it.