### PR TITLE
[18.0][FIX] sale_planner_calendar: Access error when the user's partner has a user_id assigned

### DIFF
--- a/sale_planner_calendar/security/sale_planner_calendar_security.xml
+++ b/sale_planner_calendar/security/sale_planner_calendar_security.xml
@@ -13,9 +13,12 @@
     <record id="partner_follower_rule" model="ir.rule">
         <field name="name">Partner Follower</field>
         <field ref="base.model_res_partner" name="model_id" />
-        <field
-            name="domain_force"
-        >['|','|',('message_partner_ids', 'in', user.partner_id.ids), ('user_id', '=', user.id), ('user_id', '=', False)]</field>
+        <field name="domain_force">['|','|','|',
+                ('message_partner_ids', 'in', user.partner_id.ids),
+                ('user_id', '=', user.id),
+                ('user_id', '=', False),
+                ('id', 'in', user.partner_id.ids)
+            ]</field>
         <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]" />
     </record>
 


### PR DESCRIPTION
Allow access to user partner although the partner has other user asigned.

ping @CarlosRoca13 @carlosdauden 

TT62744