### PR TITLE
[FIX] sale_automatic_workflow: move journal domain from div to field

### DIFF
--- a/sale_automatic_workflow/views/sale_workflow_process_views.xml
+++ b/sale_automatic_workflow/views/sale_workflow_process_views.xml
@@ -264,30 +264,30 @@
                                 </span>
                             </div>
                         </div>
-                        <div
-                            class="row"
-                            groups="account.group_account_invoice"
-                            domain="[('type', '=', 'sale')]"
-                        >
+                        <div class="row" groups="account.group_account_invoice">
                             <div class="col-sm-12">
                                 <label
                                     for="property_journal_id"
                                     class="col-lg-4 o_light_label"
                                 />
-                                <field name="property_journal_id" nolabel="1" />
+                                <field
+                                    name="property_journal_id"
+                                    nolabel="1"
+                                    domain="[('type', 'in', ('bank', 'cash'))]"
+                                />
                             </div>
                         </div>
-                        <div
-                            class="row"
-                            groups="account.group_account_invoice"
-                            domain="[('type', '=', 'sale')]"
-                        >
+                        <div class="row" groups="account.group_account_invoice">
                             <div class="col-sm-12">
                                 <label
                                     for="property_payment_journal_id"
                                     class="col-lg-4 o_light_label"
                                 />
-                                <field name="property_payment_journal_id" nolabel="1" />
+                                <field
+                                    name="property_payment_journal_id"
+                                    nolabel="1"
+                                    domain="[('type', 'in', ('bank', 'cash'))]"
+                                />
                             </div>
                         </div>
                         <br />


### PR DESCRIPTION
The domain on journal and payment journal fields was placed on the parent <div> element, which has no effect. Move it to the <field> element so the journal selection is properly filtered.