### PR TITLE
[18][sale_exception][FIX] no second cursor when installing modules

### DIFF
--- a/sale_exception/models/sale_order_line.py
+++ b/sale_exception/models/sale_order_line.py
@@ -55,9 +55,16 @@ class SaleOrderLine(models.Model):
 
     def _detect_exceptions(self, rule):
         records = super()._detect_exceptions(rule)
-        test_mode = config["test_enable"] and not self.env.context.get(
-            "test_base_exception"
-        )
+        # The registry is not ready yet when modules are being installed or
+        # updated: the ongoing transaction holds exclusive locks on the tables
+        # it has just modified (ALTER TABLE ...), so any query made through a
+        # second connection would wait forever on those locks (and the locks
+        # cannot be released, as the current thread is the one waiting).
+        # Use the current cursor in that case, as already done when running
+        # tests.
+        test_mode = (
+            config["test_enable"] or not self.env.registry.ready
+        ) and not self.env.context.get("test_base_exception")
         # Write exceptions in a new transaction to be committed so that we can
         #  rollback the ongoing one while keeping the exceptions stored
         with self.env.registry.cursor() as new_cr:


### PR DESCRIPTION
Same as https://github.com/OCA/server-tools/pull/3723

@rvalyi @hparfr @ivs-cetmix @simahawk @grindtildeath