### PR TITLE
[FIX] sale_automatic_workflow_job

### DIFF
--- a/sale_automatic_workflow_job/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow_job/models/automatic_workflow_job.py
@@ -1,12 +1,22 @@
 # Copyright 2020 Camptocamp (https://www.camptocamp.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import _, models
+from odoo import _, api, models
 
 from odoo.addons.queue_job.job import identity_exact
 
 
 class AutomaticWorkflowJob(models.Model):
     _inherit = "automatic.workflow.job"
+
+    @api.model
+    def _job_prepare_context_before_enqueue_keys(self):
+        res = super()._job_prepare_context_before_enqueue_keys()
+        res += (
+            "send_order_confirmation_mail_in_job",
+            "auto_delay_do_send_mail",
+            "auto_delay_do_validation_finished",
+        )
+        return res
 
     def _do_validate_sale_order_job_options(self, sale, domain_filter):
         description = _("Validate sales order {}").format(sale.display_name)
@@ -15,8 +25,43 @@ class AutomaticWorkflowJob(models.Model):
             "identity_key": identity_exact,
         }
 
+    def _do_validate_sale_order(self, sale, domain_filter):
+        send_order_confirmation_mail = self.env.context.get(
+            "send_order_confirmation_mail_in_job", False
+        )
+        result = super()._do_validate_sale_order(sale, domain_filter)
+        if send_order_confirmation_mail:
+            self.with_context(
+                auto_delay_do_validation_finished=True,
+                # if we don't clear job_uuid, then a new job will not be created
+                job_uuid=False,
+            )._do_send_order_confirmation_mail(sale)
+        return result
+
+    def _do_send_order_confirmation_mail_job_options(self, sale):
+        description = _("Send order {} confirmation mail").format(sale.display_name)
+        return {
+            "description": description,
+            "identity_key": identity_exact,
+        }
+
+    def _do_send_order_confirmation_mail(self, sale):
+        # Deliberate no-op unless the order has just been confirmed inside the
+        # validation job: the guard prevents the synchronous cron path from
+        # sending the mail before the queued confirmation runs. Do not remove.
+        if self.env.context.get("auto_delay_do_validation_finished"):
+            return super()._do_send_order_confirmation_mail(sale)
+
     def _validate_sale_orders(self, domain_filter):
-        with_context = self.with_context(auto_delay_do_validation=True)
+        with_context = self.with_context(
+            auto_delay_do_validation=True,
+            auto_delay_do_send_mail=True,
+            auto_delay_do_validation_finished=False,
+            send_order_confirmation_mail_in_job=self.env.context.get(
+                "send_order_confirmation_mail", False
+            ),
+            send_order_confirmation_mail=False,
+        )
         return super(AutomaticWorkflowJob, with_context)._validate_sale_orders(
             domain_filter
         )
@@ -76,6 +121,7 @@ class AutomaticWorkflowJob(models.Model):
             "_do_validate_invoice": "auto_delay_do_validation",
             "_do_validate_picking": "auto_delay_do_validation",
             "_do_sale_done": "auto_delay_do_sale_done",
+            "_do_send_order_confirmation_mail": "auto_delay_do_send_mail",
         }
         for method_name, context_key in mapping.items():
             self._patch_method(

--- a/sale_automatic_workflow_job/tests/test_auto_workflow_job.py
+++ b/sale_automatic_workflow_job/tests/test_auto_workflow_job.py
@@ -4,7 +4,7 @@
 from odoo.tests import tagged
 
 from odoo.addons.queue_job.job import identity_exact
-from odoo.addons.queue_job.tests.common import mock_with_delay
+from odoo.addons.queue_job.tests.common import mock_with_delay, trap_jobs
 from odoo.addons.sale_automatic_workflow.tests.common import (
     TestAutomaticWorkflowMixin,
     TestCommon,
@@ -136,3 +136,33 @@ class TestAutoWorkflowJob(TestCommon, TestAutomaticWorkflowMixin):
                 ],
             )
             self.assert_job_delayed(delayable_cls, delayable, "_do_sale_done", args)
+
+    def test_validate_sale_order_send_confirmation_mail(self):
+        # V1: with the confirmation mail option active, the mail is posted
+        # after the order is actually confirmed inside the job.
+        workflow = self.create_full_automatic({"send_order_confirmation_mail": True})
+        self.sale = self.create_sale_order(workflow)
+        msgs_before = len(self.sale.message_ids)
+        job_model = self.env["automatic.workflow.job"]
+        with trap_jobs() as trap:
+            self.run_job()  # cron enqueues _do_validate_sale_order
+            trap.assert_jobs_count(1, only=job_model._do_validate_sale_order)
+            # running the validation job confirms the order and enqueues the
+            # mail job
+            trap.perform_enqueued_jobs()
+            trap.assert_jobs_count(1, only=job_model._do_send_order_confirmation_mail)
+            trap.perform_enqueued_jobs()  # run the mail job
+        self.assertEqual(self.sale.state, "sale")
+        self.assertGreater(len(self.sale.message_ids), msgs_before)
+
+    def test_validate_sale_order_no_confirmation_mail(self):
+        # V2: without the confirmation mail option, the order is confirmed and
+        # no mail job is enqueued.
+        workflow = self.create_full_automatic({"send_order_confirmation_mail": False})
+        self.sale = self.create_sale_order(workflow)
+        job_model = self.env["automatic.workflow.job"]
+        with trap_jobs() as trap:
+            self.run_job()
+            trap.perform_enqueued_jobs()
+            trap.assert_jobs_count(0, only=job_model._do_send_order_confirmation_mail)
+        self.assertEqual(self.sale.state, "sale")


### PR DESCRIPTION
When sale_automatic_workflow_job is installed, the "Sales: Order Confirmation" email is never sent even though the workflow has Send Order Confirmation Mail (send_order_confirmation_mail) enabled. The order is still confirmed correctly, but no email is sent: nothing appears in the order chatter and no mail.mail record is created (silent skip, no error in the log).

Root cause

In the base module, _validate_sale_orders chains the mail sending to the same iteration as the validation:

```
for sale in sales:
    with savepoint(self.env.cr):
        self._do_validate_sale_order(...)        # with the job module: only ENQUEUES, does not confirm
        if self.env.context.get("send_order_confirmation_mail"):
            self._do_send_order_confirmation_mail(sale)   # runs NOW, synchronously
```

sale_automatic_workflow_job only patches _do_validate_sale_order to enqueue it as a queue job, but _do_send_order_confirmation_mail runs synchronously in the cron. At that moment the order is still in draft (its confirmation is queued, not yet executed), so the guard in the base method skips it silently:

```
def _do_send_order_confirmation_mail(self, sale):
    if not self.env["sale.order"].search_count(
        [("id", "=", sale.id), ("state", "=", "sale")]
    ):
        return "{} {} job bypassed".format(sale.display_name, sale)
```
job serialization, since _job_prepare_context_before_enqueue_keys does not include it by default.

Fix

Move the mail sending inside the validation job, right after the real action_confirm(), when the order is already in state sale:

- _do_validate_sale_order is overridden so that, after super() confirms the order, it (re)enqueues _do_send_order_confirmation_mail as a second job (job_uuid=False to allow a new job, auto_delay_do_validation_finished=True).
- _do_send_order_confirmation_mail is added to the _register_hook mapping and guarded with auto_delay_do_validation_finished to prevent a double send from the synchronous path.
- _validate_sale_orders moves the send_order_confirmation_mail flag to send_order_confirmation_mail_in_job and disables the synchronous send (send_order_confirmation_mail=False).
- _job_prepare_context_before_enqueue_keys is extended with the three context keys so they survive job serialization.

This is a backport of the 18.0 fix (OCA/sale-workflow@3f9d423), adapted to 16.0: the 16.0 translation idiom (_().format()) and the picking handling of this branch are kept; the 17+ APIs from the 18.0 file are not pulled in.

Tests

Added two tests using trap_jobs:

- test_validate_sale_order_send_confirmation_mail: workflow with the mail option enabled → the validation job confirms the order and enqueues the mail job → the confirmation message is posted to the chatter.
- test_validate_sale_order_no_confirmation_mail: with the option disabled → the order is confirmed and no mail job is enqueued.

Existing tests are unchanged.