### PR TITLE
[18.0][FIX] sale_order_line_price_history: keep order_partner_id in sync with the order

### DIFF
--- a/sale_order_line_price_history/models/sale_order_line.py
+++ b/sale_order_line_price_history/models/sale_order_line.py
@@ -7,5 +7,7 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     # In core this a related field. We need to trigger its value on view, so we can
-    # have it even when we're in a NewId
-    order_partner_id = fields.Many2one(depends=["product_id"])
+    # have it even when we're in a NewId. The original dependency must be kept as
+    # well, otherwise the stored value isn't recomputed when the order partner
+    # changes (an explicit `depends` fully replaces the related one).
+    order_partner_id = fields.Many2one(depends=["order_id.partner_id", "product_id"])


### PR DESCRIPTION
An explicit `depends` fully replaces the one derived from `related` (see `Field.get_depends` in odoo/fields.py), so declaring `depends=["product_id"]` made the stored `order_partner_id` stop depending on `order_id.partner_id`.

cc @Tecnativa

This PR solves the issue https://github.com/OCA/sale-workflow/issues/4511

ping @pedrobaeza @pilarvargas-tecnativa 