### PR TITLE
[19.0][IMP] sale_order_line_price_source: add related pricelist_id field to expose parent pricelist

### DIFF
--- a/sale_order_line_price_source/models/sale_order_line.py
+++ b/sale_order_line_price_source/models/sale_order_line.py
@@ -29,6 +29,14 @@ class SaleOrderLine(models.Model):
         "this line's price (if source is Pricelist).",
     )
 
+    pricelist_id = fields.Many2one(
+        "product.pricelist",
+        string="Price Source Pricelist",
+        related="price_source_pricelist_item_id.pricelist_id",
+        help="The pricelist that determined this "
+        "line's price (if source is Pricelist).",
+    )
+
     def _has_manual_price(self):
         """
         Mirror core manual-price detection from

--- a/sale_order_line_price_source/views/sale_order_views.xml
+++ b/sale_order_line_price_source/views/sale_order_views.xml
@@ -15,6 +15,7 @@
                     optional="hide"
                     readonly="1"
                 />
+                <field name="pricelist_id" optional="hide" readonly="1" />
             </xpath>
             <xpath expr="//field[@name='order_line']/list" position="attributes">
                 <attribute name="open_form_view">1</attribute>
@@ -30,6 +31,7 @@
             <xpath expr="//field[@name='price_unit']" position="after">
                 <field name="price_source" readonly="1" />
                 <field name="price_source_pricelist_item_id" readonly="1" />
+                <field name="pricelist_id" readonly="1" />
             </xpath>
         </field>
     </record>
@@ -46,6 +48,7 @@
                     optional="hide"
                     readonly="1"
                 />
+                <field name="pricelist_id" optional="hide" readonly="1" />
             </xpath>
         </field>
     </record>

--- a/sale_stock_picking_blocking/__manifest__.py
+++ b/sale_stock_picking_blocking/__manifest__.py
@@ -19,6 +19,7 @@
         "views/res_partner_view.xml",
         "views/account_payment_term_view.xml",
     ],
+    "maintainers": ["Ricardoalso"],
     "license": "AGPL-3",
     "installable": True,
     "application": False,


### PR DESCRIPTION
Add a related pricelist_id on sale.order.line to retrieve the pricelist linked to price_source_pricelist_item_id. This is needed because product.pricelist.item does not directly expose its parent pricelist, making it difficult to access that information.