### PR TITLE
[18][FIX] sale_automatic_workflow: Migrate company_dependent field

### DIFF
--- a/sale_automatic_workflow/migrations/18.0.1.0.0/post-migrate.py
+++ b/sale_automatic_workflow/migrations/18.0.1.0.0/post-migrate.py
@@ -1,0 +1,10 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade, openupgrade_180
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade_180.convert_company_dependent(
+        env, "sale.workflow.process", "property_journal_id"
+    )


### PR DESCRIPTION
It seems the migration script to convert the company dependent fields is missing