### PR TITLE
[18.0][FIX] sale_semaphore: qty = 0 is showing red semaphore

### DIFF
--- a/sale_semaphore/models/sale_order_line.py
+++ b/sale_semaphore/models/sale_order_line.py
@@ -24,7 +24,13 @@ class SaleOderLine(models.Model):
     price_below_semaphore = fields.Boolean(compute="_compute_price_below_semaphore")
 
     @api.depends(
-        "product_id", "price_reduce_taxinc", "price_reduce_taxexcl", "product_uom"
+        "product_id",
+        "price_reduce_taxinc",
+        "price_reduce_taxexcl",
+        "product_uom",
+        "price_unit",
+        "discount",
+        "product_uom_qty",
     )
     def _compute_semaphore(self):
         dp = self.env["decimal.precision"].precision_get("Product Price")
@@ -94,13 +100,32 @@ class SaleOderLine(models.Model):
 
     def _get_semaphore_price_reduce(self):
         """Net unit price used to evaluate the semaphore, on the company's tax
-        inclusion basis."""
+        inclusion basis.
+
+        ``price_reduce_taxinc``/``price_reduce_taxexcl`` are computed by Odoo
+        dividing the line subtotal by the quantity, so they collapse to ``0``
+        when the line has no quantity yet. That zero would be read as the
+        lowest possible price and wrongly trigger the red semaphore, so when
+        there is no quantity we fall back to the discounted unit price
+        (``price_unit`` with ``discount``), aligning taxes and rounding the
+        same way as the ``price_reduce_*`` fields.
+        """
         self.ensure_one()
-        return (
-            self.price_reduce_taxinc
-            if self.company_id.account_price_include == "tax_included"
-            else self.price_reduce_taxexcl
-        )
+        tax_included = self.company_id.account_price_include == "tax_included"
+        if self.product_uom_qty:
+            return (
+                self.price_reduce_taxinc if tax_included else self.price_reduce_taxexcl
+            )
+        price_reduce = self.price_unit * (1 - (self.discount or 0.0) / 100.0)
+        if tax_included:
+            price_reduce = self.tax_id.compute_all(
+                price_reduce,
+                currency=self.currency_id,
+                quantity=1.0,
+                product=self.product_id,
+                partner=self.order_id.partner_id,
+            )["total_included"]
+        return self.currency_id.round(price_reduce)
 
     def _get_semaphore_pricelist_price(self):
         """Pricelist price for this line expressed on the same basis as
@@ -147,7 +172,14 @@ class SaleOderLine(models.Model):
             < 0
         )
 
-    @api.depends("semaphore_active", "price_reduce_taxinc", "price_reduce_taxexcl")
+    @api.depends(
+        "semaphore_active",
+        "price_reduce_taxinc",
+        "price_reduce_taxexcl",
+        "price_unit",
+        "discount",
+        "product_uom_qty",
+    )
     def _compute_price_below_semaphore(self):
         dp = self.env["decimal.precision"].precision_get("Product Price")
         self.price_below_semaphore = False

--- a/sale_semaphore/tests/test_sale_semaphore.py
+++ b/sale_semaphore/tests/test_sale_semaphore.py
@@ -135,6 +135,21 @@ class TestSaleSemaphore(BaseCommon):
         with self.assertRaises(UserError):
             self.order.with_user(self.salesperson).action_confirm()
 
+    def test_sale_line_zero_qty_uses_unit_price(self):
+        """With no quantity the qty-dependent ``price_reduce_*`` fields are 0;
+        the semaphore must instead evaluate the discounted unit price so it is
+        not wrongly forced to red."""
+        line = self._create_line(100.0)
+        line.product_uom_qty = 0.0
+        self.assertEqual(line.price_reduce_taxexcl, 0.0)
+        # 100 with no discount -> success zone (threshold 100).
+        self.assertEqual(line.semaphore, "success")
+        self.assertFalse(line.price_below_semaphore)
+        # A discounted price in the red zone is still detected without qty.
+        line.discount = 30.0
+        self.assertEqual(line.semaphore, "danger")
+        self.assertTrue(line.price_below_semaphore)
+
     def test_sale_line_uses_category_configuration(self):
         self.product.write(
             {


### PR DESCRIPTION
The semaphore evaluated the line net price using the ``price_reduce_taxinc``/``price_reduce_taxexcl`` fields, which Odoo computes by dividing the line subtotal by the quantity and therefore collapse to 0 when the line has no quantity yet. That zero was read as the lowest possible price, wrongly forcing the semaphore to red.

Now, when there is no quantity, the net price is derived from the discounted unit price (``price_unit`` with ``discount``), aligning taxes and rounding the same way as the ``price_reduce_*`` fields.

cc @Tecnativa TT63796

ping @sergio-teruel @carlosdauden 