### PR TITLE
[17.0][FIX] sale_product_multi_add: ignore the pricelist of the wizard

### DIFF
--- a/sale_product_multi_add/wizards/sale_import_products.py
+++ b/sale_product_multi_add/wizards/sale_import_products.py
@@ -41,7 +41,6 @@ class SaleImportProducts(models.TransientModel):
                 "product_id": item.product_id.id,
                 "product_uom_qty": item.quantity,
                 "product_uom": item.product_id.uom_id.id,
-                "price_unit": item.product_id.list_price,
             }
         )
         line_values = sale_line._convert_to_write(sale_line._cache)


### PR DESCRIPTION
**Context / Current behavior**
Currently, when adding products to a Sale Order using the `sale.import.products` wizard, the `price_unit` of the newly created sale order lines is strictly hardcoded to the product's `list_price`. 

This behavior bypasses Odoo's standard pricing logic. It completely ignores the pricelist applied to the Sale Order, customer-specific discounts, B2B conditions, and the order's currency, which leads to incorrect pricing on the generated lines.

**Fix / Expected behavior**
Removed the hardcoded assignment of `"price_unit": item.product_id.list_price` in the `_get_line_values` method. 

By omitting this value during the line creation via `.new()`, Odoo's standard compute methods will natively take over and accurately calculate the `price_unit` based on the specific context of the Sale Order (Pricelist, Taxes, etc.).