### PR TITLE
[19.0][FIX] sale_order_type: preserve manual payment term when changing invoice journal

### DIFF
--- a/sale_order_type/models/account_move.py
+++ b/sale_order_type/models/account_move.py
@@ -43,9 +43,15 @@ class AccountMove(models.Model):
 
     @api.depends("sale_type_id")
     def _compute_invoice_payment_term_id(self):
+        previous = {move: move.invoice_payment_term_id for move in self}
         res = super()._compute_invoice_payment_term_id()
-        for move in self.filtered("sale_type_id.payment_term_id"):
-            move.invoice_payment_term_id = move.sale_type_id.payment_term_id
+        for move in self:
+            if move.sale_type_id.payment_term_id:
+                move.invoice_payment_term_id = move.sale_type_id.payment_term_id
+            else:
+                previous_term = previous.get(move)
+                if previous_term:
+                    move.invoice_payment_term_id = previous_term
         return res
 
     @api.depends("sale_type_id")

--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -203,6 +203,33 @@ class TestSaleOrderType(BaseCommon):
         self.assertEqual(invoice.invoice_payment_term_id, sale_type.payment_term_id)
         self.assertEqual(invoice.journal_id, sale_type.journal_id)
 
+    def test_invoice_change_journal_keeps_manual_payment_term(self):
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Invoice Term Test Partner",
+                "property_payment_term_id": self.immediate_payment.id,
+            }
+        )
+        manual_payment_term = self.env.ref("account.account_payment_term_30days")
+        sale_type_without_payment_term = self.sale_type.copy(
+            {"name": "Sale Type Without Payment Term", "payment_term_id": False}
+        )
+        other_journal = self.env["account.journal"].create(
+            {
+                "name": "Alternative Sales Journal",
+                "code": "ASJ1",
+                "type": "sale",
+                "company_id": self.env.company.id,
+            }
+        )
+        invoice = self.invoice_model.new()
+        invoice.partner_id = partner
+        invoice.sale_type_id = sale_type_without_payment_term
+        invoice.invoice_payment_term_id = manual_payment_term
+        invoice.journal_id = other_journal
+        self.assertEqual(invoice.journal_id, other_journal)
+        self.assertEqual(invoice.invoice_payment_term_id, manual_payment_term)
+
     def test_invoice_change_partner(self):
         invoice = self.create_invoice()
         self.assertEqual(invoice.sale_type_id, self.sale_type)


### PR DESCRIPTION
It's the same as #4273 

When a sale type has no payment_term_id and the user sets a manual term on the sale order, changing the invoice journal triggered a recompute chain (journal_id → company_id → sale_type_id) that caused super() to silently reset invoice_payment_term_id to the partner's default.

Skip the super() call for records where neither the partner nor the sale type changed and the sale type carries no term, so the chosen term is kept. Adds a regression test covering this scenario.
