### PR TITLE
[19.0] Revert "[FIX] sale_order_carrier_auto_assign: Set product_uom_id to prevent it from being recomputed"

### DIFF
--- a/sale_order_carrier_auto_assign/models/sale_order.py
+++ b/sale_order_carrier_auto_assign/models/sale_order.py
@@ -86,11 +86,3 @@ class SaleOrder(models.Model):
                 if result.get("success"):
                     price_unit = result["price"]
                     order._create_delivery_line(carrier, price_unit)
-
-    def _prepare_delivery_line_vals(self, carrier, price_unit):
-        values = super()._prepare_delivery_line_vals(carrier, price_unit)
-        # Set product_uom_id to prevent this field from being recomputed.
-        # remove this method when this PR is merged.
-        # https://github.com/odoo/odoo/pull/283551
-        values["product_uom_id"] = carrier.product_id.uom_id.id
-        return values


### PR DESCRIPTION
This reverts commit https://github.com/OCA/sale-workflow/commit/b0429b16db24ddf4c9bee6983e4bac20823e3c38.

This code was merged into Odoo in https://github.com/odoo/odoo/pull/283551, so it is no longer necessary here.

@Tecnativa @pedrobaeza could you please review this?