### PR TITLE
[FIX] sale_invoice_policy: field invoice_policy in product_template isn't anymore a not-stored field

### DIFF
--- a/sale_invoice_policy/migrations/16.0.3.0.0/pre-migrate.py
+++ b/sale_invoice_policy/migrations/16.0.3.0.0/pre-migrate.py
@@ -1,0 +1,16 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # fill invoice_policy with values from default_invoice_policy, as invoice_policy
+    # isn't anymore a store=False
+    if openupgrade.column_exists(env.cr, "product_template", "default_invoice_policy"):
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE product_template
+            SET invoice_policy = default_invoice_policy
+            WHERE default_invoice_policy IS NOT NULL
+            """,
+        )


### PR DESCRIPTION
In v.15.0 invoice_policy was a store=False field and the stored values was in default_invoice_policy, but in v. 16.0 this last field is removed, so invoice_policy is always False and is set to the default value.
With this PR the previous value from default_invoice_policy is restored.

This solution works in my tests even if invoice_policy was set in the previous version as store=False, so it shouldn't be writable in the pre-migration state.
If needed, I could use a classic solution saving the field in pre-migration and writing in post-migration anyway.