### PR TITLE
[18.0][FIX] sale_exception: avoid false positive in 'Not Enough Virtual Stock'

### DIFF
--- a/sale_exception/data/sale_exception_data.xml
+++ b/sale_exception/data/sale_exception_data.xml
@@ -26,7 +26,7 @@
         <field name="model">sale.order.line</field>
         <field
             name="code"
-        >failed=self.product_id and self.product_id.type == 'consu' and self.product_id.is_storable and self.virtual_available_at_date &lt; self.product_uom_qty</field>
+        >failed=bool(self.product_id and self.product_id.type == 'consu' and self.product_id.is_storable and self.state in ('draft', 'sent') and self.display_qty_widget and self.virtual_available_at_date is not False and self.virtual_available_at_date &lt; self.product_uom_qty)</field>
         <field name="active" eval="False" />
     </record>
     <record id="exception_partner_sale_warning" model="exception.rule">


### PR DESCRIPTION
The example rule compared self.virtual_available_at_date < self.product_uom_qty. On sale.order.line, virtual_available_at_date is False/0 for confirmed lines (state='sale') and whenever the stock widget is not displayed, so the comparison False < qty evaluates to True and the exception is wrongly raised (blocking edits on confirmed orders and intermittently on new draft lines, even when there is enough stock).

Guard the rule so it only applies to draft/sent lines with the stock widget displayed and a real forecast value, keeping the legitimate block when the forecast is actually lower than the ordered quantity.