### PR TITLE
[16.0][FIX] sale_stock_picking_blocking: preserve delivery_block_id on create/write

### DIFF
--- a/sale_stock_picking_blocking/README.rst
+++ b/sale_stock_picking_blocking/README.rst
@@ -95,6 +95,7 @@ Authors
 ~~~~~~~
 
 * ForgeFlow
+* Therp BV
 
 Contributors
 ~~~~~~~~~~~~

--- a/sale_stock_picking_blocking/__manifest__.py
+++ b/sale_stock_picking_blocking/__manifest__.py
@@ -1,12 +1,13 @@
 # Copyright 2019 ForgeFlow S.L.
 #   (http://www.forgeflow.com)
+# Copyright 2026 Therp BV <https://therp.nl>.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
     "name": "Sale Stock Picking Blocking",
     "summary": "Allow you to block the creation of deliveries from a sale order.",
-    "version": "16.0.1.3.1",
-    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "version": "16.0.1.4.1",
+    "author": "ForgeFlow, Therp BV, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "category": "Sales",
     "depends": ["sale_stock"],

--- a/sale_stock_picking_blocking/models/sale_order.py
+++ b/sale_stock_picking_blocking/models/sale_order.py
@@ -1,5 +1,6 @@
 # Copyright 2019 ForgeFlow S.L.
 #   (http://www.forgeflow.com)
+# Copyright 2026 Therp BV <https://therp.nl>.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
@@ -25,15 +26,45 @@ class SaleOrder(models.Model):
 
     @api.depends("partner_id", "payment_term_id")
     def _compute_delivery_block_id(self):
-        """Add the 'Default Delivery Block Reason' if set in the partner
-        or in the payment term."""
+        """Set a default delivery block reason from partner or payment term,
+        but do not overwrite an already existing value."""
         for so in self:
-            if so.partner_id.default_delivery_block:
-                so.delivery_block_id = so.partner_id.default_delivery_block
-            else:
-                so.delivery_block_id = (
-                    so.payment_term_id.default_delivery_block_reason_id or False
-                )
+            if so.delivery_block_id:
+                continue
+            so.delivery_block_id = (
+                so.partner_id.default_delivery_block
+                or so.payment_term_id.default_delivery_block_reason_id
+                or False
+            )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        orders = super().create(vals_list)
+        for order, vals in zip(orders, vals_list):
+            if not vals.get("delivery_block_id"):
+                continue
+            order.delivery_block_id = vals["delivery_block_id"]
+        return orders
+
+    def write(self, vals):
+        preserved = {}
+        if "delivery_block_id" not in vals and (
+            "partner_id" in vals or "payment_term_id" in vals
+        ):
+            preserved = {
+                so.id: so.delivery_block_id.id for so in self if so.delivery_block_id
+            }
+        res = super().write(vals)
+        if not preserved:
+            return res
+        for so in self:
+            preserved_id = preserved.get(so.id)
+            if not preserved_id:
+                continue
+            if so.delivery_block_id:
+                continue
+            so.delivery_block_id = preserved_id
+        return res
 
     def action_remove_delivery_block(self):
         """Remove the delivery block and create procurements as usual."""

--- a/sale_stock_picking_blocking/static/description/index.html
+++ b/sale_stock_picking_blocking/static/description/index.html
@@ -443,6 +443,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h3><a class="toc-backref" href="#toc-entry-5">Authors</a></h3>
 <ul class="simple">
 <li>ForgeFlow</li>
+<li>Therp BV</li>
 </ul>
 </div>
 <div class="section" id="contributors">

--- a/sale_stock_picking_blocking/tests/test_sale_stock_picking_blocking.py
+++ b/sale_stock_picking_blocking/tests/test_sale_stock_picking_blocking.py
@@ -1,5 +1,6 @@
 # Copyright 2019 ForgeFlow S.L.
 #   (http://www.forgeflow.com)
+# Copyright 2026 Therp BV <https://therp.nl>.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from odoo.tests import Form, common
 
@@ -12,6 +13,8 @@ class TestSaleDeliveryBlock(common.TransactionCase):
         cls.sol_model = cls.env["sale.order.line"]
         cls.usr_model = cls.env["res.users"]
         cls.block_model = cls.env["sale.delivery.block.reason"]
+        cls.partner_model = cls.env["res.partner"]
+        cls.payment_term_model = cls.env["account.payment.term"]
         group_ids = [
             cls.env.ref("sale_stock_picking_blocking.group_sale_delivery_block").id,
             cls.env.ref("sales_team.group_sale_manager").id,
@@ -48,6 +51,50 @@ class TestSaleDeliveryBlock(common.TransactionCase):
             "product_uom_qty": 1.0,
         }
         cls.sale_order_line = cls.sol_model.with_user(cls.user_test).create(sol_dict)
+
+        cls.block_reason_1 = cls.block_model.with_user(cls.user_test).create(
+            {"name": "Test Block 1"}
+        )
+        cls.block_reason_2 = cls.block_model.with_user(cls.user_test).create(
+            {"name": "Test Block 2"}
+        )
+
+        cls.payment_term_no_block = cls.payment_term_model.create(
+            {"name": "Test Payment Term No Block"}
+        )
+        cls.payment_term_with_block = cls.payment_term_model.create(
+            {
+                "name": "Test Payment Term With Block",
+                "default_delivery_block_reason_id": cls.block_reason_2.id,
+            }
+        )
+
+        cls.partner_no_block = cls.partner_model.create(
+            {
+                "name": "Test Partner No Block",
+                "property_payment_term_id": cls.payment_term_no_block.id,
+            }
+        )
+        cls.partner_with_block = cls.partner_model.create(
+            {
+                "name": "Test Partner With Block",
+                "default_delivery_block": cls.block_reason_1.id,
+                "property_payment_term_id": cls.payment_term_no_block.id,
+            }
+        )
+        cls.partner_with_payment_term_block = cls.partner_model.create(
+            {
+                "name": "Test Partner With Payment Term Block",
+                "property_payment_term_id": cls.payment_term_with_block.id,
+            }
+        )
+        cls.partner_with_both_blocks = cls.partner_model.create(
+            {
+                "name": "Test Partner With Both Blocks",
+                "default_delivery_block": cls.block_reason_1.id,
+                "property_payment_term_id": cls.payment_term_with_block.id,
+            }
+        )
 
     def test_block_with_auto_done_enabled(self):
         # Set active auto done configuration
@@ -112,39 +159,94 @@ class TestSaleDeliveryBlock(common.TransactionCase):
         self.assertNotEqual(pick, 0, "A delivery should have been made")
 
     def test_default_delivery_block_partner(self):
-        block_reason = self.block_model.with_user(self.user_test).create(
-            {"name": "Test Block."}
-        )
-        partner_block = self.env["res.partner"].create(
-            {
-                "name": "Foo",
-                "default_delivery_block": block_reason.id,
-            }
-        )
         so_form = Form(self.env["sale.order"])
-        so_form.partner_id = partner_block
+        so_form.partner_id = self.partner_with_block
         so = so_form.save()
-        self.assertEqual(so.delivery_block_id, block_reason)
-        self.assertEqual(so.copy().delivery_block_id, block_reason)
+        self.assertEqual(so.delivery_block_id, self.block_reason_1)
+        self.assertEqual(so.copy().delivery_block_id, self.block_reason_1)
 
     def test_default_delivery_block_payment_term(self):
-        block_reason = self.block_model.with_user(self.user_test).create(
-            {"name": "Test Block."}
-        )
-        partner_block = self.env["res.partner"].create(
-            {
-                "name": "Foo",
-            }
-        )
-        payment_term_block = self.env["account.payment.term"].create(
-            {
-                "name": "Foo",
-                "default_delivery_block_reason_id": block_reason.id,
-            }
-        )
         so_form = Form(self.env["sale.order"])
-        so_form.partner_id = partner_block
-        so_form.payment_term_id = payment_term_block
+        so_form.partner_id = self.partner_no_block
+        so_form.payment_term_id = self.payment_term_with_block
         so = so_form.save()
-        self.assertEqual(so.delivery_block_id, block_reason)
-        self.assertEqual(so.copy().delivery_block_id, block_reason)
+        self.assertEqual(so.delivery_block_id, self.block_reason_2)
+        self.assertEqual(so.copy().delivery_block_id, self.block_reason_2)
+
+    def test_default_delivery_block_partner_has_priority_over_payment_term(self):
+        so = self.so_model.create(
+            {
+                "partner_id": self.partner_with_both_blocks.id,
+                "payment_term_id": self.payment_term_with_block.id,
+                "name": "Test SO Partner Priority",
+            }
+        )
+        self.assertEqual(so.delivery_block_id, self.block_reason_1)
+
+    def test_manual_delivery_block_is_preserved_on_create(self):
+        so = self.so_model.create(
+            {
+                "partner_id": self.partner_no_block.id,
+                "payment_term_id": self.payment_term_no_block.id,
+                "delivery_block_id": self.block_reason_2.id,
+                "name": "Test SO Manual Create",
+            }
+        )
+        self.assertEqual(so.delivery_block_id, self.block_reason_2)
+
+    def test_manual_delivery_block_overrides_partner_default_on_create(self):
+        so = self.so_model.create(
+            {
+                "partner_id": self.partner_with_block.id,
+                "payment_term_id": self.payment_term_no_block.id,
+                "delivery_block_id": self.block_reason_2.id,
+                "name": "Test SO Manual Over Partner Default",
+            }
+        )
+        self.assertEqual(so.delivery_block_id, self.block_reason_2)
+
+    def test_manual_delivery_block_overrides_payment_term_default_on_create(self):
+        so = self.so_model.create(
+            {
+                "partner_id": self.partner_with_payment_term_block.id,
+                "payment_term_id": self.payment_term_with_block.id,
+                "delivery_block_id": self.block_reason_1.id,
+                "name": "Test SO Manual Over Payment Term Default",
+            }
+        )
+        self.assertEqual(so.delivery_block_id, self.block_reason_1)
+
+    def test_write_unrelated_field_keeps_delivery_block(self):
+        so = self.so_model.create(
+            {
+                "partner_id": self.partner_with_block.id,
+                "payment_term_id": self.payment_term_no_block.id,
+                "name": "Test SO Unrelated Write",
+            }
+        )
+        self.assertEqual(so.delivery_block_id, self.block_reason_1)
+
+        so.write({"client_order_ref": "REF123"})
+        self.assertEqual(so.delivery_block_id, self.block_reason_1)
+
+    def test_copy_keeps_payment_term_default_delivery_block(self):
+        so_form = Form(self.env["sale.order"])
+        so_form.partner_id = self.partner_no_block
+        so_form.payment_term_id = self.payment_term_with_block
+        so = so_form.save()
+
+        self.assertEqual(so.delivery_block_id, self.block_reason_2)
+        self.assertEqual(so.copy().delivery_block_id, self.block_reason_2)
+
+    def test_write_explicit_false_delivery_block_has_priority(self):
+        so = self.so_model.create(
+            {
+                "partner_id": self.partner_with_block.id,
+                "payment_term_id": self.payment_term_no_block.id,
+                "name": "Test SO Explicit False Delivery Block",
+            }
+        )
+        self.assertEqual(so.delivery_block_id, self.block_reason_1)
+
+        so.write({"delivery_block_id": False})
+        self.assertFalse(so.delivery_block_id)


### PR DESCRIPTION
This PR fixes an issue where the delivery_block_id set manually on a new Sales Order could be lost when saving.

In detail:
The field delivery_block_id is implemented as a stored computed field depending on partner_id and payment_term_id. During record creation, the compute method was triggered and could overwrite the value provided manually by the user, often resetting it to False or to a default.
A similar issue could occur when changing the partner or payment term on an existing Sales Order, causing an already set value to be lost.

Solution:
The field remains computed, but the logic is adjusted so that:

*existing values are never overwritten by the compute method
*defaults are only applied when the field is empty
*create() and write() ensure consistent behavior

This ensures that manually set values are always preserved, while default values are still applied as needed.

previous attempt: https://github.com/OCA/sale-workflow/pull/3906