### PR TITLE
[18.0][FIX] sale_order_type: Apply the type analytic distribution to the order lines

### DIFF
--- a/sale_order_type/README.rst
+++ b/sale_order_type/README.rst
@@ -75,6 +75,11 @@ Usage
    propagated.
 2. You can also define a type for a particular partner if you go to
    *Sales & Purchases* and set a sale order type.
+3. When the type defines an analytic distribution, it is applied to the
+   lines of its orders. As picking a type is an explicit decision taken
+   order by order, that distribution prevails over the one that the
+   analytic distribution models would resolve for the product or the
+   partner.
 
 Bug Tracker
 ===========
@@ -161,6 +166,14 @@ This module is maintained by the OCA.
 OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
+
+.. |maintainer-carlosdauden| image:: https://github.com/carlosdauden.png?size=40px
+    :target: https://github.com/carlosdauden
+    :alt: carlosdauden
+
+Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-carlosdauden| 
 
 This module is part of the `OCA/sale-workflow <https://github.com/OCA/sale-workflow/tree/18.0/sale_order_type>`_ project on GitHub.
 

--- a/sale_order_type/__manifest__.py
+++ b/sale_order_type/__manifest__.py
@@ -8,7 +8,7 @@
 
 {
     "name": "Sale Order Type",
-    "version": "18.0.1.4.0",
+    "version": "18.0.1.5.0",
     "category": "Sales Management",
     "author": "Grupo Vermon,"
     "AvanzOSC,"
@@ -33,4 +33,5 @@
         "views/res_config_settings.xml",
     ],
     "installable": True,
+    "maintainers": ["carlosdauden"],
 }

--- a/sale_order_type/migrations/18.0.1.5.0/post-migration.py
+++ b/sale_order_type/migrations/18.0.1.5.0/post-migration.py
@@ -1,0 +1,20 @@
+# Copyright 2026 Tecnativa - Carlos Dauden
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo.tools.sql import column_exists
+
+
+def migrate(cr, version):
+    """Turn the old single analytic account into a full analytic distribution."""
+    if not column_exists(cr, "sale_order_type", "analytic_account_id"):
+        return
+    cr.execute(
+        """
+        UPDATE sale_order_type
+        SET analytic_distribution = jsonb_build_object(
+            analytic_account_id::text, 100.0
+        )
+        WHERE analytic_account_id IS NOT NULL
+        AND analytic_distribution IS NULL
+        """
+    )

--- a/sale_order_type/models/sale.py
+++ b/sale_order_type/models/sale.py
@@ -219,3 +219,18 @@ class SaleOrderLine(models.Model):
             if order_type.route_id:
                 line.route_id = order_type.route_id
         return res
+
+    @api.depends("order_id.type_id")
+    def _compute_analytic_distribution(self):
+        """Let the order type define the analytic distribution of its lines.
+
+        The type is an explicit, per order choice, so it prevails over the
+        distribution resolved by ``account.analytic.distribution.model``, the
+        same way its pricelist or payment term prevail over the partner ones.
+        """
+        res = super()._compute_analytic_distribution()
+        for line in self.filtered(
+            lambda x: not x.display_type and x.order_id.type_id.analytic_distribution
+        ):
+            line.analytic_distribution = line.order_id.type_id.analytic_distribution
+        return res

--- a/sale_order_type/models/sale_order_type.py
+++ b/sale_order_type/models/sale_order_type.py
@@ -5,6 +5,7 @@ from odoo import api, fields, models
 
 class SaleOrderTypology(models.Model):
     _name = "sale.order.type"
+    _inherit = ["analytic.mixin"]
     _description = "Type of sale order"
     _check_company_auto = True
 
@@ -65,11 +66,6 @@ class SaleOrderTypology(models.Model):
     team_id = fields.Many2one(
         comodel_name="crm.team",
         string="Sales Team",
-        check_company=True,
-    )
-    analytic_account_id = fields.Many2one(
-        comodel_name="account.analytic.account",
-        string="Analytic account",
         check_company=True,
     )
     active = fields.Boolean(default=True)

--- a/sale_order_type/readme/USAGE.md
+++ b/sale_order_type/readme/USAGE.md
@@ -3,3 +3,8 @@
     propagated.
 2.  You can also define a type for a particular partner if you go to
     *Sales & Purchases* and set a sale order type.
+3.  When the type defines an analytic distribution, it is applied to the
+    lines of its orders. As picking a type is an explicit decision taken
+    order by order, that distribution prevails over the one that the
+    analytic distribution models would resolve for the product or the
+    partner.

--- a/sale_order_type/static/description/index.html
+++ b/sale_order_type/static/description/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="Docutils: https://docutils.sourceforge.io/" />
-<title>README.rst</title>
+<title>Sale Order Type</title>
 <style type="text/css">
 
 /*
@@ -420,6 +420,11 @@ the new type you have created before and all settings will be
 propagated.</li>
 <li>You can also define a type for a particular partner if you go to
 <em>Sales &amp; Purchases</em> and set a sale order type.</li>
+<li>When the type defines an analytic distribution, it is applied to the
+lines of its orders. As picking a type is an explicit decision taken
+order by order, that distribution prevails over the one that the
+analytic distribution models would resolve for the product or the
+partner.</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">
@@ -502,6 +507,8 @@ technical issues.</p>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainer</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/carlosdauden"><img alt="carlosdauden" src="https://github.com/carlosdauden.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/sale-workflow/tree/18.0/sale_order_type">OCA/sale-workflow</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>

--- a/sale_order_type/tests/test_sale_order_type.py
+++ b/sale_order_type/tests/test_sale_order_type.py
@@ -4,7 +4,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 from freezegun import freeze_time
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.tests import Form
 
 from odoo.addons.base.tests.common import BaseCommon
@@ -148,6 +148,20 @@ class TestSaleOrderType(BaseCommon):
                 "route_id": cls.sale_route.id,
             }
         )
+        cls.analytic_plan = cls.env.ref("analytic.analytic_plan_projects")
+        cls.analytic_account = cls.env["account.analytic.account"].create(
+            {"name": "Test SOT Analytic Account", "plan_id": cls.analytic_plan.id}
+        )
+        cls.analytic_account_model = cls.env["account.analytic.account"].create(
+            {"name": "Test SOT Model Analytic Account", "plan_id": cls.analytic_plan.id}
+        )
+        cls.sale_type_analytic = cls.sale_type_model.create(
+            {
+                "name": "Test Sale Order Type Analytic",
+                "journal_id": cls.journal.id,
+                "analytic_distribution": {str(cls.analytic_account.id): 100.0},
+            }
+        )
 
     def create_sale_order(self, partner=False):
         sale_form = Form(self.env["sale.order"])
@@ -238,6 +252,70 @@ class TestSaleOrderType(BaseCommon):
         }
         order.write({"order_line": [(0, 0, sale_line_dict)]})
         self.assertEqual(order.type_id.route_id, order.order_line[1].route_id)
+
+    def test_sale_order_flow_analytic_distribution(self):
+        """The type distribution is propagated to the lines of its orders."""
+        self.partner.sale_type = self.sale_type_analytic
+        order = self.create_sale_order()
+        self.assertEqual(order.type_id, self.sale_type_analytic)
+        self.assertEqual(
+            order.order_line.analytic_distribution,
+            {str(self.analytic_account.id): 100.0},
+        )
+
+    def test_sale_order_analytic_distribution_type_change(self):
+        """Changing the type redistributes existing lines and the new ones."""
+        order = self.create_sale_order()
+        self.assertFalse(order.order_line.analytic_distribution)
+        order.type_id = self.sale_type_analytic
+        self.assertEqual(
+            order.order_line.analytic_distribution,
+            {str(self.analytic_account.id): 100.0},
+        )
+        order.write(
+            {
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "name": self.product.name,
+                            "product_uom_qty": 2.0,
+                            "price_unit": self.product.lst_price,
+                        },
+                    )
+                ]
+            }
+        )
+        self.assertEqual(
+            order.order_line[1].analytic_distribution,
+            {str(self.analytic_account.id): 100.0},
+        )
+
+    def test_sale_order_analytic_distribution_prevails_over_model(self):
+        """The type distribution prevails over the one of the analytic models.
+
+        Picking a type is an explicit per order decision, so it wins over the
+        generic rules, the same way its pricelist wins over the partner one.
+        """
+        self.env["account.analytic.distribution.model"].create(
+            {
+                "partner_id": self.partner.id,
+                "analytic_distribution": {str(self.analytic_account_model.id): 100.0},
+            }
+        )
+        order = self.create_sale_order()
+        self.assertEqual(order.type_id, self.sale_type)
+        self.assertFalse(self.sale_type.analytic_distribution)
+        # Without a distribution in the type, the analytic model one is kept
+        self.assertEqual(
+            order.order_line.analytic_distribution,
+            {str(self.analytic_account_model.id): 100.0},
+        )
+        order.type_id = self.sale_type_analytic
+        self.assertEqual(
+            order.order_line.analytic_distribution,
+            {str(self.analytic_account.id): 100.0},
+        )
 
     def test_sale_order_in_draft_state_update_name(self):
         order = self.create_sale_order()

--- a/sale_order_type/views/sale_order_type_view.xml
+++ b/sale_order_type/views/sale_order_type_view.xml
@@ -35,7 +35,9 @@
                             <field name="route_id" groups="stock.group_adv_location" />
                             <field name="sequence_id" />
                             <field
-                                name="analytic_account_id"
+                                name="analytic_distribution"
+                                widget="analytic_distribution"
+                                options="{'force_applicability': 'optional', 'disable_save': true}"
                                 groups="analytic.group_analytic_accounting"
                             />
                         </group>


### PR DESCRIPTION
The migration to 18.0 dropped sale.order.analytic_account_id and its compute because the core replaced the order level analytic account by the line level analytic_distribution, but nothing took over the analytic account configured on the type: the field stayed editable on sale.order.type and had no effect at all on the orders, unlike every other setting of the type (route, pricelist, payment term, salesperson, team, incoterm), which did keep its compute adapted to the new architecture.

Following the design already merged upstream for 19.0, the type inherits analytic.mixin and now holds a full analytic distribution rather than a single account, which is how 18.0 expresses analytic assignment. A post-migration script turns the previous analytic_account_id into a 100% distribution on that same account.

sale.order.line._compute_analytic_distribution is extended with the pattern the module uses for the rest of the type settings, so the distribution of the type is applied after the one resolved by account.analytic.distribution.model and prevails over it. Choosing a type is an explicit decision taken order by order, the same way its pricelist prevails over the partner one, and a company wide catch-all distribution model would otherwise neutralize the setting completely. Lines with a display_type are skipped, as the core compute does.

@Tecnativa
ping @sergio-teruel @carlos-lopez-tecnativa @CarlosRoca13 