### PR TITLE
[19.0][IMP] sale_order_product_recommendation: use Product Price decimal precision for price_unit

### DIFF
--- a/sale_order_product_recommendation/wizards/sale_order_recommendation.py
+++ b/sale_order_product_recommendation/wizards/sale_order_recommendation.py
@@ -252,7 +252,7 @@ class SaleOrderRecommendationLine(models.TransientModel):
         related="product_id.is_favorite", store=True, readonly=False
     )
     product_uom_readonly = fields.Boolean(related="sale_line_id.product_uom_readonly")
-    price_unit = fields.Monetary(compute="_compute_price_unit")
+    price_unit = fields.Float(compute="_compute_price_unit", digits="Product Price")
     pricelist_id = fields.Many2one(related="wizard_id.order_id.pricelist_id")
     times_delivered = fields.Integer(readonly=True)
     units_delivered = fields.Float(readonly=True)


### PR DESCRIPTION
Forward-port of #3898 (merged in 17.0) to 19.0.

`price_unit` on the recommendation wizard line was a `Monetary` field, so the last sale price / pricelist price shown in the wizard was rounded to the currency's 2 decimal places, losing precision when products are priced with more decimals ("Product Price" decimal precision). Use a `Float` with `digits="Product Price"` instead, as `sale.order.line.price_unit` does.