### PR TITLE
[19.0][FIX] sale_global_discount: discount amounts on orders without …

### DIFF
--- a/sale_global_discount/models/sale_order.py
+++ b/sale_global_discount/models/sale_order.py
@@ -100,6 +100,9 @@ class SaleOrder(models.Model):
         res = super()._compute_amounts()
         for order in self:
             if not order.global_discount_ids:
+                order.amount_untaxed_before_global_discounts = order.amount_untaxed
+                order.amount_total_before_global_discounts = order.amount_total
+                order.amount_global_discount = 0.0
                 continue
             order._check_global_discounts_sanity()
             amount_untaxed_before_global_discounts = order.amount_untaxed


### PR DESCRIPTION
When modifying quantities on a confirmed order that has no global discounts, the fields amount_untaxed_before_global_discounts and amount_total_before_global_discounts were not being updated.

The _compute_amounts method used an early continue when global_discount_ids was empty, leaving those compute fields unassigned and retaining stale data in the cache/database.

Explicitly assign the standard untaxed and total amounts to the "before discount" fields, and set the global discount amount to 0.0 before continuing the loop.


<img width="1914" height="963" alt="image" src="https://github.com/user-attachments/assets/205df38c-3390-4504-b3f8-f408802fd070" />