### PR TITLE
[19.0][FIX] sale_order_global_discount: avoid general discount on dow…

### DIFF
--- a/sale_order_general_discount/models/sale_order_line.py
+++ b/sale_order_general_discount/models/sale_order_line.py
@@ -20,8 +20,17 @@ class SaleOrderLine(models.Model):
             # the case where a discount was set to a value != 0 and then
             # set again to 0 to remove the discount on all the lines at the same
             # time
-            if not line.product_id.bypass_general_discount and (
-                line.order_id.general_discount or line.order_id._origin.general_discount
+            if (
+                not line._is_downpayment_line()
+                and not line.product_id.bypass_general_discount
+                and (
+                    line.order_id.general_discount
+                    or line.order_id._origin.general_discount
+                )
             ):
                 line.discount = line.order_id.general_discount
         return res
+
+    def _is_downpayment_line(self):
+        self.ensure_one()
+        return "is_downpayment" in self._fields and self.is_downpayment

--- a/sale_order_general_discount/tests/test_sale_order_general_discount.py
+++ b/sale_order_general_discount/tests/test_sale_order_general_discount.py
@@ -180,3 +180,57 @@ class TestSaleOrderLineInput(TransactionCase):
             .id,
             self.product2.product_tmpl_id.id,
         )
+
+    def test_downpayment_line_does_not_get_general_discount(self):
+        sale_order = self.env["sale.order"].create(
+            [
+                {
+                    "partner_id": self.partner.id,
+                    "order_line": [
+                        (
+                            0,
+                            0,
+                            {
+                                "name": self.product.name,
+                                "product_id": self.product.id,
+                                "product_uom_qty": 1,
+                                "product_uom_id": self.product.uom_id.id,
+                                "price_unit": 100.0,
+                            },
+                        )
+                    ],
+                }
+            ]
+        )
+        sale_order.general_discount = 10.0
+        sale_order.action_confirm()
+
+        wizard = (
+            self.env["sale.advance.payment.inv"]
+            .with_context(
+                active_model="sale.order",
+                active_ids=sale_order.ids,
+                active_id=sale_order.id,
+            )
+            .create(
+                [
+                    {
+                        "advance_payment_method": "fixed",
+                        "fixed_amount": 50.0,
+                    }
+                ]
+            )
+        )
+        wizard.create_invoices()
+
+        downpayment_line = sale_order.order_line.filtered(
+            lambda line: line.is_downpayment and not line.display_type
+        )
+        self.assertEqual(len(downpayment_line), 1)
+        self.assertEqual(downpayment_line.discount, 0.0)
+        self.assertEqual(
+            sale_order.order_line.filtered(
+                lambda line: not line.is_downpayment
+            ).discount,
+            10.0,
+        )


### PR DESCRIPTION
In Odoo 17, `sale.advance.payment.inv._prepare_base_downpayment_line_values()`
created down payment sale order lines with an explicit `discount: 0.0`. The
invoice line was then built through `sale.order.line._prepare_invoice_line()`,
which copied `self.discount`, but that value was already zero for down payment
lines.

In Odoo 19, `sale.advance.payment.inv._create_invoices()` was refactored to
compute down payments from tax base lines. It now calls
`account.tax._prepare_down_payment_lines()` and then
`sale.order._create_down_payment_lines_from_base_lines()`, which delegates to
`sale.order._prepare_down_payment_line_values_from_base_line()`. That method
builds the down payment sale order line from the computed base line values but
does not explicitly reset `discount` to zero.

This matters for `sale_order_general_discount` because the source sale order
lines have their `discount` computed by `sale.order.line._compute_discount()`
from `order_id.general_discount`. The Odoo 19 down payment computation starts
from those discounted order lines, and the generated invoice line still uses
`sale.order.line._prepare_invoice_line()`, which copies `discount: self.discount`
to the `account.move.line`.

This change restores the previous behavior by forcing down payment sale order
lines to keep `discount = 0.0`. Down payments already represent a computed
portion of the order amount, so applying the sale order general discount again
on the invoice line would discount the advance payment twice / display an
unintended discount.