### PR TITLE
[18.0][FIX] sale_global_discount: skip tax recompute when no discount

### DIFF
--- a/sale_global_discount/models/sale_order.py
+++ b/sale_global_discount/models/sale_order.py
@@ -100,9 +100,17 @@ class SaleOrder(models.Model):
         res = super()._compute_amounts()
         for order in self:
             order._check_global_discounts_sanity()
+            discounts = order.global_discount_ids.mapped("discount")
+            if not discounts:
+                # No global discounts applied: skip re-computation to
+                # prevent floating-point rounding differences (e.g. 0.01
+                # ghost amounts) from re-computing taxes with compute_all.
+                order.amount_global_discount = 0
+                order.amount_untaxed_before_global_discounts = order.amount_untaxed
+                order.amount_total_before_global_discounts = order.amount_total
+                continue
             amount_untaxed_before_global_discounts = order.amount_untaxed
             amount_total_before_global_discounts = order.amount_total
-            discounts = order.global_discount_ids.mapped("discount")
             amount_discounted_untaxed = amount_discounted_tax = 0
             for line in order.order_line:
                 discounted_subtotal = line.price_subtotal

--- a/sale_global_discount/tests/test_sale_global_discount.py
+++ b/sale_global_discount/tests/test_sale_global_discount.py
@@ -271,3 +271,18 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         self.assertAlmostEqual(
             self.get_taxes_widget_total_tax(self.sale), self.sale.amount_tax
         )
+
+    def test_09_no_discount_no_ghost_amount(self):
+        """Verify that without discounts, amount_global_discount is exactly 0
+        and no re-computation happens (ghost amount fix)."""
+        self.sale.global_discount_ids = False
+        self.sale._compute_amounts()
+        self.assertEqual(self.sale.amount_global_discount, 0.0)
+        self.assertEqual(
+            self.sale.amount_untaxed, 
+            self.sale.amount_untaxed_before_global_discounts
+        )
+        self.assertEqual(
+            self.sale.amount_total, 
+            self.sale.amount_total_before_global_discounts
+        )

--- a/sale_global_discount/tests/test_sale_global_discount.py
+++ b/sale_global_discount/tests/test_sale_global_discount.py
@@ -279,10 +279,8 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         self.sale._compute_amounts()
         self.assertEqual(self.sale.amount_global_discount, 0.0)
         self.assertEqual(
-            self.sale.amount_untaxed, 
-            self.sale.amount_untaxed_before_global_discounts
+            self.sale.amount_untaxed, self.sale.amount_untaxed_before_global_discounts
         )
         self.assertEqual(
-            self.sale.amount_total, 
-            self.sale.amount_total_before_global_discounts
+            self.sale.amount_total, self.sale.amount_total_before_global_discounts
         )


### PR DESCRIPTION
When no global discount is assigned, `_compute_amounts` still re-computed all line taxes via `compute_all()`, which introduced floating-point rounding differences that caused $0.01 or -$0.01 ghost amounts in `amount_global_discount`, incorrectly modifying the taxable base.

**Fix**: When `discounts` is empty, skip the entire re-computation loop and preserve the correct standard Odoo amounts. Set `amount_global_discount = 0` explicitly.

Closes #4200