### PR TITLE
[18.0][FIX] sale_manual_delivery: Trying to improve performance during installation

### DIFF
--- a/sale_manual_delivery/hook.py
+++ b/sale_manual_delivery/hook.py
@@ -1,5 +1,6 @@
 def pre_init_hook(env):
     cr = env.cr
+
     cr.execute(
         """
         ALTER TABLE sale_order_line ADD COLUMN IF NOT EXISTS qty_procured numeric;
@@ -13,53 +14,77 @@ def pre_init_hook(env):
         """
     )
 
-    cr.execute(
-        """
-update sale_order_line as sol set qty_procured = r.qty_procured,
-qty_to_procure = sol.product_uom_qty - r.qty_procured
-from (select sol.id, sum(
-    case
-        when (
-        sl.usage = 'customer'
-        and sm.origin_returned_move_id is null
-        or (
-        sm.origin_returned_move_id is not null and sm.to_refund
-        )) then
-            ROUND(
-                ((sm.product_uom_qty / sm_product_uom.factor) * sol_product_uom.factor),
-                SCALE(sol_product_uom.rounding)
-                )
-        when (
-        sl.usage != 'customer'
-        and sm.to_refund
-        ) then
-        ROUND(
-                ((sm.product_uom_qty / sm_product_uom.factor) * sol_product_uom.factor),
-                SCALE(sol_product_uom.rounding)
-                ) * -1
-        else 0
-    end)
- AS qty_procured
-from
-sale_order_line as sol
-inner join (
-    select sol.id, sm.id as move_id, sm.location_id, sm.location_dest_id
-    from sale_order_line as sol
-    left join stock_move as sm on (
-        sm.state != 'cancel'
-        and sm.scrapped = false
-        and sol.product_id = sm.product_id
-        and sm.sale_line_id = sol.id
-        )
-) as q on q.id = sol.id
-left join stock_move as sm on sm.id = q.move_id
-left join product_product as pp on pp.id = sol.product_id
-left join product_template as pt on pt.id = pp.product_tmpl_id
-left join stock_location as sl on sl.id = q.location_dest_id
-LEFT JOIN uom_uom sm_product_uom ON sm.product_uom = sm_product_uom.id
-LEFT JOIN uom_uom sol_product_uom ON sol.product_uom = sol_product_uom.id
-group by sol.id, sm.product_uom, sol.product_uom
-) as r
-where r.id = sol.id
+    # Backfill qty_procured / qty_to_procure by replicating
+    # _get_qty_procurement in SQL (faster than the Python ).
+
+    # qty_procured = how much of the SO line actually reached the customer
+    # - Add outgoing moves toward customers
+    # - Substract to_refund returns
+    # - Ignore the rest: cancelled, scrapped, non-refund returns
+    cr.execute("""\
+UPDATE sale_order_line AS sol
+SET
+    qty_procured = r.qty_procured,
+    qty_to_procure = sol.product_uom_qty - r.qty_procured
+FROM (
+    SELECT
+        sol.id,
+        SUM(
+            CASE
+                WHEN (
+                    (
+                        sl.usage = 'customer'
+                        AND sm.origin_returned_move_id IS NULL
+                    )
+                    OR
+                    (
+                        sm.origin_returned_move_id IS NOT NULL
+                        AND sm.to_refund
+                    )
+                ) THEN
+                    ROUND(
+                        ((sm.product_uom_qty / sm_product_uom.factor) * sol_product_uom.factor),
+                        SCALE(sol_product_uom.rounding)
+                        )
+                WHEN (
+                    sl.usage != 'customer'
+                    AND sm.to_refund
+                ) THEN
+                ROUND(
+                        ((sm.product_uom_qty / sm_product_uom.factor) * sol_product_uom.factor),
+                        SCALE(sol_product_uom.rounding)
+                        ) * -1
+                ELSE 0
+            END
+        ) AS qty_procured
+    FROM
+    sale_order_line AS sol
+    INNER JOIN (
+        SELECT
+            sol.id,
+            sm.id AS move_id,
+            sm.location_id,
+            sm.location_dest_id
+        FROM sale_order_line AS sol
+        LEFT JOIN stock_move AS sm ON (
+            sm.state != 'cancel'
+            AND sm.scrapped = false
+            AND sol.product_id = sm.product_id
+            AND sm.sale_line_id = sol.id
+            )
+    ) AS q ON q.id = sol.id
+    LEFT JOIN stock_move AS sm ON sm.id = q.move_id
+    LEFT JOIN product_product AS pp ON pp.id = sol.product_id
+    LEFT JOIN product_template AS pt ON pt.id = pp.product_tmpl_id
+    LEFT JOIN stock_location AS sl ON sl.id = q.location_dest_id
+    LEFT JOIN uom_uom sm_product_uom ON sm.product_uom = sm_product_uom.id
+    LEFT JOIN uom_uom sol_product_uom ON sol.product_uom = sol_product_uom.id
+    GROUP BY
+        sol.id,
+        sm.product_uom,
+        sol.product_uom
+) AS r
+WHERE r.id = sol.id
     """
     )
+    raise 

--- a/sale_manual_delivery/hook.py
+++ b/sale_manual_delivery/hook.py
@@ -1,6 +1,12 @@
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
 def pre_init_hook(env):
     cr = env.cr
 
+    _logger.info("Pre-creating fields in SQL")
     cr.execute(
         """
         ALTER TABLE sale_order_line ADD COLUMN IF NOT EXISTS qty_procured numeric;
@@ -21,12 +27,9 @@ def pre_init_hook(env):
     # - Add outgoing moves toward customers
     # - Substract to_refund returns
     # - Ignore the rest: cancelled, scrapped, non-refund returns
+    _logger.info("Pre-populating fields in SQL")
     cr.execute("""\
-UPDATE sale_order_line AS sol
-SET
-    qty_procured = r.qty_procured,
-    qty_to_procure = sol.product_uom_qty - r.qty_procured
-FROM (
+WITH sol_qty_procured AS (
     SELECT
         sol.id,
         SUM(
@@ -43,48 +46,43 @@ FROM (
                     )
                 ) THEN
                     ROUND(
-                        ((sm.product_uom_qty / sm_product_uom.factor) * sol_product_uom.factor),
+                        ((sm.product_uom_qty / sm_product_uom.factor)
+                        * sol_product_uom.factor),
                         SCALE(sol_product_uom.rounding)
                         )
                 WHEN (
                     sl.usage != 'customer'
                     AND sm.to_refund
                 ) THEN
-                ROUND(
-                        ((sm.product_uom_qty / sm_product_uom.factor) * sol_product_uom.factor),
+                    ROUND(
+                        ((sm.product_uom_qty / sm_product_uom.factor)
+                        * sol_product_uom.factor),
                         SCALE(sol_product_uom.rounding)
-                        ) * -1
+                    ) * -1
                 ELSE 0
             END
         ) AS qty_procured
     FROM
     sale_order_line AS sol
-    INNER JOIN (
-        SELECT
-            sol.id,
-            sm.id AS move_id,
-            sm.location_id,
-            sm.location_dest_id
-        FROM sale_order_line AS sol
-        LEFT JOIN stock_move AS sm ON (
-            sm.state != 'cancel'
-            AND sm.scrapped = false
-            AND sol.product_id = sm.product_id
-            AND sm.sale_line_id = sol.id
-            )
-    ) AS q ON q.id = sol.id
-    LEFT JOIN stock_move AS sm ON sm.id = q.move_id
-    LEFT JOIN product_product AS pp ON pp.id = sol.product_id
-    LEFT JOIN product_template AS pt ON pt.id = pp.product_tmpl_id
-    LEFT JOIN stock_location AS sl ON sl.id = q.location_dest_id
-    LEFT JOIN uom_uom sm_product_uom ON sm.product_uom = sm_product_uom.id
-    LEFT JOIN uom_uom sol_product_uom ON sol.product_uom = sol_product_uom.id
+    INNER JOIN stock_move AS sm ON (
+        sm.state != 'cancel'
+        AND sm.scrapped = false
+        AND sol.product_id = sm.product_id
+        AND sm.sale_line_id = sol.id
+    )
+    LEFT JOIN stock_location AS sl ON sl.id = sm.location_dest_id
+    LEFT JOIN uom_uom sm_product_uom ON sm_product_uom.id = sm.product_uom
+    LEFT JOIN uom_uom sol_product_uom ON sol_product_uom.id = sol.product_uom
     GROUP BY
         sol.id,
         sm.product_uom,
         sol.product_uom
-) AS r
-WHERE r.id = sol.id
-    """
-    )
-    raise 
+)
+UPDATE sale_order_line AS sol
+SET
+    qty_procured = sol_qty_procured.qty_procured,
+    qty_to_procure = sol.product_uom_qty - sol_qty_procured.qty_procured
+FROM sol_qty_procured
+WHERE sol_qty_procured.id = sol.id
+    """)
+    _logger.info("Finished pre-populating fields")

--- a/sale_manual_delivery/tests/__init__.py
+++ b/sale_manual_delivery/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_manual_delivery
+from . import test_pre_init_hook

--- a/sale_manual_delivery/tests/test_pre_init_hook.py
+++ b/sale_manual_delivery/tests/test_pre_init_hook.py
@@ -1,0 +1,196 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.tests.common import TransactionCase
+
+from odoo.addons.sale_manual_delivery.hook import pre_init_hook
+
+
+class TestPreInitHook(TransactionCase):
+    """Non-regression tests for the ``pre_init_hook`` SQL update.
+
+    The hook runs *before* the module is installed, so at hook time the
+    ``manual_delivery`` field does not exist and no record in the database
+    can have been created through this module. The test data therefore
+    only uses standard sale/stock flows.
+
+    Each test resets the columns of its own line right before calling the
+    hook and reads them back through raw SQL, so existing data in the test
+    database can neither pollute the assertions nor be polluted by them.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create(
+            {"name": "Test Pre-Init Hook Partner"}
+        )
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Pre-Init Hook Product",
+                "type": "consu",
+                "is_storable": True,
+                "list_price": 10.0,
+            }
+        )
+        cls.service = cls.env["product.product"].create(
+            {
+                "name": "Test Pre-Init Hook Service",
+                "type": "service",
+                "list_price": 5.0,
+            }
+        )
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.env["stock.quant"]._update_available_quantity(
+            cls.product, cls.stock_location, 1000
+        )
+
+    def _create_order(self, product, qty):
+        return self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "partner_invoice_id": self.partner.id,
+                "partner_shipping_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": product.name,
+                            "product_id": product.id,
+                            "product_uom_qty": qty,
+                            "product_uom": product.uom_id.id,
+                            "price_unit": product.list_price,
+                        },
+                    )
+                ],
+            }
+        )
+
+    def _read_qty(self, line):
+        """Read raw column values, bypassing the ORM compute trigger."""
+        self.env.flush_all()
+        self.env.cr.execute(
+            "SELECT qty_procured, qty_to_procure " "FROM sale_order_line WHERE id = %s",
+            (line.id,),
+        )
+        return self.env.cr.fetchone()
+
+    def _set_qty(self, line, qty_procured, qty_to_procure):
+        """Force raw column values to simulate a given pre-hook state."""
+        self.env.flush_all()
+        self.env.cr.execute(
+            "UPDATE sale_order_line "
+            "SET qty_procured = %s, qty_to_procure = %s "
+            "WHERE id = %s",
+            (qty_procured, qty_to_procure, line.id),
+        )
+        self.env.invalidate_all()
+
+    def test_pre_init_hook_fully_delivered(self):
+        """Tout livré: standard order, picking validated for the full qty.
+
+        Expected: qty_procured = ordered qty, qty_to_procure = 0.
+        """
+        order = self._create_order(self.product, qty=10)
+        order.action_confirm()
+        picking = order.picking_ids
+        self.assertTrue(picking)
+        picking.action_assign()
+        picking.move_line_ids.write({"quantity": 10})
+        picking.button_validate()
+        self.assertEqual(picking.state, "done")
+        line = order.order_line
+
+        self._set_qty(line, None, None)
+        pre_init_hook(self.env)
+
+        qty_procured, qty_to_procure = self._read_qty(line)
+        self.assertEqual(qty_procured, 10.0)
+        self.assertEqual(qty_to_procure, 0.0)
+
+    def test_pre_init_hook_partially_delivered(self):
+        """Partiellement livré: stock move qty manually reduced below the
+        SOL qty (mimics a real-world partial state - cancelled partial
+        moves, edited moves, etc. - using only standard flows).
+
+        Expected: qty_procured = move qty, qty_to_procure = remaining.
+        """
+        order = self._create_order(self.product, qty=10)
+        order.action_confirm()
+        move = order.picking_ids.move_ids
+        self.assertEqual(len(move), 1)
+        move.product_uom_qty = 4
+        line = order.order_line
+
+        self._set_qty(line, None, None)
+        pre_init_hook(self.env)
+
+        qty_procured, qty_to_procure = self._read_qty(line)
+        self.assertEqual(qty_procured, 4.0)
+        self.assertEqual(qty_to_procure, 6.0)
+
+    def test_pre_init_hook_nothing_delivered(self):
+        """Rien livré: a service line has no stock_move at all.
+
+        Order with two lines (one service, one storable) so the test
+        observes the hook on both a no-move line and a control line:
+
+        - The control line proves the hook's UPDATE actually ran.
+        - The service line is set to a sentinel so we can see whether
+          the hook touched it or not.
+        """
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "partner_invoice_id": self.partner.id,
+                "partner_shipping_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.service.name,
+                            "product_id": self.service.id,
+                            "product_uom_qty": 5,
+                            "product_uom": self.service.uom_id.id,
+                            "price_unit": self.service.list_price,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product.name,
+                            "product_id": self.product.id,
+                            "product_uom_qty": 8,
+                            "product_uom": self.product.uom_id.id,
+                            "price_unit": self.product.list_price,
+                        },
+                    ),
+                ],
+            }
+        )
+        order.action_confirm()
+        service_line = order.order_line.filtered(
+            lambda line: line.product_id == self.service
+        )
+        control_line = order.order_line.filtered(
+            lambda line: line.product_id == self.product
+        )
+        self.assertFalse(service_line.move_ids)
+        self.assertTrue(control_line.move_ids)
+
+        self._set_qty(service_line, 42.0, 99.0)
+        self._set_qty(control_line, None, None)
+
+        pre_init_hook(self.env)
+
+        # Service line: the current SQL updates *every* SOL (the inner-
+        # join-on-self pattern doesn't filter), so the sentinel is
+        # overwritten with qty_procured=0 and qty_to_procure=ordered.
+        s_procured, s_to_procure = self._read_qty(service_line)
+        self.assertEqual(s_procured, 0.0)
+        self.assertEqual(s_to_procure, 5.0)
+        # Control line: proves the hook actually executed its UPDATE.
+        c_procured, c_to_procure = self._read_qty(control_line)
+        self.assertEqual(c_procured, 8.0)
+        self.assertEqual(c_to_procure, 0.0)

--- a/sale_manual_delivery/tests/test_pre_init_hook.py
+++ b/sale_manual_delivery/tests/test_pre_init_hook.py
@@ -86,7 +86,7 @@ class TestPreInitHook(TransactionCase):
         self.env.invalidate_all()
 
     def test_pre_init_hook_fully_delivered(self):
-        """Tout livré: standard order, picking validated for the full qty.
+        """Fully delivered: standard order, picking validated for the full qty.
 
         Expected: qty_procured = ordered qty, qty_to_procure = 0.
         """
@@ -108,7 +108,7 @@ class TestPreInitHook(TransactionCase):
         self.assertEqual(qty_to_procure, 0.0)
 
     def test_pre_init_hook_partially_delivered(self):
-        """Partiellement livré: stock move qty manually reduced below the
+        """Partially delivered: stock move qty manually reduced below the
         SOL qty (mimics a real-world partial state - cancelled partial
         moves, edited moves, etc. - using only standard flows).
 
@@ -129,14 +129,18 @@ class TestPreInitHook(TransactionCase):
         self.assertEqual(qty_to_procure, 6.0)
 
     def test_pre_init_hook_nothing_delivered(self):
-        """Rien livré: a service line has no stock_move at all.
+        """Nothing delivered: a service line has no stock_move at all.
 
-        Order with two lines (one service, one storable) so the test
-        observes the hook on both a no-move line and a control line:
+        With the INNER JOIN on stock_move, the hook does not touch such
+        lines. The test pairs it with a *control* storable line (in the
+        same order) which the hook *should* update, so the test fails
+        in two distinct regression scenarios:
 
-        - The control line proves the hook's UPDATE actually ran.
-        - The service line is set to a sentinel so we can see whether
-          the hook touched it or not.
+        - If the hook stops running its UPDATE entirely, the control
+          line stays at the sentinel and the assertion below fails.
+        - If the INNER JOIN is reverted to a LEFT JOIN, the service
+          line's sentinel is overwritten with 0 and that assertion
+          fails instead.
         """
         order = self.env["sale.order"].create(
             {
@@ -179,17 +183,17 @@ class TestPreInitHook(TransactionCase):
         self.assertFalse(service_line.move_ids)
         self.assertTrue(control_line.move_ids)
 
+        # Sentinel on the service line; NULL on the control to give the
+        # hook something visibly different to write back.
         self._set_qty(service_line, 42.0, 99.0)
         self._set_qty(control_line, None, None)
 
         pre_init_hook(self.env)
 
-        # Service line: the current SQL updates *every* SOL (the inner-
-        # join-on-self pattern doesn't filter), so the sentinel is
-        # overwritten with qty_procured=0 and qty_to_procure=ordered.
+        # Service line: hook's INNER JOIN must skip it -> sentinel kept.
         s_procured, s_to_procure = self._read_qty(service_line)
-        self.assertEqual(s_procured, 0.0)
-        self.assertEqual(s_to_procure, 5.0)
+        self.assertEqual(s_procured, 42.0)
+        self.assertEqual(s_to_procure, 99.0)
         # Control line: proves the hook actually executed its UPDATE.
         c_procured, c_to_procure = self._read_qty(control_line)
         self.assertEqual(c_procured, 8.0)


### PR DESCRIPTION
Slight performance improvment of pre_init_hook

Same logic is kept but
- Unused joins with products are removed
- Unified duplicate join on stock_move table
- Used `WITH` statement for the subquery to make it more readable.

I replaced a `LEFT JOIN` with an `INNER JOIN` to skip records that don't need updated values.

Sadly, on big table with lot of records, the bottlneck is the write, not so much the read.
Still looking for the best solution to this issue.