### PR TITLE
[FIX] sale_automatic_workflow: skip invoice creation when refund exists - fwp 4302

### DIFF
--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -31,8 +31,7 @@ class AutomaticWorkflowJob(models.Model):
 
     _name = "automatic.workflow.job"
     _description = (
-        "Scheduler that will play automatically the validation of"
-        " invoices, pickings..."
+        "Scheduler that will play automatically the validation of invoices, pickings..."
     )
 
     def _do_validate_sale_order(self, sale, domain_filter):
@@ -75,6 +74,21 @@ class AutomaticWorkflowJob(models.Model):
             [("id", "=", sale.id)] + domain_filter
         ):
             return f"{sale.display_name} {sale} job bypassed"
+        # Skip if a posted invoice already exists or has been refunded
+        posted_invoices = sale.invoice_ids.filtered(
+            lambda move: move.state == "posted" and move.move_type == "out_invoice"
+        )
+        if posted_invoices:
+            refunds = self.env["account.move"].search(
+                [
+                    ("reversed_entry_id", "in", posted_invoices.ids),
+                    ("move_type", "=", "out_refund"),
+                    ("state", "=", "posted"),
+                ]
+            )
+            if refunds:
+                return f"{sale.display_name} {sale} skipped (invoice already refunded)"
+            return f"{sale.display_name} {sale} skipped (posted invoice already exists)"
         payment = self.env["sale.advance.payment.inv"].create(
             {"sale_order_ids": sale.ids}
         )

--- a/sale_automatic_workflow/tests/test_automatic_workflow.py
+++ b/sale_automatic_workflow/tests/test_automatic_workflow.py
@@ -229,3 +229,83 @@ class TestAutomaticWorkflow(TestCommon, TestAutomaticWorkflowMixin):
         self.run_job()
         payment = self.env["account.payment"].search([], limit=1, order="id desc")
         self.assertEqual(payment.journal_id, payment_journal)
+
+    def test_do_create_invoice_bypassed_by_domain(self):
+        """Invoice creation bypassed when sale order does not match domain."""
+        workflow = self.create_full_automatic()
+        sale = self.create_sale_order(workflow)
+        job = self.env["automatic.workflow.job"]
+        result = job._do_create_invoice(sale, [("id", "=", 0)])
+        self.assertIn("job bypassed", result)
+        self.assertFalse(sale.invoice_ids)
+
+    def test_do_create_invoice_skips_when_posted_invoice_exists(self):
+        """Invoice creation skipped when a posted invoice already exists."""
+        workflow = self.create_full_automatic()
+        sale = self.create_sale_order(workflow)
+        self.run_job()
+        self.assertTrue(sale.invoice_ids)
+        self.assertEqual(sale.invoice_ids.state, "posted")
+        job = self.env["automatic.workflow.job"]
+        domain = [
+            ("state", "in", ["sale", "done"]),
+            ("workflow_process_id", "=", sale.workflow_process_id.id),
+        ]
+        result = job._do_create_invoice(sale, domain)
+        self.assertIn("posted invoice already exists", result)
+        self.assertEqual(len(sale.invoice_ids), 1)
+
+    def test_do_create_invoice_skips_when_invoice_already_refunded(self):
+        """Invoice creation skipped when a credit note exists for the invoice."""
+        workflow = self.create_full_automatic()
+        sale = self.create_sale_order(workflow)
+        self.run_job()
+        invoice = sale.invoice_ids
+        self.assertTrue(invoice)
+        self.assertEqual(invoice.state, "posted")
+        # Create a credit note (reversal)
+        refund_wizard = (
+            self.env["account.move.reversal"]
+            .with_context(active_model="account.move", active_ids=invoice.ids)
+            .create({"reason": "Test refund", "journal_id": invoice.journal_id.id})
+        )
+        refund_wizard.reverse_moves()
+        refund = self.env["account.move"].search(
+            [
+                ("reversed_entry_id", "=", invoice.id),
+                ("move_type", "=", "out_refund"),
+            ],
+            limit=1,
+        )
+        self.assertTrue(refund, "Credit note was not created")
+        if refund.state != "posted":
+            refund.action_post()
+        job = self.env["automatic.workflow.job"]
+        domain = [
+            ("state", "in", ["sale", "done"]),
+            ("workflow_process_id", "=", sale.workflow_process_id.id),
+        ]
+        result = job._do_create_invoice(sale, domain)
+        self.assertIn("invoice already refunded", result)
+        out_invoices = sale.invoice_ids.filtered(lambda m: m.move_type == "out_invoice")
+        self.assertEqual(len(out_invoices), 1)
+
+    def test_do_create_invoice_success(self):
+        """Invoice creation succeeds when no posted invoice exists."""
+        workflow = self.create_full_automatic(
+            override={
+                "create_invoice": False,
+                "validate_invoice": False,
+            }
+        )
+        sale = self.create_sale_order(workflow)
+        sale.action_confirm()
+        job = self.env["automatic.workflow.job"]
+        domain = [
+            ("state", "in", ["sale", "done"]),
+            ("workflow_process_id", "=", sale.workflow_process_id.id),
+        ]
+        self.assertFalse(sale.invoice_ids)
+        result = job._do_create_invoice(sale, domain)
+        self.assertIn("create invoice successfully", result)
+        self.assertTrue(sale.invoice_ids)


### PR DESCRIPTION
When a posted invoice is reversed by a credit note, the automatic workflow incorrectly creates a new invoice because the credit note reduces qty_invoiced, making invoice_status = 'to invoice' again.

Skip invoice creation when:
- A posted out_invoice already exists, or
- A posted out_refund linked to that invoice exists.

Forward-port of fix from PR #4302 (OCA/sale-workflow, 16.0). Original author: muslim-foda