### PR TITLE
[17.0][FIX] sale_fixed_discount: forward kwargs to super in _convert_to_tax_base_line_dict

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -17,7 +17,8 @@ odoo_test_flavor: Both
 odoo_version: 17.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
-rebel_module_groups: []
+rebel_module_groups:
+- sale_packaging_default
 repo_description: This project aim to deal with modules related to manage sale and
     their related workflow.
 repo_name: sale-workflow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,17 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.10-odoo17.0:latest
+            include: "sale_packaging_default"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.10-ocb17.0:latest
+            include: "sale_packaging_default"
+            name: test with OCB
+            makepot: "true"
+          - container: ghcr.io/oca/oca-ci/py3.10-odoo17.0:latest
+            exclude: "sale_packaging_default"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.10-ocb17.0:latest
+            exclude: "sale_packaging_default"
             name: test with OCB
             makepot: "true"
     services:
@@ -49,6 +58,9 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
+    env:
+      INCLUDE: "${{ matrix.include }}"
+      EXCLUDE: "${{ matrix.exclude }}"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/sale_fixed_discount/models/sale_order_line.py
+++ b/sale_fixed_discount/models/sale_order_line.py
@@ -76,7 +76,7 @@ class SaleOrderLine(models.Model):
                 **kwargs,
             )
 
-        return super()._convert_to_tax_base_line_dict()
+        return super()._convert_to_tax_base_line_dict(**kwargs)
 
     @api.depends("discount_fixed", "price_unit")
     def _compute_discount(self):

--- a/sale_fixed_discount/tests/test_sale_fixed_discount.py
+++ b/sale_fixed_discount/tests/test_sale_fixed_discount.py
@@ -109,6 +109,60 @@ class TestSaleFixedDiscount(TransactionCase):
         self.assertEqual(self.sale.invoice_ids.tax_totals["amount_untaxed"], 180.0)
         self.assertEqual(self.sale.invoice_ids.tax_totals["amount_total"], 207.0)
 
+    def test_06_downpayment_price_included_tax(self):
+        """A fixed-amount down payment on an order taxed with a price-included
+        tax must produce a consistent tax breakdown.
+
+        Regression test: the ``_convert_to_tax_base_line_dict`` override used to
+        drop the ``**kwargs`` (notably ``handle_price_include=False``) forwarded
+        by the down payment wizard for lines without a fixed discount. As a
+        result the down payment base was computed as tax-included, and the
+        invoice ended up with an inconsistent tax amount (base 68.31 / tax 31.69
+        instead of base 82.64 / tax 17.36 for a 100.0 down payment).
+        """
+        tax_incl = self.env["account.tax"].create(
+            {
+                "name": "TAX 21% incl",
+                "amount_type": "percent",
+                "type_tax_use": "sale",
+                "amount": 21.0,
+                "price_include": True,
+                "include_base_amount": False,
+            }
+        )
+        order = self.env["sale.order"].create(
+            {"name": "DP Order", "partner_id": self.partner.id}
+        )
+        # Build the line through a Form so that price_unit is set last and is
+        # not overwritten by the pricelist-based _compute_price_unit.
+        with Form(order) as order_form:
+            with order_form.order_line.new() as line:
+                line.product_id = self.product
+                line.product_uom_qty = 1
+                line.tax_id.clear()
+                line.tax_id.add(tax_incl)
+                line.price_unit = 1000.0
+
+        # Sanity check: the price-included tax splits 1000 into 826.45 + 173.55.
+        self.assertAlmostEqual(order.amount_untaxed, 826.45, places=2)
+        self.assertAlmostEqual(order.amount_total, 1000.0, places=2)
+
+        order.action_confirm()
+        wizard = self.env["sale.advance.payment.inv"].create(
+            {
+                "advance_payment_method": "fixed",
+                "fixed_amount": 100.0,
+                "sale_order_ids": [(6, 0, order.ids)],
+            }
+        )
+        wizard.create_invoices()
+        invoice = order.invoice_ids
+        self.assertEqual(len(invoice), 1)
+        # The total must be the requested 100.0, split coherently at 21%.
+        self.assertAlmostEqual(invoice.amount_total, 100.0, places=2)
+        self.assertAlmostEqual(invoice.amount_untaxed, 82.64, places=2)
+        self.assertAlmostEqual(invoice.amount_tax, 17.36, places=2)
+
     def test_04_fixed_discount_without_price(self):
         with Form(self.sale) as sale_order:
             with sale_order.order_line.edit(0) as line:

--- a/sale_product_configurator_widget_product_label/static/src/components/sale_product_field/sale_product_field.esm.js
+++ b/sale_product_configurator_widget_product_label/static/src/components/sale_product_field/sale_product_field.esm.js
@@ -2,10 +2,6 @@
 /* Copyright 2026 Tecnativa - Carlos Lopez
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). */
 
-import {useEffect, useState} from "@odoo/owl";
-
-import {useRecordObserver} from "@web/model/relational_model/utils";
-import {SaleOrderLineProductField} from "@sale/js/sale_product_field";
 import {
     ProductLabel,
     ProductLabelSectionAndNoteFieldAutocomplete,
@@ -13,7 +9,10 @@ import {
     useIsNote,
     useIsSection,
 } from "@web_widget_product_label_section_and_note/components/product_label_section_and_note_field/product_label_section_and_note_field.esm";
+import {useEffect, useState} from "@odoo/owl";
+import {SaleOrderLineProductField} from "@sale/js/sale_product_field";
 import {patch} from "@web/core/utils/patch";
+import {useRecordObserver} from "@web/model/relational_model/utils";
 
 patch(SaleOrderLineProductField.prototype, {
     setup() {


### PR DESCRIPTION
Lines without a fixed discount dropped the `**kwargs` (notably `handle_price_include=False`) that the down payment wizard passes, so fixed-amount down payments on price-included taxes produced an inconsistent tax breakdown.

Last commit is backport from 18.0