### PR TITLE
[18.0][FIX] sale_order_line_final_price: if price_unit is 0 technical_price_unit should be 0 too

### DIFF
--- a/sale_order_line_final_price/models/sale_order_line.py
+++ b/sale_order_line_final_price/models/sale_order_line.py
@@ -84,5 +84,7 @@ class SaleOrderLine(models.Model):
         for vals in vals_list:
             if "price_unit" in vals and "technical_price_unit" not in vals:
                 # Absurd value to not match any of the possible creation values
-                vals["technical_price_unit"] = -9999999999
+                vals["technical_price_unit"] = (
+                    -9999999999 if vals.get("price_unit") != 0 else 0
+                )
         return super()._add_precomputed_values(vals_list)


### PR DESCRIPTION
cc @Tecnativa TT63893
ping @pedrobaeza 

If we create a SO line by code setting  `price_unit`  to 0, `technical_price_unit` is set to -9999999999. This breaks our code logic to avoid computing discount. So to keep out keep our logic if `price_unit` is 0 `technical_price_unit` should be 0, so we can change `price_final` but discount will remain 0 and `price_unit` match `price_final`.