### PR TITLE
[17.0][FIX] sale_invoice_policy: drop unsupported states property

### DIFF
--- a/sale_invoice_policy/models/sale_order.py
+++ b/sale_invoice_policy/models/sale_order.py
@@ -17,7 +17,6 @@ class SaleOrder(models.Model):
         store=True,
         readonly=False,
         required=True,
-        states={"draft": [("readonly", False)], "sent": [("readonly", False)]},
         precompute=True,
         help="Ordered Quantity: Invoice based on the quantity the customer "
         "ordered.\n"

--- a/sale_invoice_policy/views/sale_view.xml
+++ b/sale_invoice_policy/views/sale_view.xml
@@ -7,7 +7,7 @@
         <field name="priority">50</field>
         <field name="arch" type="xml">
             <field name="payment_term_id" position="after">
-                <field name="invoice_policy" />
+                <field name="invoice_policy" readonly="state in ['cancel', 'sale']" />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Move readonly prop to the view, the supported way in odoo 17.0+

removing the warning introduced in https://github.com/OCA/sale-workflow/pull/4227

```
WARNING devel py.warnings: /opt/odoo/custom/src/odoo/odoo/fields.py:542: UserWarning: Since Odoo 17, property sale.order.invoice_policy.states is no longer supported.
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 542, in setup
    warnings.warn(f'Since Odoo 17, property {self}.states is no longer supported.')
```

cc @ForgeFlow