### PR TITLE
[18.0][FIX] sale_automatic_workflow: use _get_eval_domain() to support datetime in filter

### DIFF
--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -7,7 +7,6 @@ import logging
 from contextlib import contextmanager
 
 from odoo import api, fields, models
-from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
 
@@ -198,27 +197,27 @@ class AutomaticWorkflowJob(models.Model):
             self.with_context(
                 send_order_confirmation_mail=sale_workflow.send_order_confirmation_mail
             )._validate_sale_orders(
-                safe_eval(sale_workflow.order_filter_id.domain) + workflow_domain
+                sale_workflow.order_filter_id._get_eval_domain() + workflow_domain
             )
         self._handle_pickings(sale_workflow)
         if sale_workflow.create_invoice:
             self._create_invoices(
-                safe_eval(sale_workflow.create_invoice_filter_id.domain)
+                sale_workflow.create_invoice_filter_id._get_eval_domain()
                 + workflow_domain
             )
         if sale_workflow.validate_invoice:
             self._validate_invoices(
-                safe_eval(sale_workflow.validate_invoice_filter_id.domain)
+                sale_workflow.validate_invoice_filter_id._get_eval_domain()
                 + workflow_domain
             )
         if sale_workflow.sale_done:
             self._sale_done(
-                safe_eval(sale_workflow.sale_done_filter_id.domain) + workflow_domain
+                sale_workflow.sale_done_filter_id._get_eval_domain() + workflow_domain
             )
 
         if sale_workflow.register_payment:
             self._register_payments(
-                safe_eval(sale_workflow.payment_filter_id.domain) + workflow_domain
+                sale_workflow.payment_filter_id._get_eval_domain() + workflow_domain
             )
 
     @api.model

--- a/sale_automatic_workflow/tests/test_automatic_workflow.py
+++ b/sale_automatic_workflow/tests/test_automatic_workflow.py
@@ -137,6 +137,28 @@ class TestAutomaticWorkflow(TestCommon, TestAutomaticWorkflowMixin):
         invoice = sale.invoice_ids
         self.assertEqual(invoice.journal_id.id, new_sale_journal.id)
 
+    def test_filter_domain_with_datetime(self):
+        workflow = self.create_full_automatic()
+        workflow.order_filter_id = self.env["ir.filters"].create(
+            {
+                "name": "Order filter using datetime",
+                "model_id": "sale.order",
+                "domain": (
+                    "[('state', '=', 'draft'), "
+                    "('date_order', '<=', "
+                    "context_today().strftime('%Y-%m-%d %H:%M:%S'))]"
+                ),
+                "user_id": self.env.ref("base.user_root").id,
+            }
+        )
+        sale = self.create_sale_order(workflow)
+        sale.date_order = fields.Datetime.now() + timedelta(days=1)
+        self.run_job()
+        self.assertEqual(sale.state, "draft")
+        sale.date_order = fields.Datetime.now() - timedelta(days=1)
+        self.run_job()
+        self.assertEqual(sale.state, "sale")
+
     def test_no_copy(self):
         workflow = self.create_full_automatic()
         sale = self.create_sale_order(workflow)


### PR DESCRIPTION
@qrtl
QT6730