### PR TITLE
[18.0][IMP] sale_restricted_qty: readable restriction selection values

### DIFF
--- a/sale_restricted_qty/__manifest__.py
+++ b/sale_restricted_qty/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "Sale order restricted quantity: min, max, multiple-of",
-    "version": "18.0.1.0.0",
+    "version": "18.0.2.0.0",
     "category": "Sales Management",
     "author": "Akretion, Odoo Community Association (OCA)",
     "contributors": ["Ashish Hirpara"],

--- a/sale_restricted_qty/migrations/18.0.2.0.0/pre-migration.py
+++ b/sale_restricted_qty/migrations/18.0.2.0.0/pre-migration.py
@@ -1,0 +1,42 @@
+# Copyright 2026 OBS Solutions
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+from psycopg2.extensions import AsIs
+
+# The restriction selection values changed from opaque "1"/"0" to the
+# self-documenting "blocking"/"warning" for readability.
+VALUE_MAP = {
+    "1": "blocking",
+    "0": "warning",
+}
+
+# All stored Selection columns that hold a restriction value (own, inherited
+# and effective) for each restricted quantity.
+RESTRICT_COLUMNS = [
+    "sale_own_restrict_min_qty",
+    "sale_inherited_restrict_min_qty",
+    "sale_restrict_min_qty",
+    "sale_own_restrict_max_qty",
+    "sale_inherited_restrict_max_qty",
+    "sale_restrict_max_qty",
+    "sale_own_restrict_multiple_of_qty",
+    "sale_inherited_restrict_multiple_of_qty",
+    "sale_restrict_multiple_of_qty",
+]
+
+TABLES = ["product_category", "product_template", "product_product"]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    cr = env.cr
+    for table in TABLES:
+        for column in RESTRICT_COLUMNS:
+            if not openupgrade.column_exists(cr, table, column):
+                continue
+            for old_value, new_value in VALUE_MAP.items():
+                cr.execute(
+                    "UPDATE %s SET %s = %s WHERE %s = %s",
+                    (AsIs(table), AsIs(column), new_value, AsIs(column), old_value),
+                )

--- a/sale_restricted_qty/models/product_restricted_qty_mixin.py
+++ b/sale_restricted_qty/models/product_restricted_qty_mixin.py
@@ -4,8 +4,8 @@
 
 from odoo import api, fields, models
 
-RESTRICTION_ENABLED = "1"
-RESTRICTION_DISABLED = "0"
+RESTRICTION_ENABLED = "blocking"
+RESTRICTION_DISABLED = "warning"
 RESTRICTION_SELECTION = [
     (RESTRICTION_ENABLED, "Blocking"),
     (RESTRICTION_DISABLED, "Warning"),

--- a/sale_restricted_qty/tests/test_coverage_deep.py
+++ b/sale_restricted_qty/tests/test_coverage_deep.py
@@ -3,6 +3,11 @@
 
 from odoo.tests import common, tagged
 
+from odoo.addons.sale_restricted_qty.models.product_restricted_qty_mixin import (
+    RESTRICTION_DISABLED,
+    RESTRICTION_ENABLED,
+)
+
 
 @tagged("post_install", "-at_install")
 class TestCoverageDeep(common.TransactionCase):
@@ -49,9 +54,9 @@ class TestCoverageDeep(common.TransactionCase):
             inverse_restrict_set = f"_inverse_is_sale_own_restrict_{field_prefix}_set"
 
             # Inverse: Set restriction
-            setattr(template, restrict_field, "1")
+            setattr(template, restrict_field, RESTRICTION_ENABLED)
             self.assertTrue(getattr(template, own_restrict_set_field))
-            self.assertEqual(getattr(template, own_restrict_field), "1")
+            self.assertEqual(getattr(template, own_restrict_field), RESTRICTION_ENABLED)
 
             # Test the boolean flag inverse explicitly
             setattr(template, own_restrict_set_field, True)
@@ -77,11 +82,11 @@ class TestCoverageDeep(common.TransactionCase):
         parent.write(
             {
                 "sale_min_qty": 1.0,
-                "sale_restrict_min_qty": "1",
+                "sale_restrict_min_qty": RESTRICTION_ENABLED,
                 "sale_max_qty": 2.0,
-                "sale_restrict_max_qty": "1",
+                "sale_restrict_max_qty": RESTRICTION_ENABLED,
                 "sale_multiple_of_qty": 3.0,
-                "sale_restrict_multiple_of_qty": "1",
+                "sale_restrict_multiple_of_qty": RESTRICTION_ENABLED,
             }
         )
         self.assertEqual(child.sale_min_qty, 1.0)
@@ -110,11 +115,11 @@ class TestCoverageDeep(common.TransactionCase):
         parent.write(
             {
                 "sale_min_qty": 0.0,
-                "sale_restrict_min_qty": "0",
+                "sale_restrict_min_qty": RESTRICTION_DISABLED,
                 "sale_max_qty": 0.0,
-                "sale_restrict_max_qty": "0",
+                "sale_restrict_max_qty": RESTRICTION_DISABLED,
                 "sale_multiple_of_qty": 0.0,
-                "sale_restrict_multiple_of_qty": "0",
+                "sale_restrict_multiple_of_qty": RESTRICTION_DISABLED,
             }
         )
         # Also clear the template's own value, otherwise product
@@ -140,7 +145,7 @@ class TestCoverageDeep(common.TransactionCase):
             {
                 "name": "Product",
                 "sale_min_qty": 10.0,
-                "sale_restrict_min_qty": "1",
+                "sale_restrict_min_qty": RESTRICTION_ENABLED,
             }
         )
         line = self.env["sale.order.line"].new({"product_id": product.id})
@@ -161,7 +166,7 @@ class TestCoverageDeep(common.TransactionCase):
         self.assertEqual(line.product_uom_qty, 5.0)
 
         # Hits the "not enforced" branch
-        product.sale_restrict_min_qty = "0"
+        product.sale_restrict_min_qty = RESTRICTION_DISABLED
 
         # New line to pick up the change
         line2 = self.env["sale.order.line"].new({"product_id": product.id})

--- a/sale_restricted_qty/tests/test_product_category.py
+++ b/sale_restricted_qty/tests/test_product_category.py
@@ -4,6 +4,11 @@
 import odoo.tests.common as common
 from odoo.tests import tagged
 
+from odoo.addons.sale_restricted_qty.models.product_restricted_qty_mixin import (
+    RESTRICTION_DISABLED,
+    RESTRICTION_ENABLED,
+)
+
 
 @tagged("post_install", "-at_install")
 class TestProductCategory(common.TransactionCase):
@@ -22,15 +27,15 @@ class TestProductCategory(common.TransactionCase):
         self.assertEqual(parent.is_sale_min_qty_set, False)
         self.assertEqual(parent.sale_min_qty, 0.0)
         self.assertEqual(parent.is_sale_restrict_min_qty_set, False)
-        self.assertEqual(parent.sale_restrict_min_qty, "0")
+        self.assertEqual(parent.sale_restrict_min_qty, RESTRICTION_DISABLED)
         self.assertEqual(parent.is_sale_max_qty_set, False)
         self.assertEqual(parent.sale_max_qty, 0.0)
         self.assertEqual(parent.is_sale_restrict_max_qty_set, False)
-        self.assertEqual(parent.sale_restrict_max_qty, "0")
+        self.assertEqual(parent.sale_restrict_max_qty, RESTRICTION_DISABLED)
         self.assertEqual(parent.is_sale_multiple_of_qty_set, False)
         self.assertEqual(parent.sale_multiple_of_qty, 0.0)
         self.assertEqual(parent.is_sale_restrict_multiple_of_qty_set, False)
-        self.assertEqual(parent.sale_restrict_multiple_of_qty, "0")
+        self.assertEqual(parent.sale_restrict_multiple_of_qty, RESTRICTION_DISABLED)
 
         child = self.ProductCategory.create(
             {
@@ -39,20 +44,20 @@ class TestProductCategory(common.TransactionCase):
             }
         )
         self.assertEqual(child.sale_min_qty, 0.0)
-        self.assertEqual(child.sale_restrict_min_qty, "0")
+        self.assertEqual(child.sale_restrict_min_qty, RESTRICTION_DISABLED)
         self.assertEqual(child.sale_max_qty, 0.0)
-        self.assertEqual(child.sale_restrict_max_qty, "0")
+        self.assertEqual(child.sale_restrict_max_qty, RESTRICTION_DISABLED)
         self.assertEqual(child.sale_multiple_of_qty, 0.0)
-        self.assertEqual(child.sale_restrict_multiple_of_qty, "0")
+        self.assertEqual(child.sale_restrict_multiple_of_qty, RESTRICTION_DISABLED)
 
         parent.update(
             {
                 "sale_min_qty": 10.0,
-                "sale_restrict_min_qty": "1",
+                "sale_restrict_min_qty": RESTRICTION_ENABLED,
                 "sale_max_qty": 100.0,
-                "sale_restrict_max_qty": "1",
+                "sale_restrict_max_qty": RESTRICTION_ENABLED,
                 "sale_multiple_of_qty": 5.0,
-                "sale_restrict_multiple_of_qty": "1",
+                "sale_restrict_multiple_of_qty": RESTRICTION_ENABLED,
             }
         )
         self.assertTrue(child.is_sale_min_qty_set)
@@ -68,35 +73,35 @@ class TestProductCategory(common.TransactionCase):
         self.assertFalse(child.is_sale_own_multiple_of_qty_set)
         self.assertFalse(child.is_sale_own_restrict_multiple_of_qty_set)
         self.assertEqual(child.sale_min_qty, 10.0)
-        self.assertEqual(child.sale_restrict_min_qty, "1")
+        self.assertEqual(child.sale_restrict_min_qty, RESTRICTION_ENABLED)
         self.assertEqual(child.sale_max_qty, 100.0)
-        self.assertEqual(child.sale_restrict_max_qty, "1")
+        self.assertEqual(child.sale_restrict_max_qty, RESTRICTION_ENABLED)
         self.assertEqual(child.sale_multiple_of_qty, 5.0)
-        self.assertEqual(child.sale_restrict_multiple_of_qty, "1")
+        self.assertEqual(child.sale_restrict_multiple_of_qty, RESTRICTION_ENABLED)
 
         child.sale_min_qty = 20.0
         self.assertTrue(child.is_sale_own_min_qty_set)
         self.assertEqual(child.sale_own_min_qty, 20.0)
 
-        child.sale_restrict_min_qty = "0"
+        child.sale_restrict_min_qty = RESTRICTION_DISABLED
         self.assertTrue(child.is_sale_own_restrict_min_qty_set)
-        self.assertEqual(child.sale_own_restrict_min_qty, "0")
+        self.assertEqual(child.sale_own_restrict_min_qty, RESTRICTION_DISABLED)
 
         child.sale_max_qty = 200.0
         self.assertTrue(child.is_sale_own_max_qty_set)
         self.assertEqual(child.sale_own_max_qty, 200.0)
 
-        child.sale_restrict_max_qty = "0"
+        child.sale_restrict_max_qty = RESTRICTION_DISABLED
         self.assertTrue(child.is_sale_own_restrict_max_qty_set)
-        self.assertEqual(child.sale_own_restrict_max_qty, "0")
+        self.assertEqual(child.sale_own_restrict_max_qty, RESTRICTION_DISABLED)
 
         child.sale_multiple_of_qty = 10.0
         self.assertTrue(child.is_sale_own_multiple_of_qty_set)
         self.assertEqual(child.sale_own_multiple_of_qty, 10.0)
 
-        child.sale_restrict_multiple_of_qty = "0"
+        child.sale_restrict_multiple_of_qty = RESTRICTION_DISABLED
         self.assertTrue(child.is_sale_own_restrict_multiple_of_qty_set)
-        self.assertEqual(child.sale_own_restrict_multiple_of_qty, "0")
+        self.assertEqual(child.sale_own_restrict_multiple_of_qty, RESTRICTION_DISABLED)
 
         child.is_sale_own_min_qty_set = False
         child._onchange_is_sale_min_qty_set()
@@ -104,7 +109,7 @@ class TestProductCategory(common.TransactionCase):
         self.assertEqual(child.sale_own_min_qty, 0.0)
 
         child.is_sale_own_restrict_min_qty_set = False
-        self.assertEqual(child.sale_restrict_min_qty, "1")
+        self.assertEqual(child.sale_restrict_min_qty, RESTRICTION_ENABLED)
         self.assertFalse(child.sale_own_restrict_min_qty)
 
         child.is_sale_own_max_qty_set = False
@@ -113,7 +118,7 @@ class TestProductCategory(common.TransactionCase):
         self.assertEqual(child.sale_own_max_qty, 0.0)
 
         child.is_sale_own_restrict_max_qty_set = False
-        self.assertEqual(child.sale_restrict_max_qty, "1")
+        self.assertEqual(child.sale_restrict_max_qty, RESTRICTION_ENABLED)
         self.assertFalse(child.sale_own_restrict_max_qty)
 
         child.is_sale_own_multiple_of_qty_set = False
@@ -122,5 +127,5 @@ class TestProductCategory(common.TransactionCase):
         self.assertEqual(child.sale_own_multiple_of_qty, 0.0)
 
         child.is_sale_own_restrict_multiple_of_qty_set = False
-        self.assertEqual(child.sale_restrict_multiple_of_qty, "1")
+        self.assertEqual(child.sale_restrict_multiple_of_qty, RESTRICTION_ENABLED)
         self.assertFalse(child.sale_own_restrict_multiple_of_qty)

--- a/sale_restricted_qty/tests/test_product_product.py
+++ b/sale_restricted_qty/tests/test_product_product.py
@@ -4,6 +4,11 @@
 import odoo.tests.common as common
 from odoo.tests import tagged
 
+from odoo.addons.sale_restricted_qty.models.product_restricted_qty_mixin import (
+    RESTRICTION_DISABLED,
+    RESTRICTION_ENABLED,
+)
+
 
 @tagged("post_install", "-at_install")
 class TestProductTemplate(common.TransactionCase):
@@ -23,15 +28,15 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(template.is_sale_min_qty_set, False)
         self.assertEqual(template.sale_min_qty, 0.0)
         self.assertEqual(template.is_sale_restrict_min_qty_set, False)
-        self.assertEqual(template.sale_restrict_min_qty, "0")
+        self.assertEqual(template.sale_restrict_min_qty, RESTRICTION_DISABLED)
         self.assertEqual(template.is_sale_max_qty_set, False)
         self.assertEqual(template.sale_max_qty, 0.0)
         self.assertEqual(template.is_sale_restrict_max_qty_set, False)
-        self.assertEqual(template.sale_restrict_max_qty, "0")
+        self.assertEqual(template.sale_restrict_max_qty, RESTRICTION_DISABLED)
         self.assertEqual(template.is_sale_multiple_of_qty_set, False)
         self.assertEqual(template.sale_multiple_of_qty, 0.0)
         self.assertEqual(template.is_sale_restrict_multiple_of_qty_set, False)
-        self.assertEqual(template.sale_restrict_multiple_of_qty, "0")
+        self.assertEqual(template.sale_restrict_multiple_of_qty, RESTRICTION_DISABLED)
 
         product = template.product_variant_id
         product.write(
@@ -40,20 +45,20 @@ class TestProductTemplate(common.TransactionCase):
             }
         )
         self.assertEqual(product.sale_min_qty, 0.0)
-        self.assertEqual(product.sale_restrict_min_qty, "0")
+        self.assertEqual(product.sale_restrict_min_qty, RESTRICTION_DISABLED)
         self.assertEqual(product.sale_max_qty, 0.0)
-        self.assertEqual(product.sale_restrict_max_qty, "0")
+        self.assertEqual(product.sale_restrict_max_qty, RESTRICTION_DISABLED)
         self.assertEqual(product.sale_multiple_of_qty, 0.0)
-        self.assertEqual(product.sale_restrict_multiple_of_qty, "0")
+        self.assertEqual(product.sale_restrict_multiple_of_qty, RESTRICTION_DISABLED)
 
         template.update(
             {
                 "sale_min_qty": 10.0,
-                "sale_restrict_min_qty": "1",
+                "sale_restrict_min_qty": RESTRICTION_ENABLED,
                 "sale_max_qty": 100.0,
-                "sale_restrict_max_qty": "1",
+                "sale_restrict_max_qty": RESTRICTION_ENABLED,
                 "sale_multiple_of_qty": 5.0,
-                "sale_restrict_multiple_of_qty": "1",
+                "sale_restrict_multiple_of_qty": RESTRICTION_ENABLED,
             }
         )
         self.assertTrue(product.is_sale_min_qty_set)
@@ -69,35 +74,37 @@ class TestProductTemplate(common.TransactionCase):
         self.assertFalse(product.is_sale_own_multiple_of_qty_set)
         self.assertFalse(product.is_sale_own_restrict_multiple_of_qty_set)
         self.assertEqual(product.sale_min_qty, 10.0)
-        self.assertEqual(product.sale_restrict_min_qty, "1")
+        self.assertEqual(product.sale_restrict_min_qty, RESTRICTION_ENABLED)
         self.assertEqual(product.sale_max_qty, 100.0)
-        self.assertEqual(product.sale_restrict_max_qty, "1")
+        self.assertEqual(product.sale_restrict_max_qty, RESTRICTION_ENABLED)
         self.assertEqual(product.sale_multiple_of_qty, 5.0)
-        self.assertEqual(product.sale_restrict_multiple_of_qty, "1")
+        self.assertEqual(product.sale_restrict_multiple_of_qty, RESTRICTION_ENABLED)
 
         product.sale_min_qty = 20.0
         self.assertTrue(product.is_sale_own_min_qty_set)
         self.assertEqual(product.sale_own_min_qty, 20.0)
 
-        product.sale_restrict_min_qty = "0"
+        product.sale_restrict_min_qty = RESTRICTION_DISABLED
         self.assertTrue(product.is_sale_own_restrict_min_qty_set)
-        self.assertEqual(product.sale_own_restrict_min_qty, "0")
+        self.assertEqual(product.sale_own_restrict_min_qty, RESTRICTION_DISABLED)
 
         product.sale_max_qty = 200.0
         self.assertTrue(product.is_sale_own_max_qty_set)
         self.assertEqual(product.sale_own_max_qty, 200.0)
 
-        product.sale_restrict_max_qty = "0"
+        product.sale_restrict_max_qty = RESTRICTION_DISABLED
         self.assertTrue(product.is_sale_own_restrict_max_qty_set)
-        self.assertEqual(product.sale_own_restrict_max_qty, "0")
+        self.assertEqual(product.sale_own_restrict_max_qty, RESTRICTION_DISABLED)
 
         product.sale_multiple_of_qty = 10.0
         self.assertTrue(product.is_sale_own_multiple_of_qty_set)
         self.assertEqual(product.sale_own_multiple_of_qty, 10.0)
 
-        product.sale_restrict_multiple_of_qty = "0"
+        product.sale_restrict_multiple_of_qty = RESTRICTION_DISABLED
         self.assertTrue(product.is_sale_own_restrict_multiple_of_qty_set)
-        self.assertEqual(product.sale_own_restrict_multiple_of_qty, "0")
+        self.assertEqual(
+            product.sale_own_restrict_multiple_of_qty, RESTRICTION_DISABLED
+        )
 
         product.is_sale_own_min_qty_set = False
         product._onchange_is_sale_min_qty_set()
@@ -105,7 +112,7 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(product.sale_own_min_qty, 0.0)
 
         product.is_sale_own_restrict_min_qty_set = False
-        self.assertEqual(product.sale_restrict_min_qty, "1")
+        self.assertEqual(product.sale_restrict_min_qty, RESTRICTION_ENABLED)
         self.assertFalse(product.sale_own_restrict_min_qty)
 
         product.is_sale_own_max_qty_set = False
@@ -114,7 +121,7 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(product.sale_own_max_qty, 0.0)
 
         product.is_sale_own_restrict_max_qty_set = False
-        self.assertEqual(product.sale_restrict_max_qty, "1")
+        self.assertEqual(product.sale_restrict_max_qty, RESTRICTION_ENABLED)
         self.assertFalse(product.sale_own_restrict_max_qty)
 
         product.is_sale_own_multiple_of_qty_set = False
@@ -123,5 +130,5 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(product.sale_own_multiple_of_qty, 0.0)
 
         product.is_sale_own_restrict_multiple_of_qty_set = False
-        self.assertEqual(product.sale_restrict_multiple_of_qty, "1")
+        self.assertEqual(product.sale_restrict_multiple_of_qty, RESTRICTION_ENABLED)
         self.assertFalse(product.sale_own_restrict_multiple_of_qty)

--- a/sale_restricted_qty/tests/test_product_template.py
+++ b/sale_restricted_qty/tests/test_product_template.py
@@ -4,6 +4,11 @@
 import odoo.tests.common as common
 from odoo.tests import tagged
 
+from odoo.addons.sale_restricted_qty.models.product_restricted_qty_mixin import (
+    RESTRICTION_DISABLED,
+    RESTRICTION_ENABLED,
+)
+
 
 @tagged("post_install", "-at_install")
 class TestProductTemplate(common.TransactionCase):
@@ -23,15 +28,15 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(category.is_sale_min_qty_set, False)
         self.assertEqual(category.sale_min_qty, 0.0)
         self.assertEqual(category.is_sale_restrict_min_qty_set, False)
-        self.assertEqual(category.sale_restrict_min_qty, "0")
+        self.assertEqual(category.sale_restrict_min_qty, RESTRICTION_DISABLED)
         self.assertEqual(category.is_sale_max_qty_set, False)
         self.assertEqual(category.sale_max_qty, 0.0)
         self.assertEqual(category.is_sale_restrict_max_qty_set, False)
-        self.assertEqual(category.sale_restrict_max_qty, "0")
+        self.assertEqual(category.sale_restrict_max_qty, RESTRICTION_DISABLED)
         self.assertEqual(category.is_sale_multiple_of_qty_set, False)
         self.assertEqual(category.sale_multiple_of_qty, 0.0)
         self.assertEqual(category.is_sale_restrict_multiple_of_qty_set, False)
-        self.assertEqual(category.sale_restrict_multiple_of_qty, "0")
+        self.assertEqual(category.sale_restrict_multiple_of_qty, RESTRICTION_DISABLED)
 
         template = self.ProductTemplate.create(
             {
@@ -41,15 +46,15 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(template.is_sale_min_qty_set, False)
         self.assertEqual(template.sale_min_qty, 0.0)
         self.assertEqual(template.is_sale_restrict_min_qty_set, False)
-        self.assertEqual(template.sale_restrict_min_qty, "0")
+        self.assertEqual(template.sale_restrict_min_qty, RESTRICTION_DISABLED)
         self.assertEqual(template.is_sale_max_qty_set, False)
         self.assertEqual(template.sale_max_qty, 0.0)
         self.assertEqual(template.is_sale_restrict_max_qty_set, False)
-        self.assertEqual(template.sale_restrict_max_qty, "0")
+        self.assertEqual(template.sale_restrict_max_qty, RESTRICTION_DISABLED)
         self.assertEqual(template.is_sale_multiple_of_qty_set, False)
         self.assertEqual(template.sale_multiple_of_qty, 0.0)
         self.assertEqual(template.is_sale_restrict_multiple_of_qty_set, False)
-        self.assertEqual(template.sale_restrict_multiple_of_qty, "0")
+        self.assertEqual(template.sale_restrict_multiple_of_qty, RESTRICTION_DISABLED)
 
         template.update(
             {
@@ -59,24 +64,24 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(template.is_sale_min_qty_set, False)
         self.assertEqual(template.sale_min_qty, 0.0)
         self.assertEqual(template.is_sale_restrict_min_qty_set, False)
-        self.assertEqual(template.sale_restrict_min_qty, "0")
+        self.assertEqual(template.sale_restrict_min_qty, RESTRICTION_DISABLED)
         self.assertEqual(template.is_sale_max_qty_set, False)
         self.assertEqual(template.sale_max_qty, 0.0)
         self.assertEqual(template.is_sale_restrict_max_qty_set, False)
-        self.assertEqual(template.sale_restrict_max_qty, "0")
+        self.assertEqual(template.sale_restrict_max_qty, RESTRICTION_DISABLED)
         self.assertEqual(template.is_sale_multiple_of_qty_set, False)
         self.assertEqual(template.sale_multiple_of_qty, 0.0)
         self.assertEqual(template.is_sale_restrict_multiple_of_qty_set, False)
-        self.assertEqual(template.sale_restrict_multiple_of_qty, "0")
+        self.assertEqual(template.sale_restrict_multiple_of_qty, RESTRICTION_DISABLED)
 
         category.update(
             {
                 "sale_min_qty": 10.0,
-                "sale_restrict_min_qty": "1",
+                "sale_restrict_min_qty": RESTRICTION_ENABLED,
                 "sale_max_qty": 100.0,
-                "sale_restrict_max_qty": "1",
+                "sale_restrict_max_qty": RESTRICTION_ENABLED,
                 "sale_multiple_of_qty": 5.0,
-                "sale_restrict_multiple_of_qty": "1",
+                "sale_restrict_multiple_of_qty": RESTRICTION_ENABLED,
             }
         )
         self.assertTrue(template.is_sale_min_qty_set)
@@ -92,35 +97,37 @@ class TestProductTemplate(common.TransactionCase):
         self.assertFalse(template.is_sale_own_multiple_of_qty_set)
         self.assertFalse(template.is_sale_own_restrict_multiple_of_qty_set)
         self.assertEqual(template.sale_min_qty, 10.0)
-        self.assertEqual(template.sale_restrict_min_qty, "1")
+        self.assertEqual(template.sale_restrict_min_qty, RESTRICTION_ENABLED)
         self.assertEqual(template.sale_max_qty, 100.0)
-        self.assertEqual(template.sale_restrict_max_qty, "1")
+        self.assertEqual(template.sale_restrict_max_qty, RESTRICTION_ENABLED)
         self.assertEqual(template.sale_multiple_of_qty, 5.0)
-        self.assertEqual(template.sale_restrict_multiple_of_qty, "1")
+        self.assertEqual(template.sale_restrict_multiple_of_qty, RESTRICTION_ENABLED)
 
         template.sale_min_qty = 20.0
         self.assertTrue(template.is_sale_own_min_qty_set)
         self.assertEqual(template.sale_own_min_qty, 20.0)
 
-        template.sale_restrict_min_qty = "0"
+        template.sale_restrict_min_qty = RESTRICTION_DISABLED
         self.assertTrue(template.is_sale_own_restrict_min_qty_set)
-        self.assertEqual(template.sale_own_restrict_min_qty, "0")
+        self.assertEqual(template.sale_own_restrict_min_qty, RESTRICTION_DISABLED)
 
         template.sale_max_qty = 200.0
         self.assertTrue(template.is_sale_own_max_qty_set)
         self.assertEqual(template.sale_own_max_qty, 200.0)
 
-        template.sale_restrict_max_qty = "0"
+        template.sale_restrict_max_qty = RESTRICTION_DISABLED
         self.assertTrue(template.is_sale_own_restrict_max_qty_set)
-        self.assertEqual(template.sale_own_restrict_max_qty, "0")
+        self.assertEqual(template.sale_own_restrict_max_qty, RESTRICTION_DISABLED)
 
         template.sale_multiple_of_qty = 10.0
         self.assertTrue(template.is_sale_own_multiple_of_qty_set)
         self.assertEqual(template.sale_own_multiple_of_qty, 10.0)
 
-        template.sale_restrict_multiple_of_qty = "0"
+        template.sale_restrict_multiple_of_qty = RESTRICTION_DISABLED
         self.assertTrue(template.is_sale_own_restrict_multiple_of_qty_set)
-        self.assertEqual(template.sale_own_restrict_multiple_of_qty, "0")
+        self.assertEqual(
+            template.sale_own_restrict_multiple_of_qty, RESTRICTION_DISABLED
+        )
 
         template.is_sale_own_min_qty_set = False
         template._onchange_is_sale_min_qty_set()
@@ -128,7 +135,7 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(template.sale_own_min_qty, 0.0)
 
         template.is_sale_own_restrict_min_qty_set = False
-        self.assertEqual(template.sale_restrict_min_qty, "1")
+        self.assertEqual(template.sale_restrict_min_qty, RESTRICTION_ENABLED)
         self.assertFalse(template.sale_own_restrict_min_qty)
 
         template.is_sale_own_max_qty_set = False
@@ -137,7 +144,7 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(template.sale_own_max_qty, 0.0)
 
         template.is_sale_own_restrict_max_qty_set = False
-        self.assertEqual(template.sale_restrict_max_qty, "1")
+        self.assertEqual(template.sale_restrict_max_qty, RESTRICTION_ENABLED)
         self.assertFalse(template.sale_own_restrict_max_qty)
 
         template.is_sale_own_multiple_of_qty_set = False
@@ -146,5 +153,5 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(template.sale_own_multiple_of_qty, 0.0)
 
         template.is_sale_own_restrict_multiple_of_qty_set = False
-        self.assertEqual(template.sale_restrict_multiple_of_qty, "1")
+        self.assertEqual(template.sale_restrict_multiple_of_qty, RESTRICTION_ENABLED)
         self.assertFalse(template.sale_own_restrict_multiple_of_qty)

--- a/sale_restricted_qty/tests/test_sale_order_line.py
+++ b/sale_restricted_qty/tests/test_sale_order_line.py
@@ -4,6 +4,11 @@
 from odoo.exceptions import ValidationError
 from odoo.tests import common, tagged
 
+from odoo.addons.sale_restricted_qty.models.product_restricted_qty_mixin import (
+    RESTRICTION_DISABLED,
+    RESTRICTION_ENABLED,
+)
+
 
 @tagged("post_install", "-at_install")
 class TestSaleOrderLine(common.TransactionCase):
@@ -28,7 +33,7 @@ class TestSaleOrderLine(common.TransactionCase):
             {
                 "name": "Product",
                 "sale_min_qty": 10.0,
-                "sale_restrict_min_qty": "1",  # Blocking
+                "sale_restrict_min_qty": RESTRICTION_ENABLED,  # Blocking
             }
         )
 
@@ -51,7 +56,7 @@ class TestSaleOrderLine(common.TransactionCase):
             )
 
         # 2. Warning: Should NOT raise ValidationError
-        product.sale_restrict_min_qty = "0"  # Warning
+        product.sale_restrict_min_qty = RESTRICTION_DISABLED  # Warning
         so = self.SaleOrder.create(
             {
                 "partner_id": self.partner.id,
@@ -75,7 +80,7 @@ class TestSaleOrderLine(common.TransactionCase):
             {
                 "name": "Product",
                 "sale_max_qty": 10.0,
-                "sale_restrict_max_qty": "1",  # Blocking
+                "sale_restrict_max_qty": RESTRICTION_ENABLED,  # Blocking
             }
         )
 
@@ -98,7 +103,7 @@ class TestSaleOrderLine(common.TransactionCase):
             )
 
         # 2. Warning
-        product.sale_restrict_max_qty = "0"
+        product.sale_restrict_max_qty = RESTRICTION_DISABLED
         so = self.SaleOrder.create(
             {
                 "partner_id": self.partner.id,
@@ -122,7 +127,7 @@ class TestSaleOrderLine(common.TransactionCase):
             {
                 "name": "Product",
                 "sale_multiple_of_qty": 5.0,
-                "sale_restrict_multiple_of_qty": "1",  # Blocking
+                "sale_restrict_multiple_of_qty": RESTRICTION_ENABLED,  # Blocking
             }
         )
 
@@ -145,7 +150,7 @@ class TestSaleOrderLine(common.TransactionCase):
             )
 
         # 2. Warning
-        product.sale_restrict_multiple_of_qty = "0"
+        product.sale_restrict_multiple_of_qty = RESTRICTION_DISABLED
         so = self.SaleOrder.create(
             {
                 "partner_id": self.partner.id,
@@ -169,7 +174,7 @@ class TestSaleOrderLine(common.TransactionCase):
             {
                 "name": "Parent Categ",
                 "sale_min_qty": 100.0,
-                "sale_restrict_min_qty": "1",
+                "sale_restrict_min_qty": RESTRICTION_ENABLED,
             }
         )
         child_categ = self.ProductCategory.create(
@@ -188,7 +193,7 @@ class TestSaleOrderLine(common.TransactionCase):
 
         # Verify initial inheritance
         self.assertEqual(product.sale_min_qty, 100.0)
-        self.assertEqual(product.sale_restrict_min_qty, "1")
+        self.assertEqual(product.sale_restrict_min_qty, RESTRICTION_ENABLED)
 
         # Override at Template level
         template.sale_min_qty = 50.0
@@ -205,7 +210,7 @@ class TestSaleOrderLine(common.TransactionCase):
             {
                 "name": "Product",
                 "sale_min_qty": 10.0,
-                "sale_restrict_min_qty": "1",
+                "sale_restrict_min_qty": RESTRICTION_ENABLED,
             }
         )
 
@@ -231,7 +236,7 @@ class TestSaleOrderLine(common.TransactionCase):
                 "name": "Product",
                 "uom_id": self.uom_unit.id,
                 "sale_min_qty": 24.0,  # 2 Dozen
-                "sale_restrict_min_qty": "1",
+                "sale_restrict_min_qty": RESTRICTION_ENABLED,
             }
         )
 
@@ -288,9 +293,9 @@ class TestSaleOrderLine(common.TransactionCase):
         self.assertEqual(product.sale_min_qty, 0.0)
 
         # Test restriction selection inverse
-        product.sale_restrict_min_qty = "1"
+        product.sale_restrict_min_qty = RESTRICTION_ENABLED
         self.assertTrue(product.is_sale_own_restrict_min_qty_set)
-        self.assertEqual(product.sale_own_restrict_min_qty, "1")
+        self.assertEqual(product.sale_own_restrict_min_qty, RESTRICTION_ENABLED)
 
     def test_historical_skip(self):
         """Ensure confirmed orders skip constraints."""
@@ -316,7 +321,7 @@ class TestSaleOrderLine(common.TransactionCase):
         product.write(
             {
                 "sale_min_qty": 10.0,
-                "sale_restrict_min_qty": "1",
+                "sale_restrict_min_qty": RESTRICTION_ENABLED,
             }
         )
         # This shouldn't crash or fail validation on re-read/write


### PR DESCRIPTION
Follow-up to #3959, as [discussed there](https://github.com/OCA/sale-workflow/pull/3959#discussion_r2960979507).

## What

The Blocking/Warning restriction fields (`sale_restrict_min_qty`, `sale_restrict_max_qty`, `sale_restrict_multiple_of_qty`, and their `own_`/`inherited_` variants) used opaque `"1"`/`"0"` selection values. This replaces them with the self-documenting `"blocking"`/`"warning"`, as suggested by @marielejeune during the review of #3959, to ease code and database comprehension.

```python
RESTRICTION_ENABLED = "blocking"   # was "1"
RESTRICTION_DISABLED = "warning"   # was "0"
```

## Changes

- `RESTRICTION_ENABLED` / `RESTRICTION_DISABLED` now hold real string values. All model code already referenced the constants, so no logic changes.
- A `18.0.2.0.0` pre-migration converts the stored values (`"1"`→`"blocking"`, `"0"`→`"warning"`) on `product.category`, `product.template` and `product.product`, across the own / inherited / effective columns of the three restricted quantities.
- Tests now reference the `RESTRICTION_ENABLED` / `RESTRICTION_DISABLED` constants instead of the raw values.

## Testing

Validated in an OCA-CI container (`py3.10-odoo18.0`):
- Fresh install + full test suite: 15/15 pass with the new values.
- End-to-end upgrade `18.0.1.0.0` → `18.0.2.0.0`: seeded legacy `"1"`/`"0"` data converts cleanly to `blocking`/`warning`, no leftover old values, no errors.

@marielejeune @rousseldenis