### PR TITLE
[19.0][FIX] sale_stock_picking_blocking: allow removing block with auto_done

### DIFF
--- a/sale_stock_picking_blocking/models/sale_order.py
+++ b/sale_stock_picking_blocking/models/sale_order.py
@@ -17,10 +17,16 @@ class SaleOrder(models.Model):
         store=True,
     )
 
+    @property
+    def _user_has_auto_done_setting_group(self):
+        """Whether the current user has the "auto_done_setting" group."""
+        return self.env.user.has_group("sale.group_auto_done_setting")
+
     @api.constrains("delivery_block_id")
     def _check_not_auto_done(self):
-        auto_done = self.env.user.has_group("sale.group_auto_done_setting")
-        if auto_done and any(so.delivery_block_id for so in self):
+        if self._user_has_auto_done_setting_group and any(
+            so.delivery_block_id for so in self
+        ):
             raise ValidationError(
                 self.env._(
                     'You cannot block a sale order with "auto_done_setting" active.'
@@ -32,7 +38,11 @@ class SaleOrder(models.Model):
         """Add the 'Default Delivery Block Reason' if set in the partner
         or in the payment term."""
         for so in self:
-            if so.partner_id.default_delivery_block:
+            if so._user_has_auto_done_setting_group:
+                # Delivery blocks are incompatible with "auto_done_setting"
+                # (see _check_not_auto_done), so do not auto-apply any default.
+                so.delivery_block_id = False
+            elif so.partner_id.default_delivery_block:
                 so.delivery_block_id = so.partner_id.default_delivery_block
             else:
                 so.delivery_block_id = (

--- a/sale_stock_picking_blocking/tests/test_sale_stock_picking_blocking.py
+++ b/sale_stock_picking_blocking/tests/test_sale_stock_picking_blocking.py
@@ -18,6 +18,7 @@ class TestSaleDeliveryBlock(TransactionCase):
             cls.env.ref("sale_stock_picking_blocking.group_sale_delivery_block").id,
             cls.env.ref("sales_team.group_sale_manager").id,
             cls.env.ref("product.group_product_manager").id,
+            cls.env.ref("account.group_account_invoice").id,
         ]
         user_dict = {
             "name": "User test",
@@ -65,6 +66,33 @@ class TestSaleDeliveryBlock(TransactionCase):
         # Check settings constraints
         with self.assertRaises(ValidationError):
             so.write({"delivery_block_id": block_reason.id})
+
+    def test_auto_done_skips_default_delivery_block(self):
+        """With "auto_done_setting" active, the default delivery block coming
+        from the partner (or payment term) must not be auto-applied, otherwise
+        saving the order raises a ValidationError (see _check_not_auto_done)."""
+        # Set active auto done configuration
+        config = self.env["res.config.settings"].create(
+            {"group_auto_done_setting": True}
+        )
+        config.execute()
+        block_reason = self.block_model.with_user(self.user_test).create(
+            {"name": "Test Block."}
+        )
+        partner_block = self.env["res.partner"].create(
+            {
+                "name": "Foo",
+                "default_delivery_block": block_reason.id,
+            }
+        )
+        # Creating/saving a sale order for a partner with a default delivery
+        # block must not raise when "auto_done_setting" is active.
+        so_form = Form(self.env["sale.order"].with_user(self.user_test))
+        so_form.partner_id = partner_block
+        so = so_form.save()
+        self.assertFalse(
+            so.delivery_block_id,
+        )
 
     def _picking_comp(self, so):
         """count created pickings"""


### PR DESCRIPTION
When auto_done_setting is active, saving a sale order after removing delivery_block_id could still raise ValidationError.

The stored compute for delivery_block_id could reapply partner/payment-term defaults on save, making the constraint fail again.