### PR TITLE
[17.0][FIX] sale_discount_display_amount: avoid crash when discount = 0

### DIFF
--- a/sale_discount_display_amount/models/sale_order_line.py
+++ b/sale_discount_display_amount/models/sale_order_line.py
@@ -35,6 +35,7 @@ class SaleOrderLine(models.Model):
             line.price_subtotal_no_discount = 0
             line.price_total_no_discount = 0
             line.discount_total = 0
+            line.discount_subtotal = 0
             if not line.discount:
                 line.price_subtotal_no_discount = line.price_subtotal
                 line.price_total_no_discount = line.price_total

--- a/sale_discount_display_amount/tests/test_discount_display_amount.py
+++ b/sale_discount_display_amount/tests/test_discount_display_amount.py
@@ -40,3 +40,47 @@ class TestDiscountDisplay(TransactionCase):
         )
         first_line = so2.order_line[0]
         self.assertEqual(first_line.price_total_no_discount, first_line.price_total)
+
+    def test_discount_subtotal_no_discount(self):
+        """
+        Regression test: ensure `discount_subtotal` is always assigned when
+        discount = 0.
+        Context
+        -------
+        In Odoo, computed fields must be assigned for every record during their compute
+        method execution. Failing to do so raises a runtime error:
+            ValueError: Compute method failed to assign <field>
+        A bug in `sale_discount_display_amount` caused `discount_subtotal` not to be
+        assigned when `discount = 0`, because the computation branch skipped it.
+        This resulted in crashes when:
+            - opening sale orders
+            - triggering onchange
+            - loading views
+        What this test validates
+        ------------------------
+        - The compute method `_compute_amount` does not crash when discount = 0
+        - The field `discount_subtotal` is properly assigned
+        - The assigned value is consistent with business logic (0)
+        This is a regression test to prevent future changes from reintroducing
+        the issue.
+        """
+        product = self.env["product.product"].create(
+            {"name": "Product TEST", "type": "consu"}
+        )
+        customer = self.env["res.partner"].create(
+            {"name": "Customer TEST", "email": "test@test.com"}
+        )
+        so = self.env["sale.order"].create({"partner_id": customer.id})
+        line = self.env["sale.order.line"].create(
+            {
+                "order_id": so.id,
+                "product_id": product.id,
+                "price_unit": 100,
+                "product_uom_qty": 1,
+                "discount": 0,
+            }
+        )
+        # Trigger compute explicitly (defensive: ensures execution in test context)
+        line._compute_amount()
+        # Core assertion: field must be assigned and correct
+        self.assertEqual(line.discount_subtotal, 0)


### PR DESCRIPTION
@BinhexTeam

## Problem

When `discount = 0`, the compute method `_compute_amount` in
`sale_discount_display_amount` does not assign the field
`discount_subtotal`.

This violates Odoo's compute contract and triggers a runtime error:
ValueError: Compute method failed to assign sale.order.line(…).discount_subtotal

This issue can occur when:
- opening sale orders
- triggering onchange
- loading views

## Cause

In `_update_discount_display_fields`, the branch handling
`not line.discount` does not assign `discount_subtotal`.

## Solution

Ensure `discount_subtotal` is always initialized for every record,
even when `discount = 0`.

## Additional changes

- Add a regression test to prevent reintroducing the issue.

## Related context

This is related to inconsistencies in discount handling reported in:

- https://github.com/OCA/sale-workflow/issues/3849
- https://github.com/OCA/sale-workflow/pull/3927

Although not the same bug, they highlight similar issues around
discount computation and display logic.

## Impact

- Fixes crash in UI and RPC calls
- Stabilizes compute logic
- No functional change in expected business values

## Checklist

- [x] Tests added
- [x] No breaking changes
- [x] Follows OCA guidelines