### PR TITLE
[19.0][FIX] sale_stock_picking_blocking: Preserve delivery block on recompute

### DIFF
--- a/sale_stock_picking_blocking/__manifest__.py
+++ b/sale_stock_picking_blocking/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Sale Stock Picking Blocking",
     "summary": "Allow you to block the creation of deliveries from a sale order.",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "author": "ForgeFlow, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",
     "category": "Sales",

--- a/sale_stock_picking_blocking/models/sale_order.py
+++ b/sale_stock_picking_blocking/models/sale_order.py
@@ -15,6 +15,8 @@ class SaleOrder(models.Model):
         string="Delivery Block Reason",
         compute="_compute_delivery_block_id",
         store=True,
+        readonly=False,
+        precompute=True,
     )
 
     @api.constrains("delivery_block_id")
@@ -27,11 +29,23 @@ class SaleOrder(models.Model):
                 )
             )
 
-    @api.depends("partner_id", "payment_term_id")
+    @api.depends(
+        "partner_id",
+        "partner_id.default_delivery_block",
+        "payment_term_id",
+        "payment_term_id.default_delivery_block_reason_id",
+    )
     def _compute_delivery_block_id(self):
         """Add the 'Default Delivery Block Reason' if set in the partner
-        or in the payment term."""
+        or in the payment term.
+
+        Only seed the default when no reason is set yet: a manually chosen
+        reason must never be wiped by a later recompute (e.g. on module
+        upgrade/redeploy), otherwise blocked orders would get deliveries.
+        """
         for so in self:
+            if so.delivery_block_id:
+                continue
             if so.partner_id.default_delivery_block:
                 so.delivery_block_id = so.partner_id.default_delivery_block
             else:

--- a/sale_stock_picking_blocking/models/sale_order_line.py
+++ b/sale_stock_picking_blocking/models/sale_order_line.py
@@ -8,8 +8,6 @@ from odoo import models
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    def _action_launch_stock_rule(self, previous_product_uom_qty=False):
-        return super(
-            SaleOrderLine,
-            self.filtered(lambda line: not line.order_id.delivery_block_id),
-        )._action_launch_stock_rule(previous_product_uom_qty=previous_product_uom_qty)
+    def _action_launch_stock_rule(self, **kwargs):
+        allowed = self.filtered(lambda line: not line.order_id.delivery_block_id)
+        return super(SaleOrderLine, allowed)._action_launch_stock_rule(**kwargs)

--- a/sale_stock_picking_blocking/tests/test_sale_stock_picking_blocking.py
+++ b/sale_stock_picking_blocking/tests/test_sale_stock_picking_blocking.py
@@ -132,6 +132,48 @@ class TestSaleDeliveryBlock(TransactionCase):
         self.assertEqual(so.delivery_block_id, block_reason)
         self.assertEqual(so.copy().delivery_block_id, block_reason)
 
+    def test_manual_block_survives_partner_change(self):
+        """A manually-set block must survive a recompute triggered by a
+        dependency change (here, switching to a partner without a default)."""
+        block_reason = self.block_model.with_user(self.user_test).create(
+            {"name": "Manual Block."}
+        )
+        partner_no_default = self.env["res.partner"].create({"name": "NoDefault"})
+        so = self.sale_order
+        so.write({"delivery_block_id": block_reason.id})
+        # Changing partner_id triggers a recompute of delivery_block_id.
+        so.write({"partner_id": partner_no_default.id})
+        self.assertEqual(
+            so.delivery_block_id,
+            block_reason,
+            "A manually-set block must survive a partner change",
+        )
+
+    def test_manual_block_survives_recompute_and_still_blocks(self):
+        """Regression: a manually-set block must not be wiped by a later
+        recompute of the stored computed field (as happens on module
+        upgrade/redeploy), which previously caused deliveries to be created
+        for blocked orders."""
+        block_reason = self.block_model.with_user(self.user_test).create(
+            {"name": "Manual Block."}
+        )
+        so = self.sale_order  # partner/payment term have no default block
+        so.write({"delivery_block_id": block_reason.id})
+        # Force the stored computed field to recompute, as on an upgrade.
+        self.env.add_to_compute(so._fields["delivery_block_id"], so)
+        so.flush_recordset()
+        self.assertEqual(
+            so.delivery_block_id,
+            block_reason,
+            "A manually-set block must survive a recompute",
+        )
+        so.action_confirm()
+        self.assertEqual(
+            self._picking_comp(so),
+            0,
+            "The delivery should still be blocked after a recompute",
+        )
+
     def test_commercial_fields(self):
         self.assertIn(
             "default_delivery_block",


### PR DESCRIPTION
The delivery_block_id field is a stored computed field, but its compute unconditionally overwrote the stored value with the partner/payment-term default (or False when none is configured). Any recompute therefore wiped a manually-set blocking reason: changing the partner/payment term, or an upgrade/redeploy recomputing the stored field. Once cleared, deliveries were launched for orders that should have been blocked, which surfaced as "the block works on install but is gone a day later".

Guard the compute so it only seeds the default when no reason is set yet, preserving a manually-chosen reason on every recompute. Add precompute=True and readonly=False so an explicitly-entered value also survives the create-time pass (the first-save wipe of issue #3815, fixed for create by PR #3906). Complete the @api.depends so changing a partner/payment-term default propagates to orders that have no block yet.

Align the _action_launch_stock_rule override signature with core 19.0 and add regression tests covering the recompute and partner-change paths.