### PR TITLE
[18.0][FIX] sale_stock_secondary_unit: Propagate secondary unit through multi-step buy routes

### DIFF
--- a/sale_stock_secondary_unit/models/stock_move.py
+++ b/sale_stock_secondary_unit/models/stock_move.py
@@ -1,3 +1,5 @@
+# Copyright 2026 Tecnativa - Carlos Dauden
+
 from odoo import models
 
 
@@ -6,8 +8,14 @@ class StockMove(models.Model):
 
     def _prepare_procurement_values(self):
         vals = super()._prepare_procurement_values()
-        vals["secondary_uom_id"] = self.sale_line_id.secondary_uom_id.id
+        # A multi-step "buy" route procures an intermediate move (e.g. the
+        # vendor receipt), which has no sale_line_id of its own - only the
+        # eventual delivery move, elsewhere in its chain, is linked to the
+        # sale order line. sale_stock's own _get_sale_order_lines() already
+        # walks the whole chain (both directions) to find it.
+        sale_line = self.sale_line_id or self._get_sale_order_lines()[:1]
+        vals["secondary_uom_id"] = sale_line.secondary_uom_id.id
         vals["secondary_uom_qty"] = self.env.context.get(
             "procure_secondary_uom_qty", {}
-        ).get(self.id, self.sale_line_id.secondary_uom_qty)
+        ).get(self.id, sale_line.secondary_uom_qty)
         return vals


### PR DESCRIPTION
_prepare_procurement_values() on stock.move read the secondary unit off self.sale_line_id directly, assuming the move triggering the purchase procurement is always the customer delivery itself. With a multi-step reception route, that is not the case: the move that actually gets procured is an intermediate one (e.g. the vendor-to-input receipt), which has no sale_line_id of its own - only the delivery move, elsewhere in its chain, carries it. The secondary unit ended up silently dropped on the resulting purchase order line: both the id and the quantity, with no error anywhere.

Fixed by falling back to sale_stock's own _get_sale_order_lines(), which already walks the whole move chain (both directions) to find the sale order line associated with any move in it - the same lookup this module was missing, not a new one.

@Tecnativa

Ping @sergio-teruel @CarlosRoca13 