### PR TITLE
[18.0][IMP] sale_order_line_cancel post-migration improvments

### DIFF
--- a/sale_order_line_cancel/models/sale_order_line.py
+++ b/sale_order_line_cancel/models/sale_order_line.py
@@ -29,9 +29,13 @@ class SaleOrderLine(models.Model):
             "Product Unit of Measure"
         )
         for rec in self:
-            rec.can_cancel_remaining_qty = float_compare(
-                rec.product_qty_remains_to_deliver, 0, precision_digits=precision
-            ) == 1 and rec.state in ("sale", "done")
+            rec.can_cancel_remaining_qty = (
+                float_compare(
+                    rec.product_qty_remains_to_deliver, 0, precision_digits=precision
+                )
+                == 1
+                and rec.state == "sale"
+            )
 
     @api.depends(
         "product_uom_qty",

--- a/sale_order_line_cancel/views/sale_order.xml
+++ b/sale_order_line_cancel/views/sale_order.xml
@@ -22,7 +22,7 @@
                 expr="//field[@name='order_line']/list/field[@name='qty_delivered']"
                 position="after"
             >
-                <field name="can_cancel_remaining_qty" invisible="1" />
+                <field name="can_cancel_remaining_qty" column_invisible="1" />
                 <button
                     title="Cancel remaining qty"
                     name="%(action_sale_order_line_cancel)d"

--- a/sale_order_line_cancel/views/sale_order_line.xml
+++ b/sale_order_line_cancel/views/sale_order_line.xml
@@ -7,7 +7,7 @@
             <xpath expr="//field[@name='qty_delivered']" position="after">
                 <field name="product_qty_canceled" string="Canceled" />
                 <field name="product_qty_remains_to_deliver" string="To Deliver" />
-                <field name="can_cancel_remaining_qty" invisible="1" />
+                <field name="can_cancel_remaining_qty" column_invisible="1" />
                 <button
                     title="Cancel remaining qty"
                     name="%(sale_order_line_cancel.action_sale_order_line_cancel)d"


### PR DESCRIPTION
A column is currently displayed with no value due to the `invisible="1"` used.  
It should have been `column_invisible="1"` since V17

Also removed state `done` from the possible states of a sale.order.line since the state does not exist anymore