### PR TITLE
[19.0][FIX] sale_fixed_discount: fix portal fixed discount disp…

### DIFF
--- a/sale_fixed_discount/views/sale_portal_templates.xml
+++ b/sale_fixed_discount/views/sale_portal_templates.xml
@@ -27,7 +27,9 @@
         </xpath>
 
         <xpath expr="//div[@t-field='line.price_unit']" position="attributes">
-            <attribute name="t-if">line.discount &gt;= 0 or line.discount_fixed &gt;= 0</attribute>
+            <attribute
+                name="t-if"
+            >line.discount &gt;= 0 or line.discount_fixed &gt;= 0</attribute>
             <attribute name="t-att-style">
                 (line.discount or line.discount_fixed) and 'text-decoration: line-through' or None
             </attribute>

--- a/sale_fixed_discount/views/sale_portal_templates.xml
+++ b/sale_fixed_discount/views/sale_portal_templates.xml
@@ -13,9 +13,10 @@
                 t-value="True in [line.discount_fixed > 0 for line in sale_order.order_line]"
             />
         </xpath>
+
         <xpath
             expr="//section[@id='details']//table/thead//th[@t-if='display_discount']"
-            position="before"
+            position="after"
         >
             <th
                 t-if="display_discount_fixed"
@@ -24,27 +25,36 @@
                 <span>Disc. Fixed Amount</span>
             </th>
         </xpath>
+
         <xpath expr="//div[@t-field='line.price_unit']" position="attributes">
-            <attribute
-                name="t-if"
-            >line.discount &gt;= 0 or line.fixed_discount &gt;= 0</attribute>
-            <attribute
-                name="t-att-style"
-            >(line.discount or line.discount_fixed) and 'text-decoration: line-through' or None</attribute>
-            <attribute
-                name="t-att-class"
-            >((line.discount or line.discount_fixed) and 'text-danger' or '') + ' text-right'</attribute>
+            <attribute name="t-if">line.discount &gt;= 0 or line.discount_fixed &gt;= 0</attribute>
+            <attribute name="t-att-style">
+                (line.discount or line.discount_fixed) and 'text-decoration: line-through' or None
+            </attribute>
+            <attribute name="t-att-class">
+                ((line.discount or line.discount_fixed) and 'text-danger' or '') + ' text-right'
+            </attribute>
         </xpath>
-        <xpath expr="//div[@t-if='line.discount']/t" position="attributes">
-            <attribute name="t-out">line.price_unit - line.discount_fixed</attribute>
+
+        <xpath expr="//div[@t-if='line.discount']" position="after">
+            <div t-elif="line.discount_fixed">
+                <t
+                    t-out="line.price_unit - line.discount_fixed"
+                    t-options='{"widget": "float", "decimal_precision": "Product Price"}'
+                />
+            </div>
         </xpath>
-        <xpath expr="//td[@t-if='display_discount']" position="before">
+
+        <xpath expr="//td[@t-if='display_discount']" position="after">
             <td
                 t-if="display_discount_fixed"
                 t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}"
             >
                 <strong t-if="line.discount_fixed &gt; 0" class="text-info">
-                    <t t-esc="line.discount_fixed" />
+                    <t
+                        t-out="line.discount_fixed"
+                        t-options='{"widget": "float", "decimal_precision": "Product Price"}'
+                    />
                 </strong>
             </td>
         </xpath>


### PR DESCRIPTION
This PR fixes the portal display for fixed discounts in 19.0.

Changes:
- port the missing fix from 17.0 (#3945) so the discounted unit price is shown when discount_fixed is set
- add a proper t-elif branch for fixed discount rendering
- fix portal column misalignment by correcting xpath insertion positions
- ensure fixed discount amount and discount percentage are displayed in correct columns

Closes #4172