### PR TITLE
[FIX] sale_invoice_blocking: return str from _nothing_to_invoice_error_message

### DIFF
--- a/sale_invoice_blocking/__manifest__.py
+++ b/sale_invoice_blocking/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sale Invoice Blocking",
     "summary": "Allow you to block the creation of invoices from a sale order.",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "author": "Camptocamp, " "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "category": "Sales",

--- a/sale_invoice_blocking/models/sale_order.py
+++ b/sale_invoice_blocking/models/sale_order.py
@@ -1,7 +1,6 @@
 # Copyright 2021 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError
 
 
 class SaleOrder(models.Model):
@@ -35,4 +34,4 @@ class SaleOrder(models.Model):
             "\nAdditionally, you may have an invoice blocking reason on the sale order."
         )
 
-        return UserError(error)
+        return error


### PR DESCRIPTION
## Description

The base `sale.order._nothing_to_invoice_error_message` returns a plain `str`, and the caller `sale.order._create_invoices` wraps it in a `UserError` itself:

```python
raise UserError(self._nothing_to_invoice_error_message())
```

Other modules that override `_nothing_to_invoice_error_message` rely on this contract — for example, `sale_subscription` (Odoo Enterprise) appends additional hints via `+=`:

```python
def _nothing_to_invoice_error_message(self):
    error_message = super()._nothing_to_invoice_error_message()
    if any(self.mapped("is_subscription")):
        error_message += _("\n- ...")
    return error_message
```

`sale_invoice_blocking` currently breaks this contract by wrapping the message in a `UserError` and returning that:

```python
return UserError(error)
```

When `sale_subscription` sits above `sale_invoice_blocking` in the MRO, its `+=` is asked to add a `str` to a `UserError` and raises `TypeError: unsupported operand type(s) for +=: 'UserError' and 'str'` on the Create Invoice wizard.

## Fix

Return the message as a `str`. The caller wraps it in `UserError` already, so the user-visible behaviour is unchanged for installs that don't include a downstream override.

## Reproduction (before this PR)

1. Install `sale_invoice_blocking` and `sale_subscription` (Enterprise).
2. Create a Sale Order with no invoiceable lines and an `invoice_blocking_reason_id`.
3. Try to invoice it via the Create Invoice wizard — `TypeError` instead of `UserError`.

## Test plan

- [x] Existing `test_sales_order_invoicing` still passes — it asserts `UserError` is raised on `_create_invoices()`, which remains true since the base wraps the returned str.