### PR TITLE
[19.0][IMP] sale_order_type: allow ordering default types

### DIFF
--- a/sale_order_type/README.rst
+++ b/sale_order_type/README.rst
@@ -42,6 +42,9 @@ You can see sale types as lines of business.
 You are able to select a sales order type by partner so that when you
 add a partner to a sales order it will get the related info to it.
 
+When no partner or context default applies, the first available sale
+order type by sequence is used as the default.
+
 Additionally, it adds a warning message to notify users when there is a
 mismatch between the partner's default pricelist and the effective
 pricelist set by the sales order type. This ensures clarity when
@@ -66,6 +69,9 @@ To configure Sale Order Types you need to:
 
 1. Go to **Sales > Configuration > Sales Orders Types**
 2. Create a new sale order type with all the settings you want
+3. Use the drag handle in the list view to define the priority of the
+   sale order types. The first matching type for the current company is
+   used as the default when no partner or context default applies.
 
 Usage
 =====
@@ -75,6 +81,9 @@ Usage
    propagated.
 2. You can also define a type for a particular partner if you go to
    *Sales & Purchases* and set a sale order type.
+3. When no type is set on the partner and no default is provided in the
+   context, the sale order uses the first available type according to
+   the sequence configured on sale order types.
 
 Bug Tracker
 ===========
@@ -145,6 +154,9 @@ Contributors
 - Tharathip Chaweewongphan <tharathipc@ecosoft.co.th>
 - Isaac Gallart <igallart@puntsistemes.es>
 - Denis Rousse <denis.roussel@acsone.eu>
+- `Camptocamp <https://www.camptocamp.com>`__
+
+  - Maksym Yankin
 
 Do not contact contributors directly about support or help with
 technical issues.

--- a/sale_order_type/models/sale_order_type.py
+++ b/sale_order_type/models/sale_order_type.py
@@ -6,10 +6,12 @@ from odoo import api, fields, models
 class SaleOrderTypology(models.Model):
     _name = "sale.order.type"
     _description = "Type of sale order"
+    _order = "sequence, id"
     _check_company_auto = True
     _inherit = ["analytic.mixin"]
 
     name = fields.Char(required=True, translate=True)
+    sequence = fields.Integer(default=10)
     description = fields.Text(translate=True)
     sequence_id = fields.Many2one(
         comodel_name="ir.sequence",

--- a/sale_order_type/readme/CONFIGURE.md
+++ b/sale_order_type/readme/CONFIGURE.md
@@ -2,3 +2,6 @@ To configure Sale Order Types you need to:
 
 1.  Go to **Sales \> Configuration \> Sales Orders Types**
 2.  Create a new sale order type with all the settings you want
+3.  Use the drag handle in the list view to define the priority of the
+    sale order types. The first matching type for the current company is
+    used as the default when no partner or context default applies.

--- a/sale_order_type/readme/CONTRIBUTORS.md
+++ b/sale_order_type/readme/CONTRIBUTORS.md
@@ -26,6 +26,8 @@
 - Tharathip Chaweewongphan \<<tharathipc@ecosoft.co.th>\>
 - Isaac Gallart \<<igallart@puntsistemes.es>\>
 - Denis Rousse \<<denis.roussel@acsone.eu>\>
+- [Camptocamp](https://www.camptocamp.com)
+  - Maksym Yankin
 
 Do not contact contributors directly about support or help with
 technical issues.

--- a/sale_order_type/readme/DESCRIPTION.md
+++ b/sale_order_type/readme/DESCRIPTION.md
@@ -8,6 +8,9 @@ You can see sale types as lines of business.
 You are able to select a sales order type by partner so that when you
 add a partner to a sales order it will get the related info to it.
 
+When no partner or context default applies, the first available sale
+order type by sequence is used as the default.
+
 Additionally, it adds a warning message to notify users when there is a mismatch between the partner's default pricelist
 and the effective pricelist set by the sales order type. This ensures clarity when creating sales orders, as the
 effective pricelist (determined by the sales order type) will take precedence over the partner's default pricelist.

--- a/sale_order_type/readme/USAGE.md
+++ b/sale_order_type/readme/USAGE.md
@@ -3,3 +3,6 @@
     propagated.
 2.  You can also define a type for a particular partner if you go to
     *Sales & Purchases* and set a sale order type.
+3.  When no type is set on the partner and no default is provided in the
+    context, the sale order uses the first available type according to
+    the sequence configured on sale order types.

--- a/sale_order_type/static/description/index.html
+++ b/sale_order_type/static/description/index.html
@@ -382,6 +382,8 @@ payment term, a pricelist and an incoterm.</p>
 <p>You can see sale types as lines of business.</p>
 <p>You are able to select a sales order type by partner so that when you
 add a partner to a sales order it will get the related info to it.</p>
+<p>When no partner or context default applies, the first available sale
+order type by sequence is used as the default.</p>
 <p>Additionally, it adds a warning message to notify users when there is a
 mismatch between the partner’s default pricelist and the effective
 pricelist set by the sales order type. This ensures clarity when
@@ -410,6 +412,9 @@ and when there is a mismatch between the two pricelists.</p>
 <ol class="arabic simple">
 <li>Go to <strong>Sales &gt; Configuration &gt; Sales Orders Types</strong></li>
 <li>Create a new sale order type with all the settings you want</li>
+<li>Use the drag handle in the list view to define the priority of the
+sale order types. The first matching type for the current company is
+used as the default when no partner or context default applies.</li>
 </ol>
 </div>
 <div class="section" id="usage">
@@ -420,6 +425,9 @@ the new type you have created before and all settings will be
 propagated.</li>
 <li>You can also define a type for a particular partner if you go to
 <em>Sales &amp; Purchases</em> and set a sale order type.</li>
+<li>When no type is set on the partner and no default is provided in the
+context, the sale order uses the first available type according to
+the sequence configured on sale order types.</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">
@@ -489,6 +497,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Tharathip Chaweewongphan &lt;<a class="reference external" href="mailto:tharathipc&#64;ecosoft.co.th">tharathipc&#64;ecosoft.co.th</a>&gt;</li>
 <li>Isaac Gallart &lt;<a class="reference external" href="mailto:igallart&#64;puntsistemes.es">igallart&#64;puntsistemes.es</a>&gt;</li>
 <li>Denis Rousse &lt;<a class="reference external" href="mailto:denis.roussel&#64;acsone.eu">denis.roussel&#64;acsone.eu</a>&gt;</li>
+<li><a class="reference external" href="https://www.camptocamp.com">Camptocamp</a><ul>
+<li>Maksym Yankin</li>
+</ul>
+</li>
 </ul>
 <p>Do not contact contributors directly about support or help with
 technical issues.</p>

--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -222,6 +222,16 @@ class TestSaleOrderType(BaseCommon):
         )
         self.assertEqual(sale_order.type_id, sale_type)
 
+    def test_sale_order_default_type_sequence(self):
+        high_sequence_type = self.default_sale_type_id
+        high_sequence_type.sequence = 20
+        low_sequence_type = self.sale_type_quot
+        low_sequence_type.sequence = 1
+
+        sale_order = self.sale_order_model.new()
+
+        self.assertEqual(sale_order.type_id, low_sequence_type)
+
     def test_invoice_onchange_type(self):
         sale_type = self.sale_type
         invoice = self.create_invoice()

--- a/sale_order_type/views/sale_order_type_view.xml
+++ b/sale_order_type/views/sale_order_type_view.xml
@@ -65,6 +65,7 @@
         <field name="model">sale.order.type</field>
         <field name="arch" type="xml">
             <list>
+                <field name="sequence" widget="handle" />
                 <field name="name" />
                 <field
                     name="warehouse_id"


### PR DESCRIPTION
Add sequence based ordering for sale order types so the fallback default type can be configured predictably.