### PR TITLE
[16.0] [IMP] sale_invoice_plan: manage invoiced order

### DIFF
--- a/sale_invoice_plan/models/sale.py
+++ b/sale_invoice_plan/models/sale.py
@@ -33,6 +33,13 @@ class SaleOrder(models.Model):
         compute="_compute_invoice_plan_total",
         string="Total Amount",
     )
+    amount_invoiced_before_plan = fields.Monetary(
+        compute="_compute_amount_invoiced_before_plan",
+        string="Already Invoiced (before plan)",
+        help="Untaxed amount already invoiced on this order before the invoice "
+        "plan was created. The plan installments only cover the remaining "
+        "amount, so: Untaxed Amount = Already Invoiced + Plan Total.",
+    )
 
     @api.depends("invoice_plan_ids")
     def _compute_invoice_plan_total(self):
@@ -40,6 +47,20 @@ class SaleOrder(models.Model):
             installments = rec.invoice_plan_ids.filtered("installment")
             rec.invoice_plan_total_percent = sum(installments.mapped("percent"))
             rec.invoice_plan_total_amount = sum(installments.mapped("amount"))
+
+    @api.depends(
+        "order_line.qty_invoiced_before_plan",
+        "order_line.price_unit",
+        "order_line.discount",
+    )
+    def _compute_amount_invoiced_before_plan(self):
+        for rec in self:
+            rec.amount_invoiced_before_plan = sum(
+                line.qty_invoiced_before_plan
+                * line.price_unit
+                * (1 - (line.discount or 0.0) / 100.0)
+                for line in rec.order_line
+            )
 
     def _compute_invoice_plan_process(self):
         for rec in self:
@@ -143,3 +164,12 @@ class SaleOrder(models.Model):
                 move._compute_date()
             plan.invoice_move_ids += moves
         return moves
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    qty_invoiced_before_plan = fields.Float(
+        string="Invoiced Quantity Before Plan",
+        digits="Product Unit of Measure",
+    )

--- a/sale_invoice_plan/models/sale_invoice_plan.py
+++ b/sale_invoice_plan/models/sale_invoice_plan.py
@@ -95,7 +95,13 @@ class SaleInvoicePlan(models.Model):
     @api.depends("percent")
     def _compute_amount(self):
         for rec in self:
-            amount_untaxed = rec.sale_id._origin.amount_untaxed
+            amount_invoiced = sum(
+                line.qty_invoiced_before_plan
+                * line.price_unit
+                * (1 - (line.discount or 0.0) / 100.0)
+                for line in rec.sale_id._origin.order_line
+            )
+            amount_untaxed = rec.sale_id._origin.amount_untaxed - amount_invoiced
             # With invoice already created, no recompute
             if rec.invoiced:
                 rec.amount = rec.amount_invoiced
@@ -115,6 +121,13 @@ class SaleInvoicePlan(models.Model):
     def _inverse_amount(self):
         for rec in self:
             if rec.sale_id.amount_untaxed != 0:
+                amount_invoiced = sum(
+                    line.qty_invoiced_before_plan
+                    * line.price_unit
+                    * (1 - (line.discount or 0.0) / 100.0)
+                    for line in rec.sale_id.order_line
+                )
+                amount_untaxed = rec.sale_id.amount_untaxed - amount_invoiced
                 if rec.last:
                     installments = rec.sale_id.invoice_plan_ids.filtered(
                         lambda l: l.invoice_type == "installment"
@@ -122,7 +135,7 @@ class SaleInvoicePlan(models.Model):
                     prev_percent = sum((installments - rec).mapped("percent"))
                     rec.percent = 100 - prev_percent
                     continue
-                rec.percent = rec.amount / rec.sale_id.amount_untaxed * 100
+                rec.percent = rec.amount / amount_untaxed * 100
                 continue
             rec.percent = 0
 
@@ -210,7 +223,10 @@ class SaleInvoicePlan(models.Model):
 
     @api.model
     def _get_plan_qty(self, order_line, percent):
-        plan_qty = order_line.product_uom_qty * (percent / 100)
+        product_uom_qty = (
+            order_line.product_uom_qty - order_line.qty_invoiced_before_plan
+        )
+        plan_qty = product_uom_qty * (percent / 100)
         return plan_qty
 
     def unlink(self):

--- a/sale_invoice_plan/tests/test_sale_invoice_plan.py
+++ b/sale_invoice_plan/tests/test_sale_invoice_plan.py
@@ -328,3 +328,151 @@ class TestSaleInvoicePlan(common.TestSaleCommon):
         self.so_service.invoice_plan_ids._compute_amount()
         self.assertEqual(first_install.amount, 280.0)
         self.assertEqual(first_install.percent, 9.090909)
+
+    def test_amount_invoiced_before_plan_via_manual_invoice(self):
+        """Full flow: invoice part of the order manually (outside any plan)
+        before creating the invoice plan. The wizard snapshots the invoiced
+        quantity, the plan covers only the remaining amount, and the plan tab
+        reconciles: Untaxed Amount = Already Invoiced (before plan) + Plan Total.
+        """
+        # Service invoiced on delivered quantity, so a partial delivery can be
+        # invoiced manually before any plan exists.
+        product = self.env["product.product"].create(
+            {
+                "name": "Service delivered",
+                "type": "service",
+                "service_type": "manual",
+                "invoice_policy": "delivery",
+                "taxes_id": False,
+                "categ_id": self.product_category.id,
+            }
+        )
+        so = (
+            self.env["sale.order"]
+            .with_user(self.company_data["default_user_salesman"])
+            .create(
+                {
+                    "partner_id": self.partner_customer_usd.id,
+                    "partner_invoice_id": self.partner_customer_usd.id,
+                    "partner_shipping_id": self.partner_customer_usd.id,
+                    "use_invoice_plan": False,
+                    "order_line": [
+                        (
+                            0,
+                            0,
+                            {
+                                "name": product.name,
+                                "product_id": product.id,
+                                "product_uom_qty": 10,
+                                "product_uom": product.uom_id.id,
+                                "price_unit": 1000,
+                            },
+                        )
+                    ],
+                    "pricelist_id": self.env.ref("product.list0").id,
+                }
+            )
+        )
+        self.assertEqual(so.amount_untaxed, 10000)
+        self.assertEqual(so.amount_invoiced_before_plan, 0)
+        # Confirm without an invoice plan, then invoice part of it manually
+        so.action_confirm()
+        self.assertEqual(so.state, "sale")
+        so.order_line.qty_delivered = 4.0
+        so._create_invoices()  # native invoice, outside any plan
+        self.assertEqual(so.order_line.qty_invoiced, 4)
+        # Now plan the remaining amount
+        so.use_invoice_plan = True
+        ctx = {
+            "active_id": so.id,
+            "active_ids": [so.id],
+            "all_remain_invoices": True,
+        }
+        f = Form(self.env["sale.create.invoice.plan"])
+        f.num_installment = 4
+        f.save().with_context(**ctx).sale_create_invoice_plan()
+        # The wizard snapshots the already-invoiced quantity
+        self.assertEqual(so.order_line.qty_invoiced_before_plan, 4)
+        self.assertEqual(so.amount_invoiced_before_plan, 4000)
+        # Installments cover only the remaining 6000
+        self.assertEqual(so.invoice_plan_total_amount, 6000)
+        self.assertEqual(
+            so.amount_untaxed,
+            so.amount_invoiced_before_plan + so.invoice_plan_total_amount,
+        )
+
+    def test_amount_invoiced_before_plan_with_discount(self):
+        """Regression for the residual miscalculation with discounted lines.
+
+        The already-invoiced-before-plan amount must be net of the line
+        discount, consistent with amount_untaxed. Before the fix it used the
+        gross price_unit, overstating the invoiced part and understating the
+        residual (real case: a 20% line billed 50% up-front showed 5000/3000
+        instead of 4000/4000).
+        """
+        product = self.env["product.product"].create(
+            {
+                "name": "Service delivered (discounted)",
+                "type": "service",
+                "service_type": "manual",
+                "invoice_policy": "delivery",
+                "taxes_id": False,
+                "categ_id": self.product_category.id,
+            }
+        )
+        so = (
+            self.env["sale.order"]
+            .with_user(self.company_data["default_user_salesman"])
+            .create(
+                {
+                    "partner_id": self.partner_customer_usd.id,
+                    "partner_invoice_id": self.partner_customer_usd.id,
+                    "partner_shipping_id": self.partner_customer_usd.id,
+                    "use_invoice_plan": False,
+                    "order_line": [
+                        (
+                            0,
+                            0,
+                            {
+                                "name": product.name,
+                                "product_id": product.id,
+                                "product_uom_qty": 10,
+                                "product_uom": product.uom_id.id,
+                                "price_unit": 1000,
+                                "discount": 20,  # gross 10000 -> net 8000
+                            },
+                        )
+                    ],
+                    "pricelist_id": self.env.ref("product.list0").id,
+                }
+            )
+        )
+        # amount_untaxed is net of discount; nothing invoiced yet
+        self.assertEqual(so.amount_untaxed, 8000)
+        self.assertEqual(so.amount_invoiced_before_plan, 0)
+        # Confirm without a plan, then invoice half of it manually
+        so.action_confirm()
+        self.assertEqual(so.state, "sale")
+        so.order_line.qty_delivered = 5.0
+        so._create_invoices()  # native invoice, outside any plan
+        self.assertEqual(so.order_line.qty_invoiced, 5)
+        # Now plan the remaining amount
+        so.use_invoice_plan = True
+        ctx = {
+            "active_id": so.id,
+            "active_ids": [so.id],
+            "all_remain_invoices": True,
+        }
+        f = Form(self.env["sale.create.invoice.plan"])
+        f.num_installment = 4
+        f.save().with_context(**ctx).sale_create_invoice_plan()
+        # The wizard snapshots the already-invoiced quantity
+        self.assertEqual(so.order_line.qty_invoiced_before_plan, 5)
+        # Already invoiced must be net of the 20% discount: 5 * 1000 * 0.8
+        self.assertEqual(so.amount_invoiced_before_plan, 4000)
+        # Installments cover only the remaining 4000, not 3000
+        self.assertEqual(so.invoice_plan_total_amount, 4000)
+        self.assertEqual(
+            so.amount_untaxed,
+            so.amount_invoiced_before_plan + so.invoice_plan_total_amount,
+        )

--- a/sale_invoice_plan/views/sale_view.xml
+++ b/sale_invoice_plan/views/sale_view.xml
@@ -115,24 +115,28 @@
                         string="⇒ Create Invoice Plan"
                         type="action"
                         class="oe_link"
-                        attrs="{'invisible': ['|', ('invoice_plan_ids', '!=', []), ('invoice_count', '>', 0)]}"
+                        attrs="{'invisible': [('invoice_plan_ids', '!=', [])]}"
                     />
                     <button
                         name="remove_invoice_plan"
                         string="⇒ Remove Invoice Plan"
                         type="object"
                         class="oe_link"
-                        attrs="{'invisible': ['|', ('invoice_plan_ids', '=', []), ('invoice_count', '>', 0)]}"
+                        attrs="{'invisible': [('invoice_plan_ids', '=', [])]}"
                         confirm="Are you sure to remove this invoice plan?"
                     />
                     <field
                         name="invoice_plan_ids"
                         context="{'tree_view_ref': 'sale_invoice_plan.view_sale_invoice_plan_tree'}"
-                        attrs="{'invisible': [('invoice_plan_ids', '=', [])]}"
                     />
                     <group class="oe_subtotal_footer oe_right">
+                        <field name="amount_untaxed" string="Untaxed Amount" />
+                        <field
+                            name="amount_invoiced_before_plan"
+                            attrs="{'invisible': [('amount_invoiced_before_plan', '=', 0)]}"
+                        />
                         <field name="invoice_plan_total_percent" />
-                        <field name="invoice_plan_total_amount" />
+                        <field name="invoice_plan_total_amount" string="Plan Total" />
                     </group>
                 </page>
             </xpath>

--- a/sale_invoice_plan/wizard/sale_create_invoice_plan.py
+++ b/sale_invoice_plan/wizard/sale_create_invoice_plan.py
@@ -40,6 +40,8 @@ class SaleCreateInvoicePlan(models.TransientModel):
     def sale_create_invoice_plan(self):
         sale = self.env["sale.order"].browse(self._context.get("active_id"))
         self.ensure_one()
+        for line in sale.order_line:
+            line.qty_invoiced_before_plan = line.qty_invoiced
         sale.create_invoice_plan(
             self.num_installment,
             self.installment_date,


### PR DESCRIPTION
Allow creating an invoice plan on an order that has already been partially invoiced outside any plan. Until now the "Create Invoice Plan" button was hidden as soon as an invoice existed, and the plan always split 100% of the untaxed amount.

The wizard now snapshots qty_invoiced per order line into a new qty_invoiced_before_plan field, and the installment computation reduces the basis by the already-invoiced amount:

    plan basis = amount_untaxed - sum(qty_invoiced_before_plan * price_unit)

so the installments cover only the remaining amount, and _get_plan_qty plans only the not-yet-invoiced quantity. The invoice_count > 0 guards on the Create/Remove buttons and the plan field are dropped accordingly.

The Invoice Plan tab footer also shows a read-only "Already Invoiced (before plan)" figure, next to the untaxed amount, so the tab reconciles at a glance:

    Untaxed Amount = Already Invoiced (before plan) + Plan Total

The figure reuses the same qty_invoiced_before_plan * price_unit basis, is hidden when zero (leaving plan-from-scratch orders unchanged), and the plan total is relabelled "Plan Total" for clarity.

Add a test covering the full flow: invoice part of the order manually before creating the plan, then assert the snapshot, the remaining-only installments and the reconciliation.

Mirrors purchase_invoice_plan (OCA/purchase-workflow#2571).

Assisted-by: Claude Opus 4.8