### PR TITLE
[18.0][FIX] sale_payment_sheet: add company_currency_id to invoice list view

### DIFF
--- a/sale_payment_sheet/views/sale_payment_sheet_menu.xml
+++ b/sale_payment_sheet/views/sale_payment_sheet_menu.xml
@@ -39,6 +39,7 @@
                     optional="show"
                 />
                 <field name="currency_id" column_invisible="1" />
+                <field name="company_currency_id" column_invisible="1" />
             </list>
         </field>
     </record>


### PR DESCRIPTION
The amount_*_signed monetary fields use company_currency_id as their currency_field, but it was missing from the list view. Without it the monetary widget could not resolve the currency, showing "No currency provided" and hiding the column totals.

cc @Tecnativa TT63334

ping @carlosdauden @sergio-teruel 