### PR TITLE
[16.0][FIX] sale_blanket_order: remaining_qty should not force UoM rounding

### DIFF
--- a/sale_blanket_order/models/blanket_orders.py
+++ b/sale_blanket_order/models/blanket_orders.py
@@ -680,7 +680,7 @@ class BlanketOrderLine(models.Model):
             )
             line.remaining_uom_qty = line.original_uom_qty - line.ordered_uom_qty
             line.remaining_qty = line.product_uom._compute_quantity(
-                line.remaining_uom_qty, line.product_id.uom_id
+                line.remaining_uom_qty, line.product_id.uom_id, round=False
             )
 
     def _validate(self):

--- a/sale_blanket_order/tests/test_blanket_orders.py
+++ b/sale_blanket_order/tests/test_blanket_orders.py
@@ -350,6 +350,75 @@ class TestSaleBlanketOrders(common.TransactionCase):
         self.assertEqual(blanket_order.line_ids[0].remaining_qty, 12.0)
         self.assertEqual(sale_order.order_line[0].price_unit, 20.0)
 
+    def test_05b_remaining_qty_precision_survives_uom_rounding(self):
+        """remaining_qty must not be truncated by an extra, independent
+        rounding step against the product's reference UoM ``rounding``
+        (0.01 by default) on top of whatever precision the blanket
+        line's own UoM already uses - mirroring a fine-grained
+        measurement unit on the line versus a coarser generic
+        reference UoM on the product. It must always equal
+        remaining_uom_qty exactly: any mismatch can only come from
+        that extra rounding.
+        """
+        reference_uom = self.product.uom_id
+        reference_uom.rounding = 0.5
+        fine_uom = self.env["uom.uom"].create(
+            {
+                "name": "Test-Fine",
+                "category_id": reference_uom.category_id.id,
+                "uom_type": "smaller",
+                "factor": reference_uom.factor,
+                "rounding": 0.000001,
+            }
+        )
+        blanket_order = self.blanket_order_obj.create(
+            {
+                "partner_id": self.partner.id,
+                "validity_date": fields.Date.to_string(self.tomorrow),
+                "payment_term_id": self.payment_term.id,
+                "pricelist_id": self.sale_pricelist.id,
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom": fine_uom.id,
+                            "original_uom_qty": 1.0,
+                            "price_unit": 30.0,
+                        },
+                    )
+                ],
+            }
+        )
+        blanket_order.sudo().onchange_partner_id()
+        blanket_order.sudo().action_confirm()
+
+        sale_order = self.so_obj.create(
+            {
+                "partner_id": self.partner.id,
+                "payment_term_id": self.payment_term.id,
+                "pricelist_id": self.sale_pricelist.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom": fine_uom.id,
+                            "product_uom_qty": 0.633,
+                            "price_unit": 30.0,
+                        },
+                    )
+                ],
+            }
+        )
+        sale_order.order_line[0].onchange_product_id()
+        sale_order.order_line[0].onchange_blanket_order_line()
+
+        line = blanket_order.line_ids[0]
+        self.assertEqual(line.remaining_qty, line.remaining_uom_qty)
+
     def test_06_create_sale_orders_from_blanket_order(self):
         """We create a blanket order and create three sale orders
         where the first two consume the first blanket order line


### PR DESCRIPTION
@Escodoo 

[HT02034]

cc @marcelsavegnago @douglascstd @WesleyOliveira98 @CristianoMafraJunior 

`remaining_qty` converts `remaining_uom_qty` into the product's reference UoM (`product_id.uom_id`), but forces rounding to that UoM's own `rounding` attribute (0.01 by default) via `_compute_quantity(..., round=True)`. This rounding is completely independent of the "Product Unit of Measure" decimal precision that already governs `remaining_uom_qty` and every other quantity field on the line.

In practice, this silently truncates the remaining balance whenever the blanket order line's own UoM tracks finer fractions than the product's reference UoM allows — e.g. `original_uom_qty = 1.00`, an order for `0.633` is placed, the expected remainder is `0.367`, but `remaining_qty` ends up rounded to `0.36`/`0.37` instead, while `remaining_uom_qty` correctly stays at the finer precision. This breaks any workflow that needs to sequence further partial orders against the same blanket order line down to an exact remaining fraction (e.g. services billed by progressive measurement).

## What changed

- `sale_blanket_order/models/blanket_orders.py`: `_compute_quantities()` now converts `remaining_qty` with `round=False`, so it is not forced through the reference UoM's own rounding on top of whatever precision `remaining_uom_qty` already has.
- `sale_blanket_order/tests/test_blanket_orders.py`: added `test_05b_remaining_qty_precision_survives_uom_rounding`, which deliberately coarsens the product's reference UoM rounding and asserts `remaining_qty` stays equal to `remaining_uom_qty` instead of being independently rounded away.

## Test plan
- [x] New test fails against the pre-fix code (`0.5 != 0.37`) and passes with the fix.
- [x] Full `sale_blanket_order` test suite: 10/10 tests pass.
- [x] pre-commit (black, isort, flake8, pylint_odoo) clean.