### PR TITLE
[18.0][FIX] pricelist_cache_rest: fix resource model name in ir_exports

### DIFF
--- a/pricelist_cache_rest/data/ir_exports_data.xml
+++ b/pricelist_cache_rest/data/ir_exports_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <record id="ir_exp_cache_item" model="ir.exports">
         <field name="name">Pricelist Cache Parser</field>
-        <field name="resource">pricelist.cache</field>
+        <field name="resource">product.pricelist.cache</field>
     </record>
 
     <record id="ir_exp_cache_item_product_id" model="ir.exports.line">


### PR DESCRIPTION
The `ir.exports` resource field used `pricelist.cache` instead of the actual model name `product.pricelist.cache`, causing a ParseError during module installation:

```
ParseError: Field 'product_id' not found in model 'False'
```

**Fix**: Correct the resource model name on line 5 of `ir_exports_data.xml`.

Closes #4267