### PR TITLE
[14.0][FIX] sale_procurement_group_by_line: Don't return super(), run_procu…

### DIFF
--- a/sale_procurement_group_by_line/model/sale.py
+++ b/sale_procurement_group_by_line/model/sale.py
@@ -25,6 +25,22 @@ class SaleOrderLine(models.Model):
         """
         return 8, self.order_id.id
 
+    def _get_qty_procurement(self, previous_product_uom_qty=False):
+        """Override to respect previous_product_uom_qty for lines already
+        processed by _action_launch_stock_rule.
+
+        Without this, modules like sale_mrp override _get_qty_procurement for
+        kit products and ignore previous_product_uom_qty, returning 0 for
+        nested kit components. This causes super()._action_launch_stock_rule
+        to run procurement a second time, doubling all stock moves.
+        """
+        self.ensure_one()
+        if previous_product_uom_qty and self.id in previous_product_uom_qty:
+            return previous_product_uom_qty[self.id]
+        return super()._get_qty_procurement(
+            previous_product_uom_qty=previous_product_uom_qty
+        )
+
     def _action_launch_stock_rule(self, previous_product_uom_qty=False):
         """
         Launch procurement group run method.
@@ -36,9 +52,6 @@ class SaleOrderLine(models.Model):
         groups = {}
         if not previous_product_uom_qty:
             previous_product_uom_qty = {}
-
-        processed_lines = self.env["sale.order.line"]
-
         for line in self:
             line = line.with_company(line.company_id)
             if line.state != "sale" or line.product_id.type not in ("consu", "product"):
@@ -80,6 +93,7 @@ class SaleOrderLine(models.Model):
             line.procurement_group_id = group_id
             # Also keep the sale order synched
             line.order_id.procurement_group_id = group_id
+
             values = line._prepare_procurement_values(group_id=group_id)
             product_qty = line.product_uom_qty - qty
 
@@ -104,21 +118,8 @@ class SaleOrderLine(models.Model):
             # duplicated procurements, specially for dropshipping and kits.
             previous_product_uom_qty[line.id] = line.product_uom_qty
 
-            processed_lines |= line
-
         if procurements:
             self.env["procurement.group"].run(procurements)
-
-        # Only call super() for lines not handled above (e.g. service lines,
-        # lines already fully procured, or lines skipped for other reasons).
-        # Calling super() on processed lines would re-run procurement via
-        # native _action_launch_stock_rule, causing doubled moves on nested
-        # kits when sale_mrp is installed (see OCA/sale-workflow#4372).
-        remaining_lines = self - processed_lines
-        if remaining_lines:
-            return super(
-                SaleOrderLine, remaining_lines.with_context(sale_group_by_line=True)
-            )._action_launch_stock_rule(
-                previous_product_uom_qty=previous_product_uom_qty
-            )
-        return True
+        return super(
+            SaleOrderLine, self.with_context(sale_group_by_line=True)
+        )._action_launch_stock_rule(previous_product_uom_qty=previous_product_uom_qty)

--- a/sale_procurement_group_by_line/model/sale.py
+++ b/sale_procurement_group_by_line/model/sale.py
@@ -36,6 +36,9 @@ class SaleOrderLine(models.Model):
         groups = {}
         if not previous_product_uom_qty:
             previous_product_uom_qty = {}
+
+        processed_lines = self.env["sale.order.line"]
+
         for line in self:
             line = line.with_company(line.company_id)
             if line.state != "sale" or line.product_id.type not in ("consu", "product"):
@@ -75,7 +78,8 @@ class SaleOrderLine(models.Model):
                 if updated_vals:
                     group_id.write(updated_vals)
             line.procurement_group_id = group_id
-
+            # Also keep the sale order synched
+            line.order_id.procurement_group_id = group_id
             values = line._prepare_procurement_values(group_id=group_id)
             product_qty = line.product_uom_qty - qty
 
@@ -99,9 +103,22 @@ class SaleOrderLine(models.Model):
             # We store the procured quantity in the UoM of the line to avoid
             # duplicated procurements, specially for dropshipping and kits.
             previous_product_uom_qty[line.id] = line.product_uom_qty
+
+            processed_lines |= line
+
         if procurements:
             self.env["procurement.group"].run(procurements)
-            return True
-        return super(
-            SaleOrderLine, self.with_context(sale_group_by_line=True)
-        )._action_launch_stock_rule(previous_product_uom_qty=previous_product_uom_qty)
+
+        # Only call super() for lines not handled above (e.g. service lines,
+        # lines already fully procured, or lines skipped for other reasons).
+        # Calling super() on processed lines would re-run procurement via
+        # native _action_launch_stock_rule, causing doubled moves on nested
+        # kits when sale_mrp is installed (see OCA/sale-workflow#4372).
+        remaining_lines = self - processed_lines
+        if remaining_lines:
+            return super(
+                SaleOrderLine, remaining_lines.with_context(sale_group_by_line=True)
+            )._action_launch_stock_rule(
+                previous_product_uom_qty=previous_product_uom_qty
+            )
+        return True

--- a/sale_procurement_group_by_line/model/sale.py
+++ b/sale_procurement_group_by_line/model/sale.py
@@ -101,6 +101,7 @@ class SaleOrderLine(models.Model):
             previous_product_uom_qty[line.id] = line.product_uom_qty
         if procurements:
             self.env["procurement.group"].run(procurements)
+            return True
         return super(
             SaleOrderLine, self.with_context(sale_group_by_line=True)
         )._action_launch_stock_rule(previous_product_uom_qty=previous_product_uom_qty)

--- a/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
+++ b/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
@@ -64,6 +64,28 @@ class TestSaleProcurementGroupByLine(TransactionCase):
         )
         return self.sale
 
+    def _create_kit_product(self, name, components):
+        """Create a storable product with a phantom (kit) BoM."""
+        kit_product = self.product_model.create(
+            {
+                "name": name,
+                "categ_id": self.product_ctg.id,
+                "type": "product",
+            }
+        )
+        self.env["mrp.bom"].create(
+            {
+                "product_id": kit_product.id,
+                "product_tmpl_id": kit_product.product_tmpl_id.id,
+                "type": "phantom",
+                "bom_line_ids": [
+                    (0, 0, {"product_id": comp.id, "product_qty": 1.0})
+                    for comp in components
+                ],
+            }
+        )
+        return kit_product
+
     def test_01_procurement_group_by_line(self):
         self.sale.action_confirm()
         self.assertEqual(
@@ -137,3 +159,71 @@ class TestSaleProcurementGroupByLine(TransactionCase):
         self.sale.order_line[1].product_uom_qty += 1
         self.assertEqual(self.sale.order_line[1].procurement_group_id, proc_group)
         self.assertEqual(len(self.line1.move_ids), 1)
+
+    def test_07_nested_kit_no_double_procurement(self):
+        """Selling a kit whose BoM contains a component that is itself a kit
+        should create exactly one stock move per leaf component, not doubled.
+        """
+        leaf1 = self.product_model.create(
+            {
+                "name": "leaf_component_1",
+                "categ_id": self.product_ctg.id,
+                "type": "product",
+            }
+        )
+        leaf2 = self.product_model.create(
+            {
+                "name": "leaf_component_2",
+                "categ_id": self.product_ctg.id,
+                "type": "product",
+            }
+        )
+        inner_kit = self._create_kit_product("inner_kit", [leaf1, leaf2])
+        plain = self.product_model.create(
+            {
+                "name": "plain_component",
+                "categ_id": self.product_ctg.id,
+                "type": "product",
+            }
+        )
+        outer_kit = self._create_kit_product("outer_kit", [plain, inner_kit])
+        sale = self.sale_model.create(
+            {
+                "partner_id": self.customer.id,
+                "warehouse_id": self.warehouse_id.id,
+                "picking_policy": "direct",
+            }
+        )
+        self.order_line_model.create(
+            {
+                "order_id": sale.id,
+                "product_id": outer_kit.id,
+                "product_uom_qty": 1.0,
+                "name": "Nested kit sale line",
+            }
+        )
+        # Simulate the sale_mrp _get_qty_procurement bug: for any product with
+        # a phantom BoM, return 0 — as if component moves don't match.
+        # This is what causes super() to re-run procurement on nested kits.
+        original = self.env["sale.order.line"].__class__._get_qty_procurement
+
+        def broken_get_qty_procurement(self_line, previous_product_uom_qty=False):
+            bom = self_line.env["mrp.bom"]._bom_find(
+                product=self_line.product_id, bom_type="phantom"
+            )
+            if bom:
+                return 0.0
+            return original(self_line, previous_product_uom_qty)
+
+        self.env[
+            "sale.order.line"
+        ].__class__._get_qty_procurement = broken_get_qty_procurement
+        try:
+            sale.action_confirm()
+        finally:
+            self.env["sale.order.line"].__class__._get_qty_procurement = original
+        all_moves = sale.picking_ids.mapped("move_lines")
+        self.assertEqual(len(all_moves), 3)
+        for move in all_moves:
+            # without fix quantity is 2
+            self.assertEqual(move.product_uom_qty, 1.0)

--- a/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
+++ b/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
@@ -164,6 +164,10 @@ class TestSaleProcurementGroupByLine(TransactionCase):
         """Selling a kit whose BoM contains a component that is itself a kit
         should create exactly one stock move per leaf component, not doubled.
         """
+        # if the model does not exist in db
+        # do not run the test
+        if "mrp.bom" not in self.env:
+            self.skipTest("mrp not installed — cannot create kit BoMs")
         leaf1 = self.product_model.create(
             {
                 "name": "leaf_component_1",

--- a/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
+++ b/sale_procurement_group_by_line/tests/test_sale_procurement_group_by_line.py
@@ -3,6 +3,7 @@
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
 
@@ -163,11 +164,24 @@ class TestSaleProcurementGroupByLine(TransactionCase):
     def test_07_nested_kit_no_double_procurement(self):
         """Selling a kit whose BoM contains a component that is itself a kit
         should create exactly one stock move per leaf component, not doubled.
+
+        Without the fix, _action_launch_stock_rule() runs procurements and
+        then calls super(). When sale_mrp is installed, its
+        _get_qty_procurement() override ignores previous_product_uom_qty for
+        kit products, returning 0 for nested kit components. Super then
+        re-runs procurement, doubling all moves.
+
+        The fix overrides _get_qty_procurement() in this module to check
+        previous_product_uom_qty first, so super() sees the full qty already
+        procured and skips re-running procurement.
+
+        The broken _get_qty_procurement behavior is simulated by patching at
+        the sale_stock level (below this module in the MRO), so our fix still
+        intercepts correctly — just as it would with sale_mrp installed.
         """
-        # if the model does not exist in db
-        # do not run the test
         if "mrp.bom" not in self.env:
             self.skipTest("mrp not installed — cannot create kit BoMs")
+
         leaf1 = self.product_model.create(
             {
                 "name": "leaf_component_1",
@@ -191,6 +205,7 @@ class TestSaleProcurementGroupByLine(TransactionCase):
             }
         )
         outer_kit = self._create_kit_product("outer_kit", [plain, inner_kit])
+
         sale = self.sale_model.create(
             {
                 "partner_id": self.customer.id,
@@ -206,10 +221,17 @@ class TestSaleProcurementGroupByLine(TransactionCase):
                 "name": "Nested kit sale line",
             }
         )
-        # Simulate the sale_mrp _get_qty_procurement bug: for any product with
-        # a phantom BoM, return 0 — as if component moves don't match.
-        # This is what causes super() to re-run procurement on nested kits.
-        original = self.env["sale.order.line"].__class__._get_qty_procurement
+
+        # Patch _get_qty_procurement at the sale_stock level — below this
+        # module in the MRO — to simulate sale_mrp's broken behavior:
+        # for any product with a phantom BoM, return 0 as if no moves match.
+        # Our _get_qty_procurement fix intercepts above this in the MRO,
+        # returning the correct qty from previous_product_uom_qty instead.
+        from odoo.addons.sale_stock.models.sale_order import (
+            SaleOrderLine as SaleStockLine,
+        )
+
+        original = SaleStockLine._get_qty_procurement
 
         def broken_get_qty_procurement(self_line, previous_product_uom_qty=False):
             bom = self_line.env["mrp.bom"]._bom_find(
@@ -219,15 +241,29 @@ class TestSaleProcurementGroupByLine(TransactionCase):
                 return 0.0
             return original(self_line, previous_product_uom_qty)
 
-        self.env[
-            "sale.order.line"
-        ].__class__._get_qty_procurement = broken_get_qty_procurement
+        SaleStockLine._get_qty_procurement = broken_get_qty_procurement
         try:
             sale.action_confirm()
         finally:
-            self.env["sale.order.line"].__class__._get_qty_procurement = original
+            SaleStockLine._get_qty_procurement = original
+
         all_moves = sale.picking_ids.mapped("move_lines")
-        self.assertEqual(len(all_moves), 3)
+
+        # Without fix: 6 moves (plain + leaf1 + leaf2 each procured twice)
+        # With fix: 3 moves (plain + leaf1 + leaf2 each procured once)
+        self.assertEqual(
+            len(all_moves),
+            3,
+            "Expected 3 stock moves (plain + 2 inner kit components), got %d: %s"
+            % (
+                len(all_moves),
+                all_moves.mapped(lambda m: (m.product_id.name, m.product_uom_qty)),
+            ),
+        )
         for move in all_moves:
-            # without fix quantity is 2
-            self.assertEqual(move.product_uom_qty, 1.0)
+            self.assertEqual(
+                move.product_uom_qty,
+                1.0,
+                "Move for %s should have qty 1.0, got %s"
+                % (move.product_id.name, move.product_uom_qty),
+            )


### PR DESCRIPTION
…rements executed twice