### PR TITLE
[18.0][FIX] sale_line_name_option: avoid duplicate product name in invoice line

### DIFF
--- a/sale_line_name_option/models/__init__.py
+++ b/sale_line_name_option/models/__init__.py
@@ -1,3 +1,4 @@
 from . import product_product
 from . import res_company
 from . import res_config_settings
+from . import sale_order_line

--- a/sale_line_name_option/models/sale_order_line.py
+++ b/sale_line_name_option/models/sale_order_line.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Quartile (https://www.quartile.co)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _prepare_invoice_line(self, **optional_values):
+        if self.env.company.no_product_code_in_sale_line_name:
+            self = self.with_context(display_default_code=False)
+        return super()._prepare_invoice_line(**optional_values)

--- a/sale_line_name_option/tests/test_sale_line_name_option.py
+++ b/sale_line_name_option/tests/test_sale_line_name_option.py
@@ -1,10 +1,12 @@
 # Copyright 2025 Quartile (https://www.quartile.co)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests.common import TransactionCase
+from odoo.fields import Command
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestSaleLineNameOption(TransactionCase):
+class TestSaleLineNameOption(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -23,3 +25,21 @@ class TestSaleLineNameOption(TransactionCase):
         result = self.product.get_product_multiline_description_sale()
         self.assertNotIn(self.product.default_code, result)
         self.assertIn(self.product.description_sale, result)
+
+    def test_prepare_invoice_line_no_duplicate_name(self):
+        self.env.company.no_product_code_in_sale_line_name = True
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    Command.create(
+                        {"product_id": self.product.id, "product_uom_qty": 1},
+                    )
+                ],
+            }
+        )
+        line = order.order_line
+        self.assertNotIn(self.product.default_code, line.name)
+        order.action_confirm()
+        invoice_line_vals = line._prepare_invoice_line()
+        self.assertEqual(invoice_line_vals["name"], line.name)


### PR DESCRIPTION
Override `_prepare_invoice_line` to suppress `default_code` when the `no_product_code_in_sale_line_name` option is enabled, preventing the product name from appearing twice in the invoice line description.

@qrtl QT6595