### PR TITLE
[18.0][IMP] sale_planner_calendar: allow sales managers to edit non-private events

### DIFF
--- a/sale_planner_calendar/models/calendar_event.py
+++ b/sale_planner_calendar/models/calendar_event.py
@@ -460,3 +460,16 @@ class CalendarEvent(models.Model):
             months=self.env.company.sale_planner_forward_months, day=31
         )
         events_to_update.until = new_date
+
+    def _compute_user_can_edit(self):
+        # Allow sales managers to edit any non-private event, on top of the
+        # default editability rules computed by the parent method.
+        res = super()._compute_user_can_edit()
+        for event in self:
+            if (
+                event.target_partner_id
+                and self.env.context.get("force_user_can_edit_event")
+                and self.env.user.has_group("sales_team.group_sale_manager")
+            ):
+                event.user_can_edit = True
+        return res

--- a/sale_planner_calendar/models/res_partner.py
+++ b/sale_planner_calendar/models/res_partner.py
@@ -49,6 +49,7 @@ class ResPartner(models.Model):
                 )
             ],
             "choose_unlink_method": True,
+            "force_user_can_edit_event": True,
         }
         if not self.env.company.sale_planner_mail_to_attendees:
             action["context"].update(

--- a/sale_planner_calendar/views/calendar_view.xml
+++ b/sale_planner_calendar/views/calendar_view.xml
@@ -44,6 +44,7 @@
             'default_recurrency':True,
             'search_default_user_id':uid,
             'choose_unlink_method': True,
+            'force_user_can_edit_event': True,
         }</field>
         <field name="domain">[('recurrency', '=', True),
             ("is_base_recurrent_event", "=", True), ('target_partner_id', '!=', False), '|', ('recurrence_id.until', '>=', datetime.date.today().strftime("%Y-%m-%d")), ('recurrence_id.until', '=', False)]</field>


### PR DESCRIPTION
Override _compute_user_can_edit so users in the group_sale_manager group can edit any event that is not marked as private, in addition to the default editability rules.

cc @Tecnativa TT62811

ping @carlosdauden @sergio-teruel 