### PR TITLE
[19.0][IMP] sale_require_po_doc: add a context to permit exceptions to the

### DIFF
--- a/sale_require_po_doc/models/sale_order.py
+++ b/sale_require_po_doc/models/sale_order.py
@@ -26,6 +26,8 @@ class SaleOrder(models.Model):
     sale_document_note = fields.Text(string="Sale Documentation Notes")
 
     def action_confirm(self):
+        if self.env.context.get("skip_sale_require_po_doc"):
+            return super().action_confirm()
         for order in self:
             if order.customer_need_po and not order.client_order_ref:
                 raise ValidationError(


### PR DESCRIPTION
Add a context to permit exceptions to the required customer ref rule. 

Example: ecommerce orders or orders coming from repairs