### PR TITLE
[18.0][FIX] sale_restricted_qty: restriction mode inheritance + hygiene

### DIFF
--- a/sale_restricted_qty/migrations/18.0.3.0.0/post-migration.py
+++ b/sale_restricted_qty/migrations/18.0.3.0.0/post-migration.py
@@ -1,0 +1,13 @@
+# Copyright 2026 OBS Solutions
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # The restriction "own-set" flags became independent stored booleans in this
+    # version and the effective restriction now re-inherits from the parent
+    # unless that flag is set. Repair databases that carried stale/pinned
+    # restriction modes (see the model method for the full policy).
+    env["product.product"]._repair_restrict_inheritance()

--- a/sale_restricted_qty/models/product_restricted_qty_mixin.py
+++ b/sale_restricted_qty/models/product_restricted_qty_mixin.py
@@ -45,10 +45,7 @@ class ProductRestrictedQtyMixin(models.AbstractModel):
         digits="Product Unit of Measure",
     )
 
-    is_sale_own_restrict_min_qty_set = fields.Boolean(
-        compute="_compute_is_sale_own_restrict_min_qty_set",
-        inverse="_inverse_is_sale_own_restrict_min_qty_set",
-    )
+    is_sale_own_restrict_min_qty_set = fields.Boolean()
     is_sale_inherited_restrict_min_qty_set = fields.Boolean(
         compute="_compute_is_sale_inherited_restrict_min_qty_set",
         recursive=True,
@@ -105,10 +102,7 @@ class ProductRestrictedQtyMixin(models.AbstractModel):
         digits="Product Unit of Measure",
     )
 
-    is_sale_own_restrict_max_qty_set = fields.Boolean(
-        compute="_compute_is_sale_own_restrict_max_qty_set",
-        inverse="_inverse_is_sale_own_restrict_max_qty_set",
-    )
+    is_sale_own_restrict_max_qty_set = fields.Boolean()
     is_sale_inherited_restrict_max_qty_set = fields.Boolean(
         compute="_compute_is_sale_inherited_restrict_max_qty_set",
         recursive=True,
@@ -165,10 +159,7 @@ class ProductRestrictedQtyMixin(models.AbstractModel):
         digits="Product Unit of Measure",
     )
 
-    is_sale_own_restrict_multiple_of_qty_set = fields.Boolean(
-        compute="_compute_is_sale_own_restrict_multiple_of_qty_set",
-        inverse="_inverse_is_sale_own_restrict_multiple_of_qty_set",
-    )
+    is_sale_own_restrict_multiple_of_qty_set = fields.Boolean()
     is_sale_inherited_restrict_multiple_of_qty_set = fields.Boolean(
         compute="_compute_is_sale_inherited_restrict_multiple_of_qty_set",
         recursive=True,
@@ -206,6 +197,10 @@ class ProductRestrictedQtyMixin(models.AbstractModel):
             self.sale_own_min_qty = self.sale_inherited_min_qty
         else:
             self.sale_own_min_qty = 0.0
+        # A restriction mode is meaningless without a quantity value.
+        if not self.is_sale_min_qty_set:
+            self.is_sale_own_restrict_min_qty_set = False
+            self.sale_own_restrict_min_qty = False
 
     def _get_is_sale_inherited_min_qty_set(self):
         self.ensure_one()
@@ -278,19 +273,6 @@ class ProductRestrictedQtyMixin(models.AbstractModel):
         else:
             self.sale_own_restrict_min_qty = False
 
-    def _compute_is_sale_own_restrict_min_qty_set(self):
-        for rec in self:
-            rec.is_sale_own_restrict_min_qty_set = bool(rec.sale_own_restrict_min_qty)
-
-    def _inverse_is_sale_own_restrict_min_qty_set(self):
-        if self.env.context.get("skip_sale_own_restrict_min_qty"):
-            return
-        for rec in self:
-            if rec.is_sale_own_restrict_min_qty_set:
-                rec.sale_own_restrict_min_qty = rec.sale_inherited_restrict_min_qty
-            else:
-                rec.sale_own_restrict_min_qty = None
-
     def _get_is_sale_inherited_restrict_min_qty_set(self):
         self.ensure_one()
         parent_field = self._sale_restricted_qty_parent_field
@@ -315,8 +297,8 @@ class ProductRestrictedQtyMixin(models.AbstractModel):
             )
 
     @api.depends(
-        "sale_own_restrict_min_qty",
-        "sale_inherited_restrict_min_qty",
+        "is_sale_own_restrict_min_qty_set",
+        "is_sale_inherited_restrict_min_qty_set",
     )
     def _compute_is_sale_restrict_min_qty_set(self):
         for rec in self:
@@ -346,19 +328,28 @@ class ProductRestrictedQtyMixin(models.AbstractModel):
             )
 
     @api.depends(
+        "is_sale_own_restrict_min_qty_set",
         "sale_own_restrict_min_qty",
         "sale_inherited_restrict_min_qty",
     )
     def _compute_sale_restrict_min_qty(self):
         for rec in self:
-            rec.sale_restrict_min_qty = (
-                rec.sale_own_restrict_min_qty or rec.sale_inherited_restrict_min_qty
-            )
+            if rec.is_sale_own_restrict_min_qty_set:
+                rec.sale_restrict_min_qty = rec.sale_own_restrict_min_qty
+            else:
+                rec.sale_restrict_min_qty = rec.sale_inherited_restrict_min_qty
 
     def _inverse_sale_restrict_min_qty(self):
-        for rec in self.with_context(skip_sale_own_restrict_min_qty=True):
-            rec.is_sale_own_restrict_min_qty_set = True
-            rec.sale_own_restrict_min_qty = rec.sale_restrict_min_qty
+        for rec in self:
+            if (
+                rec.sale_restrict_min_qty
+                and rec.sale_restrict_min_qty != rec.sale_inherited_restrict_min_qty
+            ):
+                rec.sale_own_restrict_min_qty = rec.sale_restrict_min_qty
+                rec.is_sale_own_restrict_min_qty_set = True
+            else:
+                rec.sale_own_restrict_min_qty = False
+                rec.is_sale_own_restrict_min_qty_set = False
 
     # --- max_qty ---
 
@@ -368,6 +359,10 @@ class ProductRestrictedQtyMixin(models.AbstractModel):
             self.sale_own_max_qty = self.sale_inherited_max_qty
         else:
             self.sale_own_max_qty = 0.0
+        # A restriction mode is meaningless without a quantity value.
+        if not self.is_sale_max_qty_set:
+            self.is_sale_own_restrict_max_qty_set = False
+            self.sale_own_restrict_max_qty = False
 
     def _get_is_sale_inherited_max_qty_set(self):
         self.ensure_one()
@@ -440,19 +435,6 @@ class ProductRestrictedQtyMixin(models.AbstractModel):
         else:
             self.sale_own_restrict_max_qty = False
 
-    def _compute_is_sale_own_restrict_max_qty_set(self):
-        for rec in self:
-            rec.is_sale_own_restrict_max_qty_set = bool(rec.sale_own_restrict_max_qty)
-
-    def _inverse_is_sale_own_restrict_max_qty_set(self):
-        if self.env.context.get("skip_sale_own_restrict_max_qty"):
-            return
-        for rec in self:
-            if rec.is_sale_own_restrict_max_qty_set:
-                rec.sale_own_restrict_max_qty = rec.sale_inherited_restrict_max_qty
-            else:
-                rec.sale_own_restrict_max_qty = None
-
     def _get_is_sale_inherited_restrict_max_qty_set(self):
         self.ensure_one()
         parent_field = self._sale_restricted_qty_parent_field
@@ -477,8 +459,8 @@ class ProductRestrictedQtyMixin(models.AbstractModel):
             )
 
     @api.depends(
-        "sale_own_restrict_max_qty",
-        "sale_inherited_restrict_max_qty",
+        "is_sale_own_restrict_max_qty_set",
+        "is_sale_inherited_restrict_max_qty_set",
     )
     def _compute_is_sale_restrict_max_qty_set(self):
         for rec in self:
@@ -508,19 +490,28 @@ class ProductRestrictedQtyMixin(models.AbstractModel):
             )
 
     @api.depends(
+        "is_sale_own_restrict_max_qty_set",
         "sale_own_restrict_max_qty",
         "sale_inherited_restrict_max_qty",
     )
     def _compute_sale_restrict_max_qty(self):
         for rec in self:
-            rec.sale_restrict_max_qty = (
-                rec.sale_own_restrict_max_qty or rec.sale_inherited_restrict_max_qty
-            )
+            if rec.is_sale_own_restrict_max_qty_set:
+                rec.sale_restrict_max_qty = rec.sale_own_restrict_max_qty
+            else:
+                rec.sale_restrict_max_qty = rec.sale_inherited_restrict_max_qty
 
     def _inverse_sale_restrict_max_qty(self):
-        for rec in self.with_context(skip_sale_own_restrict_max_qty=True):
-            rec.is_sale_own_restrict_max_qty_set = True
-            rec.sale_own_restrict_max_qty = rec.sale_restrict_max_qty
+        for rec in self:
+            if (
+                rec.sale_restrict_max_qty
+                and rec.sale_restrict_max_qty != rec.sale_inherited_restrict_max_qty
+            ):
+                rec.sale_own_restrict_max_qty = rec.sale_restrict_max_qty
+                rec.is_sale_own_restrict_max_qty_set = True
+            else:
+                rec.sale_own_restrict_max_qty = False
+                rec.is_sale_own_restrict_max_qty_set = False
 
     # --- multiple_of_qty ---
 
@@ -530,6 +521,10 @@ class ProductRestrictedQtyMixin(models.AbstractModel):
             self.sale_own_multiple_of_qty = self.sale_inherited_multiple_of_qty
         else:
             self.sale_own_multiple_of_qty = 0.0
+        # A restriction mode is meaningless without a quantity value.
+        if not self.is_sale_multiple_of_qty_set:
+            self.is_sale_own_restrict_multiple_of_qty_set = False
+            self.sale_own_restrict_multiple_of_qty = False
 
     def _get_is_sale_inherited_multiple_of_qty_set(self):
         self.ensure_one()
@@ -619,23 +614,6 @@ class ProductRestrictedQtyMixin(models.AbstractModel):
         else:
             self.sale_own_restrict_multiple_of_qty = None
 
-    def _compute_is_sale_own_restrict_multiple_of_qty_set(self):
-        for rec in self:
-            rec.is_sale_own_restrict_multiple_of_qty_set = bool(
-                rec.sale_own_restrict_multiple_of_qty
-            )
-
-    def _inverse_is_sale_own_restrict_multiple_of_qty_set(self):
-        if self.env.context.get("skip_sale_own_restrict_multiple_of_qty"):
-            return
-        for rec in self:
-            if rec.is_sale_own_restrict_multiple_of_qty_set:
-                rec.sale_own_restrict_multiple_of_qty = (
-                    rec.sale_inherited_restrict_multiple_of_qty
-                )
-            else:
-                rec.sale_own_restrict_multiple_of_qty = None
-
     def _get_is_sale_inherited_restrict_multiple_of_qty_set(self):
         self.ensure_one()
         parent_field = self._sale_restricted_qty_parent_field
@@ -660,8 +638,8 @@ class ProductRestrictedQtyMixin(models.AbstractModel):
             )
 
     @api.depends(
-        "sale_own_restrict_multiple_of_qty",
-        "sale_inherited_restrict_multiple_of_qty",
+        "is_sale_own_restrict_multiple_of_qty_set",
+        "is_sale_inherited_restrict_multiple_of_qty_set",
     )
     def _compute_is_sale_restrict_multiple_of_qty_set(self):
         for rec in self:
@@ -694,17 +672,76 @@ class ProductRestrictedQtyMixin(models.AbstractModel):
             )
 
     @api.depends(
+        "is_sale_own_restrict_multiple_of_qty_set",
         "sale_own_restrict_multiple_of_qty",
         "sale_inherited_restrict_multiple_of_qty",
     )
     def _compute_sale_restrict_multiple_of_qty(self):
         for rec in self:
-            rec.sale_restrict_multiple_of_qty = (
-                rec.sale_own_restrict_multiple_of_qty
-                or rec.sale_inherited_restrict_multiple_of_qty
-            )
+            if rec.is_sale_own_restrict_multiple_of_qty_set:
+                rec.sale_restrict_multiple_of_qty = (
+                    rec.sale_own_restrict_multiple_of_qty
+                )
+            else:
+                rec.sale_restrict_multiple_of_qty = (
+                    rec.sale_inherited_restrict_multiple_of_qty
+                )
 
     def _inverse_sale_restrict_multiple_of_qty(self):
-        for rec in self.with_context(skip_sale_own_restrict_multiple_of_qty=True):
-            rec.is_sale_own_restrict_multiple_of_qty_set = True
-            rec.sale_own_restrict_multiple_of_qty = rec.sale_restrict_multiple_of_qty
+        for rec in self:
+            if (
+                rec.sale_restrict_multiple_of_qty
+                and rec.sale_restrict_multiple_of_qty
+                != rec.sale_inherited_restrict_multiple_of_qty
+            ):
+                rec.sale_own_restrict_multiple_of_qty = (
+                    rec.sale_restrict_multiple_of_qty
+                )
+                rec.is_sale_own_restrict_multiple_of_qty_set = True
+            else:
+                rec.sale_own_restrict_multiple_of_qty = False
+                rec.is_sale_own_restrict_multiple_of_qty_set = False
+
+    # --- data repair (called from migrations/18.0.3.0.0) ---
+
+    @api.model
+    def _repair_restrict_inheritance(self):
+        """Normalise stored restriction modes after the own-set flags became
+        independent stored booleans.
+
+        - ``product.category`` / ``product.template``: keep a genuine override
+          (own mode set, differing from the inherited mode, with a quantity
+          value to act on) and mark the new flag; drop redundant (own equal to
+          inherited) or orphan (no value) modes so they re-inherit.
+        - ``product.product`` (variant): drop every own restriction mode so
+          variants always inherit their template. Variant-level restriction
+          overrides were, in practice, artefacts of the previous always-pinning
+          inverse; deliberate configuration lives on the template/category.
+        """
+        config_models = (
+            ("product.category", "parent_path"),
+            ("product.template", "id"),
+        )
+        for field in ("min", "max", "multiple_of"):
+            own_field = f"sale_own_restrict_{field}_qty"
+            inherited_field = f"sale_inherited_restrict_{field}_qty"
+            flag_field = f"is_sale_own_restrict_{field}_qty_set"
+            value_set_field = f"is_sale_{field}_qty_set"
+
+            for model_name, order in config_models:
+                for rec in self.env[model_name].search([], order=order):
+                    own = rec[own_field]
+                    if not own:
+                        continue
+                    if not rec[value_set_field] or own == rec[inherited_field]:
+                        rec[own_field] = False
+                        rec[flag_field] = False
+                    else:
+                        rec[flag_field] = True
+                # Flush so children recompute their inherited value.
+                self.env.invalidate_all()
+
+            variants = self.env["product.product"].search([(own_field, "!=", False)])
+            if variants:
+                variants.write({own_field: False, flag_field: False})
+                self.env.invalidate_all()

--- a/sale_restricted_qty/tests/__init__.py
+++ b/sale_restricted_qty/tests/__init__.py
@@ -4,4 +4,5 @@ from . import (
     test_product_template,
     test_sale_order_line,
     test_coverage_deep,
+    test_migration_repair,
 )

--- a/sale_restricted_qty/tests/test_coverage_deep.py
+++ b/sale_restricted_qty/tests/test_coverage_deep.py
@@ -46,24 +46,23 @@ class TestCoverageDeep(common.TransactionCase):
             setattr(template, own_set_field, False)
             getattr(template, onchange_val)()
 
-            # 2. Test Restrict logic
+            # 2. Test Restrict logic (mirrors the value logic above; a
+            # restriction only matters when a value is set).
             restrict_field = f"sale_restrict_{field_prefix}"
             own_restrict_field = f"sale_own_restrict_{field_prefix}"
             own_restrict_set_field = f"is_sale_own_restrict_{field_prefix}_set"
             onchange_restrict = f"_onchange_is_sale_restrict_{field_prefix}_set"
-            inverse_restrict_set = f"_inverse_is_sale_own_restrict_{field_prefix}_set"
 
-            # Inverse: Set restriction
+            setattr(template, val_field, 10.0)
+
+            # Inverse: Set restriction (differs from inherited -> pinned own)
             setattr(template, restrict_field, RESTRICTION_ENABLED)
             self.assertTrue(getattr(template, own_restrict_set_field))
             self.assertEqual(getattr(template, own_restrict_field), RESTRICTION_ENABLED)
 
-            # Test the boolean flag inverse explicitly
-            setattr(template, own_restrict_set_field, True)
-            getattr(template, inverse_restrict_set)()
-
-            setattr(template, own_restrict_set_field, False)
-            getattr(template, inverse_restrict_set)()
+            # Inverse: Reset to the inherited mode -> unsets (re-inherits)
+            setattr(template, restrict_field, RESTRICTION_DISABLED)
+            self.assertFalse(getattr(template, own_restrict_set_field))
 
             # Onchange: Set
             setattr(template, own_restrict_set_field, True)
@@ -71,6 +70,8 @@ class TestCoverageDeep(common.TransactionCase):
             # Onchange: Unset
             setattr(template, own_restrict_set_field, False)
             getattr(template, onchange_restrict)()
+
+            setattr(template, val_field, 0.0)
 
     def test_model_overrides_coverage(self):
         """Hit the 12 compute methods in each model by changing hierarchy."""

--- a/sale_restricted_qty/tests/test_migration_repair.py
+++ b/sale_restricted_qty/tests/test_migration_repair.py
@@ -1,0 +1,74 @@
+# Copyright 2026 OBS Solutions
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests import common, tagged
+
+from odoo.addons.sale_restricted_qty.models.product_restricted_qty_mixin import (
+    RESTRICTION_DISABLED,
+    RESTRICTION_ENABLED,
+)
+
+
+@tagged("post_install", "-at_install")
+class TestMigrationRepair(common.TransactionCase):
+    """Cover the 18.0.3.0.0 data-repair logic exposed as a model method."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.Category = cls.env["product.category"]
+        cls.Template = cls.env["product.template"]
+
+    def _pin(self, record, mode):
+        """Force a raw stored own restriction mode, as older data / the buggy
+        inverse would have left it."""
+        record.write(
+            {
+                "sale_own_restrict_min_qty": mode,
+                "is_sale_own_restrict_min_qty_set": True,
+            }
+        )
+
+    def test_repair_restrict_inheritance(self):
+        # Top category: Warning with a value (the inherited baseline).
+        category = self.Category.create(
+            {
+                "name": "Cat",
+                "sale_min_qty": 10.0,
+                "sale_restrict_min_qty": RESTRICTION_DISABLED,  # Warning
+            }
+        )
+
+        # 1. Variant artefact: template inherits Warning, but the variant is
+        #    frozen on Blocking (the reported bug).
+        template_a = self.Template.create({"name": "A", "categ_id": category.id})
+        variant_a = template_a.product_variant_id
+        self._pin(variant_a, RESTRICTION_ENABLED)
+        self.assertEqual(variant_a.sale_restrict_min_qty, RESTRICTION_ENABLED)
+
+        # 2. Genuine template override: Blocking, differs from the category.
+        template_b = self.Template.create({"name": "B", "categ_id": category.id})
+        self._pin(template_b, RESTRICTION_ENABLED)
+
+        # 3. Redundant template override: Warning, same as the category.
+        template_c = self.Template.create({"name": "C", "categ_id": category.id})
+        self._pin(template_c, RESTRICTION_DISABLED)
+
+        # 4. Orphan: restriction set on a category with no quantity value.
+        orphan = self.Category.create({"name": "Orphan"})
+        self._pin(orphan, RESTRICTION_ENABLED)
+
+        self.env["product.product"]._repair_restrict_inheritance()
+
+        # 1. Variant re-inherits the template's (inherited) Warning.
+        self.assertFalse(variant_a.is_sale_own_restrict_min_qty_set)
+        self.assertEqual(variant_a.sale_restrict_min_qty, RESTRICTION_DISABLED)
+        # 2. Genuine template override is kept.
+        self.assertTrue(template_b.is_sale_own_restrict_min_qty_set)
+        self.assertEqual(template_b.sale_restrict_min_qty, RESTRICTION_ENABLED)
+        # 3. Redundant override dropped -> re-inherits.
+        self.assertFalse(template_c.is_sale_own_restrict_min_qty_set)
+        self.assertFalse(template_c.sale_own_restrict_min_qty)
+        # 4. Orphan dropped.
+        self.assertFalse(orphan.is_sale_own_restrict_min_qty_set)
+        self.assertFalse(orphan.sale_own_restrict_min_qty)

--- a/sale_restricted_qty/tests/test_product_category.py
+++ b/sale_restricted_qty/tests/test_product_category.py
@@ -109,6 +109,7 @@ class TestProductCategory(common.TransactionCase):
         self.assertEqual(child.sale_own_min_qty, 0.0)
 
         child.is_sale_own_restrict_min_qty_set = False
+        child._onchange_is_sale_restrict_min_qty_set()
         self.assertEqual(child.sale_restrict_min_qty, RESTRICTION_ENABLED)
         self.assertFalse(child.sale_own_restrict_min_qty)
 
@@ -118,6 +119,7 @@ class TestProductCategory(common.TransactionCase):
         self.assertEqual(child.sale_own_max_qty, 0.0)
 
         child.is_sale_own_restrict_max_qty_set = False
+        child._onchange_is_sale_restrict_max_qty_set()
         self.assertEqual(child.sale_restrict_max_qty, RESTRICTION_ENABLED)
         self.assertFalse(child.sale_own_restrict_max_qty)
 
@@ -127,5 +129,6 @@ class TestProductCategory(common.TransactionCase):
         self.assertEqual(child.sale_own_multiple_of_qty, 0.0)
 
         child.is_sale_own_restrict_multiple_of_qty_set = False
+        child._onchange_is_sale_restrict_multiple_of_qty_set()
         self.assertEqual(child.sale_restrict_multiple_of_qty, RESTRICTION_ENABLED)
         self.assertFalse(child.sale_own_restrict_multiple_of_qty)

--- a/sale_restricted_qty/tests/test_product_product.py
+++ b/sale_restricted_qty/tests/test_product_product.py
@@ -112,6 +112,7 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(product.sale_own_min_qty, 0.0)
 
         product.is_sale_own_restrict_min_qty_set = False
+        product._onchange_is_sale_restrict_min_qty_set()
         self.assertEqual(product.sale_restrict_min_qty, RESTRICTION_ENABLED)
         self.assertFalse(product.sale_own_restrict_min_qty)
 
@@ -121,6 +122,7 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(product.sale_own_max_qty, 0.0)
 
         product.is_sale_own_restrict_max_qty_set = False
+        product._onchange_is_sale_restrict_max_qty_set()
         self.assertEqual(product.sale_restrict_max_qty, RESTRICTION_ENABLED)
         self.assertFalse(product.sale_own_restrict_max_qty)
 
@@ -130,5 +132,36 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(product.sale_own_multiple_of_qty, 0.0)
 
         product.is_sale_own_restrict_multiple_of_qty_set = False
+        product._onchange_is_sale_restrict_multiple_of_qty_set()
         self.assertEqual(product.sale_restrict_multiple_of_qty, RESTRICTION_ENABLED)
         self.assertFalse(product.sale_own_restrict_multiple_of_qty)
+
+    def test_variant_restrict_inheritance_and_override(self):
+        """A variant inherits the template restrict, can override it, and
+        follows the template again once the override is removed."""
+        template = self.ProductTemplate.create(
+            {
+                "name": "Template",
+                "sale_min_qty": 10.0,
+                "sale_restrict_min_qty": RESTRICTION_DISABLED,  # Warning
+            }
+        )
+        product = template.product_variant_id
+
+        # Inherits, without an own override.
+        self.assertFalse(product.is_sale_own_restrict_min_qty_set)
+        self.assertEqual(product.sale_restrict_min_qty, RESTRICTION_DISABLED)
+
+        # Explicit variant override is honoured...
+        product.sale_restrict_min_qty = RESTRICTION_ENABLED
+        self.assertTrue(product.is_sale_own_restrict_min_qty_set)
+        self.assertEqual(product.sale_restrict_min_qty, RESTRICTION_ENABLED)
+
+        # ...and removing it re-inherits the template value.
+        product.is_sale_own_restrict_min_qty_set = False
+        product._onchange_is_sale_restrict_min_qty_set()
+        self.assertEqual(product.sale_restrict_min_qty, RESTRICTION_DISABLED)
+
+        # Changing the template now propagates to the variant.
+        template.sale_restrict_min_qty = RESTRICTION_ENABLED
+        self.assertEqual(product.sale_restrict_min_qty, RESTRICTION_ENABLED)

--- a/sale_restricted_qty/tests/test_product_template.py
+++ b/sale_restricted_qty/tests/test_product_template.py
@@ -135,6 +135,7 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(template.sale_own_min_qty, 0.0)
 
         template.is_sale_own_restrict_min_qty_set = False
+        template._onchange_is_sale_restrict_min_qty_set()
         self.assertEqual(template.sale_restrict_min_qty, RESTRICTION_ENABLED)
         self.assertFalse(template.sale_own_restrict_min_qty)
 
@@ -144,6 +145,7 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(template.sale_own_max_qty, 0.0)
 
         template.is_sale_own_restrict_max_qty_set = False
+        template._onchange_is_sale_restrict_max_qty_set()
         self.assertEqual(template.sale_restrict_max_qty, RESTRICTION_ENABLED)
         self.assertFalse(template.sale_own_restrict_max_qty)
 
@@ -153,5 +155,25 @@ class TestProductTemplate(common.TransactionCase):
         self.assertEqual(template.sale_own_multiple_of_qty, 0.0)
 
         template.is_sale_own_restrict_multiple_of_qty_set = False
+        template._onchange_is_sale_restrict_multiple_of_qty_set()
         self.assertEqual(template.sale_restrict_multiple_of_qty, RESTRICTION_ENABLED)
         self.assertFalse(template.sale_own_restrict_multiple_of_qty)
+
+    def test_restrict_cleared_when_value_unset(self):
+        """Hygiene: unsetting the quantity value clears the now-meaningless
+        restriction mode."""
+        template = self.ProductTemplate.create(
+            {
+                "name": "Template",
+                "sale_min_qty": 10.0,
+                "sale_restrict_min_qty": RESTRICTION_ENABLED,
+            }
+        )
+        self.assertTrue(template.is_sale_own_restrict_min_qty_set)
+
+        template.is_sale_own_min_qty_set = False
+        template._onchange_is_sale_min_qty_set()
+
+        self.assertFalse(template.is_sale_min_qty_set)
+        self.assertFalse(template.is_sale_own_restrict_min_qty_set)
+        self.assertFalse(template.sale_own_restrict_min_qty)

--- a/sale_restricted_qty/tests/test_sale_order_line.py
+++ b/sale_restricted_qty/tests/test_sale_order_line.py
@@ -168,6 +168,69 @@ class TestSaleOrderLine(common.TransactionCase):
         )
         self.assertTrue(so.order_line.is_not_multiple_of_qty)
 
+    def test_restrict_warning_inherited_by_variant_does_not_block(self):
+        """Regression: a variant must inherit its template's Warning restrict,
+        so a below-minimum line only warns instead of blocking."""
+        template = self.ProductTemplate.create(
+            {
+                "name": "Warn Template",
+                "sale_min_qty": 10.0,
+                "sale_restrict_min_qty": RESTRICTION_DISABLED,  # Warning
+            }
+        )
+        product = template.product_variant_id
+        # The variant follows the template; it does not pin its own mode.
+        self.assertFalse(product.is_sale_own_restrict_min_qty_set)
+        self.assertEqual(product.sale_restrict_min_qty, RESTRICTION_DISABLED)
+
+        so = self.SaleOrder.create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (0, 0, {"product_id": product.id, "product_uom_qty": 5.0})
+                ],
+            }
+        )
+        line = so.order_line
+        self.assertFalse(line.restrict_min_qty)
+        self.assertTrue(line.is_below_min_qty)
+
+    def test_restrict_blocking_inherited_by_variant_blocks(self):
+        """A variant inheriting a Blocking template restrict is blocked."""
+        template = self.ProductTemplate.create(
+            {
+                "name": "Block Template",
+                "sale_min_qty": 10.0,
+                "sale_restrict_min_qty": RESTRICTION_ENABLED,  # Blocking
+            }
+        )
+        product = template.product_variant_id
+        self.assertEqual(product.sale_restrict_min_qty, RESTRICTION_ENABLED)
+        with self.assertRaises(ValidationError):
+            self.SaleOrder.create(
+                {
+                    "partner_id": self.partner.id,
+                    "order_line": [
+                        (0, 0, {"product_id": product.id, "product_uom_qty": 5.0})
+                    ],
+                }
+            )
+
+    def test_template_restrict_change_propagates_to_variant(self):
+        """Softening the template's restrict follows through to the variant."""
+        template = self.ProductTemplate.create(
+            {
+                "name": "Template",
+                "sale_min_qty": 10.0,
+                "sale_restrict_min_qty": RESTRICTION_ENABLED,  # Blocking
+            }
+        )
+        product = template.product_variant_id
+        self.assertEqual(product.sale_restrict_min_qty, RESTRICTION_ENABLED)
+        template.sale_restrict_min_qty = RESTRICTION_DISABLED  # -> Warning
+        self.assertFalse(product.is_sale_own_restrict_min_qty_set)
+        self.assertEqual(product.sale_restrict_min_qty, RESTRICTION_DISABLED)
+
     def test_multi_level_inheritance(self):
         """Test inheritance from Category -> Template -> Product."""
         parent_categ = self.ProductCategory.create(

--- a/sale_restricted_qty/views/product_category_views.xml
+++ b/sale_restricted_qty/views/product_category_views.xml
@@ -35,8 +35,12 @@
                         </div>
 
                         <field name="is_sale_restrict_min_qty_set" invisible="1" />
-                        <label for="sale_restrict_min_qty" string="Restrict" />
-                        <div>
+                        <label
+                            for="sale_restrict_min_qty"
+                            string="Restrict"
+                            invisible="not is_sale_min_qty_set"
+                        />
+                        <div invisible="not is_sale_min_qty_set">
                             <field
                                 name="is_sale_own_restrict_min_qty_set"
                                 class="oe_inline"
@@ -76,8 +80,12 @@
                         </div>
 
                         <field name="is_sale_restrict_max_qty_set" invisible="1" />
-                        <label for="sale_restrict_max_qty" string="Restrict" />
-                        <div>
+                        <label
+                            for="sale_restrict_max_qty"
+                            string="Restrict"
+                            invisible="not is_sale_max_qty_set"
+                        />
+                        <div invisible="not is_sale_max_qty_set">
                             <field
                                 name="is_sale_own_restrict_max_qty_set"
                                 class="oe_inline"
@@ -123,8 +131,12 @@
                             name="is_sale_restrict_multiple_of_qty_set"
                             invisible="1"
                         />
-                        <label for="sale_restrict_multiple_of_qty" string="Restrict" />
-                        <div>
+                        <label
+                            for="sale_restrict_multiple_of_qty"
+                            string="Restrict"
+                            invisible="not is_sale_multiple_of_qty_set"
+                        />
+                        <div invisible="not is_sale_multiple_of_qty_set">
                             <field
                                 name="is_sale_own_restrict_multiple_of_qty_set"
                                 class="oe_inline"

--- a/sale_restricted_qty/views/product_template_views.xml
+++ b/sale_restricted_qty/views/product_template_views.xml
@@ -35,8 +35,12 @@
                         </div>
 
                         <field name="is_sale_restrict_min_qty_set" invisible="1" />
-                        <label for="sale_restrict_min_qty" string="Restrict" />
-                        <div>
+                        <label
+                            for="sale_restrict_min_qty"
+                            string="Restrict"
+                            invisible="not is_sale_min_qty_set"
+                        />
+                        <div invisible="not is_sale_min_qty_set">
                             <field
                                 name="is_sale_own_restrict_min_qty_set"
                                 class="oe_inline"
@@ -76,8 +80,12 @@
                         </div>
 
                         <field name="is_sale_restrict_max_qty_set" invisible="1" />
-                        <label for="sale_restrict_max_qty" string="Restrict" />
-                        <div>
+                        <label
+                            for="sale_restrict_max_qty"
+                            string="Restrict"
+                            invisible="not is_sale_max_qty_set"
+                        />
+                        <div invisible="not is_sale_max_qty_set">
                             <field
                                 name="is_sale_own_restrict_max_qty_set"
                                 class="oe_inline"
@@ -123,8 +131,12 @@
                             name="is_sale_restrict_multiple_of_qty_set"
                             invisible="1"
                         />
-                        <label for="sale_restrict_multiple_of_qty" string="Restrict" />
-                        <div>
+                        <label
+                            for="sale_restrict_multiple_of_qty"
+                            string="Restrict"
+                            invisible="not is_sale_multiple_of_qty_set"
+                        />
+                        <div invisible="not is_sale_multiple_of_qty_set">
                             <field
                                 name="is_sale_own_restrict_multiple_of_qty_set"
                                 class="oe_inline"


### PR DESCRIPTION
## Problem

The Blocking/Warning **restriction mode** did not follow the same inheritance as the quantity **value**. A product variant that ever had a restriction mode stored on it — via the 16/17→18 migration of the legacy `force` flag, or via the previous always-pinning inverse — stayed **frozen** on that mode and stopped following its template.

Concretely: a template set to `min_qty = 10`, Restrict = **Warning**, whose single variant was stuck on **Blocking**, so a sale order line of qty 5 was *blocked* (red line + `ValidationError`) instead of only warned. The sale order line reads the **variants** effective mode (`sale.py`: `restrict_min_qty == product_id.sale_restrict_min_qty == "blocking"`), so the stuck variant drove the wrong behaviour.

## Fix

Align the restriction-mode chain with the (correct) value chain, for `min` / `max` / `multiple_of`:

- `is_sale_own_restrict_*_qty_set` are now **independent stored booleans** (were computed `bool(own)`).
- effective mode = `own if own-set else inherited` (was `own or inherited`).
- the inverse **re-inherits** when the effective mode equals the inherited one, instead of *always* pinning `own`.

A variant with no genuine override now follows its template, and softening a template from Blocking to Warning propagates to its variants.

## Data hygiene

A restriction mode is meaningless without a quantity value, so the **Restrict** widget is now hidden until a value is set, and unsetting the value clears the mode.

## Migration

Existing data is normalised (`_repair_restrict_inheritance`, run from the `18.0.3.0.0` post-migration):
- **categories / templates**: keep genuine overrides (own set, differs from inherited, has a value); drop redundant (own == inherited) or orphan (no value) ones so they re-inherit.
- **variants**: drop all own restriction modes → always inherit the template. Variant-level restriction overrides were, in practice, artefacts of the previous bug; deliberate configuration lives on the template/category.

> [!NOTE]
> No manifest version bump is included (left to ocabot). The repair lives under `migrations/18.0.3.0.0/`, so please **`/ocabot merge minor`** so the version becomes `18.0.3.0.0` and the migration runs.

## Tests

New: SO-line regression (Warning inherited by variant no longer blocks; Blocking does; template change propagates), variant inheritance + override + re-inherit, restrict-without-value hygiene, and a migration-repair unit test. Existing restrict tests updated to the new flag semantics.

Validated in an OCA-CI container (`py3.10-odoo18.0`): fresh install **21/21 tests pass**, and an end-to-end `18.0.2.0.0 → 18.0.3.0.0` upgrade with seeded buggy data confirms the variant re-inherits Warning, a genuine template override is kept, and an orphan mode is cleared.