### PR TITLE
[18.0][IMP] sale_elaboration: use state instead of parent.state

### DIFF
--- a/sale_elaboration/views/sale_order_views.xml
+++ b/sale_elaboration/views/sale_order_views.xml
@@ -13,12 +13,12 @@
                     <field
                         name="elaboration_ids"
                         widget="many2many_tags"
-                        readonly="not product_updatable or parent.state in ('done', 'cancel')"
+                        readonly="not product_updatable or state in ('done', 'cancel')"
                         domain="elaboration_profile_id and [('profile_ids', 'in', [elaboration_profile_id])] or []"
                     />
                     <field
                         name="elaboration_note"
-                        readonly="not product_updatable or parent.state in ('done', 'cancel')"
+                        readonly="not product_updatable or state in ('done', 'cancel')"
                     />
                     <field
                         name="elaboration_price_unit"
@@ -41,12 +41,12 @@
                     <field
                         name="elaboration_ids"
                         widget="many2many_tags"
-                        readonly="not product_updatable or parent.state in ('done', 'cancel')"
+                        readonly="not product_updatable or state in ('done', 'cancel')"
                         domain="elaboration_profile_id and [('profile_ids', 'in', [elaboration_profile_id])] or []"
                     />
                     <field
                         name="elaboration_note"
-                        readonly="not product_updatable or parent.state in ('done', 'cancel')"
+                        readonly="not product_updatable or state in ('done', 'cancel')"
                     />
                     <field
                         name="elaboration_price_unit"
@@ -64,13 +64,13 @@
                 <field
                     name="elaboration_ids"
                     widget="many2many_tags"
-                    readonly="not product_updatable or parent.state in ('done', 'cancel')"
+                    readonly="not product_updatable or state in ('done', 'cancel')"
                     domain="elaboration_profile_id and [('profile_ids', 'in', [elaboration_profile_id])] or []"
                     optional="show"
                 />
                 <field
                     name="elaboration_note"
-                    readonly="not product_updatable or parent.state in ('done', 'cancel')"
+                    readonly="not product_updatable or state in ('done', 'cancel')"
                     optional="show"
                 />
                 <field


### PR DESCRIPTION
`parent.state` is only available when a view is rendered embedded inside a One2many (e.g. the order_line subform). When `sale.order.line` is opened as a standalone form (sale_order_line_view_form_readonly), there is no parent context, causing Owl to raise:

EvalError: Name 'parent' is not defined

`sale.order.line` already exposes `state = fields.Selection(related='order_id.state')`, so replacing `parent.state` with `state` is semantically equivalent and works in both embedded and standalone contexts.

cc @Tecnativa TT62707

ping @sergio-teruel @carlosdauden 