### PR TITLE
[FIX] sale_partner_primeship : freeze time in tests to avoid errors d…

### DIFF
--- a/sale_partner_primeship/tests/test_sale_order_primeship.py
+++ b/sale_partner_primeship/tests/test_sale_order_primeship.py
@@ -4,10 +4,12 @@
 from datetime import date
 
 from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
 
 from .common import TestCommon
 
 
+@freeze_time("2025-04-01 12:00:00")
 class TestSaleOrderPrimeship(TestCommon):
     def test_action_confirm_creates_primeship(self):
         order_line = self.make_order_line()

--- a/sale_partner_primeship/tests/test_sale_primeship.py
+++ b/sale_partner_primeship/tests/test_sale_primeship.py
@@ -4,6 +4,7 @@
 from datetime import date, timedelta
 
 import psycopg2
+from freezegun import freeze_time
 
 from odoo import fields
 from odoo.exceptions import ValidationError
@@ -12,6 +13,7 @@ from odoo.tools.misc import mute_logger
 from .common import TestCommon
 
 
+@freeze_time("2025-04-01 12:00:00")
 class TestSalePrimeship(TestCommon):
     def test_compute_name(self):
         primeship = self.make_primeship("2024-01-01", "2024-12-31")


### PR DESCRIPTION
…ue to DST

Following #4251 (thanks to @sergiocorato)

Freeze time in all other tests as the issue #4192 is still there for 2 tests
See https://github.com/OCA/sale-workflow/actions/runs/24109913027/job/70341911143
