### PR TITLE
[18.0][FIX] sale_semaphore: Use _get_product_price

### DIFF
--- a/sale_semaphore/models/sale_order.py
+++ b/sale_semaphore/models/sale_order.py
@@ -29,8 +29,8 @@ class SaleOderLine(models.Model):
                     line.price_reduce_taxinc
                     if line.company_id.account_price_include == "tax_included"
                     else line.price_reduce_taxexcl,
-                    line.order_id.pricelist_id.get_product_price(
-                        line.product_id, line.product_uom_qty, line.order_id.partner_id
+                    line.order_id.pricelist_id._get_product_price(
+                        line.product_id, line.product_uom_qty
                     ),
                     precision_digits=dp,
                 )

--- a/sale_semaphore/tests/test_sale_semaphore.py
+++ b/sale_semaphore/tests/test_sale_semaphore.py
@@ -1,6 +1,7 @@
 # Copyright 2026
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.exceptions import UserError
 from odoo.tests import tagged
 
 from odoo.addons.base.tests.common import BaseCommon
@@ -132,6 +133,8 @@ class TestSaleSemaphore(BaseCommon):
         self.assertFalse(warning_line.price_below_semaphore)
         self.assertFalse(danger_line.price_below_semaphore)
         self.assertTrue(below_limit_line.price_below_semaphore)
+        with self.assertRaises(UserError):
+            self.order.with_user(self.env.ref("base.user_demo")).action_confirm()
 
     def test_sale_line_uses_category_configuration(self):
         self.product.write(


### PR DESCRIPTION
Avoid error:
`AttributeError: 'product.pricelist' object has no attribute 'get_product_price'`
when a non manager user confirm a sale with danger semaphore 
@Tecnativa TT61891
@CarlosRoca13 @sergio-teruel 