### PR TITLE
[18.0][IMP] sale_order_line_sequence: Change the string in the PDF invoices to #

### DIFF
--- a/sale_order_line_sequence/views/account_move_view.xml
+++ b/sale_order_line_sequence/views/account_move_view.xml
@@ -12,6 +12,8 @@
                 <field
                     name="related_so_sequence"
                     column_invisible="parent.move_type != 'out_invoice'"
+                    string="#"
+                    optional="show"
                 />
             </xpath>
         </field>

--- a/sale_order_line_sequence/views/report_invoice.xml
+++ b/sale_order_line_sequence/views/report_invoice.xml
@@ -9,9 +9,7 @@
             <th
                 name="th_linenumber"
                 t-if="(o.move_type == 'out_invoice' or o.move_type == 'out_refund') and any(l.related_so_sequence for l in o.invoice_line_ids)"
-            >
-                Line Number
-            </th>
+            >#</th>
         </xpath>
         <!--complicated expr to be compatible with other modules-->
         <xpath expr="//table/tbody//span[1]/.." position="before">

--- a/sale_order_line_sequence/views/report_saleorder.xml
+++ b/sale_order_line_sequence/views/report_saleorder.xml
@@ -9,7 +9,7 @@
             position="before"
         >
             <th name="th_visible_sequence">
-                <strong>Line Number</strong>
+                <strong>#</strong>
             </th>
         </xpath>
         <xpath

--- a/sale_order_line_sequence/views/sale_portal_templates.xml
+++ b/sale_order_line_sequence/views/sale_portal_templates.xml
@@ -8,7 +8,7 @@
             position="before"
         >
             <th class="text-start" id="line_number_header">
-                Line Number
+                #
             </th>
         </xpath>
 

--- a/sale_order_line_sequence/views/sale_view.xml
+++ b/sale_order_line_sequence/views/sale_view.xml
@@ -14,7 +14,7 @@
                 expr="//field[@name='order_line']/list/field[@name='product_id']"
                 position="before"
             >
-                <field name="visible_sequence" />
+                <field name="visible_sequence" string="#" optional="show" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/sale-workflow/pull/4531

Extra changes:
- [x] Change string to sale order pdf
- [x] Change string to sale order portal
- [x] Change string to invoice form view
- [x] Change string to invoice pdf


Please @pedrobaeza can you review it?

@Tecnativa TT64227