### PR TITLE
[16.0] [FIX] sale_order_invoice_amount: invoiced_amount value when SO and invoices share a foreign currency

### DIFF
--- a/sale_order_invoice_amount/models/sale_order.py
+++ b/sale_order_invoice_amount/models/sale_order.py
@@ -32,18 +32,15 @@ class SaleOrder(models.Model):
                 rec.invoiced_amount = 0.0
                 for invoice in rec.invoice_ids:
                     if invoice.state != "cancel":
-                        if (
-                            invoice.currency_id != rec.currency_id
-                            and rec.currency_id != invoice.company_currency_id
-                        ):
+                        if rec.currency_id == invoice.company_currency_id:
+                            rec.invoiced_amount += invoice.amount_total_signed
+                        else:
                             rec.invoiced_amount += invoice.currency_id._convert(
                                 invoice.amount_total_in_currency_signed,
                                 rec.currency_id,
                                 invoice.company_id,
                                 invoice.invoice_date or fields.Date.today(),
                             )
-                        else:
-                            rec.invoiced_amount += invoice.amount_total_signed
                 # Uninvoiced amount could not be equal to total - invoiced amount.
                 # For example if the amount invoiced does not match with the price unit.
                 rec.uninvoiced_amount = max(

--- a/sale_order_invoice_amount/tests/test_sale_order_invoice_amount.py
+++ b/sale_order_invoice_amount/tests/test_sale_order_invoice_amount.py
@@ -403,3 +403,53 @@ class TestSaleOrderInvoiceAmount(common.TransactionCase):
             0.0,
             "Uninvoiced Amount should be calculated.",
         )
+
+    def test_04_sale_order_invoiced_amount_different_currencies_company(self):
+        """Test when SO and invoices share a foreign currency"""
+        pricelist_eur = self.env["product.pricelist"].create(
+            {"name": "EUR Pricelist", "currency_id": self.currency_eur.id}
+        )
+        # Setting this pricelist sets the currency of the sale to eur
+        self.sale_order_1.pricelist_id = pricelist_eur
+        self.sale_order_1.action_confirm()
+        aml1 = self.order_line_1._prepare_invoice_line(
+            **{
+                "currency_id": self.currency_eur.id,
+            }
+        )
+        aml2 = self.order_line_2._prepare_invoice_line(
+            **{
+                "currency_id": self.currency_eur.id,
+            }
+        )
+        self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "invoice_date": fields.Date.from_string("2024-01-01"),
+                "date": fields.Date.from_string("2024-01-01"),
+                "partner_id": self.res_partner_1.id,
+                "currency_id": self.currency_eur.id,
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        aml1,
+                    ),
+                    (
+                        0,
+                        0,
+                        aml2,
+                    ),
+                ],
+            }
+        )
+        self.assertEqual(
+            self.sale_order_1.invoiced_amount,
+            242.0,
+            "Invoiced Amount should be 242",
+        )
+        self.assertEqual(
+            self.sale_order_1.uninvoiced_amount,
+            121.0,
+            "Uninvoiced Amount should be 121, as the lines keep uninvoiced.",
+        )

--- a/sale_order_invoice_amount/tests/test_sale_order_invoice_amount.py
+++ b/sale_order_invoice_amount/tests/test_sale_order_invoice_amount.py
@@ -70,6 +70,9 @@ class TestSaleOrderInvoiceAmount(common.TransactionCase):
                 "tax_id": cls.tax,
             }
         )
+        cls.delta = sum(cls.sale_order_1.order_line.mapped("product_uom_qty")) / (
+            2 * 10 ** cls.env.ref("product.decimal_price").digits
+        )  # 0.005 * (25  + 20 + 10) = 0.275
 
     def test_01_sale_order_invoiced_amount(self):
         self.assertEqual(
@@ -196,10 +199,11 @@ class TestSaleOrderInvoiceAmount(common.TransactionCase):
             }
         )
         test_invoice.action_post()
-        self.assertEqual(
+        self.assertAlmostEqual(
             self.sale_order_1.invoiced_amount,
-            242.11,
-            "Invoiced Amount should be 242.11.",
+            242.0,
+            msg="Invoiced Amount should be approximately 242.00.",
+            delta=self.delta,
         )
         self.assertEqual(
             self.sale_order_1.uninvoiced_amount,
@@ -311,10 +315,11 @@ class TestSaleOrderInvoiceAmount(common.TransactionCase):
             }
         )
         test_invoice.action_post()
-        self.assertEqual(
+        self.assertAlmostEqual(
             self.sale_order_1.invoiced_amount,
-            242.13,
-            "Invoiced Amount should be 242.13.",
+            242.0,
+            msg="Invoiced Amount should be approximately 242.0.",
+            delta=self.delta,
         )
         self.assertEqual(
             self.sale_order_1.uninvoiced_amount,
@@ -387,10 +392,11 @@ class TestSaleOrderInvoiceAmount(common.TransactionCase):
             ]
         )
         test_invoice.action_post()
-        self.assertEqual(
+        self.assertAlmostEqual(
             self.sale_order_1.invoiced_amount,
-            363.06,
-            "Invoiced Amount should be 363.06.",
+            363.00,
+            msg="Invoiced Amount should be approximately 363.00.",
+            delta=self.delta,
         )
         self.assertEqual(
             self.sale_order_1.uninvoiced_amount,


### PR DESCRIPTION
Fixes the use case explained in https://github.com/OCA/sale-workflow/issues/4337

   

Unit tests have been improved in a separate commit. The hardcoded invoiced amounts used in the asserts contained very specific decimal overflow errors that:
- Causes the tests be less robust.
- Are only present in this version (see [version 18.0](https://github.com/OCA/sale-workflow/blob/db78d3e0a47964e6fd732c8b1e43bf2b2db7e935/sale_order_invoice_amount/tests/test_sale_order_invoice_amount.py#L205-L210))



Regarding the FIX:
- The `rec.invoiced_amount += invoice.amount_total_signed` line only works correcly if both monetary fields have the same currency. rec.currency_id for rec.invoiced_amount, and invoice.company_currency_id for invoice.amount_total_signed. A condition to verify that has been added.

- The `rec.invoiced_amount += invoice.currency_id._convert(
                                invoice.amount_total_in_currency_signed,
                                rec.currency_id,
                                invoice.company_id,
                                invoice.invoice_date or fields.Date.today()
                            )` operation correctly converts all currencies to the sale currency, as the amount_total_in_currency_signed already has the total amount of the invoice converted to the currency of the invoice (In case the currency of the invoice and the company currency are different). Taking this into account, that operation has been moved to the else directive, applying it in the rest of the cases


A unit test of this use case has been added. This tests fails without this FIX

T-9647

