### PR TITLE
[19.0][FIX] sale_invoice_frequency: move back to sales tab

### DIFF
--- a/sale_invoice_frequency/README.rst
+++ b/sale_invoice_frequency/README.rst
@@ -49,7 +49,7 @@ To use this module, you need to:
 
 1. Go to *Sales/Configuration/Invoicing frequency* and create your
    custom frequencies.
-2. Set these frequencies in the customer form *Invoicing* tab.
+2. Set these frequencies in the customer form *Sales* tab.
 3. When a sale is created, the Invoicing frequency of the field
    ``partner_id`` is propagated.
 4. An user can change Invoicing frequency on sales and customers if has

--- a/sale_invoice_frequency/readme/USAGE.md
+++ b/sale_invoice_frequency/readme/USAGE.md
@@ -2,7 +2,7 @@ To use this module, you need to:
 
 1.  Go to *Sales/Configuration/Invoicing frequency* and create your
     custom frequencies.
-2.  Set these frequencies in the customer form *Invoicing* tab.
+2.  Set these frequencies in the customer form *Sales* tab.
 3.  When a sale is created, the Invoicing frequency of the field
     `partner_id` is propagated.
 4.  An user can change Invoicing frequency on sales and customers if has

--- a/sale_invoice_frequency/static/description/index.html
+++ b/sale_invoice_frequency/static/description/index.html
@@ -399,7 +399,7 @@ Invoicing frequency field is propagated to its children when changed.</p>
 <ol class="arabic simple">
 <li>Go to <em>Sales/Configuration/Invoicing frequency</em> and create your
 custom frequencies.</li>
-<li>Set these frequencies in the customer form <em>Invoicing</em> tab.</li>
+<li>Set these frequencies in the customer form <em>Sales</em> tab.</li>
 <li>When a sale is created, the Invoicing frequency of the field
 <tt class="docutils literal">partner_id</tt> is propagated.</li>
 <li>An user can change Invoicing frequency on sales and customers if has

--- a/sale_invoice_frequency/views/res_partner_view.xml
+++ b/sale_invoice_frequency/views/res_partner_view.xml
@@ -7,11 +7,12 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="account.view_partner_property_form" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//group[@id='invoice_send_settings']/field[@name='invoice_sending_method']"
-                position="before"
-            >
-                <field name="invoice_frequency_id" options="{'no_create': True}" />
+            <xpath expr="//group[@name='sale']" position="inside">
+                <field
+                    name="invoice_frequency_id"
+                    options="{'no_create': True}"
+                    groups="account.group_account_invoice"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
fw of:

- https://github.com/OCA/sale-workflow/pull/4229

In the migration to v18 the invoice frequency field was moved to the invoicing tab in the partner form. This seemd pretty convient as it's an invoicing setting, but it's breaking the users workflow that need to set different frequency for different addresses.

cc @Moduon MT-14294

please review @yajo  @Gelojr 