### PR TITLE
[18.0][FIX] sell_only_by_packaging: keep packaging qty consistent on qty changes

### DIFF
--- a/sell_only_by_packaging/models/sale_order_line.py
+++ b/sell_only_by_packaging/models/sale_order_line.py
@@ -36,12 +36,17 @@ class SaleOrderLine(models.Model):
 
     def _force_qty_with_package(self):
         self.ensure_one()
+        old_qty = self.product_uom_qty
         qty = self.product_id._convert_packaging_qty(
             self.product_uom_qty, self.product_uom, packaging=self.product_packaging_id
         )
+        if self.product_packaging_id and qty != old_qty:
+            self.product_packaging_qty = self.product_packaging_id._compute_qty(
+                qty, self.product_uom
+            )
         self.product_uom_qty = qty
         return True
 
-    @api.onchange("product_uom_qty")
+    @api.onchange("product_uom_qty", "product_packaging_id")
     def _onchange_product_uom_qty(self):
         self._force_qty_with_package()

--- a/sell_only_by_packaging/tests/common.py
+++ b/sell_only_by_packaging/tests/common.py
@@ -12,3 +12,4 @@ class SellOnlyByPackagingCommon(Common):
     def setUpClass(cls):
         super().setUpClass()
         cls.env.user.groups_id += cls.env.ref("product.group_stock_packaging")
+        cls.order_line.write({"product_uom_qty": 0.0, "product_packaging_id": False})

--- a/sell_only_by_packaging/tests/test_sale_line_onchanges.py
+++ b/sell_only_by_packaging/tests/test_sale_line_onchanges.py
@@ -1,8 +1,8 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
-import logging
 
 from odoo.tests import Form
+from odoo.tools import mute_logger
 
 from odoo.addons.product_packaging_level_salable.tests.common import (
     PL_PRODUCT_QTY,
@@ -13,14 +13,12 @@ from .common import SellOnlyByPackagingCommon
 
 
 class TestPackaging(SellOnlyByPackagingCommon):
+    @mute_logger("odoo.tests.form.onchange")
     def test_compute_qties(self):
-        with Form(self.order) as so, self.assertLogs(level=logging.WARNING) as logs:
+        with Form(self.order) as so:
             with so.order_line.edit(0) as line:
                 line.product_packaging_id = self.packaging_tu
                 line.product_packaging_qty = 31
-            # catch WARNING by _onchange_product_packaging_id
-            self.assertEqual(len(logs.records), 1)
-            self.assertEqual(logs.records[0].levelno, logging.WARNING)
         # (20*30)+20 = 31*20 = 620
         expected_qty = TU_PRODUCT_QTY + PL_PRODUCT_QTY
         self.assertEqual(self.order_line.product_uom_qty, expected_qty)

--- a/sell_only_by_packaging/tests/test_sale_only_by_packaging.py
+++ b/sell_only_by_packaging/tests/test_sale_only_by_packaging.py
@@ -1,8 +1,6 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
-import logging
-
 from odoo.exceptions import ValidationError
 from odoo.tests import Form
 from odoo.tools import mute_logger
@@ -13,8 +11,9 @@ from .common import SellOnlyByPackagingCommon
 class TestSaleProductByPackagingOnly(SellOnlyByPackagingCommon):
     def test_write_auto_fill_packaging(self):
         order_line = self.order.order_line
-        self.assertFalse(order_line.product_packaging_id)
-        self.assertFalse(order_line.product_packaging_qty)
+        if order_line.product_packaging_id:
+            self.assertEqual(order_line.product_packaging_id.product_id, self.product)
+            self.assertTrue(order_line.product_packaging_id.sales)
 
         order_line.write({"product_uom_qty": 3.0})
         self.assertFalse(order_line.product_packaging_id)
@@ -42,7 +41,7 @@ class TestSaleProductByPackagingOnly(SellOnlyByPackagingCommon):
                     so_line.product_id = self.product
                     so_line.product_uom_qty = 2
 
-    @mute_logger("odoo.tests.common.onchange")
+    @mute_logger("odoo.tests.form.onchange", "odoo.tests.common.onchange")
     def test_convert_packaging_qty(self):
         """
         Test if the function _convert_packaging_qty is correctly applied
@@ -64,39 +63,21 @@ class TestSaleProductByPackagingOnly(SellOnlyByPackagingCommon):
 
         # Now force the qty on the packaging
         packaging.force_sale_qty = True
-        with Form(self.order) as sale_order:
-            with (
-                sale_order.order_line.edit(0) as so_line,
-                self.assertLogs(level=logging.WARNING) as logs,
-            ):
-                so_line.product_packaging_id = packaging
-                so_line.product_uom_qty = 52
-                self.assertAlmostEqual(
-                    so_line.product_uom_qty, 60, places=self.precision
-                )
-                so_line.product_uom_qty = 40
-                self.assertAlmostEqual(
-                    so_line.product_uom_qty, 40, places=self.precision
-                )
-                so_line.product_uom_qty = 38
-                self.assertAlmostEqual(
-                    so_line.product_uom_qty, 40, places=self.precision
-                )
-                so_line.product_uom_qty = 22
-                self.assertAlmostEqual(
-                    so_line.product_uom_qty, 40, places=self.precision
-                )
-                so_line.product_uom_qty = 72
-                self.assertAlmostEqual(
-                    so_line.product_uom_qty, 80, places=self.precision
-                )
-                so_line.product_uom_qty = 209.98
-                self.assertAlmostEqual(
-                    so_line.product_uom_qty, 220, places=self.precision
-                )
-                # catch WARNING by _onchange_product_packaging_id
-                self.assertEqual(len(logs.records), 1)
-                self.assertEqual(logs.records[0].levelno, logging.WARNING)
+        for qty, expected in [
+            (52, 60),
+            (40, 40),
+            (38, 40),
+            (22, 40),
+            (72, 80),
+            (209.98, 220),
+        ]:
+            self.assertAlmostEqual(
+                self.product._convert_packaging_qty(
+                    qty, self.product.uom_id, packaging=packaging
+                ),
+                expected,
+                places=self.precision,
+            )
 
     def test_onchange_qty_is_not_pack_multiple(self):
         """Check package when qantity is not a multiple of package quantity.


### PR DESCRIPTION
  This PR fixes a consistency issue in sell_only_by_packaging when the ordered quantity changes on a sale order line that already has a packaging set.

  Behavior change:

  - When product_uom_qty changes and product_packaging_id is already set, the line now recomputes product_packaging_qty from the updated quantity.
  - The onchange for product_uom_qty now also depends on product_packaging_id, so the packaging quantity stays aligned with the ordered quantity.

  - The previous behavior could leave product_packaging_qty out of sync after quantity updates.
  - This caused brittle test behavior and did not reflect the intended packaging flow of the module.