### PR TITLE
[19.0][FIX] sale_order_type: solving date format error

### DIFF
--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -163,7 +163,9 @@ class SaleOrder(models.Model):
                 sale_type = self.env["sale.order.type"].browse(vals["type_id"])
                 if sale_type.sequence_id:
                     vals["name"] = sale_type.sequence_id.next_by_id(
-                        sequence_date=vals.get("date_order")
+                        sequence_date=fields.Datetime.to_datetime(
+                            vals.get("date_order")
+                        )
                     )
         return super().create(vals_list)
 
@@ -189,7 +191,9 @@ class SaleOrder(models.Model):
                     ):
                         new_vals = vals.copy()
                         new_vals["name"] = sale_type.sequence_id.next_by_id(
-                            sequence_date=vals.get("date_order")
+                            sequence_date=fields.Datetime.to_datetime(
+                                vals.get("date_order")
+                            )
                         )
                         super().write(new_vals)
                     else:


### PR DESCRIPTION
Odoo change which causes this error: https://github.com/odoo/odoo/commit/4b9dd7893f968ead2e54169833993e2813d56736#diff-9f0d74242c7d2eb1872323ccd91e1e37dd6f142efa6c33fcc13990f885c163deR270

Fix `sequence_date` type when creating sale orders with sale order types

When a sale order is created from the web client, `date_order` may arrive in `vals` as a string.

If the selected sale order type has its own sequence using date ranges, `sale_order_type` passes that string directly to:

`sequence_id.next_by_id(sequence_date=vals.get("date_order"))`

Error to solve:
<img width="1036" height="620" alt="imagen" src="https://github.com/user-attachments/assets/2ba36b27-7049-4697-b216-5e39bd75a9e9" />
