### PR TITLE
[18.0][FIX] sale_company_currency: Fix currency conversion (division not multiplication)

### DIFF
--- a/sale_company_currency/models/sale_order.py
+++ b/sale_company_currency/models/sale_order.py
@@ -29,5 +29,5 @@ class SaleOrder(models.Model):
             if order.currency_id.id == order.company_id.currency_id.id:
                 to_amount = order.amount_total
             else:
-                to_amount = order.amount_total * order.currency_rate
+                to_amount = order.amount_total / order.currency_rate
             order.amount_total_curr = to_amount

--- a/sale_company_currency/tests/test_sale_company_currency.py
+++ b/sale_company_currency/tests/test_sale_company_currency.py
@@ -139,11 +139,15 @@ class TestSaleOrder(TransactionCase):
         """Test rate change triggers recomputation of amount_total_curr."""
         self.sale_order.currency_id = self.currency_eur
         self._set_currency_rate(self.currency_eur, 0.5)
+        # Invalidate currency_rate to force Odoo to look up the new rate record
+        self.sale_order.invalidate_recordset(["currency_rate"])
         self.sale_order.flush_recordset(["amount_total_curr"])
         first_total_curr = self.sale_order.amount_total_curr
 
         # Change the rate and check if amount_total_curr is updated automatically
         self._set_currency_rate(self.currency_eur, 0.25)
+        # Invalidate again for the second change
+        self.sale_order.invalidate_recordset(["currency_rate"])
         self.sale_order.flush_recordset(["amount_total_curr"])
 
         self.assertNotEqual(self.sale_order.amount_total_curr, first_total_curr)

--- a/sale_company_currency/tests/test_sale_company_currency.py
+++ b/sale_company_currency/tests/test_sale_company_currency.py
@@ -5,21 +5,15 @@ class TestSaleOrder(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # currencies
         cls.currency_usd = cls.env.ref("base.USD")
         cls.currency_eur = cls.env.ref("base.EUR")
-
-        # Customer
         cls.partner = cls.env.ref("base.res_partner_2")
-
-        # Company
         cls.company = cls.env.ref("base.main_company")
-
-        # Products
         cls.product1 = cls.env.ref("product.product_product_4")
         cls.product2 = cls.env.ref("product.product_product_5")
 
-        # Create a sale order with the same currency as the company
+        # Fix broken setUpClass: original had two order line dicts
+        # inside a single (0, 0, ...) command tuple.
         cls.sale_order = cls.env["sale.order"].create(
             {
                 "partner_id": cls.partner.id,
@@ -34,41 +28,124 @@ class TestSaleOrder(TransactionCase):
                             "product_uom_qty": 2,
                             "price_unit": 50.0,
                         },
+                    ),
+                    (
+                        0,
+                        0,
                         {
                             "product_id": cls.product2.id,
                             "product_uom_qty": 1,
                             "price_unit": 100.0,
                         },
-                    )
+                    ),
                 ],
             }
         )
 
+    def _set_currency_rate(self, currency, rate):
+        today = self.sale_order.date_order.date()
+        rate_rec = self.env["res.currency.rate"].search(
+            [
+                ("currency_id", "=", currency.id),
+                ("name", "=", today),
+                ("company_id", "=", self.company.id),
+            ],
+            limit=1,
+        )
+        if rate_rec:
+            rate_rec.rate = rate
+        else:
+            self.env["res.currency.rate"].create(
+                {
+                    "currency_id": currency.id,
+                    "name": today,
+                    "company_id": self.company.id,
+                    "rate": rate,
+                }
+            )
+
     def test_01_amount_total_curr_same_currency(self):
-        """Test amount_total_curr when sale order currency matches company currency."""
-        self.sale_order.currency_id = self.currency_usd
-        self.sale_order._compute_amount_company()
+        self.sale_order.currency_id = self.company.currency_id
+        # Force a recompute of amount_total_curr (no manual call)
         self.assertEqual(
             self.sale_order.amount_total_curr,
             self.sale_order.amount_total,
-            "Amount in company currency should match the total amount when currencies "
-            "are the same.",
         )
 
     def test_02_amount_total_curr_different_currency(self):
-        """Test amount_total_curr when sale order currency differs from company
-        currency."""
         self.sale_order.currency_id = self.currency_eur
-        self.sale_order._compute_amount_company()
-        amount_total_curr_rounded = round(self.sale_order.amount_total_curr, 2)
-        amount_total_converted_rounded = round(
-            self.sale_order.amount_total * self.sale_order.currency_rate, 2
+        # Create rate via res.currency.rate so compute chain is exercised
+        self._set_currency_rate(self.currency_eur, 0.85)
+        # Flush to trigger recomputes
+        self.sale_order.flush_recordset(["amount_total_curr"])
+        expected = self.sale_order.amount_total / self.sale_order.currency_rate
+        self.assertAlmostEqual(
+            self.sale_order.amount_total_curr,
+            expected,
+            places=2,
+            msg="Amount in company currency should be converted using division.",
         )
+
+    def test_03_amount_total_curr_rate_one(self):
+        self.sale_order.currency_id = self.currency_eur
+        self._set_currency_rate(self.currency_eur, 1.0)
+        self.sale_order.flush_recordset(["amount_total_curr"])
         self.assertEqual(
-            amount_total_curr_rounded,
-            amount_total_converted_rounded,
-            msg=(
-                "Amount in company currency should be converted "
-                "using the currency rate."
-            ),
+            self.sale_order.amount_total_curr,
+            self.sale_order.amount_total,
         )
+
+    def test_04_amount_total_curr_multiple_orders(self):
+        sale_order_2 = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+                "currency_id": self.currency_eur.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product1.id,
+                            "product_uom_qty": 3,
+                            "price_unit": 75.0,
+                        },
+                    ),
+                ],
+            }
+        )
+        self.sale_order.currency_id = self.currency_eur
+        self._set_currency_rate(self.currency_eur, 0.85)
+
+        # Flush all modified orders to trigger recomputes
+        orders = self.sale_order + sale_order_2
+        orders.flush_recordset(["amount_total_curr"])
+
+        expected_1 = self.sale_order.amount_total / self.sale_order.currency_rate
+        expected_2 = sale_order_2.amount_total / sale_order_2.currency_rate
+
+        self.assertAlmostEqual(
+            self.sale_order.amount_total_curr,
+            expected_1,
+            places=2,
+        )
+        self.assertAlmostEqual(
+            sale_order_2.amount_total_curr,
+            expected_2,
+            places=2,
+        )
+
+    def test_05_automatic_recompute_on_rate_change(self):
+        """Test rate change triggers recomputation of amount_total_curr."""
+        self.sale_order.currency_id = self.currency_eur
+        self._set_currency_rate(self.currency_eur, 0.5)
+        self.sale_order.flush_recordset(["amount_total_curr"])
+        first_total_curr = self.sale_order.amount_total_curr
+
+        # Change the rate and check if amount_total_curr is updated automatically
+        self._set_currency_rate(self.currency_eur, 0.25)
+        self.sale_order.flush_recordset(["amount_total_curr"])
+
+        self.assertNotEqual(self.sale_order.amount_total_curr, first_total_curr)
+        expected = self.sale_order.amount_total / 0.25
+        self.assertAlmostEqual(self.sale_order.amount_total_curr, expected, places=2)


### PR DESCRIPTION
Change `order.amount_total * order.currency_rate` to `order.amount_total / order.currency_rate` in the currency conversion logic.

The conversion rate returned by `_get_conversion_rate(from_company, to_order)` is the amount of company currency per unit of order currency. To convert an order amount to the company currency, division is required, not multiplication. This aligns with how Odoo core uses `currency_rate`, e.g. in `_compute_partner_credit_warning` on `sale.order`.

Also fix the broken `setUpClass` where both order line dictionaries were placed inside a single `(0, 0, ...)` command tuple, which silently truncated to one line and broke `amount_total`. The new tests use `res.currency.rate` records instead of writing directly to the computed `currency_rate` field, so the full compute chain is exercised end-to-end.

Closes #4026

**Note on forward-port suggestion**: PR #3240 on 16.0 changed `/` to `*`, which introduced the bug. This fix (`*` to `/`) is the correct direction — forward-porting #3240 would re-introduce the multiplication bug.