### PR TITLE
[18.0][FIX] sale_semaphore: do not block confirmation when price matches pricelist

### DIFF
--- a/sale_semaphore/models/sale_order.py
+++ b/sale_semaphore/models/sale_order.py
@@ -3,7 +3,6 @@
 
 from odoo import _, fields, models
 from odoo.exceptions import UserError
-from odoo.tools import float_compare
 
 
 class SaleOderLine(models.Model):
@@ -19,22 +18,12 @@ class SaleOderLine(models.Model):
             )
 
     def action_confirm(self):
-        dp = self.env["decimal.precision"].precision_get("Product Price")
         if not self.env.user.has_group("sales_team.group_sale_manager") and any(
             so.price_below_semaphore for so in self
         ):
             lines_price_below_pricelist = self.order_line.filtered(
                 lambda line: line.price_below_semaphore
-                and float_compare(
-                    line.price_reduce_taxinc
-                    if line.company_id.account_price_include == "tax_included"
-                    else line.price_reduce_taxexcl,
-                    line.order_id.pricelist_id._get_product_price(
-                        line.product_id, line.product_uom_qty
-                    ),
-                    precision_digits=dp,
-                )
-                < 0
+                and line._is_price_below_pricelist()
             )
             if lines_price_below_pricelist:
                 raise UserError(

--- a/sale_semaphore/models/sale_order_line.py
+++ b/sale_semaphore/models/sale_order_line.py
@@ -35,11 +35,7 @@ class SaleOderLine(models.Model):
             if not semaphore_data:
                 continue
             record.semaphore_active = True
-            price_reduce = (
-                record.price_reduce_taxinc
-                if record.company_id.account_price_include == "tax_included"
-                else record.price_reduce_taxexcl
-            )
+            price_reduce = record._get_semaphore_price_reduce()
             price_reduce = record.product_uom._compute_price(
                 price_reduce, record.product_id.uom_id
             )
@@ -85,20 +81,57 @@ class SaleOderLine(models.Model):
         vals["semaphore"] = self.semaphore
         return vals
 
+    def _get_semaphore_price_reduce(self):
+        """Net unit price used to evaluate the semaphore, on the company's tax
+        inclusion basis."""
+        self.ensure_one()
+        return (
+            self.price_reduce_taxinc
+            if self.company_id.account_price_include == "tax_included"
+            else self.price_reduce_taxexcl
+        )
+
+    def _get_semaphore_pricelist_price(self):
+        """Pricelist price for this line expressed on the same basis as
+        :meth:`_get_semaphore_price_reduce` so both values are comparable.
+        """
+        self.ensure_one()
+        price = self.order_id.pricelist_id._get_product_price(
+            self.product_id, self.product_uom_qty, uom=self.product_uom
+        )
+        if self.company_id.account_price_include == "tax_included":
+            price = self.tax_id.compute_all(
+                price,
+                currency=self.currency_id,
+                quantity=1.0,
+                product=self.product_id,
+                partner=self.order_id.partner_id,
+            )["total_included"]
+        return self.currency_id.round(price)
+
+    def _is_price_below_pricelist(self):
+        """Return whether the line net price is actually lower than the price
+        the pricelist would set (i.e. the salesperson lowered it)."""
+        self.ensure_one()
+        dp = self.env["decimal.precision"].precision_get("Product Price")
+        return (
+            float_compare(
+                self._get_semaphore_price_reduce(),
+                self._get_semaphore_pricelist_price(),
+                precision_digits=dp,
+            )
+            < 0
+        )
+
     @api.depends("price_reduce_taxinc", "price_reduce_taxexcl")
     def _compute_price_below_semaphore(self):
         dp = self.env["decimal.precision"].precision_get("Product Price")
         self.price_below_semaphore = False
         for record in self.filtered(lambda line: line.product_id.semaphore_active):
-            price_reduce = (
-                record.price_reduce_taxinc
-                if record.company_id.account_price_include == "tax_included"
-                else record.price_reduce_taxexcl
-            )
             record.price_below_semaphore = (
                 float_compare(
                     record.semaphore_max_price_danger,
-                    price_reduce,
+                    record._get_semaphore_price_reduce(),
                     precision_digits=dp,
                 )
                 > 0
@@ -106,7 +139,6 @@ class SaleOderLine(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        dp = self.env["decimal.precision"].precision_get("Product Price")
         if ("price_unit" in vals or "discount" in vals) and not self.env.user.has_group(
             "sales_team.group_sale_manager"
         ):
@@ -114,28 +146,15 @@ class SaleOderLine(models.Model):
                 lambda line: line.price_below_semaphore
                 and line.state in ["sale", "done"]
             )
-            if lines_below_semaphore:
-                lines_price_below_pricelist = lines_below_semaphore.filtered(
-                    lambda line: float_compare(
-                        line.price_reduce_taxinc
-                        if line.company_id.account_price_include == "tax_included"
-                        else line.price_reduce_taxexcl,
-                        line.order_id.pricelist_id.get_product_price(
-                            line.product_id,
-                            line.product_uom_qty,
-                            line.order_id.partner_id,
-                        ),
-                        precision_digits=dp,
+            if lines_below_semaphore.filtered(
+                lambda line: line._is_price_below_pricelist()
+            ):
+                raise UserError(
+                    _(
+                        "There's a line with price below semaphore's accepted.\n\n"
+                        "Please set the prices in a way that they are accepted "
+                        "by the semaphore, or contact the purchasing "
+                        "administrators."
                     )
-                    < 0
                 )
-                if lines_price_below_pricelist:
-                    raise UserError(
-                        _(
-                            "There's a line with price below semaphore's accepted.\n\n"
-                            "Please set the prices in a way that they are accepted "
-                            "by the semaphore, or contact the purchasing "
-                            "administrators."
-                        )
-                    )
         return res

--- a/sale_semaphore/tests/test_sale_semaphore.py
+++ b/sale_semaphore/tests/test_sale_semaphore.py
@@ -37,6 +37,15 @@ class TestSaleSemaphore(BaseCommon):
             }
         )
         cls.order = cls.env["sale.order"].create({"partner_id": cls.partner.id})
+        cls.salesperson = cls.env["res.users"].create(
+            {
+                "name": "Semaphore Salesperson",
+                "login": "semaphore_salesperson",
+                "groups_id": [
+                    (6, 0, [cls.env.ref("sales_team.group_sale_salesman").id])
+                ],
+            }
+        )
 
     def _create_line(self, price_unit):
         return self.env["sale.order.line"].create(
@@ -134,7 +143,7 @@ class TestSaleSemaphore(BaseCommon):
         self.assertFalse(danger_line.price_below_semaphore)
         self.assertTrue(below_limit_line.price_below_semaphore)
         with self.assertRaises(UserError):
-            self.order.with_user(self.env.ref("base.user_demo")).action_confirm()
+            self.order.with_user(self.salesperson).action_confirm()
 
     def test_sale_line_uses_category_configuration(self):
         self.product.write(
@@ -156,3 +165,86 @@ class TestSaleSemaphore(BaseCommon):
         line = self._create_line(95.0)
         invoice_vals = line._prepare_invoice_line()
         self.assertEqual(invoice_vals["semaphore"], "warning")
+
+    def test_pricelist_price_in_red_zone_does_not_block(self):
+        """A line priced exactly at the pricelist must confirm even if the
+        pricelist price falls in the red zone and has more decimals than the
+        currency (regression: rounding made it look below the pricelist)."""
+        # Danger threshold = 100 * (1 - 20%) = 80, so 79.9902 is in the red zone.
+        pricelist = self.env["product.pricelist"].create(
+            {
+                "name": "Semaphore Pricelist",
+                "item_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "applied_on": "1_product",
+                            "product_tmpl_id": self.product.product_tmpl_id.id,
+                            "compute_price": "fixed",
+                            "fixed_price": 79.9902,
+                        },
+                    )
+                ],
+            }
+        )
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "pricelist_id": pricelist.id,
+                "user_id": self.salesperson.id,
+            }
+        )
+        line = self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.product.id,
+                "name": self.product.name,
+                "product_uom_qty": 1.0,
+                "product_uom": self.product.uom_id.id,
+            }
+        )
+        # Price comes straight from the pricelist (salesperson did not touch it).
+        self.assertEqual(line.price_unit, 79.9902)
+        self.assertTrue(line.price_below_semaphore)
+        self.assertFalse(line._is_price_below_pricelist())
+        # Must not raise for a regular salesperson.
+        order.with_user(self.salesperson).action_confirm()
+        self.assertEqual(order.state, "sale")
+
+    def test_price_below_pricelist_blocks(self):
+        """Lowering the price below the pricelist still blocks confirmation."""
+        pricelist = self.env["product.pricelist"].create(
+            {
+                "name": "Semaphore Pricelist Block",
+                "item_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "applied_on": "1_product",
+                            "product_tmpl_id": self.product.product_tmpl_id.id,
+                            "compute_price": "fixed",
+                            "fixed_price": 79.9902,
+                        },
+                    )
+                ],
+            }
+        )
+        order = self.env["sale.order"].create(
+            {"partner_id": self.partner.id, "pricelist_id": pricelist.id}
+        )
+        line = self.env["sale.order.line"].create(
+            {
+                "order_id": order.id,
+                "product_id": self.product.id,
+                "name": self.product.name,
+                "product_uom_qty": 1.0,
+                "product_uom": self.product.uom_id.id,
+                "price_unit": 70.0,
+            }
+        )
+        self.assertTrue(line.price_below_semaphore)
+        self.assertTrue(line._is_price_below_pricelist())
+        with self.assertRaises(UserError):
+            order.with_user(self.salesperson).action_confirm()


### PR DESCRIPTION
A line priced exactly at the pricelist could wrongly block confirmation for regular salespeople, even without lowering the price.

Additionally, the write() guard called pricelist.get_product_price(), a method that does not exist in this Odoo version and would raise AttributeError when a salesperson edited the price of a confirmed line.

Centralize the logic in _get_semaphore_price_reduce(), _get_semaphore_pricelist_price() (aligning uom, tax basis and currency rounding) and _is_price_below_pricelist(), and reuse them in action_confirm() and write(). Add regression tests covering both the no-block and block cases.

cc @Tecnativa TT63319

ping @sergio-teruel @carlosdauden 