### PR TITLE
[19.0][IMP] sale_automatic_workflow: support dynamic dates in filter domains

### DIFF
--- a/sale_automatic_workflow/models/automatic_workflow_job.py
+++ b/sale_automatic_workflow/models/automatic_workflow_job.py
@@ -6,7 +6,7 @@
 import logging
 from contextlib import contextmanager
 
-from odoo import api, fields, models
+from odoo import api, fields, models, tools
 from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
@@ -189,34 +189,47 @@ class AutomaticWorkflowJob(models.Model):
     def _sale_workflow_domain(self, workflow):
         return [("workflow_process_id", "=", workflow.id)]
 
+    def _get_eval_context(self):
+        return {
+            "time": tools.safe_eval.time,
+            "datetime": tools.safe_eval.datetime,
+            "dateutil": tools.safe_eval.dateutil,
+            "timezone": tools.safe_eval.pytz.timezone,
+            "context_today": lambda: fields.Date.context_today(self),
+        }
+
     @api.model
     def run_with_workflow(self, sale_workflow):
         workflow_domain = self._sale_workflow_domain(sale_workflow)
+        eval_ctx = self._get_eval_context()
         if sale_workflow.validate_order:
             self.with_context(
                 send_order_confirmation_mail=sale_workflow.send_order_confirmation_mail
             )._validate_sale_orders(
-                safe_eval(sale_workflow.order_filter_id.domain) + workflow_domain
+                safe_eval(sale_workflow.order_filter_id.domain, eval_ctx)
+                + workflow_domain
             )
         self._handle_pickings(sale_workflow)
         if sale_workflow.create_invoice:
             self._create_invoices(
-                safe_eval(sale_workflow.create_invoice_filter_id.domain)
+                safe_eval(sale_workflow.create_invoice_filter_id.domain, eval_ctx)
                 + workflow_domain
             )
         if sale_workflow.validate_invoice:
             self._validate_invoices(
-                safe_eval(sale_workflow.validate_invoice_filter_id.domain)
+                safe_eval(sale_workflow.validate_invoice_filter_id.domain, eval_ctx)
                 + workflow_domain
             )
         if sale_workflow.sale_done:
             self._sale_done(
-                safe_eval(sale_workflow.sale_done_filter_id.domain) + workflow_domain
+                safe_eval(sale_workflow.sale_done_filter_id.domain, eval_ctx)
+                + workflow_domain
             )
 
         if sale_workflow.register_payment:
             self._register_payments(
-                safe_eval(sale_workflow.payment_filter_id.domain) + workflow_domain
+                safe_eval(sale_workflow.payment_filter_id.domain, eval_ctx)
+                + workflow_domain
             )
 
     @api.model

--- a/sale_automatic_workflow/tests/test_automatic_workflow.py
+++ b/sale_automatic_workflow/tests/test_automatic_workflow.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 from freezegun import freeze_time
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.tests import tagged
 
 from .common import TestAutomaticWorkflowMixin, TestCommon
@@ -135,6 +135,28 @@ class TestAutomaticWorkflow(TestCommon, TestAutomaticWorkflowMixin):
         self.assertTrue(sale.invoice_ids)
         invoice = sale.invoice_ids
         self.assertEqual(invoice.journal_id.id, new_sale_journal.id)
+
+    def test_filter_domain_with_datetime(self):
+        workflow = self.create_full_automatic()
+        workflow.order_filter_id = self.env["ir.filters"].create(
+            {
+                "name": "Order filter using datetime",
+                "model_id": "sale.order",
+                "domain": (
+                    "[('state', '=', 'draft'), "
+                    "('date_order', '<=', "
+                    "context_today().strftime('%Y-%m-%d %H:%M:%S'))]"
+                ),
+                "user_ids": [Command.link(self.env.ref("base.user_root").id)],
+            }
+        )
+        sale = self.create_sale_order(workflow)
+        sale.date_order = fields.Datetime.now() + timedelta(days=1)
+        self.run_job()
+        self.assertEqual(sale.state, "draft")
+        sale.date_order = fields.Datetime.now() - timedelta(days=1)
+        self.run_job()
+        self.assertEqual(sale.state, "sale")
 
     def test_no_copy(self):
         workflow = self.create_full_automatic()


### PR DESCRIPTION
Forward port of https://github.com/OCA/sale-workflow/pull/4426/change but I use different approach since `_get_eval_domain` in v19.0 doesn't use datetime and context_today anymore.

@qrtl QT5088