### PR TITLE
[IMP] sale_partner_address_restrict: Allows selecting a contact as the order customer and choosing alternative contacts linked to the same commercial partner.

### DIFF
--- a/sale_partner_address_restrict/models/sale_order.py
+++ b/sale_partner_address_restrict/models/sale_order.py
@@ -21,7 +21,11 @@ class SaleOrder(models.Model):
             for company, sales in activated_sales.partition("company_id").items():
                 for sale in sales:
                     sale.partner_address_restriction_domain = [
-                        ("commercial_partner_id", "=", sale.partner_id.id),
+                        (
+                            "commercial_partner_id",
+                            "=",
+                            sale.partner_id.commercial_partner_id.id,
+                        ),
                         "|",
                         ("company_id", "=", False),
                         ("company_id", "=", company.id),
@@ -34,10 +38,13 @@ class SaleOrder(models.Model):
                 order.company_id.sale_partner_address_restriction
                 and order.partner_id
                 and (
-                    (order.partner_invoice_id.commercial_partner_id != order.partner_id)
+                    (
+                        order.partner_invoice_id.commercial_partner_id
+                        != order.partner_id.commercial_partner_id
+                    )
                     or (
                         order.partner_shipping_id.commercial_partner_id
-                        != order.partner_id
+                        != order.partner_id.commercial_partner_id
                     )
                 )
             ):

--- a/sale_partner_address_restrict/tests/test_sale_order.py
+++ b/sale_partner_address_restrict/tests/test_sale_order.py
@@ -28,7 +28,11 @@ class TestSaleOrder(BaseCommon):
         sale_order = order_form.save()
 
         expected_domain = [
-            ("commercial_partner_id", "=", sale_order.partner_id.id),
+            (
+                "commercial_partner_id",
+                "=",
+                sale_order.partner_id.commercial_partner_id.id,
+            ),
             "|",
             ("company_id", "=", False),
             ("company_id", "=", sale_order.company_id.id),
@@ -40,13 +44,36 @@ class TestSaleOrder(BaseCommon):
         with Form(sale_order) as sale_order:
             sale_order.partner_id = self.partner2
             expected_domain = [
-                ("commercial_partner_id", "=", sale_order.partner_id.id),
+                (
+                    "commercial_partner_id",
+                    "=",
+                    sale_order.partner_id.commercial_partner_id.id,
+                ),
                 "|",
                 ("company_id", "=", False),
                 ("company_id", "=", sale_order.company_id.id),
             ]
             partners = self.env["res.partner"].search(expected_domain)
             self.assertEqual(len(partners), 1)
+
+    def test_sale_order_address_domain_from_contact(self):
+        order_form = Form(self.env["sale.order"])
+        order_form.partner_id = self.child_1
+        sale_order = order_form.save()
+
+        expected_domain = [
+            (
+                "commercial_partner_id",
+                "=",
+                sale_order.partner_id.commercial_partner_id.id,
+            ),
+            "|",
+            ("company_id", "=", False),
+            ("company_id", "=", sale_order.company_id.id),
+        ]
+
+        partners = self.env["res.partner"].search(expected_domain)
+        self.assertEqual(len(partners), 3)
 
     def test_sale_order_partner_unallowed(self):
         order_form = Form(self.env["sale.order"])


### PR DESCRIPTION
With this PR you can now set a contact of a partner as main partner of the sale order, and still be able to choose the invoicing or shipping address of the same partner.