### PR TITLE
[18.0][FIX] sale_order_general_discount: Restore discount reset on removal

### DIFF
--- a/sale_order_general_discount/models/sale_order_line.py
+++ b/sale_order_general_discount/models/sale_order_line.py
@@ -20,8 +20,10 @@ class SaleOrderLine(models.Model):
             # the case where a discount was set to a value != 0 and then
             # set again to 0 to remove the discount on all the lines at the same
             # time
-            if not line.product_id.bypass_general_discount and (
-                line.order_id.general_discount or line.order_id._origin.general_discount
-            ):
+            if line.product_id.bypass_general_discount:
+                continue
+            if line.order_id.general_discount or line.order_id._origin.general_discount:
                 line.discount = line.order_id.general_discount
+            else:
+                line.discount = 0
         return res

--- a/sale_order_general_discount/tests/test_sale_order_general_discount.py
+++ b/sale_order_general_discount/tests/test_sale_order_general_discount.py
@@ -167,6 +167,15 @@ class TestSaleOrderLineInput(TransactionCase):
         self.assertEqual(self.order.order_line[0].discount, 10)
         self.assertEqual(self.order.order_line[1].discount, 2)
 
+    def test_compute_discount_reset_on_removal(self):
+        """Removing the general discount must reset every line discount to 0,
+        not just leave whatever the line already had.
+        """
+        self.order.general_discount = 10
+        self.assertEqual(self.order.order_line[0].discount, 10)
+        self.order.general_discount = 0
+        self.assertEqual(self.order.order_line[0].discount, 0)
+
     def test_product_template(self):
         self.assertFalse(self.product.product_tmpl_id.bypass_general_discount)
         self.assertTrue(self.product2.product_tmpl_id.bypass_general_discount)


### PR DESCRIPTION
_compute_discount() lost its reset-to-zero branch between 17.0 and 18.0 - removing the order's general discount no longer cleared it back off of already-discounted lines, leaving them stuck at the last applied percentage.

Restructured rather than literally restoring the old else branch: the current test suite's own expectation (confirmed unrelated to this bug) is that a bypass_general_discount line is never touched by this compute at all, not reset to 0 either - skip those lines entirely, then apply the general discount or reset to 0 for the rest.

@Tecnativa

ping @sergio-teruel @CarlosRoca13 @carlos-lopez-tecnativa 