### PR TITLE
[19.0][FIX] sale_exception: fix traceback when exception rule has no description

### DIFF
--- a/sale_exception/models/sale_order_line.py
+++ b/sale_exception/models/sale_order_line.py
@@ -39,7 +39,7 @@ class SaleOrderLine(models.Model):
 
     def _get_exception_summary(self):
         items = "".join(
-            f"<li>{html.escape(e.name)}: <i>{html.escape(e.description)}</i></li>"
+            f"<li>{html.escape(e.name)}: <i>{html.escape(e.description or '')}</i></li>"
             for e in self.exception_ids
         )
         return f"<ul>{items}</ul>"


### PR DESCRIPTION
This happens in `SaleOrderLine._get_exception_summary()`, which calls
`html.escape(e.description)` directly. Since `description` is an empty
`Text`/`Html` field, Odoo returns `False` rather than an empty string,
and `html.escape()` fails trying to call `.replace()` on it.

The equivalent method on `base.exception` (used for `sale.order`-level
rules) already guards against this with `e.description or ""`, which is
why order-level rules aren't affected — only line-level rules are, since
`sale_exception` overrides `_get_exception_summary` on `sale.order.line`
without this guard.

Fix: fall back to an empty string when `description` is falsy, matching
the base module's behavior.