### PR TITLE
[IMP] sale_order_line_chained_move: Fill in related sale line in moves with SQL

### DIFF
--- a/sale_order_line_chained_move/hooks.py
+++ b/sale_order_line_chained_move/hooks.py
@@ -1,31 +1,45 @@
 # Copyright 2021 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.tools import SQL
 
 
-def __find_origin_moves(moves, visited=None):
-    all_moves = moves
-    unvisited_moves = (moves - visited) if visited else moves
-    for move in unvisited_moves:
-        visited = visited + move if visited else move
-        if move.move_orig_ids:
-            all_moves |= __find_origin_moves(move.move_orig_ids, visited)
-    return all_moves
+def _fill_in_related_sale_line_sql(env):
+    """
+    Update all the chained moves with the related sale line
+    """
+    query = SQL(
+        """
+            WITH RECURSIVE linked_moves AS (
+                SELECT
+                    id AS move_id,
+                    sale_line_id AS root_sale_line_id
+                FROM
+                    stock_move
+                WHERE
+                    sale_line_id IS NOT NULL
 
-
-def __fill_related(moves, line_id):
-    for move in moves:
-        moves_to_write = move
-        if move.move_orig_ids:
-            moves_to_write |= __find_origin_moves(move.move_orig_ids)
-        moves_to_write.write({"related_sale_line_id": line_id.id})
-
-
-def _fill_in_related_sale_line(env):
-    """Update related_sale_line_id on recursive moves"""
-    moves = env["stock.move"].search([("sale_line_id", "!=", False)])
-    for move in moves:
-        __fill_related(move.move_orig_ids, move.sale_line_id)
+                UNION
+                SELECT
+                    smr.move_orig_id AS move_id,
+                    lm.root_sale_line_id
+                FROM
+                    stock_move_move_rel smr
+                INNER JOIN
+                    linked_moves lm ON smr.move_dest_id = lm.move_id
+            )
+            UPDATE
+                stock_move sm
+            SET
+                related_sale_line_id = lm.root_sale_line_id
+            FROM
+                linked_moves lm
+            WHERE
+                sm.id = lm.move_id
+                ;
+        """
+    )
+    env.cr.execute(query)
 
 
 def post_init_hook(env):
-    _fill_in_related_sale_line(env)
+    _fill_in_related_sale_line_sql(env)


### PR DESCRIPTION


As module install on an existing database can last, using an sql query is better.