### PR TITLE
[18.0][FIX] sale_stock_reservation_issue_on_qty_at_date_widget: default color

### DIFF
--- a/sale_stock_reservation_issue_on_qty_at_date_widget/static/src/widgets/qty_at_date_widget.xml
+++ b/sale_stock_reservation_issue_on_qty_at_date_widget/static/src/widgets/qty_at_date_widget.xml
@@ -10,7 +10,7 @@
         <xpath expr="//a[@t-on-click='showPopup']" position="attributes">
             <attribute
                 name="t-attf-class"
-            >fa fa-area-chart cursor-pointer {{ calcData.forecasted_issue ? 'text-danger' : calcData.reservation_issue ? 'text-warning' : 'text-primary' }}</attribute>
+            >fa fa-area-chart cursor-pointer {{ calcData.forecasted_issue ? 'text-danger' : calcData.reservation_issue ? 'text-warning' : '' }}</attribute>
         </xpath>
     </t>
 


### PR DESCRIPTION
Before:

<img width="113" height="181" alt="image" src="https://github.com/user-attachments/assets/94d3b121-2999-4661-b888-3fe433bf71c7" />

After:

<img width="113" height="181" alt="image" src="https://github.com/user-attachments/assets/eb2a4967-932e-478e-bbee-6f1628a42de3" />


cc @moduon MT-14284


please review @Shide @yajo 