### PR TITLE
[19.0][FIX] sale_delivery_state: remove duplicate delivery_status column in tree view

### DIFF
--- a/sale_delivery_state/views/sale_order_views.xml
+++ b/sale_delivery_state/views/sale_order_views.xml
@@ -29,23 +29,8 @@
         </field>
     </record>
 
-    <record id="view_order_tree_inherit_delivery_status" model="ir.ui.view">
-        <field name="name">sale.order.tree</field>
-        <field name="inherit_id" ref="sale.view_order_tree" />
-        <field name="model">sale.order</field>
-        <field name="arch" type="xml">
-            <field name="invoice_status" position="before">
-                <field
-                    name="delivery_status"
-                    widget="badge"
-                    optional="hide"
-                    decoration-info="delivery_status == 'pending'"
-                    decoration-warning="delivery_status in ('partial', 'started')"
-                    decoration-success="delivery_status == 'full'"
-                />
-            </field>
-        </field>
-    </record>
+    <!-- Removed: Odoo 19+ sale_stock already adds delivery_status to the tree view.
+         See: https://github.com/OCA/sale-workflow/issues/4290 -->
 
     <record
         id="sale_order_view_search_inherit_sale_inherit_delivery_status"


### PR DESCRIPTION
## Description

In Odoo 19, `sale_stock` already adds the `delivery_status` field to the sale order tree view with badge widget and color decorations. This OCA module was adding it again, resulting in a duplicate column.

This PR removes the redundant tree view inheritance since core already provides this functionality.

## Changes

- Removed `view_order_tree_inherit_delivery_status` view record from `views/sale_order_views.xml`
- Added comment explaining why the view was removed

## Before/After

**Before:** Two `delivery_status` columns shown in sale order list view
**After:** Single column from Odoo core, with same badge widget and decorations

## Related

- Fixes #4290