### PR TITLE
[19.0][FIX] sale_pricelist_global_rule: cannot access local variable 'res'

### DIFF
--- a/sale_pricelist_global_rule/models/sale_order_line.py
+++ b/sale_pricelist_global_rule/models/sale_order_line.py
@@ -17,6 +17,7 @@ class SaleOrderLine(models.Model):
         # Store the data in a dictionary to avoid redundant computations
         # for the same order multiple times.
         sale_data = self._prepare_pricelist_global_cumulative_quantity()
+        res = None
         for line in self:
             qty_data = sale_data[line.order_id]
             res = super(
@@ -32,6 +33,7 @@ class SaleOrderLine(models.Model):
         # pricelist, then here the cumulative quantities are not set in the context, so
         # we need to perform the same operation
         sale_data = self._prepare_pricelist_global_cumulative_quantity()
+        res = None
         for line in self:
             qty_data = sale_data[line.order_id]
             res = super(
@@ -43,6 +45,7 @@ class SaleOrderLine(models.Model):
     def _compute_discount(self):
         # Same case as _compute_price_unit
         sale_data = self._prepare_pricelist_global_cumulative_quantity()
+        res = None
         for line in self:
             qty_data = sale_data[line.order_id]
             res = super(


### PR DESCRIPTION
@Tecnativa TT64094
@pedrobaeza @pilarvargas-tecnativa 

When self is empty, an error was raised because res was defined inside the for loop. This should fix the issue.