### PR TITLE
[18.0][FIX] sale_order_invoicing_finished_task: Incorrect assignation in tests

### DIFF
--- a/sale_order_invoicing_finished_task/tests/test_sale_order_invoicing_finished_task.py
+++ b/sale_order_invoicing_finished_task/tests/test_sale_order_invoicing_finished_task.py
@@ -192,7 +192,7 @@ class TestInvoicefinishedTask(BaseCommon):
         task = self.env["project.task"].create(
             {
                 "name": "Other Task",
-                "partner_id": self.manager.id,
+                "partner_id": self.manager.partner_id.id,
                 "user_ids": [Command.link(self.manager.id)],
                 "project_id": self.project.id,
                 "sale_line_id": self.sale_order.order_line.id,


### PR DESCRIPTION
`self.manager` is a `res.users` record, so assigning it to a many2one field for `res.partner` is not correct.

This has worked by chance if the ID of the user exists in the partner table.

@Tecnativa 