### PR TITLE
[16.0][FIX] sale_blanket_order: quantity fields not respecting "Product Unit of Measure" decimal precision

### DIFF
--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -150,30 +150,35 @@ class BlanketOrder(models.Model):
         string="Original quantity",
         compute="_compute_uom_qty",
         search="_search_original_uom_qty",
+        digits="Product Unit of Measure",
         default=0.0,
     )
     ordered_uom_qty = fields.Float(
         string="Ordered quantity",
         compute="_compute_uom_qty",
         search="_search_ordered_uom_qty",
+        digits="Product Unit of Measure",
         default=0.0,
     )
     invoiced_uom_qty = fields.Float(
         string="Invoiced quantity",
         compute="_compute_uom_qty",
         search="_search_invoiced_uom_qty",
+        digits="Product Unit of Measure",
         default=0.0,
     )
     remaining_uom_qty = fields.Float(
         string="Remaining quantity",
         compute="_compute_uom_qty",
         search="_search_remaining_uom_qty",
+        digits="Product Unit of Measure",
         default=0.0,
     )
     delivered_uom_qty = fields.Float(
         string="Delivered quantity",
         compute="_compute_uom_qty",
         search="_search_delivered_uom_qty",
+        digits="Product Unit of Measure",
         default=0.0,
     )
 
@@ -448,21 +453,34 @@ class BlanketOrderLine(models.Model):
         string="Original quantity", default=1, digits="Product Unit of Measure"
     )
     ordered_uom_qty = fields.Float(
-        string="Ordered quantity", compute="_compute_quantities", store=True
+        string="Ordered quantity",
+        compute="_compute_quantities",
+        store=True,
+        digits="Product Unit of Measure",
     )
     invoiced_uom_qty = fields.Float(
-        string="Invoiced quantity", compute="_compute_quantities", store=True
+        string="Invoiced quantity",
+        compute="_compute_quantities",
+        store=True,
+        digits="Product Unit of Measure",
     )
     remaining_uom_qty = fields.Float(
-        string="Remaining quantity", compute="_compute_quantities", store=True
+        string="Remaining quantity",
+        compute="_compute_quantities",
+        store=True,
+        digits="Product Unit of Measure",
     )
     remaining_qty = fields.Float(
         string="Remaining quantity in base UoM",
         compute="_compute_quantities",
         store=True,
+        digits="Product Unit of Measure",
     )
     delivered_uom_qty = fields.Float(
-        string="Delivered quantity", compute="_compute_quantities", store=True
+        string="Delivered quantity",
+        compute="_compute_quantities",
+        store=True,
+        digits="Product Unit of Measure",
     )
     sale_lines = fields.One2many(
         "sale.order.line",

--- a/sale_blanket_order/wizard/create_sale_orders.py
+++ b/sale_blanket_order/wizard/create_sale_orders.py
@@ -225,8 +225,15 @@ class BlanketOrderWizardLine(models.TransientModel):
         "uom.uom", related="blanket_line_id.product_uom", string="Unit of Measure"
     )
     date_schedule = fields.Date(string="Scheduled Date")
-    remaining_uom_qty = fields.Float(related="blanket_line_id.remaining_uom_qty")
-    qty = fields.Float(string="Quantity to Order", required=True)
+    remaining_uom_qty = fields.Float(
+        related="blanket_line_id.remaining_uom_qty",
+        digits="Product Unit of Measure",
+    )
+    qty = fields.Float(
+        string="Quantity to Order",
+        required=True,
+        digits="Product Unit of Measure",
+    )
     price_unit = fields.Float(related="blanket_line_id.price_unit")
     currency_id = fields.Many2one("res.currency", related="blanket_line_id.currency_id")
     partner_id = fields.Many2one(


### PR DESCRIPTION
@Escodoo SO571-71
### Problem
On sale.blanket.order and sale.blanket.order.line, only original_uom_qty declared digits="Product Unit of Measure". The other quantity fields — ordered_uom_qty, invoiced_uom_qty, delivered_uom_qty, remaining_uom_qty, remaining_qty (and their aggregates on the blanket order) — had no digits at all.

Odoo's web client falls back to 2 decimals when a Float field has no digits (see formatFloat in web/static/src/views/fields/formatters.js). So whenever the Decimal Accuracy for "Product Unit of Measure" is set to more than 2 (e.g. 4), the "Original quantity" column showed the correct precision while every other quantity column silently rounded to 2 decimals.

This was not just cosmetic: in the "Create Sale Order" wizard (sale.blanket.order.wizard.line), the editable qty field ("Quantity to Order") had the same gap. Since it feeds product_uom_qty on the sale order line created from the blanket order, any remaining quantity with more than 2 significant decimals got truncated the moment a sale order was generated from the blanket order.

### Fix
Add digits="Product Unit of Measure" to all the affected quantity fields:

`sale.blanket.order: original_uom_qty, ordered_uom_qty, invoiced_uom_qty, remaining_uom_qty, delivered_uom_qty`
`sale.blanket.order.line: ordered_uom_qty, invoiced_uom_qty, remaining_uom_qty, remaining_qty, delivered_uom_qty`
`sale.blanket.order.wizard.line: remaining_uom_qty (related) and qty`
No view/XML changes needed (none of them hardcode digits), and no data migration is required — float columns are stored as double precision regardless of digits; the attribute only affects rounding-on-write and display formatting.

cc @marcelsavegnago @douglascstd @kaynnan @WesleyOliveira98 