### PR TITLE
[16.0][FIX] sale_blanket_order: display_type = false

### DIFF
--- a/sale_blanket_order/views/sale_blanket_order_line_views.xml
+++ b/sale_blanket_order/views/sale_blanket_order_line_views.xml
@@ -166,6 +166,7 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">sale.blanket.order.line</field>
         <field name="view_mode">tree,form</field>
+        <field name="domain">[('display_type', '=', False)]</field>
         <field name="search_view_id" ref="sale_blanket_order_line_search" />
     </record>
 


### PR DESCRIPTION
**Reason**: The "Blanket Order Lines" screen was listing all lines from the blanket order, including section and note lines (used only to organize/comment the order, with no product attached). That's why blank rows (no product) showed up in the list, as seen in the screenshot.

**Change**: I added a filter (domain) to the action that opens this screen, excluding section/note lines (display_type), so it only shows actual product lines — which is the correct and expected behavior for this list.

cc @kaynnan @marcelsavegnago @WesleyOliveira98 