### PR TITLE
[MIG] sale_exception: add post-migration for noupdate rules using removed sale_warn fields

### DIFF
--- a/sale_exception/__manifest__.py
+++ b/sale_exception/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Sale Exception",
     "summary": "Custom exceptions on sale order",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "category": "Generic Modules/Sale",
     "author": "Akretion, Sodexis, Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/sale-workflow",

--- a/sale_exception/migrations/19.0.1.0.1/noupdate_changes.xml
+++ b/sale_exception/migrations/19.0.1.0.1/noupdate_changes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="exception_partner_sale_warning" model="exception.rule">
+        <field name="code">failed=bool(self.partner_id.sale_warn_msg)</field>
+    </record>
+    <record id="exception_product_sale_warning" model="exception.rule">
+        <field name="code">failed=bool(self.product_id.sale_line_warn_msg)</field>
+    </record>
+</odoo>

--- a/sale_exception/migrations/19.0.1.0.1/post-migration.py
+++ b/sale_exception/migrations/19.0.1.0.1/post-migration.py
@@ -1,0 +1,8 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env, "sale_exception", "migrations/19.0.1.0.1/noupdate_changes.xml"
+    )


### PR DESCRIPTION
## Summary

In v19, `sale_line_warn` (product) and `sale_warn` (partner) selection fields were removed from Odoo core. Only the `_msg` variants remain.

The `sale_exception_data.xml` ships two `exception.rule` records inside `<odoo noupdate="1">`. The data file was correctly updated in the v19 migration commit, but since these records are marked `noupdate`, existing databases migrated from v18 retain the old `code` expressions and raise `AttributeError` when confirming a sale order.

## Changes

- **New**: `sale_exception/migrations/19.0.1.0.1/post-migration.py` — uses `openupgradelib.load_data` to rewrite the two affected records.
- **New**: `sale_exception/migrations/19.0.1.0.1/noupdate_changes.xml` — declares the corrected `code` for both rules.
- **Bump**: `sale_exception/__manifest__.py` `19.0.1.0.0` → `19.0.1.0.1`.