### PR TITLE
[18.0][FIX] sale_order_lot_selection: Wrong state comparison when reassigning moves

### DIFF
--- a/sale_order_lot_selection/models/stock_move.py
+++ b/sale_order_lot_selection/models/stock_move.py
@@ -13,5 +13,5 @@ class StockMove(models.Model):
         self.restrict_lot_id = lot
         self._do_unreserve()
         self.filtered(
-            lambda move: move.state in ("confirmed', 'partially_available")
+            lambda move: move.state in ("confirmed", "partially_available")
         )._action_assign()


### PR DESCRIPTION
Backport from 19.0: https://github.com/OCA/sale-workflow/pull/4385

Wrong state comparison when reassigning moves

The tuple ('confirmed', 'partially_available') was written as a single string, so moves were never reassigned after changing the lot on the sale order line.

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa 