### PR TITLE
[17.0][FIX] sale_order_secondary_unit: avoid recursive qty recompute cycle (backport)

### DIFF
--- a/sale_order_secondary_unit/models/sale_order.py
+++ b/sale_order_secondary_unit/models/sale_order.py
@@ -18,20 +18,13 @@ class SaleOrderLine(models.Model):
     )
 
     product_uom_qty = fields.Float(copy=True)
+    # Convert the secondary unit into product_uom_qty through an inverse to
+    # avoid a recursive dependency with the base packaging compute.
+    secondary_uom_qty = fields.Float(inverse="_inverse_secondary_uom_qty")
 
-    @api.depends(
-        "display_type",
-        "product_id",
-        "product_packaging_qty",
-        "secondary_uom_qty",
-        "secondary_uom_id",
-        "product_uom_qty",
-    )
-    def _compute_product_uom_qty(self):
-        res = super()._compute_product_uom_qty()
+    def _inverse_secondary_uom_qty(self):
         for line in self:
             line._compute_helper_target_field_qty()
-        return res
 
     @api.depends("product_id")
     def _compute_product_uom(self):

--- a/sale_order_secondary_unit/tests/test_sale_order.py
+++ b/sale_order_secondary_unit/tests/test_sale_order.py
@@ -64,6 +64,21 @@ class TestSaleOrder(BaseCommon):
         )
         self.assertEqual(self.order.order_line.secondary_uom_qty, 7.0)
 
+    def test_packaging_qty_updates_quantities(self):
+        # Regression: changing the number of packages must propagate to both
+        # product_uom_qty and secondary_uom_qty, also on a programmatic write.
+        # The secondary unit sync used to run inside a _compute_product_uom_qty
+        # override that created a recursive dependency and silently discarded
+        # the packaging change (e.g. combined with sale_packaging_default).
+        packaging = self.env["product.packaging"].create(
+            {"name": "box-10", "product_id": self.product.id, "qty": 10.0}
+        )
+        line = self.order.order_line
+        line.secondary_uom_id = self.secondary_unit.id
+        line.write({"product_packaging_id": packaging.id, "product_packaging_qty": 2})
+        self.assertEqual(line.product_uom_qty, 20.0)
+        self.assertEqual(line.secondary_uom_qty, 40.0)
+
     def test_default_secondary_unit(self):
         self.order.order_line._onchange_product_id_warning()
         self.assertEqual(self.order.order_line.secondary_uom_id, self.secondary_unit)


### PR DESCRIPTION
The _compute_product_uom_qty override depended on product_uom_qty and secondary_uom_qty, creating a recursive cycle with the base packaging compute: changing product_packaging_qty was silently discarded (e.g. combined with sale_packaging_default). Move the secondary->product sync to an inverse method on secondary_uom_qty so it only runs on write.


Also includes backport of OCA/sale-workflow#4435 to 17.0.