### PR TITLE
 [18.0][FIX] sale_order_line_input: avoid overwriting order_id from unsaved parent order

### DIFF
--- a/sale_order_line_input/models/sale_order.py
+++ b/sale_order_line_input/models/sale_order.py
@@ -47,8 +47,13 @@ class SaleOrderLine(models.Model):
     def _compute_name(self):
         # A NewId is needed to set the product for the parent method to set
         # the language correctly. Empty id leads to error in ‘_get_lang’.
+        # We only create a dummy order when there is truly no order context at
+        # all (neither a real id nor an origin record). Checking _origin avoids
+        # overwriting the parent’s virtual id when the line is being edited
+        # inside an unsaved sale order form, which would cause the server to
+        # lose the order reference and raise "Invalid fields: Order Reference".
         for line in self:
-            if not line.order_id and line.product_id:
+            if not line.order_id and not line._origin.order_id and line.product_id:
                 SaleOrder = self.env["sale.order"]
                 line.order_id = SaleOrder.new({})
         return super()._compute_name()


### PR DESCRIPTION
In _compute_name, the guard condition was only checking line.order_id, which evaluates to False when the server-side onchange RPC cannot resolve the parent order's virtual NewId (because the sale order has not been saved to DB yet). This caused the method to assign a blank SaleOrder.new({}) as order_id, discarding the parent context and triggering "Invalid fields: Order Reference" when the user tried to save an order line from a new unsaved sale order.

 The fix adds a check on line._origin.order_id so that the dummy order is only created when the line has no order context at all (standalone use case), and not when it is being edited inside an unsaved sale order form.

 cc @Tecnativa TT62673

ping @pedrobaeza @carlos-lopez-tecnativa 