### PR TITLE
[16.0][FIX] sale_order_line_cancel: Give back canceled qty when the ordered qty is raised again

### DIFF
--- a/sale_order_line_cancel/models/sale_order_line.py
+++ b/sale_order_line_cancel/models/sale_order_line.py
@@ -44,6 +44,31 @@ class SaleOrderLine(models.Model):
             qty_remaining = max(0, qty_to_deliver - line.product_qty_canceled)
             line.product_qty_remains_to_deliver = qty_remaining
 
+    def write(self, values):
+        # When the ordered qty is raised again after some qty was canceled,
+        # give the canceled qty back so the line becomes deliverable again.
+        # This must happen before super() so the qty is already restored when
+        # the procurement (and any resulting move merge/cancel) runs.
+        if "product_uom_qty" in values and "product_qty_canceled" not in values:
+            precision = self.env["decimal.precision"].precision_get(
+                "Product Unit of Measure"
+            )
+            new_qty = values["product_uom_qty"]
+            for line in self:
+                increase = new_qty - line.product_uom_qty
+                if (
+                    line.company_id.on_sale_line_cancel_decrease_line_qty
+                    and float_compare(
+                        line.product_qty_canceled, 0, precision_digits=precision
+                    )
+                    > 0
+                    and float_compare(increase, 0, precision_digits=precision) > 0
+                ):
+                    line.product_qty_canceled = max(
+                        0, line.product_qty_canceled - increase
+                    )
+        return super().write(values)
+
     def _update_qty_canceled(self):
         """Update SO line qty canceled only when all remaining moves are canceled"""
         for line in self:

--- a/sale_order_line_cancel/tests/test_sale_order_line_cancel.py
+++ b/sale_order_line_cancel/tests/test_sale_order_line_cancel.py
@@ -41,6 +41,35 @@ class TestSaleOrderLineCancel(TestSaleOrderLineCancelBase):
         self.assertEqual(line.qty_delivered, 0)
         self.assertEqual(line.product_uom_qty, 0)
 
+    def test_increase_product_uom_qty_after_cancel(self):
+        sale = self.sale
+        line = sale.order_line
+        sale.company_id.on_sale_line_cancel_decrease_line_qty = True
+        sale.with_context(disable_cancel_warning=True).action_cancel()
+        sale.action_draft()
+        sale.action_confirm()
+        line.cancel_remaining_qty()
+        self.assertEqual(line.product_uom_qty, 0)
+        self.assertEqual(line.product_qty_canceled, 10)
+        line.product_uom_qty = 10
+        self.assertEqual(line.product_uom_qty, 10)
+        self.assertEqual(line.product_qty_canceled, 0)
+        self.assertEqual(line.product_qty_remains_to_deliver, 10)
+
+    def test_no_decrease_qty_canceled_without_flag(self):
+        sale = self.sale
+        line = sale.order_line
+        sale.with_context(disable_cancel_warning=True).action_cancel()
+        sale.action_draft()
+        sale.action_confirm()
+        line.cancel_remaining_qty()
+        # flag off: the ordered qty is not lowered on cancel
+        self.assertEqual(line.product_uom_qty, 10)
+        self.assertEqual(line.product_qty_canceled, 10)
+        line.product_uom_qty = 12
+        # flag off: the canceled qty is not given back
+        self.assertEqual(line.product_qty_canceled, 10)
+
     def test_ensure_no_decrease_product_uom_qty_on_so_cancel(self):
         sale = self.sale
         line = sale.order_line

--- a/sale_order_line_cancel_sale_stock/tests/test_sale_order_line_cancel.py
+++ b/sale_order_line_cancel_sale_stock/tests/test_sale_order_line_cancel.py
@@ -165,6 +165,51 @@ class TestSaleOrderLineCancel(TestSaleOrderLineCancelBase):
         self.assertEqual(line.qty_delivered, 4)
         self.assertEqual(line.product_uom_qty, 4)
 
+    def _confirm_sale_with_decrease_product_uom_qty(self):
+        sale = self.sale
+        sale.company_id.on_sale_line_cancel_decrease_line_qty = True
+        sale.with_context(disable_cancel_warning=True).action_cancel()
+        sale.picking_ids.unlink()
+        sale.action_draft()
+        sale.action_confirm()
+        return sale
+
+    def test_increase_product_uom_qty_after_cancel(self):
+        sale = self._confirm_sale_with_decrease_product_uom_qty()
+        line = sale.order_line
+        self.wiz.with_context(
+            active_id=line.id, active_model="sale.order.line"
+        ).cancel_remaining_qty()
+        self.assertEqual(line.product_uom_qty, 0)
+        self.assertEqual(line.product_qty_canceled, 10)
+        self.assertEqual(sale.picking_ids.state, "cancel")
+        line.product_uom_qty = 10
+        self.assertEqual(line.product_uom_qty, 10)
+        self.assertEqual(line.product_qty_canceled, 0)
+        self.assertEqual(line.product_qty_remains_to_deliver, 10)
+        self.assertEqual(line.qty_to_deliver, 10)
+        self.assertTrue(line.can_cancel_remaining_qty)
+        ship = sale.picking_ids.filtered(lambda p: p.state != "cancel")
+        self.assertEqual(ship.move_ids.product_uom_qty, 10)
+
+    def test_increase_product_uom_qty_after_cancel_in_steps(self):
+        sale = self._confirm_sale_with_decrease_product_uom_qty()
+        line = sale.order_line
+        self.wiz.with_context(
+            active_id=line.id, active_model="sale.order.line"
+        ).cancel_remaining_qty()
+        line.product_uom_qty = 5
+        self.assertEqual(line.product_uom_qty, 5)
+        # The re-added qty gives back the canceled qty by the same amount.
+        self.assertEqual(line.product_qty_canceled, 5)
+        self.assertEqual(line.product_qty_remains_to_deliver, 0)
+        line.product_uom_qty = 10
+        self.assertEqual(line.product_uom_qty, 10)
+        self.assertEqual(line.product_qty_canceled, 0)
+        self.assertEqual(line.product_qty_remains_to_deliver, 10)
+        moves = line.move_ids.filtered(lambda m: m.state != "cancel")
+        self.assertEqual(sum(moves.mapped("product_uom_qty")), 10)
+
     def test_ensure_no_decrease_product_uom_qty_on_so_cancel(self):
         sale = self.sale
         sale.with_context(disable_cancel_warning=True).action_cancel()


### PR DESCRIPTION
cc @vuwnevska @rousseldenis @jbaudoux @lmignon 