### PR TITLE
[19.0][IMP] sale_order_line_sequence: Change the string in the PDF invoices to

### DIFF
--- a/sale_order_line_sequence/README.rst
+++ b/sale_order_line_sequence/README.rst
@@ -62,13 +62,13 @@ Authors
 Contributors
 ------------
 
-- ForgeFlow S.L. <contact@forgeflow.com>
-- Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
-- Rattapong Chokmasermkul <rattapongc@ecosoft.co.th>
-- Marcin Chechłacz <marcin.chechlacz@braintec.com>
-- `Heliconia Solutions Pvt. Ltd. <https://www.heliconia.io>`__
+-  ForgeFlow S.L. <contact@forgeflow.com>
+-  Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+-  Rattapong Chokmasermkul <rattapongc@ecosoft.co.th>
+-  Marcin Chechłacz <marcin.chechlacz@braintec.com>
+-  `Heliconia Solutions Pvt. Ltd. <https://www.heliconia.io>`__
 
-  - Bhavesh Heliconia
+   -  Bhavesh Heliconia
 
 Other credits
 -------------
@@ -76,8 +76,8 @@ Other credits
 Images
 ~~~~~~
 
-- Odoo Community Association:
-  `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`__.
+-  Odoo Community Association:
+   `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`__.
 
 Maintainers
 -----------

--- a/sale_order_line_sequence/__manifest__.py
+++ b/sale_order_line_sequence/__manifest__.py
@@ -13,6 +13,7 @@
     "data": [
         "views/sale_view.xml",
         "views/report_saleorder.xml",
+        "views/sale_portal_templates.xml",
         "views/account_move_view.xml",
         "views/report_invoice.xml",
     ],

--- a/sale_order_line_sequence/views/account_move_view.xml
+++ b/sale_order_line_sequence/views/account_move_view.xml
@@ -12,6 +12,8 @@
                 <field
                     name="related_so_sequence"
                     column_invisible="parent.move_type != 'out_invoice'"
+                    string="#"
+                    optional="show"
                 />
             </xpath>
         </field>

--- a/sale_order_line_sequence/views/report_invoice.xml
+++ b/sale_order_line_sequence/views/report_invoice.xml
@@ -8,9 +8,7 @@
         <xpath expr="//table/thead/tr/th[1]" position="before">
             <th
                 t-if="(o.move_type == 'out_invoice' or o.move_type == 'out_refund') and any(l.related_so_sequence for l in o.invoice_line_ids)"
-            >
-                Line Number
-            </th>
+            >#</th>
         </xpath>
         <!--complicated expr to be compatible with other modules-->
         <xpath expr="//table/tbody//span[1]/.." position="before">

--- a/sale_order_line_sequence/views/report_saleorder.xml
+++ b/sale_order_line_sequence/views/report_saleorder.xml
@@ -9,7 +9,7 @@
             position="before"
         >
             <th name="th_visible_sequence">
-                <span>Line Number</span>
+                <strong>#</strong>
             </th>
         </xpath>
         <xpath

--- a/sale_order_line_sequence/views/sale_portal_templates.xml
+++ b/sale_order_line_sequence/views/sale_portal_templates.xml
@@ -5,7 +5,7 @@
     >
         <th id="product_name_header" position="before">
             <th class="text-start" id="line_number_header">
-                Line Number
+                #
             </th>
         </th>
         <td name="td_product_name" position="before">

--- a/sale_order_line_sequence/views/sale_portal_templates.xml
+++ b/sale_order_line_sequence/views/sale_portal_templates.xml
@@ -1,0 +1,17 @@
+<odoo>
+    <template
+        id="sale_order_portal_content_sequence"
+        inherit_id="sale.sale_order_portal_content"
+    >
+        <th id="product_name_header" position="before">
+            <th class="text-start" id="line_number_header">
+                Line Number
+            </th>
+        </th>
+        <td name="td_product_name" position="before">
+            <td class="text-start" id="line_number">
+                <span t-field="line.visible_sequence" />
+            </td>
+        </td>
+    </template>
+</odoo>

--- a/sale_order_line_sequence/views/sale_view.xml
+++ b/sale_order_line_sequence/views/sale_view.xml
@@ -14,7 +14,7 @@
                 expr="//field[@name='order_line']/list/field[@name='product_id']"
                 position="before"
             >
-                <field name="visible_sequence" />
+                <field name="visible_sequence" string="#" optional="show" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
FWP from 18.0: https://github.com/OCA/sale-workflow/pull/4530 + https://github.com/OCA/sale-workflow/pull/4344

Extra changes:
- [x] Change string to sale order pdf
- [x] Change string to sale order portal
- [x] Change string to invoice form view
- [x] Change string to invoice pdf


Please @pedrobaeza can you review it?

@Tecnativa TT64227