### PR TITLE
[19.0][FIX] sale_order_line_description: description update

### DIFF
--- a/sale_order_line_description/__manifest__.py
+++ b/sale_order_line_description/__manifest__.py
@@ -9,5 +9,13 @@
     "license": "AGPL-3",
     "depends": ["sale"],
     "data": ["security/sale_security.xml", "views/res_config_settings_views.xml"],
+    "assets": {
+        "web.assets_backend": [
+            "sale_order_line_description/static/src/js/sale_product_field.esm.js",
+        ],
+        "web.assets_tests": [
+            "sale_order_line_description/static/tests/tours/*.js",
+        ],
+    },
     "installable": True,
 }

--- a/sale_order_line_description/static/src/js/sale_product_field.esm.js
+++ b/sale_order_line_description/static/src/js/sale_product_field.esm.js
@@ -1,0 +1,26 @@
+/* Copyright 2026 Moduon
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+
+import {SaleOrderLineProductField} from "@sale/js/sale_product_field";
+import {onWillStart} from "@odoo/owl";
+import {patch} from "@web/core/utils/patch";
+import {user} from "@web/core/user";
+
+patch(SaleOrderLineProductField.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.useProductDescriptionPerSOLine = false;
+        onWillStart(async () => {
+            this.useProductDescriptionPerSOLine = await user.hasGroup(
+                "sale_order_line_description.group_use_product_description_per_so_line"
+            );
+        });
+    },
+
+    parseLabel(value) {
+        if (this.useProductDescriptionPerSOLine) {
+            return value || "";
+        }
+        return super.parseLabel(value);
+    },
+});

--- a/sale_order_line_description/static/tests/tours/sale_order_line_description.esm.js
+++ b/sale_order_line_description/static/tests/tours/sale_order_line_description.esm.js
@@ -1,0 +1,22 @@
+/* Copyright 2026 Moduon
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
+import {registry} from "@web/core/registry";
+import {stepUtils} from "@web_tour/tour_utils";
+
+registry.category("web_tour.tours").add("sale_order_line_description_manual_edit", {
+    steps: () => [
+        {
+            content: "Open the sale order line editor",
+            trigger:
+                '.o_field_product_label_section_and_note_cell:contains("Sale description for test product")',
+            run: "click",
+        },
+        {
+            content: "Edit the sale order line description",
+            trigger:
+                ".o_selected_row .o_field_product_label_section_and_note_cell textarea",
+            run: "edit Sale description for test product test",
+        },
+        ...stepUtils.saveForm(),
+    ],
+});

--- a/sale_order_line_description/tests/__init__.py
+++ b/sale_order_line_description/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_sale
+from . import test_sale_ui

--- a/sale_order_line_description/tests/test_sale.py
+++ b/sale_order_line_description/tests/test_sale.py
@@ -1,12 +1,14 @@
 # Copyright 2017 Simone Rubino - Agile Business Group
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import odoo.tests.common as common
-from odoo.tests import tagged
+from odoo.tests import Form, tagged
+from odoo.tests.common import new_test_user, users
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
 @tagged("post_install", "-at_install")
-class TestSaleOrderLineDescriptionChange(common.TransactionCase):
+class TestSaleOrderLineDescriptionChange(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -16,16 +18,15 @@ class TestSaleOrderLineDescriptionChange(common.TransactionCase):
         cls.sale_order_line_model = cls.env["sale.order.line"]
         cls.partner_model = cls.env["res.partner"]
         cls.product_model = cls.env["product.product"]
-        cls.user_model = cls.env["res.users"].with_context(
-            no_reset_password=True, mail_create_nosubscribe=True
+        cls.env["res.config.settings"].create(
+            {"group_use_product_description_per_so_line": True}
+        ).execute()
+        new_test_user(
+            cls.env,
+            login="test_sale_description_only",
+            groups="sales_team.group_sale_manager",
+            context={"no_reset_password": True, "mail_create_nosubscribe": True},
         )
-
-        # Create two different users
-        cls.group_only_sale_description = cls.env.ref(
-            "sale_order_line_description.group_use_product_description_per_so_line"
-        )
-        cls.user_1 = cls._create_user(cls, "TestUser1")
-        cls.user_2 = cls._create_user(cls, "TestUser2", cls.group_only_sale_description)
 
         # Create the sale order
         cls.partner = cls.partner_model.create({"name": "Test partner"})
@@ -38,43 +39,27 @@ class TestSaleOrderLineDescriptionChange(common.TransactionCase):
             }
         )
 
-    def _create_user(self, name, group=None):
-        groups = self.env.user.group_ids
-        if group:
-            groups += group
-        return self.user_model.create(
-            {
-                "name": name,
-                "login": name,
-                "email": name + "@example.com",
-                "group_ids": groups,
-            }
+    @users("test_sale_description_only")
+    def test_check_only_sale_order_line_description(self):
+        sale_order_line = self.sale_order_line_model.create(
+            {"order_id": self.sale_order.id, "product_id": self.product.id}
         )
-
-    def test_check_sale_order_line_description(self):
-        line_values = {"order_id": self.sale_order.id, "product_id": self.product.id}
-
-        # Create sale order line with TestUser1
-        sale_order_line = self.sale_order_line_model.with_user(self.user_1).create(
-            line_values.copy()
-        )
-
-        self.assertEqual(
-            sale_order_line.name,
-            "\n".join([self.product.name, self.product.description_sale]),
-            "Standard behavior does not concatenate "
-            "product description and product sale description",
-        )
-
-        # Create sale order line with TestUser2
-        sale_order_line = self.sale_order_line_model.with_user(self.user_2).create(
-            line_values.copy()
-        )
-
         self.assertEqual(
             sale_order_line.name,
             self.product.description_sale,
-            "Adding group "
-            + self.group_only_sale_description.name
-            + " does not modify sale order line description",
+            "Enabling the product-description-only setting does not modify sale order "
+            "line description",
+        )
+
+    @users("test_sale_description_only")
+    def test_manual_description_edit_keeps_product_name_hidden(self):
+        with Form(self.sale_order_model) as order_form:
+            order_form.partner_id = self.partner
+            with order_form.order_line.new() as line_form:
+                line_form.product_id = self.product
+                line_form.name = f"{self.product.description_sale} test"
+        sale_order = order_form.save()
+
+        self.assertEqual(
+            sale_order.order_line.name, f"{self.product.description_sale} test"
         )

--- a/sale_order_line_description/tests/test_sale_ui.py
+++ b/sale_order_line_description/tests/test_sale_ui.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Moduon
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.fields import Command
+from odoo.tests import HttpCase, tagged
+from odoo.tests.common import new_test_user
+
+
+@tagged("post_install", "-at_install")
+class TestSaleOrderLineDescriptionUi(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env["res.config.settings"].create(
+            {"group_use_product_description_per_so_line": True}
+        ).execute()
+        cls.tour_user = new_test_user(
+            cls.env,
+            login="sol_description_tour_user",
+            groups="sales_team.group_sale_manager,account.group_account_invoice",
+            context={"no_reset_password": True, "mail_create_nosubscribe": True},
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "Test partner"})
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test product",
+                "description_sale": "Sale description for test product",
+            }
+        )
+        cls.sale_order = (
+            cls.env["sale.order"]
+            .with_user(cls.tour_user)
+            .create(
+                {
+                    "partner_id": cls.partner.id,
+                    "order_line": [Command.create({"product_id": cls.product.id})],
+                }
+            )
+        )
+
+    def test_manual_description_edit_keeps_product_name_hidden_tour(self):
+        self.assertEqual(self.sale_order.order_line.name, self.product.description_sale)
+
+        self.start_tour(
+            f"/odoo/sales/{self.sale_order.id}",
+            "sale_order_line_description_manual_edit",
+            login="sol_description_tour_user",
+        )
+
+        self.sale_order.order_line.invalidate_recordset(["name"])
+        self.assertEqual(
+            self.sale_order.order_line.name,
+            f"{self.product.description_sale} test",
+        )


### PR DESCRIPTION
When we changed the description manually, the product name was readded by the SaleOrderLineProductField js mechanisms.

- Backend tests improved
- Added tour as regression test

https://www.loom.com/share/f73a409780874fc7b34db550499707bb

cc @moduon MT-15180

please review @yajo @Gelojr 