### PR TITLE
[18.0][FIX] sale_procurement_group_by_line: avoid duplicate procurement

### DIFF
--- a/sale_procurement_group_by_line/model/sale.py
+++ b/sale_procurement_group_by_line/model/sale.py
@@ -36,6 +36,7 @@ class SaleOrderLine(models.Model):
         )
         procurements = []
         groups = {}
+        procured_line_ids = set()
         if not previous_product_uom_qty:
             previous_product_uom_qty = {}
         for line in self:
@@ -99,6 +100,7 @@ class SaleOrderLine(models.Model):
             procurements += line._create_procurements(
                 product_qty, procurement_uom, origin, values
             )
+            procured_line_ids.add(line.id)
             # We store the procured quantity in the UoM of the line to avoid
             # duplicated procurements, specially for dropshipping and kits.
             previous_product_uom_qty[line.id] = line.product_uom_qty
@@ -114,6 +116,7 @@ class SaleOrderLine(models.Model):
             if pickings_to_confirm:
                 # Trigger the Scheduler for Pickings
                 pickings_to_confirm.action_confirm()
+        remaining_lines = self - self.browse(procured_line_ids)
         return super(
-            SaleOrderLine, self.with_context(sale_group_by_line=True)
+            SaleOrderLine, remaining_lines.with_context(sale_group_by_line=True)
         )._action_launch_stock_rule(previous_product_uom_qty=previous_product_uom_qty)

--- a/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
+++ b/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
@@ -17,15 +17,62 @@ class TestSaleProcurementGroupByLine(TransactionCase):
         cls.proc_group_model = cls.env["procurement.group"]
         cls.sale_model = cls.env["sale.order"]
         cls.order_line_model = cls.env["sale.order.line"]
+        cls.location_model = cls.env["stock.location"]
+        cls.route_model = cls.env["stock.route"]
+        cls.rule_model = cls.env["stock.rule"]
         # Customer
         cls.customer = cls.env.ref("base.res_partner_2")
         # Warehouse
         cls.warehouse_id = cls.env.ref("stock.warehouse0")
+
         # Create product category
         cls.product_ctg = cls._create_product_category()
         # Create Products
         cls.new_product1 = cls._create_product("test_product1")
         cls.new_product2 = cls._create_product("test_product2")
+        # Create internal destination location
+        cls.internal_dest = cls.location_model.create(
+            {
+                "name": "Internal Consumed-in-Testing",
+                "usage": "internal",
+                "location_id": cls.warehouse_id.view_location_id.id,
+            }
+        )
+        # Create route to pull stock
+        # from the warehouse to internal location
+        cls.internal_route = cls.route_model.create(
+            {
+                "name": "Stock -> Internal Test Dest",
+                "product_selectable": True,
+                "sequence": 1,
+            }
+        )
+        cls.rule_model.create(
+            {
+                "name": "Stock -> Internal Consumed-in-Testing",
+                "route_id": cls.internal_route.id,
+                "location_src_id": cls.warehouse_id.lot_stock_id.id,
+                "location_dest_id": cls.internal_dest.id,
+                "action": "pull",
+                "procure_method": "make_to_stock",
+                "picking_type_id": cls.warehouse_id.out_type_id.id,
+                "warehouse_id": cls.warehouse_id.id,
+            }
+        )
+        # Create product with internal destination route
+        cls.product_internal_dest = cls.product_model.create(
+            {
+                "name": "test_product_internal_dest",
+                "categ_id": cls.product_ctg.id,
+                "is_storable": True,
+                "route_ids": [(6, 0, [cls.internal_route.id])],
+            }
+        )
+        # Create customer pointing to internal delivery location
+        cls.customer_internal = cls.customer.copy(
+            {"property_stock_customer": cls.internal_dest.id}
+        )
+        # Create sale order
         cls.sale = cls._create_sale_order()
 
     @classmethod
@@ -142,3 +189,30 @@ class TestSaleProcurementGroupByLine(TransactionCase):
         self.sale.order_line[1].product_uom_qty += 1
         self.assertEqual(self.sale.order_line[1].procurement_group_id, proc_group)
         self.assertEqual(len(self.line1.move_ids), 1)
+
+    def test_07_no_duplicate_procurement_final_location_is_internal(self):
+        """
+        Ensure we don't create duplicate stock moves when SO line is delivered
+        to an internal location instead of a customer location
+        """
+        sale = self.sale_model.create(
+            {
+                "partner_id": self.customer_internal.id,
+                "warehouse_id": self.warehouse_id.id,
+                "picking_policy": "direct",
+            }
+        )
+        line = self.order_line_model.create(
+            {
+                "order_id": sale.id,
+                "product_id": self.product_internal_dest.id,
+                "product_uom_qty": 3.0,
+                "name": "Internal Dest Line",
+            }
+        )
+        sale.action_confirm()
+        moves = line.move_ids.filtered(lambda m: m.state != "cancel")
+        # Check that only ONE move was created
+        self.assertEqual(len(moves), 1)
+        self.assertEqual(moves.product_uom_qty, 3.0)
+        self.assertEqual(moves.location_final_id, self.internal_dest)


### PR DESCRIPTION
Delivering SO line to an internal location creates duplicate stock moves and duplicate MOs.

This module processes procurements for each SO line and then calls `super()`. Core Odoo relies on `_get_qty_procurement()` to skip lines that are already processed. However, that core method only counts moves going to "outgoing" locations.

With this fix, we track the SO lines processed by this module and filter them before calling `super()`. This ensures no line is processed twice, regardless of its destination type.