### PR TITLE
[19.0][FIX] sale_fixed_discount: fix portal template typo and discounted price display

### DIFF
--- a/sale_fixed_discount/views/sale_portal_templates.xml
+++ b/sale_fixed_discount/views/sale_portal_templates.xml
@@ -27,7 +27,7 @@
         <xpath expr="//div[@t-field='line.price_unit']" position="attributes">
             <attribute
                 name="t-if"
-            >line.discount &gt;= 0 or line.fixed_discount &gt;= 0</attribute>
+            >line.discount &gt;= 0 or line.discount_fixed &gt;= 0</attribute>
             <attribute
                 name="t-att-style"
             >(line.discount or line.discount_fixed) and 'text-decoration: line-through' or None</attribute>
@@ -35,8 +35,13 @@
                 name="t-att-class"
             >((line.discount or line.discount_fixed) and 'text-danger' or '') + ' text-right'</attribute>
         </xpath>
-        <xpath expr="//div[@t-if='line.discount']/t" position="attributes">
-            <attribute name="t-out">line.price_unit - line.discount_fixed</attribute>
+        <xpath expr="//div[@t-if='line.discount']" position="after">
+            <div t-elif="line.discount_fixed">
+                <t
+                    t-out="line.price_unit - line.discount_fixed"
+                    t-options='{"widget": "float", "decimal_precision": "Product Price"}'
+                />
+            </div>
         </xpath>
         <xpath expr="//td[@t-if='display_discount']" position="before">
             <td


### PR DESCRIPTION
## Description

Two fixes in `sale_fixed_discount/views/sale_portal_templates.xml`:

### 1. Typo: `line.fixed_discount` → `line.discount_fixed`

The field defined in the model is `discount_fixed`, not `fixed_discount`. This was a latent bug since `line.discount >= 0` short-circuits the `or` condition.

### 2. Discounted price not shown when only fixed discount is set

The original code modified the `<t>` inside `<div t-if="line.discount">`, but when `discount=0` and `discount_fixed>0`, the parent div doesn't render at all, so the discounted price is never displayed.

**Fix:** Replace with a `t-elif` sibling element that renders the discounted price whenever a fixed discount is applied, regardless of percentage discount.

## Related

- Fixes #4172
- Port of fix from PR #3945 (17.0) to 19.0
- Symptoms also reported in #3768 and #3769