### PR TITLE
[16.0][FIX] sale_blanket_order: exclude section/note lines from line count and list view

### DIFF
--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -182,7 +182,9 @@ class BlanketOrder(models.Model):
 
     @api.depends("line_ids")
     def _compute_line_count(self):
-        self.line_count = len(self.mapped("line_ids"))
+        self.line_count = len(
+            self.mapped("line_ids").filtered(lambda l: not l.display_type)
+        )
 
     def _compute_sale_count(self):
         for blanket_order in self:
@@ -333,7 +335,7 @@ class BlanketOrder(models.Model):
         action = self.env["ir.actions.act_window"]._for_xml_id(
             "sale_blanket_order.act_open_sale_blanket_order_lines_view_tree"
         )
-        lines = self.mapped("line_ids")
+        lines = self.mapped("line_ids").filtered(lambda l: not l.display_type)
         if len(lines) > 0:
             action["domain"] = [("id", "in", lines.ids)]
         return action


### PR DESCRIPTION
@Escodoo SO571-57

Section (line_section) and note (line_note) lines were being included in two places where only product lines should appear:

- The "Lines" smart button counter was inflated — it counted sections and notes as lines.
- The flat lines view (opened by clicking that button) also showed section/note lines, which had no product, price or quantity — appearing as confusing blank rows.
Fix: filter display_type out in both _compute_line_count and action_view_sale_blanket_order_line.

cc @kaynnan @WesleyOliveira98 @marcelsavegnago 