### PR TITLE
[18.0][FIX] sale_automatic_workflow_stock: add missing migration script

### DIFF
--- a/sale_automatic_workflow_stock/__init__.py
+++ b/sale_automatic_workflow_stock/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .init_hook import pre_init_hook

--- a/sale_automatic_workflow_stock/__manifest__.py
+++ b/sale_automatic_workflow_stock/__manifest__.py
@@ -20,4 +20,5 @@
         "data/automatic_workflow_data.xml",
     ],
     "auto_install": True,
+    "pre_init_hook": "pre_init_hook",
 }

--- a/sale_automatic_workflow_stock/init_hook.py
+++ b/sale_automatic_workflow_stock/init_hook.py
@@ -1,0 +1,22 @@
+import logging
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+
+def pre_init_hook(env):
+    # on v16 automatic_workflow_picking_filter
+    # is in sale_automatic_workflow module
+
+    old_xmlid = "sale_automatic_workflow.automatic_workflow_picking_filter"
+    new_xmlid = "sale_automatic_workflow_stock.automatic_workflow_picking_filter"
+
+    _logger.info(f"XML ID migration {old_xmlid} to {new_xmlid}")
+    # it's safe to run even if old_xmlid do not exits
+    openupgrade.rename_xmlids(
+        env.cr,
+        [
+            (old_xmlid, new_xmlid),
+        ],
+    )

--- a/sale_automatic_workflow_stock/readme/CONTRIBUTORS.md
+++ b/sale_automatic_workflow_stock/readme/CONTRIBUTORS.md
@@ -11,3 +11,4 @@
 - Silvija Butko \<<silvija@focusate.eu>\>
 - Tri Doan \<\<<tridm@trobz.com>\>\>
 - Chau Le \<\<<chaulb@trobz.com>\>\>
+- Raphaël Reverdy \<\<raphael.reverdy@akretion.com>\>\>


### PR DESCRIPTION
`sale_automatic_workflow` has been splitted in v17. automatic_workflow_picking_filter has been moved to `sale_automatic_workflow_stock`
`sale_automatic_workflow_stock` is auto installable from v18.

If `sale_automatic_workflow` has been installed in a previous version (v16), the xml_id automatic_workflow_picking_filter is bound to `sale_automatic_workflow`.

During the migration to v18, an unicity constraint breaks the (automatic) installation of  `sale_automatic_workflow_stock` because of the xmlid 
`sale_automatic_workflow_stock.automatic_workflow_picking_filter`

This fix rename the xml id if needed at install time.
