### PR TITLE
[FIX] sale_fixed_discount: correct field name in portal template (19.0)

### DIFF
--- a/sale_fixed_discount/views/sale_portal_templates.xml
+++ b/sale_fixed_discount/views/sale_portal_templates.xml
@@ -27,7 +27,7 @@
         <xpath expr="//div[@t-field='line.price_unit']" position="attributes">
             <attribute
                 name="t-if"
-            >line.discount &gt;= 0 or line.fixed_discount &gt;= 0</attribute>
+            >line.discount &gt;= 0 or line.discount_fixed &gt;= 0</attribute>
             <attribute
                 name="t-att-style"
             >(line.discount or line.discount_fixed) and 'text-decoration: line-through' or None</attribute>


### PR DESCRIPTION
[FIX] sale_fixed_discount: correct field name in portal template

The portal template referenced `line.fixed_discount` which does not
exist; the correct field name is `line.discount_fixed`.

This typo caused the price_unit display condition in the portal
sale order view to fail silently.

Fixes OCA/sale-workflow#4172