### PR TITLE
[FIX] sale_global_discount: group lines by tax combination to avoid rounding errors

### DIFF
--- a/sale_global_discount/models/sale_order.py
+++ b/sale_global_discount/models/sale_order.py
@@ -130,14 +130,16 @@ class SaleOrder(models.Model):
                 tax_groups[tax_key]["base"] += discounted_subtotal
             # Compute taxes once per group to avoid rounding accumulation
             for group in tax_groups.values():
-                discounted_tax = group["tax_ids"].with_context(
-                    force_price_include=False
-                ).compute_all(
-                    group["base"],
-                    group["currency"],
-                    1.0,
-                    product=group["product"],
-                    partner=group["partner"],
+                discounted_tax = (
+                    group["tax_ids"]
+                    .with_context(force_price_include=False)
+                    .compute_all(
+                        group["base"],
+                        group["currency"],
+                        1.0,
+                        product=group["product"],
+                        partner=group["partner"],
+                    )
                 )
                 amount_discounted_tax += sum(
                     t.get("amount", 0.0) for t in discounted_tax.get("taxes", [])

--- a/sale_global_discount/models/sale_order.py
+++ b/sale_global_discount/models/sale_order.py
@@ -109,6 +109,8 @@ class SaleOrder(models.Model):
             amount_total_before_global_discounts = order.amount_total
             discounts = order.global_discount_ids.mapped("discount")
             amount_discounted_untaxed = amount_discounted_tax = 0
+            # Group lines by tax combination to avoid accumulated rounding errors
+            tax_groups = {}
             for line in order.order_line:
                 discounted_subtotal = line.price_subtotal
                 if not line.product_id.bypass_global_discount:
@@ -116,14 +118,26 @@ class SaleOrder(models.Model):
                         line.price_subtotal, discounts.copy()
                     )
                 amount_discounted_untaxed += discounted_subtotal
-                discounted_tax = line.tax_ids.with_context(
+                tax_key = line.tax_ids
+                if tax_key not in tax_groups:
+                    tax_groups[tax_key] = {
+                        "tax_ids": line.tax_ids,
+                        "base": 0.0,
+                        "product": line.product_id,
+                        "partner": line.order_id.partner_shipping_id,
+                        "currency": line.order_id.currency_id,
+                    }
+                tax_groups[tax_key]["base"] += discounted_subtotal
+            # Compute taxes once per group to avoid rounding accumulation
+            for group in tax_groups.values():
+                discounted_tax = group["tax_ids"].with_context(
                     force_price_include=False
                 ).compute_all(
-                    discounted_subtotal,
-                    line.order_id.currency_id,
+                    group["base"],
+                    group["currency"],
                     1.0,
-                    product=line.product_id,
-                    partner=line.order_id.partner_shipping_id,
+                    product=group["product"],
+                    partner=group["partner"],
                 )
                 amount_discounted_tax += sum(
                     t.get("amount", 0.0) for t in discounted_tax.get("taxes", [])

--- a/sale_global_discount/models/sale_order.py
+++ b/sale_global_discount/models/sale_order.py
@@ -118,7 +118,7 @@ class SaleOrder(models.Model):
                         line.price_subtotal, discounts.copy()
                     )
                 amount_discounted_untaxed += discounted_subtotal
-                tax_key = line.tax_ids
+                tax_key = frozenset(line.tax_ids.ids)
                 if tax_key not in tax_groups:
                     tax_groups[tax_key] = {
                         "tax_ids": line.tax_ids,

--- a/sale_global_discount/tests/test_sale_global_discount.py
+++ b/sale_global_discount/tests/test_sale_global_discount.py
@@ -174,7 +174,7 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         self.assertAlmostEqual(self.sale.amount_untaxed_before_global_discounts, 249.99)
         self.assertAlmostEqual(self.sale.amount_total, 104.99)
         self.assertAlmostEqual(self.sale.amount_total_before_global_discounts, 299.99)
-        self.assertAlmostEqual(self.sale.amount_tax, 17.51)
+        self.assertAlmostEqual(self.sale.amount_tax, 17.49)
         self.assertAlmostEqual(
             self.get_taxes_widget_total_tax(self.sale), self.sale.amount_tax
         )
@@ -194,7 +194,7 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         self.assertAlmostEqual(discount_amount, 162.49)
         self.assertAlmostEqual(move.amount_untaxed_before_global_discounts, 249.99)
         self.assertAlmostEqual(move.amount_untaxed, 87.5)
-        self.assertAlmostEqual(move.amount_total, 104.99)
+        self.assertAlmostEqual(move.amount_total, 105.01)
         # Expected Journal Entry
         # credit    debit    account
         # ========  =======  =========
@@ -213,7 +213,7 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         term_line = move.line_ids.filtered(
             lambda x: x.account_id.account_type == "asset_receivable"
         )
-        self.assertAlmostEqual(term_line.debit, 104.99)
+        self.assertAlmostEqual(term_line.debit, 105.01)
         discount_lines = move.line_ids.filtered("invoice_global_discount_id")
         self.assertEqual(len(discount_lines), 2)
         self.assertAlmostEqual(sum(discount_lines.mapped("debit")), 162.49)

--- a/sale_global_discount/tests/test_sale_global_discount.py
+++ b/sale_global_discount/tests/test_sale_global_discount.py
@@ -172,7 +172,7 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         self.assertAlmostEqual(self.sale.amount_global_discount, 162.49)
         self.assertAlmostEqual(self.sale.amount_untaxed, 87.5)
         self.assertAlmostEqual(self.sale.amount_untaxed_before_global_discounts, 249.99)
-        self.assertAlmostEqual(self.sale.amount_total, 104.99 )
+        self.assertAlmostEqual(self.sale.amount_total, 104.99)
         self.assertAlmostEqual(self.sale.amount_total_before_global_discounts, 299.99)
         self.assertAlmostEqual(self.sale.amount_tax, 17.51)
         self.assertAlmostEqual(
@@ -194,7 +194,7 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         self.assertAlmostEqual(discount_amount, 162.49)
         self.assertAlmostEqual(move.amount_untaxed_before_global_discounts, 249.99)
         self.assertAlmostEqual(move.amount_untaxed, 87.5)
-        self.assertAlmostEqual(move.amount_total, 104.99 )
+        self.assertAlmostEqual(move.amount_total, 104.99)
         # Expected Journal Entry
         # credit    debit    account
         # ========  =======  =========
@@ -213,7 +213,7 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         term_line = move.line_ids.filtered(
             lambda x: x.account_id.account_type == "asset_receivable"
         )
-        self.assertAlmostEqual(term_line.debit, 104.99 )
+        self.assertAlmostEqual(term_line.debit, 104.99)
         discount_lines = move.line_ids.filtered("invoice_global_discount_id")
         self.assertEqual(len(discount_lines), 2)
         self.assertAlmostEqual(sum(discount_lines.mapped("debit")), 162.49)

--- a/sale_global_discount/tests/test_sale_global_discount.py
+++ b/sale_global_discount/tests/test_sale_global_discount.py
@@ -159,7 +159,7 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         #    99.99        0  Test Product 2
         #    13.13        0  Test TAX 15%
         #     4.38        0  TAX 5%
-        #        0   104.99
+        #        0   105.01
         #        0       75  Test Discount 2 (30.00%) - Test TAX 15%, TAX 5%
         #        0    87.49  Test Discount 3 (50.00%) - Test TAX 15%, TAX 5%
         # ========  =======  ===============================================
@@ -172,9 +172,9 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         self.assertAlmostEqual(self.sale.amount_global_discount, 162.49)
         self.assertAlmostEqual(self.sale.amount_untaxed, 87.5)
         self.assertAlmostEqual(self.sale.amount_untaxed_before_global_discounts, 249.99)
-        self.assertAlmostEqual(self.sale.amount_total, 104.99)
+        self.assertAlmostEqual(self.sale.amount_total, 105.01)
         self.assertAlmostEqual(self.sale.amount_total_before_global_discounts, 299.99)
-        self.assertAlmostEqual(self.sale.amount_tax, 17.49)
+        self.assertAlmostEqual(self.sale.amount_tax, 17.51)
         self.assertAlmostEqual(
             self.get_taxes_widget_total_tax(self.sale), self.sale.amount_tax
         )
@@ -202,7 +202,7 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         #    99.99        0  400000 (line 2)
         #    13.13        0  400000 (line_tax_1)
         #     4.38        0  400000 (line_tax_2)
-        #        0   104.99  121000 (Base)
+        #        0   105.01  121000 (Base)
         #        0       75  TEST99999 (Global discount 1)
         #        0    87.49  TEST99999 (Global discount 2)
         #   267.50   267.50  <- Balance
@@ -270,6 +270,22 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         self.assertTrue(self.sale.amount_tax > 0)
         self.assertTrue(
             self.sale.amount_total < self.sale.amount_total_before_global_discounts
+        )
+        self.assertAlmostEqual(
+            self.get_taxes_widget_total_tax(self.sale), self.sale.amount_tax
+        )
+
+    def test_09_group_lines_by_tax_combination(self):
+        """Lines with different tax combinations must be grouped separately
+        when computing the global discount taxes, keeping the totals
+        consistent with the core-computed taxes widget."""
+        self.sale.order_line[0].tax_ids = self.tax_1
+        self.sale.order_line[1].tax_ids = self.tax_2
+        self.sale.global_discount_ids = self.global_discount_1
+        self.sale._compute_tax_totals()
+        self.assertAlmostEqual(
+            self.sale.amount_total,
+            self.sale.amount_untaxed + self.sale.amount_tax,
         )
         self.assertAlmostEqual(
             self.get_taxes_widget_total_tax(self.sale), self.sale.amount_tax

--- a/sale_global_discount/tests/test_sale_global_discount.py
+++ b/sale_global_discount/tests/test_sale_global_discount.py
@@ -159,7 +159,7 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         #    99.99        0  Test Product 2
         #    13.13        0  Test TAX 15%
         #     4.38        0  TAX 5%
-        #        0   105.01
+        #        0   104.99
         #        0       75  Test Discount 2 (30.00%) - Test TAX 15%, TAX 5%
         #        0    87.49  Test Discount 3 (50.00%) - Test TAX 15%, TAX 5%
         # ========  =======  ===============================================
@@ -172,7 +172,7 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         self.assertAlmostEqual(self.sale.amount_global_discount, 162.49)
         self.assertAlmostEqual(self.sale.amount_untaxed, 87.5)
         self.assertAlmostEqual(self.sale.amount_untaxed_before_global_discounts, 249.99)
-        self.assertAlmostEqual(self.sale.amount_total, 105.01)
+        self.assertAlmostEqual(self.sale.amount_total, 104.99 )
         self.assertAlmostEqual(self.sale.amount_total_before_global_discounts, 299.99)
         self.assertAlmostEqual(self.sale.amount_tax, 17.51)
         self.assertAlmostEqual(
@@ -194,7 +194,7 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         self.assertAlmostEqual(discount_amount, 162.49)
         self.assertAlmostEqual(move.amount_untaxed_before_global_discounts, 249.99)
         self.assertAlmostEqual(move.amount_untaxed, 87.5)
-        self.assertAlmostEqual(move.amount_total, 105.01)
+        self.assertAlmostEqual(move.amount_total, 104.99 )
         # Expected Journal Entry
         # credit    debit    account
         # ========  =======  =========
@@ -202,7 +202,7 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         #    99.99        0  400000 (line 2)
         #    13.13        0  400000 (line_tax_1)
         #     4.38        0  400000 (line_tax_2)
-        #        0   105.01  121000 (Base)
+        #        0   104.99  121000 (Base)
         #        0       75  TEST99999 (Global discount 1)
         #        0    87.49  TEST99999 (Global discount 2)
         #   267.50   267.50  <- Balance
@@ -213,7 +213,7 @@ class TestSaleGlobalDiscount(AccountTestInvoicingCommon):
         term_line = move.line_ids.filtered(
             lambda x: x.account_id.account_type == "asset_receivable"
         )
-        self.assertAlmostEqual(term_line.debit, 105.01)
+        self.assertAlmostEqual(term_line.debit, 104.99 )
         discount_lines = move.line_ids.filtered("invoice_global_discount_id")
         self.assertEqual(len(discount_lines), 2)
         self.assertAlmostEqual(sum(discount_lines.mapped("debit")), 162.49)


### PR DESCRIPTION
When a sale order has multiple lines with compound taxes, computing taxes line by line causes accumulated rounding errors because each line's tax amount is rounded individually before accumulation.

The fix groups order lines by their tax combination before calling compute_all, mirroring Odoo core's approach. This ensures rounding is applied once per tax group rather than once per line, eliminating the accumulated rounding error.

Fixes #4397