### PR TITLE
[18.0][FIX] sale_order_line_final_price: Prevent the ZeroDivisionError if price_unit is 0

### DIFF
--- a/sale_order_line_final_price/models/sale_order_line.py
+++ b/sale_order_line_final_price/models/sale_order_line.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Tecnativa - Eduardo Ezerouali
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import api, fields, models
-from odoo.tools import config, float_compare, float_round
+from odoo.tools import config, float_compare, float_is_zero, float_round
 
 
 class SaleOrderLine(models.Model):
@@ -69,7 +69,9 @@ class SaleOrderLine(models.Model):
                 line.price_final, line._get_discounted_price(), precision_digits=dp
             ):
                 handled += line
-                if not line.technical_price_unit:
+                if not line.technical_price_unit or float_is_zero(
+                    line.price_unit, precision_digits=dp
+                ):
                     line.discount = 0
                 else:
                     line.discount = float_round(

--- a/sale_order_line_final_price/tests/test_sale_order_line_final_price.py
+++ b/sale_order_line_final_price/tests/test_sale_order_line_final_price.py
@@ -83,6 +83,17 @@ class TestSaleOrderLineFinalPrice(BaseCommon):
         self.line.price_final = 33.33
         self.assertEqual(self.line.discount, 66.67)
 
+    def test_price_unit_0_change_price_final_0(self):
+        self.line.write(
+            {
+                "price_unit": 0,
+                "discount": 0,
+                "price_final": 0,
+            }
+        )
+        self.line.price_final = 100
+        self.assertEqual(self.line.discount, 0)
+
     def test_price_final_without_unit_price(self):
         """The line is created with the agreed price as its unit price, and the
         amounts take it into account."""


### PR DESCRIPTION
Prevent the ZeroDivisionError if price_unit is 0

```
 File "/opt/odoo/auto/addons/sale_order_line_final_price/models/sale_order_line.py", line 76, in _compute_discount
    (1 - line.price_final / line.price_unit) * 100,
ZeroDivisionError: float division by zero
```

@Tecnativa TT64429