### PR TITLE
[19.0][FIX] sale_order_line_description: make the manual edit tour robust

### DIFF
--- a/sale_order_line_description/static/tests/tours/sale_order_line_description.esm.js
+++ b/sale_order_line_description/static/tests/tours/sale_order_line_description.esm.js
@@ -8,8 +8,13 @@ registry.category("web_tour.tours").add("sale_order_line_description_manual_edit
         {
             content: "Open the sale order line editor",
             trigger:
-                '.o_field_product_label_section_and_note_cell:contains("Sale description for test product")',
+                '.o_field_product_label_section_and_note_cell:has(:contains("Test product"), input:value("Test product"))',
             run: "click",
+        },
+        {
+            content: "Check the product name is not prepended to the description",
+            trigger:
+                '.o_selected_row .o_field_product_label_section_and_note_cell textarea:value("Sale description for test product")',
         },
         {
             content: "Edit the sale order line description",


### PR DESCRIPTION
The first step matched the description through :contains(), which only reads text content. That text exists solely in the readonly rendering of the cell, so the step timed out on slower runners before the row was rendered.

Select the line by product name, accepting both the text and the many2one input value as core's own sale tour utils do, and assert the description through the textarea value once the row is in edit mode.