### PR TITLE
[18.0][IMP] Making columns optional&hidden by default

### DIFF
--- a/sale_order_line_cancel/README.rst
+++ b/sale_order_line_cancel/README.rst
@@ -96,6 +96,15 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
+
+.. |maintainer-jbaudoux| image:: https://github.com/jbaudoux.png?size=40px
+    :target: https://github.com/jbaudoux
+    :alt: jbaudoux
+
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-jbaudoux| 
+
 This module is part of the `OCA/sale-workflow <https://github.com/OCA/sale-workflow/tree/18.0/sale_order_line_cancel>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/sale_order_line_cancel/views/sale_order.xml
+++ b/sale_order_line_cancel/views/sale_order.xml
@@ -35,8 +35,12 @@
                 expr="//field[@name='order_line']/list//field[@name='qty_delivered']"
                 position="after"
             >
-                <field name="product_qty_canceled" string="Canceled" />
-                <field name="product_qty_remains_to_deliver" string="To Deliver" />
+                <field name="product_qty_canceled" string="Canceled" optional="hide" />
+                <field
+                    name="product_qty_remains_to_deliver"
+                    string="To Deliver"
+                    optional="hide"
+                />
             </xpath>
         </field>
     </record>

--- a/sale_order_line_cancel/views/sale_order_line.xml
+++ b/sale_order_line_cancel/views/sale_order_line.xml
@@ -5,8 +5,12 @@
         <field name="inherit_id" ref="sale.view_order_line_tree" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='qty_delivered']" position="after">
-                <field name="product_qty_canceled" string="Canceled" />
-                <field name="product_qty_remains_to_deliver" string="To Deliver" />
+                <field name="product_qty_canceled" string="Canceled" optional="hide" />
+                <field
+                    name="product_qty_remains_to_deliver"
+                    string="To Deliver"
+                    optional="hide"
+                />
                 <field name="can_cancel_remaining_qty" column_invisible="1" />
                 <button
                     title="Cancel remaining qty"

--- a/sale_order_line_cancel_sale_stock/README.rst
+++ b/sale_order_line_cancel_sale_stock/README.rst
@@ -100,6 +100,15 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
+
+.. |maintainer-jbaudoux| image:: https://github.com/jbaudoux.png?size=40px
+    :target: https://github.com/jbaudoux
+    :alt: jbaudoux
+
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-jbaudoux| 
+
 This module is part of the `OCA/sale-workflow <https://github.com/OCA/sale-workflow/tree/18.0/sale_order_line_cancel_sale_stock>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.


### PR DESCRIPTION
Made the fields `Qty Canceled` and `Qty To Deliver` hidden by default.    
Not all users need to see these fields.