### PR TITLE
[15.0][FIX] sale_stock_secondary_unit: update chained moves on secondary qty changes

### DIFF
--- a/sale_stock_secondary_unit/models/sale_order.py
+++ b/sale_stock_secondary_unit/models/sale_order.py
@@ -17,16 +17,25 @@ class SaleOrderLine(models.Model):
         return values
 
     def write(self, vals):
+        lines = self.env["sale.order.line"]
+        previous_product_uom_qty = {}
+        procure_secondary_uom_qty = {}
         if "secondary_uom_qty" in vals:
             lines = self.filtered(lambda r: r.state == "sale" and not r.is_expense)
+            previous_product_uom_qty = {line.id: line.product_uom_qty for line in lines}
             procure_secondary_uom_qty = {
                 line.id: float_round(
                     vals["secondary_uom_qty"] - line.secondary_uom_qty,
-                    precision_rounding=self.secondary_uom_id.uom_id.rounding or 0.01,
+                    precision_rounding=line.secondary_uom_id.uom_id.rounding or 0.01,
                 )
                 for line in lines
             }
             self = self.with_context(
                 procure_secondary_uom_qty=procure_secondary_uom_qty
             )
-        return super().write(vals)
+        res = super().write(vals)
+        if lines and "product_uom_qty" not in vals:
+            lines.with_context(
+                procure_secondary_uom_qty=procure_secondary_uom_qty
+            )._action_launch_stock_rule(previous_product_uom_qty)
+        return res

--- a/sale_stock_secondary_unit/tests/test_sale_stock_secondary_unit.py
+++ b/sale_stock_secondary_unit/tests/test_sale_stock_secondary_unit.py
@@ -90,3 +90,22 @@ class TestSaleStockOrderSecondaryUnit(TransactionCase):
         picking = self.order.picking_ids
         # Second qty on sml only manage done quantities
         self.assertEqual(picking.move_line_ids.secondary_uom_qty, 0.0)
+
+    def test_update_secondary_qty_on_pack_picking(self):
+        self.warehouse.delivery_steps = "pick_pack_ship"
+        self.order.order_line.write(
+            {"secondary_uom_id": self.secondary_unit.id, "secondary_uom_qty": 4}
+        )
+        self.order.action_confirm()
+        pack_picking = self.order.picking_ids.filtered(
+            lambda picking: picking.picking_type_id == self.warehouse.pack_type_id
+        )
+        self.assertEqual(pack_picking.move_lines.secondary_uom_qty, 4)
+
+        self.order.order_line.write({"secondary_uom_qty": 6})
+
+        self.assertEqual(pack_picking.move_lines.secondary_uom_qty, 6)
+
+        self.order.order_line.write({"secondary_uom_qty": 3})
+
+        self.assertEqual(pack_picking.move_lines.secondary_uom_qty, 3)


### PR DESCRIPTION
When a confirmed sale order line using a secondary unit was updated, the
secondary quantity was not correctly propagated to chained delivery moves.

This was especially visible in warehouses configured with multi-step delivery
routes. For example, with a product sold in Kg and a secondary unit in pieces:

1. Configure a warehouse with pick + pack + ship delivery steps.
2. Create a sale order for 4 pieces.
3. Confirm the sale order.
4. The PACK picking correctly has 4 pieces.
5. Increase the sale order line to 6 pieces.
6. The PACK picking must be updated to 6 pieces.
7. Reduce the sale order line to 3 pieces.
8. The PACK picking must be updated to 3 pieces.

Before this fix, changing only `secondary_uom_qty` on an already confirmed sale
order did not always launch the stock rule update, because the standard sale
stock flow only reacts to `product_uom_qty` in the written values.

This change stores the previous primary quantity, computes the secondary
quantity delta, and launches the stock rule update when only the secondary
quantity changes.

A regression test has been added covering the full flow:
4 pieces -> 6 pieces -> 3 pieces on the PACK picking.

Depends on:
- [ ] https://github.com/OCA/stock-logistics-warehouse/pull/2598

cc @Tecnativa TT62494
Ping @carlosdauden @CarlosRoca13 
