### PR TITLE
[FIX]Sale_order_secondary_unit: erase the default secondary unit of sale when the uom is deactivated

### DIFF
--- a/sale_order_secondary_unit/models/product.py
+++ b/sale_order_secondary_unit/models/product.py
@@ -3,6 +3,18 @@
 from odoo import fields, models
 
 
+class ProductSecondaryUnit(models.Model):
+    _inherit = "product.secondary.unit"
+
+    def write(self, vals):
+        if "active" in vals and not vals["active"]:
+            products = self.env["product.product"].search(
+                [("sale_secondary_uom_id", "in", self.ids)]
+            )
+            products.sale_secondary_uom_id = False
+        return super().write(vals)
+
+
 class ProductProduct(models.Model):
     _inherit = "product.product"
 


### PR DESCRIPTION
If i have a default secondary unit for sales and i deactivate this UoM, it doesn't erase the UoM from the default secondary unit for sale, not only allowing the user to still use that UoM in a sale order, but also selecting this secondary UoM as default in the sale order.
<img width="1177" height="952" alt="image" src="https://github.com/user-attachments/assets/845396c2-6777-46b8-89e5-31ad1adfdb7e" />
<img width="1194" height="710" alt="image" src="https://github.com/user-attachments/assets/d1d3cf13-0d30-417c-852f-e11fa36495c4" />
