### PR TITLE
[FIX] sale_quotation_number: Name change doesn't fail on dynamic prefixes

### DIFF
--- a/sale_quotation_number/__manifest__.py
+++ b/sale_quotation_number/__manifest__.py
@@ -16,6 +16,6 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "depends": ["sale_management"],
+    "depends": ["sale_management", "sequence_regex"],
     "data": ["data/ir_sequence_data.xml", "views/sales_config.xml"],
 }

--- a/sale_quotation_number/models/sale_order.py
+++ b/sale_quotation_number/models/sale_order.py
@@ -44,13 +44,18 @@ class SaleOrder(models.Model):
         return super().copy(default)
 
     def action_confirm(self):
-        sequence = self.env["ir.sequence"].search(
-            [("code", "=", "sale.quotation")], limit=1
-        )
         for order in self:
-            if sequence and self.name[: len(sequence.prefix)] != sequence.prefix:
-                continue
             if order.state not in ("draft", "sent") or order.company_id.keep_name_so:
+                continue
+            sequence = self.env["ir.sequence"].search(
+                [
+                    ("code", "=", "sale.quotation"),
+                    ("company_id", "in", [order.company_id.id, False]),
+                ],
+                order="company_id",
+                limit=1,
+            )
+            if sequence and not sequence.name_fits_sequence(order.name):
                 continue
             if order.origin and order.origin != "":
                 quo = order.origin + ", " + order.name

--- a/sale_quotation_number/oca_dependencies.txt
+++ b/sale_quotation_number/oca_dependencies.txt
@@ -1,0 +1,1 @@
+server-tools

--- a/sale_quotation_number/tests/test_sale_order.py
+++ b/sale_quotation_number/tests/test_sale_order.py
@@ -2,113 +2,228 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import UserError
-from odoo.tests.common import TransactionCase
+
+from odoo.addons.base.tests.common import BaseCommon
 
 
-class TestSaleOrder(TransactionCase):
+class TestSaleOrder(BaseCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.sale_order_model = cls.env["sale.order"]
-        company = cls.env.company
-        company.keep_name_so = False
-        cls.company1 = cls.env["res.company"].create(
-            {"name": "Test Company 1", "keep_name_so": False}
+        # Creating our own sequences for the company to make tests easier
+        cls.sequence_so = cls.env["ir.sequence"].create(
+            {
+                "name": "Sales Order",
+                "prefix": "SO/",
+                "padding": 5,
+                "code": "sale.order",
+                "company_id": cls.company.id,
+            }
         )
-        cls.partner = cls.env["res.partner"].create({"name": "Test Partner"})
+        cls.sequence_sq = cls.env["ir.sequence"].create(
+            {
+                "name": "Sales Quotation",
+                "prefix": "SQ/",
+                "padding": 3,
+                "code": "sale.quotation",
+                "company_id": cls.company.id,
+            }
+        )
+        name = cls.sequence_sq._next_do()
         cls.order_company1 = cls.env["sale.order"].create(
             {
-                "name": "SQ/2023/001",
+                "name": name,
                 "partner_id": cls.partner.id,
-                "company_id": cls.company1.id,
+                "company_id": cls.company.id,
             }
         )
 
+    @classmethod
+    def setup_independent_company(cls, **kwargs):
+        return cls._create_company(name="Test Company 1", keep_name_so=False, **kwargs)
+
+    def test_create_without_name(self):
+        order = self.sale_order_model.create(
+            {
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+            }
+        )
+        # It needs to assign a name based on the sale.quotation sequence
+        self.assertRegex(order.name, "SQ/")
+        self.assertTrue(self.sequence_sq.name_fits_sequence(order.name))
+
+    def test_create_with_specific_name(self):
+        order = self.sale_order_model.create(
+            {
+                "name": "CustomName",
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+            }
+        )
+        # It needs to keep the custom name
+        self.assertEqual(order.name, "CustomName")
+
+    def test_create_with_dynamic_prefix(self):
+        self.sequence_sq.write({"prefix": "SQ/%(year)s/"})
+        order = self.sale_order_model.create(
+            {
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+            }
+        )
+        # It needs to assign a name based on the sale.quotation sequence
+        # This checks that name_fits_sequence works even for dynamic prefixes
+        self.assertRegex(order.name, r"SQ/(19|20|21)\d{2}/")
+        self.assertTrue(self.sequence_sq.name_fits_sequence(order.name))
+
+    def test_sequence_assignment(self):
+        next_name = self.sequence_so.get_next_char(self.sequence_so.number_next_actual)
+        self.order_company1.action_confirm()
+        # It needs to detect that this needs a new name
+        # from the sale.order sequence and assign it
+        self.assertEqual(next_name, self.order_company1.name)
+
+    def test_sequence_assignment_negative(self):
+        order = self.sale_order_model.create(
+            {
+                "name": "CustomName",
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+            }
+        )
+        order.action_confirm()
+        # It needs to preserve the custom name during the confirmation
+        self.assertEqual(order.name, "CustomName")
+
+    def test_sequence_assignment_negative_regex(self):
+        # Create a sale order with an *almost* correct name
+        name = "SQ/002 - Copy"
+        order = self.sale_order_model.create(
+            {
+                "name": name,
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+            }
+        )
+        order.action_confirm()
+        # It needs to preserve the custom name during the confirmation
+        # since while it shares the prefix, it does not fit the full regex
+        self.assertEqual(order.name, name)
+
+    def test_sequence_assignment_multicompany(self):
+        new_company = self.env["res.company"].create(
+            {"name": "Test Company 2", "keep_name_so": False}
+        )
+        base_sequence = self.env["ir.sequence"].search(
+            [
+                ("code", "=", "sale.order"),
+                ("company_id", "=", False),
+            ]
+        )
+        # Set the company-free sequence to have a very
+        # different prefix than the company_1 sequence
+        base_sequence.write({"prefix": "ORD/%(y)s-%(month)s/"})
+        next_name = base_sequence.get_next_char(base_sequence.number_next_actual)
+        order = self.sale_order_model.create(
+            {
+                "partner_id": self.partner.id,
+                "company_id": new_company.id,
+            }
+        )
+        # Confirm orders belonging to multiple companies at once
+        (self.order_company1 | order).action_confirm()
+        # Check that the new name belongs to the base_sequence,
+        # not the company_1 sequence
+        self.assertEqual(order.name, next_name)
+        self.assertTrue(base_sequence.name_fits_sequence(order.name))
+        self.assertFalse(self.sequence_so.name_fits_sequence(order.name))
+
+    def test_confirm_no_origin(self):
+        old_name = self.order_company1.name
+        self.order_company1.action_confirm()
+        # The old name of the quotation is found in the origin
+        self.assertEqual(self.order_company1.origin, old_name)
+
+    def test_confirm_with_origin(self):
+        origin = "origin"
+        order1 = self.sale_order_model.create(
+            {
+                "origin": origin,
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+            }
+        )
+        quotation1_name = order1.name
+        order1.action_confirm()
+
+        # The origin of the quotation is appended to the old name
+        self.assertEqual(order1.origin, ", ".join([origin, quotation1_name]))
+
     def test_enumeration(self):
         order1 = self.sale_order_model.create(
-            {"partner_id": self.env.ref("base.res_partner_1").id}
+            {
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+            }
         )
         quotation1_name = order1.name
         order2 = self.sale_order_model.create(
-            {"partner_id": self.env.ref("base.res_partner_1").id}
+            {
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+            }
         )
         quotation2_name = order2.name
 
-        self.assertRegex(quotation1_name, "SQ")
-        self.assertRegex(quotation2_name, "SQ")
-        self.assertLess(int(quotation1_name[2:]), int(quotation2_name[2:]))
+        # Check that the Quotation created first has the lower index
+        self.assertLess(quotation1_name, quotation2_name)
 
         order2.action_confirm()
         order1.action_confirm()
 
-        self.assertRegex(order1.name, "S")
-        self.assertEqual(order1.origin, quotation1_name)
-
-        self.assertRegex(order2.name, "S")
-        self.assertEqual(order2.origin, quotation2_name)
-        self.assertLess(int(order2.name[1:]), int(order1.name[1:]))
-
-    def test_with_origin(self):
-        origin = "origin"
-        order1 = self.sale_order_model.create(
-            {"origin": origin, "partner_id": self.env.ref("base.res_partner_1").id}
-        )
-        quotation1_name = order1.name
-        order1.action_confirm()
-
-        self.assertRegex(order1.name, "S")
-        self.assertEqual(order1.origin, ", ".join([origin, quotation1_name]))
-
-    def test_copy_no_origin(self):
-        order1 = self.sale_order_model.create(
-            {"partner_id": self.env.ref("base.res_partner_1").id}
-        )
-        order_copy = order1.copy()
-
-        self.assertEqual(order1.name, order_copy.origin)
-
-    def test_copy_with_origin(self):
-        origin = "origin"
-        order1 = self.sale_order_model.create(
-            {"origin": origin, "partner_id": self.env.ref("base.res_partner_1").id}
-        )
-        order_copy = order1.copy()
-
-        self.assertEqual(", ".join([origin, order1.name]), order_copy.origin)
+        # Check that the Order confirmed first has the lower index
+        self.assertLess(order2.name, order1.name)
 
     def test_error_confirmation_sequence(self):
         order = self.sale_order_model.create(
-            {"partner_id": self.env.ref("base.res_partner_1").id, "state": "sale"}
+            {
+                "partner_id": self.partner.id,
+                "state": "sale",
+                "company_id": self.company.id,
+            }
         )
-        # An exception is forced
-        sequence_id = self.env["ir.sequence"].search(
-            [
-                ("code", "=", "sale.order"),
-                ("company_id", "in", [order.company_id.id, False]),
-            ]
-        )
-        next_name = sequence_id.get_next_char(sequence_id.number_next_actual)
+        next_name = self.sequence_so.get_next_char(self.sequence_so.number_next_actual)
+        # An exception is forced by confirming a confirmed order
         with self.assertRaises(UserError):
             order.action_confirm()
         order.update({"state": "draft"})
         # Now the SQ can be confirmed
         order.action_confirm()
+        # Checks that the faulty confirmation attempt did not consume a sequence number
         self.assertEqual(next_name, order.name)
 
-    def test_sequence_assignment(self):
-        sequence_id = self.env["ir.sequence"].search(
-            [
-                ("code", "=", "sale.order"),
-                ("company_id", "in", [self.order_company1.company_id.id, False]),
-            ]
+    def test_copy_no_origin(self):
+        order1 = self.sale_order_model.create(
+            {
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+            }
         )
-        next_name = sequence_id.get_next_char(sequence_id.number_next_actual)
-        self.order_company1.action_confirm()
-        self.assertEqual(next_name, self.order_company1.name)
+        order_copy = order1.copy()
+        # Check the duplicate has the original as origin
+        self.assertEqual(order1.name, order_copy.origin)
 
-    def test_create_with_specific_name(self):
-        order = self.sale_order_model.create(
-            {"name": "CustomName", "partner_id": self.env.ref("base.res_partner_1").id}
+    def test_copy_with_origin(self):
+        origin = "origin"
+        order1 = self.sale_order_model.create(
+            {
+                "origin": origin,
+                "partner_id": self.partner.id,
+                "company_id": self.company.id,
+            }
         )
-        self.assertEqual(order.name, "CustomName")
+        order_copy = order1.copy()
+        # Check the duplicate has the original's origin prepended
+        self.assertEqual(", ".join([origin, order1.name]), order_copy.origin)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
 odoo-test-helper
+odoo-addon-sequence_regex @ git+https://github.com/OCA/server-tools.git@refs/pull/3672/head#subdirectory=sequence_regex


### PR DESCRIPTION
…ynamic prefixesDescription of the issue/feature this PR addresses:
sale_quotation_number does not work when the prefix for the sale.quotation sequence includes a dynamic placeholder. sale_quotation_number also fails to account for the sequence suffix.

Current behavior before PR:
When the prefix of the sale.quotation sequence includes a dynamic placeholder, the detection during `action_confirm()` that sale order name is not custom fails. This is because it just compares the first part of the name with the value of the `prefix` field of the sequence ([Link](https://github.com/OCA/sale-workflow/blob/6e079fbec359ba033476ff3c885ab08efa5e9a70/sale_quotation_number/models/sale_order.py#L51)). For a dynamic placeholder, this will never be true, because both the length and the content of the formatting string are of course not equivalent to the formatted string output of `next_by_code()`.
As a side consequence, the detection can also result in false positives when prefixes overlap, e.g. if the sale.quotation prefix were "S" and the sale.order prefix were "SO" - a confirmed, then reset sale order would get a new name.
There is absolutely no check against the suffix, including no check that the sale order name wasn't edited by appending something behind the sequence-generated part.

Desired behavior after PR is merged:
The detection for whether a sale order name fits the sale.quotation scheme compares the whole order name, not just the prefix part. It accounts for dynamic placeholders by generating a fitting regex string that matches the possible outputs very closely.
The tests have been updated and extended accordingly.