### PR TITLE
[18.0][IMP] sale_order_lot_selection: Filter pending moves only

### DIFF
--- a/sale_order_lot_selection/models/sale_order_line.py
+++ b/sale_order_lot_selection/models/sale_order_line.py
@@ -104,13 +104,13 @@ class SaleOrderLine(models.Model):
             lambda x: x.product_id and x.product_tracking != "none" and x.move_ids
         ):
             moves = item.move_ids.filtered(lambda x: x.restrict_lot_id)
-            if any(move.state == "done" for move in moves):
+            if all(move.state in ("cancel", "done") for move in moves):
                 raise ValidationError(
                     self.env._(
                         "You can't modify the Lot/Serial number "
-                        "because some stock move has already been done."
+                        "because all stock move has already been done."
                     )
                 )
-            pending_moves = moves.filtered(lambda x: x.state != "cancel")
+            pending_moves = moves.filtered(lambda x: x.state not in ("cancel", "done"))
             if pending_moves:
                 pending_moves._set_restrict_lot_id_from_sol(item.lot_id)

--- a/sale_order_lot_selection/models/sale_order_line.py
+++ b/sale_order_lot_selection/models/sale_order_line.py
@@ -104,7 +104,7 @@ class SaleOrderLine(models.Model):
             lambda x: x.product_id and x.product_tracking != "none" and x.move_ids
         ):
             moves = item.move_ids.filtered(lambda x: x.restrict_lot_id)
-            if all(move.state in ("cancel", "done") for move in moves):
+            if all(move.state == "done" for move in moves):
                 raise ValidationError(
                     self.env._(
                         "You can't modify the Lot/Serial number "
@@ -112,5 +112,13 @@ class SaleOrderLine(models.Model):
                     )
                 )
             pending_moves = moves.filtered(lambda x: x.state not in ("cancel", "done"))
+            # It is important to exclude pending return stock moves if the source move
+            # is no longer pending; otherwise, a "lot incompatibility" error will occur
+            # in stock_restrict_lot
+            moves_to_exclude = self.env["stock.move"]
+            for move in pending_moves.filtered(lambda x: x.origin_returned_move_id):
+                if move.origin_returned_move_id not in pending_moves:
+                    moves_to_exclude = move
+            pending_moves -= moves_to_exclude
             if pending_moves:
                 pending_moves._set_restrict_lot_id_from_sol(item.lot_id)

--- a/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
+++ b/sale_order_lot_selection/tests/test_sale_order_lot_selection.py
@@ -400,7 +400,7 @@ class TestSaleOrderLotSelection(BaseCommon):
         self.assertEqual(picking.state, "done")
         msg = (
             "You can't modify the Lot/Serial number "
-            "because some stock move has already been done."
+            "because all stock move has already been done."
         )
         with self.assertRaisesRegex(ValidationError, msg):
             line_0.lot_id = lot_extra_2


### PR DESCRIPTION
Filter pending moves only

Example use case:
- 2 steps delivery
- Move a > Picking step 1 (lot a) > done
- Move b > Picking step 2 (lot a) > backorder
- Move b > Backorder > Set lot_id=lot b to sale order line

Exclude pending move return in certain cases.

Example use case:
- 2 steps delivery
- Move a > Picking step 1 (lot a) > done
- Move b > Picking step 2 (lot a) > pending
- Move c > Return move a (lot a) > pending

If we change the lot in the sales order line to lot b, that lot should only be changed in move b

@Tecnativa TT61067