### PR TITLE
[18.0][FIX] sale_order_secondary_unit: keep packaging and secondary qty in sync

### DIFF
--- a/sale_order_secondary_unit/models/sale_order.py
+++ b/sale_order_secondary_unit/models/sale_order.py
@@ -19,19 +19,13 @@ class SaleOrderLine(models.Model):
 
     product_uom_qty = fields.Float(copy=True)
 
-    @api.depends(
-        "display_type",
-        "product_id",
-        "product_packaging_qty",
+    @api.onchange(
         "secondary_uom_qty",
         "secondary_uom_id",
-        "product_uom_qty",
     )
-    def _compute_product_uom_qty(self):
-        res = super()._compute_product_uom_qty()
+    def _compute_target_field_qty(self):
         for line in self:
             line._compute_helper_target_field_qty()
-        return res
 
     @api.depends("product_id")
     def _compute_product_uom(self):
@@ -42,12 +36,22 @@ class SaleOrderLine(models.Model):
 
     @api.onchange("product_id")
     def _onchange_product_id_warning(self):
+        """
+        If default sales secondary unit set on product, put on secondary
+        quantity 1 for being the default quantity. We override this method,
+        that is the one that sets by default 1 on the other quantity with that
+        purpose.
+        """
         res = super()._onchange_product_id_warning()
         if self.product_id and not self.env.context.get("skip_secondary_uom_default"):
+            line_uom_qty = self.product_uom_qty
             self.secondary_uom_id = self.product_id.sale_secondary_uom_id
-            if self.product_uom_qty == 1.0:
-                self.secondary_uom_qty = 1.0
-                self._onchange_helper_product_uom_for_secondary()
+            if self.secondary_uom_id:
+                if line_uom_qty == 1.0:
+                    self.secondary_uom_qty = 1.0
+                    self._compute_helper_target_field_qty()
+                else:
+                    self.product_uom_qty = line_uom_qty
         return res
 
     @api.depends("secondary_uom_qty", "product_uom_qty", "price_unit")

--- a/sale_order_secondary_unit/models/sale_order.py
+++ b/sale_order_secondary_unit/models/sale_order.py
@@ -18,20 +18,19 @@ class SaleOrderLine(models.Model):
     )
 
     product_uom_qty = fields.Float(copy=True)
+    # Inverse (not a compute) to avoid a recursive dependency with the base
+    # packaging compute; it also covers write()/imports/EDI, unlike onchange.
+    secondary_uom_qty = fields.Float(inverse="_inverse_secondary_uom_qty")
 
-    @api.depends(
-        "display_type",
-        "product_id",
-        "product_packaging_qty",
-        "secondary_uom_qty",
-        "secondary_uom_id",
-        "product_uom_qty",
-    )
-    def _compute_product_uom_qty(self):
-        res = super()._compute_product_uom_qty()
+    def _inverse_secondary_uom_qty(self):
         for line in self:
             line._compute_helper_target_field_qty()
-        return res
+
+    @api.onchange("secondary_uom_qty")
+    def _onchange_secondary_uom_qty(self):
+        # The inverse only runs on write; mirror it for live feedback in the form.
+        for line in self:
+            line._compute_helper_target_field_qty()
 
     @api.depends("product_id")
     def _compute_product_uom(self):

--- a/sale_order_secondary_unit/models/sale_order.py
+++ b/sale_order_secondary_unit/models/sale_order.py
@@ -18,12 +18,17 @@ class SaleOrderLine(models.Model):
     )
 
     product_uom_qty = fields.Float(copy=True)
+    # Inverse (not a compute) to avoid a recursive dependency with the base
+    # packaging compute; it also covers write()/imports/EDI, unlike onchange.
+    secondary_uom_qty = fields.Float(inverse="_inverse_secondary_uom_qty")
 
-    @api.onchange(
-        "secondary_uom_qty",
-        "secondary_uom_id",
-    )
-    def _compute_target_field_qty(self):
+    def _inverse_secondary_uom_qty(self):
+        for line in self:
+            line._compute_helper_target_field_qty()
+
+    @api.onchange("secondary_uom_qty", "secondary_uom_id")
+    def _onchange_secondary_uom_qty(self):
+        # The inverse only runs on write; mirror it for live feedback in the form.
         for line in self:
             line._compute_helper_target_field_qty()
 

--- a/sale_order_secondary_unit/tests/test_sale_order.py
+++ b/sale_order_secondary_unit/tests/test_sale_order.py
@@ -63,6 +63,38 @@ class TestSaleOrder(BaseCommon):
         )
         self.assertEqual(self.order.order_line.secondary_uom_qty, 7.0)
 
+    def test_packaging_qty_updates_quantities(self):
+        # Regression: changing the number of packages must propagate to both
+        # product_uom_qty and secondary_uom_qty, also on a programmatic write.
+        packaging = self.env["product.packaging"].create(
+            {"name": "box-10", "product_id": self.product.id, "qty": 10.0}
+        )
+        line = self.order.order_line
+        line.secondary_uom_id = self.secondary_unit.id
+        line.write({"product_packaging_id": packaging.id, "product_packaging_qty": 2})
+        self.assertEqual(line.product_uom_qty, 20.0)
+        self.assertEqual(line.secondary_uom_qty, 40.0)
+
+    def test_packaging_then_secondary_onchange_no_regression(self):
+        # Secondary unit and packaging fields are only shown to these groups.
+        self.env.user.groups_id |= self.env.ref("uom.group_uom")
+        self.env.user.groups_id |= self.env.ref("product.group_stock_packaging")
+        packaging = self.env["product.packaging"].create(
+            {"name": "box-10", "product_id": self.product.id, "qty": 10.0}
+        )
+        with Form(self.order) as order_form:
+            with order_form.order_line.edit(0) as line:
+                line.secondary_uom_id = self.secondary_unit
+                # Match the packaging size first so the "you should sell N"
+                # onchange warning does not fire when assigning the packaging.
+                line.product_uom_qty = 10
+                line.product_packaging_id = packaging
+                line.product_packaging_qty = 2
+                self.assertEqual(line.product_uom_qty, 20.0)
+                self.assertEqual(line.secondary_uom_qty, 40.0)
+                line.secondary_uom_qty = 60.0
+                self.assertEqual(line.product_uom_qty, 30.0)
+
     def test_default_secondary_unit(self):
         self.order.order_line._onchange_product_id_warning()
         self.assertEqual(self.order.order_line.secondary_uom_id, self.secondary_unit)


### PR DESCRIPTION
## Problem
When a product is sold using both a packaging and a secondary unit of
measure, changing the number of packages (`product_packaging_qty`) on the
sale order line did not recompute `product_uom_qty` nor `secondary_uom_qty`.

The module overrode `_compute_product_uom_qty` to call `super()` (base
packaging → quantity logic) and then re-derive the quantity from the
secondary unit. Since `secondary_uom_qty` is itself computed from
`product_uom_qty`, this created a recursive dependency between both fields
and the packaging compute, and the packaging change was discarded.

## Fix
Move the `secondary unit → product_uom_qty` conversion out of the compute
and into an `inverse` on `secondary_uom_qty`:

- `product_uom_qty → secondary_uom_qty` stays an `@api.depends` compute, so
  it reacts to any quantity change (manual, packaging-driven, programmatic).
- `secondary_uom_qty → product_uom_qty` is handled by the inverse, which
  fires on `write()` too (unlike an `@api.onchange`) and does not create a
  recompute cycle.

## Relation to #3875
Alternative to #3875 (thanks @maq-adhoc), which fixed the same bug by
switching `_compute_product_uom_qty` to an `@api.onchange`. Keeping the
computed-field design works on programmatic writes (`write()`, imports, EDI,
API) — an `onchange` only fires in the form view — and preserves the base
`super()` packaging logic and the documented mixin pattern.

## Tests
- `test_packaging_qty_updates_quantities`: changing the packaging quantity
  propagates to both `product_uom_qty` and `secondary_uom_qty`, also on a
  programmatic `write()`.
