### PR TITLE
[19.0][IMP] sale_exception_line_tooltip

### DIFF
--- a/sale_exception_line_tooltip/views/sale_order_views.xml
+++ b/sale_exception_line_tooltip/views/sale_order_views.xml
@@ -5,7 +5,7 @@
         <field name="inherit_id" ref="sale.view_order_form" />
         <field name="arch" type="xml">
             <xpath
-                expr="//field[@name='order_line']/list/field[@name='product_template_id']"
+                expr="//field[@name='order_line']/list/field[@name='name']"
                 position="before"
             >
                 <field


### PR DESCRIPTION
Problem: 
If I display the product template on the sale order line, the warning symbol appears before the product, if I display the product variant, then it appears after the product.

before:
<img width="1258" height="1165" alt="image" src="https://github.com/user-attachments/assets/f3a78da6-fa69-4a25-96ca-d0e739bab1b2" />

<img width="1224" height="1187" alt="image" src="https://github.com/user-attachments/assets/168987cd-9f80-4959-a1a3-90c7fdfd5eba" />


after:
<img width="1320" height="1212" alt="image" src="https://github.com/user-attachments/assets/332914bd-5138-4dc3-87d8-184f0df0cc38" />

<img width="1561" height="1169" alt="image" src="https://github.com/user-attachments/assets/a4b43057-dc6f-424c-bd96-aa9333fb2862" />
